### PR TITLE
Add a convenience function to set ENV vars if not present

### DIFF
--- a/proxy/src/env.rs
+++ b/proxy/src/env.rs
@@ -1,0 +1,24 @@
+/// Convenience function for setting env vars only if they are unset.
+pub fn set_if_unset (key: &str, val: &str) {
+    use std::env::{var,set_var};
+    var(key).unwrap_or_else(|_| { set_var(key, val); var(key).unwrap() });
+}
+
+#[test]
+fn test_set_if_unset() {
+    match std::env::var("DUMMY_VALUE") {
+        Ok(_val) => {
+            // should be unset
+            panic!("$DUMMY_VALUE should be unset.")
+        },
+        Err(_e) => {
+            set_if_unset("DUMMY_VALUE", "hello world")
+        }
+    }
+    match std::env::var("DUMMY_VALUE") {
+        Ok(val) => { assert_eq!(val, "hello world") },
+        Err(_e) => {
+            panic!("$DUMMY_VALUE is still unset.")
+        }
+    }
+}

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -25,10 +25,12 @@ mod schema;
 mod server_warp;
 /// Origin of data required like the on-chain Registry.
 mod source;
+/// lib functions
+mod env;
 
 fn main() {
-    std::env::set_var("RUST_BACKTRACE", "full");
-    std::env::set_var("RUST_LOG", "info");
+    env::set_if_unset("RUST_BACKTRACE", "full");
+    env::set_if_unset("RUST_LOG", "debug");
     pretty_env_logger::init();
 
     let source_type = std::env::args().nth(1).expect("no source was given");


### PR DESCRIPTION
I noticed the `set_var` calls were changing between versions, implying that folks are hardcoding values as needed. This PR adds a `set_if_unset` function which only sets an env var if it is unset, allowing you to set log levels and backtrace behavior as necessary while retaining useful defaults.