### PR TITLE
proxy: Remove explicit dependency on registry runtime

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1941,7 +1941,6 @@ dependencies = [
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "radicle-surf 0.1.0 (git+https://github.com/radicle-dev/radicle-surf.git?rev=3ddc170c109b10273ea04659eb64ec6918189f70)",
  "radicle_registry_client 0.1.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=58e3b8bc79e556053d8e17dc21f72c8bbdf243e5)",
- "radicle_registry_runtime 0.1.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=58e3b8bc79e556053d8e17dc21f72c8bbdf243e5)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -30,10 +30,6 @@ warp = "0.1"
 git = "https://github.com/radicle-dev/radicle-registry.git"
 rev = "58e3b8bc79e556053d8e17dc21f72c8bbdf243e5"
 
-[dependencies.radicle_registry_runtime]
-git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "58e3b8bc79e556053d8e17dc21f72c8bbdf243e5"
-
 [dependencies.radicle-surf]
 git = "https://github.com/radicle-dev/radicle-surf.git"
 rev = "3ddc170c109b10273ea04659eb64ec6918189f70"

--- a/proxy/src/source.rs
+++ b/proxy/src/source.rs
@@ -1,8 +1,7 @@
 use futures::future::Future;
 use std::collections::HashMap;
 
-use radicle_registry_client::{CryptoPair as _, H256};
-use radicle_registry_runtime::registry::{ProjectDomain, ProjectName};
+use radicle_registry_client::{CryptoPair as _, ProjectDomain, ProjectName, H256};
 
 /// Newtype for the registry `oscoin_client::AccountId`.
 #[derive(Clone, Eq, Hash, PartialEq)]


### PR DESCRIPTION
We remove the explicit dependency on the registry runtime so that the API of only one package is used. (This does not improve the dependency footprint)