### PR TITLE
Fix app distribution builds

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -59,4 +59,4 @@ echo "--- Starting proxy daemon and runing app tests"
 (cd app && time ELECTRON_ENABLE_LOGGING=1 yarn test)
 
 echo "--- Packaging and uploading app binaries"
-(cd app && time yarn ci:dist)
+(cd app && time yarn dist)

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -58,8 +58,5 @@ echo "--- Run proxy lints"
 echo "--- Starting proxy daemon and runing app tests"
 (cd app && time ELECTRON_ENABLE_LOGGING=1 yarn test)
 
-echo "--- Build proxy release"
-(cd app && time yarn proxy:build:release)
-
 echo "--- Packaging and uploading app binaries"
 (cd app && time yarn ci:dist)

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -38,7 +38,7 @@ else
   echo "Cache $target_cache not available"
 fi
 
-echo "--- Updateing submodules"
+echo "--- Updating submodules"
 (cd app && time git submodule update --init --recursive)
 (cd app && time git submodule foreach "git fetch --all")
 

--- a/app/package.json
+++ b/app/package.json
@@ -53,7 +53,6 @@
     "test:debug": "TZ='UTC' run-p --race svelte:watch proxy:start:test cypress:open",
     "test:run": "wait-on http://localhost:8080 && yarn svelte:build && yarn cypress:run",
     "dist": "rm -rf ./dist && mkdir ./dist && yarn svelte:clean && yarn svelte:build && yarn proxy:build:release && cp ../proxy/target/release/proxy dist && electron-builder",
-    "ci:dist": "rm -rf ./dist && mkdir ./dist && cp ../proxy/target/release/proxy dist && electron-builder",
     "electron:start": "wait-on ./public/bundle.js && wait-on ./native/main.comp.js && wait-on http://localhost:8080 && NODE_ENV=development electron .",
     "svelte:clean": "rm -rf public/bundle.*",
     "svelte:build": "yarn svelte:clean && rollup -c",

--- a/app/package.json
+++ b/app/package.json
@@ -52,7 +52,7 @@
     "test": "TZ='UTC' run-p --race proxy:start:test test:run",
     "test:debug": "TZ='UTC' run-p --race svelte:watch proxy:start:test cypress:open",
     "test:run": "wait-on http://localhost:8080 && yarn svelte:build && yarn cypress:run",
-    "dist": "rm -rf ./dist && mkdir ./dist && yarn svelte:clean && yarn svelte:build && yarn proxy:build && cp ../proxy/target/release/proxy dist && electron-builder",
+    "dist": "rm -rf ./dist && mkdir ./dist && yarn svelte:clean && yarn svelte:build && yarn proxy:build:release && cp ../proxy/target/release/proxy dist && electron-builder",
     "ci:dist": "rm -rf ./dist && mkdir ./dist && cp ../proxy/target/release/proxy dist && electron-builder",
     "electron:start": "wait-on ./public/bundle.js && wait-on ./native/main.comp.js && wait-on http://localhost:8080 && NODE_ENV=development electron .",
     "svelte:clean": "rm -rf public/bundle.*",


### PR DESCRIPTION
This was not working locally if the proxy hasn't been built in release
mode. It worked on CI, because we already build proxy in a separate
step via .buildkite/run.sh