### PR TITLE
Add missing autoconf dependency

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,8 +1,9 @@
 FROM gcr.io/opensourcecoin/radicle-registry/ci-base
 
 RUN apt-get -y update
+
 # install cypress deps
-RUN apt-get -y install git nettle-dev m4 gnupg xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+RUN apt-get -y install autoconf git nettle-dev m4 gnupg xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 
 # install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
@@ -10,5 +11,3 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 RUN apt-get -y update
 RUN apt-get -y install yarn
 RUN rustup component add clippy --toolchain nightly-2019-11-17-x86_64-unknown-linux-gnu
-
-RUN yarn --version

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,7 @@
     platform: "linux"
   timeout_in_minutes: 60
   env:
-    DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.9'
+    DOCKER_IMAGE: 'gcr.io/opensourcecoin/radicle-upstream:0.2.1'
     SHARED_MASTER_CACHE: true
   command: '.buildkite/run.sh'
   artifact_paths:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,78 @@
+[![Build status][0]][1]
+
 # radicle-upstream
 
 A monorepo for related Radicle projects:
 
-- `app`: Cross-platform desktop app, currently used for product explorations.
-- `proxy`: Intermediate serving a specialised API to the app frontend via GraphQL.
+- `app`: Cross-platform desktop client for radicle.
+- `proxy`: Intermediate serving a specialised API to the app frontend
+  via GraphQL.
 
 See the README.md of each respective project for further details, including
 installation, usage, and testing instructions.
+
 
 ## Development
 
 Notes and guidelines for committers:
 
-- [Use tpope commit norms](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html): Capitalize commit messages, use the imperative present tense, wrap commit messages at 50 characters.
+- [Use tpope commit norms][2]: Capitalize commit messages, use the imperative
+  present tense, wrap commit messages at 50 characters.
+
+
+#### CI
+
+CI is configured via:
+
+```
+radicle-upstream/.buildkite
+.
+├── Dockerfile
+├── pipeline.yaml
+└── run.sh
+```
+
+The build process is run for every commit that is pushed to GitHub. When the
+tests pass, the build process spits out and uploads an app binary as build
+artifact. When the tests fail, screenshots of the failing tests will be
+uploaded instead of the binary.
+
+
+#### Buildkite setup
+
+We use a Docker image that has all of the system dependencies installed to run
+tests on Buildkite. Follow these steps if you need to update the dependencies
+bundled in the image:
+
+1. Install [Google Cloud SDK][3]
+
+2. Authenticate with Google Cloud: `gcloud auth configure-docker`, pick
+   `[1] opensourcecoin` when asked for which project to use
+
+3. Prepare a new docker image with all the necessary dependencies by editing:
+   `.buildkite/Dockerfile`
+
+4. Get the current image version from `pipeline.yaml` and build a new Docker
+   image (remember to bump the version):
+```
+cd .buildkite
+docker build . -t gcr.io/opensourcecoin/radicle-upstream:0.2.1
+docker push gcr.io/opensourcecoin/radicle-upstream:0.2.1
+```
+
+5. Push the new image version to Google Cloud:
+   `docker push gcr.io/opensourcecoin/radicle-upstream:0.2.1`
+
+6. Update the image version in `pipeline.yaml`:
+```
+DOCKER_IMAGE: 'gcr.io/opensourcecoin/radicle-upstream:0.2.1'
+
+```
+7. Commit changes to `Dockerfile` and `pipeline.yaml` and push to origin, this
+   should build the new branch with the updated image
+
+
+[0]: https://badge.buildkite.com/4fb43c6b471ab7cc26509eae235b0e4bbbaace11cc1848eae6.svg?branch=master
+[1]: https://buildkite.com/monadic/radicle-upstream
+[2]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[3]: https://cloud.google.com/sdk/docs/quickstart-macos

--- a/app/README.md
+++ b/app/README.md
@@ -1,8 +1,8 @@
-[![Build status](https://badge.buildkite.com/4fb43c6b471ab7cc26509eae235b0e4bbbaace11cc1848eae6.svg?branch=master)](https://buildkite.com/monadic/radicle-upstream)
+# radicle desktop client
 
-# radicle-upstream
+This is a cross-platform desktop client for Radicle.
+We currently support Linux and macOS.
 
-This is a cross-platform desktop app for product explorations.
 
 ## Development
 
@@ -11,6 +11,7 @@ script execution we use `yarn`.
 
 Code formatting is dictated by [prettier][0] and we enforce it locally on
 a pre-commit basis with [husky][1] and [lint-staged][2].
+
 
 ### Setup
 
@@ -36,52 +37,6 @@ To run the tests do: `yarn test`.
 To troubleshoot tests in the Cypress GUI, run: `yarn test:debug`.
 
 
-#### CI
-
-CI is configured via:
-```
-radicle-upstream/.buildkite
-.
-├── Dockerfile
-├── pipeline.yaml
-└── run.sh
-```
-
-The build process is run for every commit that is pushed to GitHub. When the
-tests pass, the build process spits out and uploads an app binary as build
-artifact. When the tests fail, screenshots of the failing tests will be
-uploaded instead of the binary.
-
-
-#### Buildkite setup
-
-We use a Docker image that has all of the system dependencies installed to run
-tests on Buildkite. Follow these steps if you need to update the dependencies
-bundled in the image:
-
-1. Install [Google Cloud SDK][3]
-2. Authenticate with Google Cloud: `gcloud auth configure-docker`, pick
-   `[1] opensourcecoin` when asked for which project to use
-3. Prepare a new docker image with all the necessary dependencies by editing:
-   `../.buildkite/Dockerfile`
-4. Get the current image version from `pipeline.yaml` and build a new Docker
-   image (remember to bump the version):
-```
-cd .buildkite
-docker build . -t gcr.io/opensourcecoin/mvp:0.1.3
-docker push gcr.io/opensourcecoin/mvp:0.1.3
-```
-5. Push the new image version to Google Cloud:
-   `docker push gcr.io/opensourcecoin/mvp:0.1.3`
-
-6. Update the image version in `pipeline.yaml`:
-```
-DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.3'
-```
-7. Commit changes to `Dockerfile` and `pipeline.yaml` and push to origin, this
-   should build the new branch with the updated image
-
-
 ### Scripts
 
 ```
@@ -102,7 +57,7 @@ yarn svelte:build    - compile svelte to JS
 yarn svelte:watch    - compile svelte to JS on every change to the code
 ```
 
+
 [0]: https://prettier.io/
 [1]: https://github.com/typicode/husky
 [2]: https://github.com/okonet/lint-staged
-[3]: https://cloud.google.com/sdk/docs/quickstart-macos


### PR DESCRIPTION
Radicle-link depends on `nettle` which in turn requires `autoconf` to be installed. This PR updates the docker container to include `autoconf`. Additionally:
  - rename the docker image from `mvp` -> `radicle-upstream`
  - move CI documentation to top-level `README.md`