### PR TITLE
Switch to new surf revparser

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2460,7 +2460,6 @@ dependencies = [
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=8689536f7e30d5e4839141658d2357e2cc550755)",
- "radicle-surf 0.2.1 (git+https://github.com/radicle-dev/radicle-surf.git?rev=5c04b846cf53763a70bf0c168ce40293bbce0bd6)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1527,18 +1527,20 @@ dependencies = [
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=0034bd0fca27596b6fd2982ec875daa426ded120#0034bd0fca27596b6fd2982ec875daa426ded120"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=4cedafaeb46deee4ec11d0e4b779a1a0d124d599#4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nettle 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "nonempty 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nonempty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "radicle-surf 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "radicle-keystore 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=4cedafaeb46deee4ec11d0e4b779a1a0d124d599)",
+ "radicle-surf 0.2.1 (git+https://github.com/radicle-dev/radicle-surf.git?rev=5c04b846cf53763a70bf0c168ce40293bbce0bd6)",
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sequoia-openpgp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1883,11 +1885,6 @@ dependencies = [
  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "nonempty"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nonempty"
@@ -2456,14 +2453,14 @@ dependencies = [
  "juniper 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_codegen 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_warp 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "librad 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=0034bd0fca27596b6fd2982ec875daa426ded120)",
+ "librad 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=4cedafaeb46deee4ec11d0e4b779a1a0d124d599)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nonempty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pico-args 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=8689536f7e30d5e4839141658d2357e2cc550755)",
- "radicle-surf 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "radicle-surf 0.2.1 (git+https://github.com/radicle-dev/radicle-surf.git?rev=5c04b846cf53763a70bf0c168ce40293bbce0bd6)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2503,6 +2500,18 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "radicle-keystore"
+version = "0.1.0"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=4cedafaeb46deee4ec11d0e4b779a1a0d124d599#4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
+dependencies = [
+ "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secstr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2583,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "radicle-surf"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/radicle-dev/radicle-surf.git?rev=5c04b846cf53763a70bf0c168ce40293bbce0bd6#5c04b846cf53763a70bf0c168ce40293bbce0bd6"
 dependencies = [
  "git2 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nonempty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2774,6 +2783,15 @@ dependencies = [
 name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rpassword"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rust-argon2"
@@ -4404,7 +4422,7 @@ dependencies = [
 "checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
 "checksum libgit2-sys 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4870c781f6063efb83150cd22c1ddf6ecf58531419e7570cdcced46970f64a16"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum librad 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=0034bd0fca27596b6fd2982ec875daa426ded120)" = "<none>"
+"checksum librad 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=4cedafaeb46deee4ec11d0e4b779a1a0d124d599)" = "<none>"
 "checksum libsecp256k1 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "df6edf84fd62aad1c93932b39324eaeda3912c1d26bc18dfaee6293848e49a50"
 "checksum libsodium-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1c344ff12b90ef8fa1f0fffacd348c1fd041db331841fec9eab23fdb991f5e73"
 "checksum libssh2-sys 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "36aa6e813339d3a063292b77091dfbbb6152ff9006a459895fa5bebed7d34f10"
@@ -4440,7 +4458,6 @@ dependencies = [
 "checksum new_debug_unreachable 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum nonempty 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4f962080273ac958f790079cfc886b5b9d722969dbd7b03f473902bdfe5c69b1"
 "checksum nonempty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6954982ece17426b038f84895b4a6771c541299dc7141fab20ee676b19d9d97f"
 "checksum num-bigint 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f115de20ad793e857f76da2563ff4a09fbcfd6fe93cca0c5d996ab5f3ee38d"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
@@ -4504,10 +4521,11 @@ dependencies = [
 "checksum quickcheck 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum radicle-keystore 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=4cedafaeb46deee4ec11d0e4b779a1a0d124d599)" = "<none>"
 "checksum radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=8689536f7e30d5e4839141658d2357e2cc550755)" = "<none>"
 "checksum radicle-registry-core 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=8689536f7e30d5e4839141658d2357e2cc550755)" = "<none>"
 "checksum radicle-registry-runtime 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=8689536f7e30d5e4839141658d2357e2cc550755)" = "<none>"
-"checksum radicle-surf 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "36d596927be3ded0ebb71ff65d41adadacc47025b344cc95d2f70ed7c1b55fa6"
+"checksum radicle-surf 0.2.1 (git+https://github.com/radicle-dev/radicle-surf.git?rev=5c04b846cf53763a70bf0c168ce40293bbce0bd6)" = "<none>"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
@@ -4529,6 +4547,7 @@ dependencies = [
 "checksum regex-syntax 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+"checksum rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -32,14 +32,15 @@ warp = "0.1"
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "0034bd0fca27596b6fd2982ec875daa426ded120"
+rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
 rev = "8689536f7e30d5e4839141658d2357e2cc550755"
 
 [dependencies.radicle-surf]
-version = "0.2"
+git = "https://github.com/radicle-dev/radicle-surf.git"
+rev = "5c04b846cf53763a70bf0c168ce40293bbce0bd6"
 
 [dev-dependencies]
 indexmap = "1.3"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -38,10 +38,6 @@ rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 git = "https://github.com/radicle-dev/radicle-registry.git"
 rev = "8689536f7e30d5e4839141658d2357e2cc550755"
 
-[dependencies.radicle-surf]
-git = "https://github.com/radicle-dev/radicle-surf.git"
-rev = "5c04b846cf53763a70bf0c168ce40293bbce0bd6"
-
 [dev-dependencies]
 indexmap = "1.3"
 pretty_assertions = "0.6"

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -11,8 +11,8 @@ use librad::meta::{self, common::Url};
 use librad::paths::Paths;
 use librad::peer;
 use librad::project;
-use radicle_surf as surf;
-use radicle_surf::git::git2;
+use librad::surf;
+use librad::surf::git::git2;
 
 use crate::error;
 
@@ -165,7 +165,7 @@ pub fn blob(paths: &Paths, id: &str, revision: &str, path: &str) -> Result<Blob,
     let mut p = surf::file_system::Path::from_str(path)?;
 
     let file = root.find_file(&p).ok_or_else(|| {
-        radicle_surf::file_system::error::Error::Path(radicle_surf::file_system::error::Path::Empty)
+        surf::file_system::error::Error::Path(surf::file_system::error::Path::Empty)
     })?;
 
     let mut commit_path = surf::file_system::Path::root();
@@ -243,10 +243,10 @@ pub fn commit(paths: &Paths, id: &str, sha1: &str) -> Result<Commit, error::Erro
         project::Project::Git(git_project) => git_project.browser()?,
     };
 
-    browser.commit(radicle_surf::git::Oid::from_str(sha1)?)?;
+    browser.commit(surf::git::Oid::from_str(sha1)?)?;
 
     let history = browser.get();
-    let commit = history.0.first();
+    let commit = history.first();
 
     Ok(Commit::from(commit))
 }
@@ -301,9 +301,7 @@ pub fn tree(paths: &Paths, id: &str, revision: &str, prefix: &str) -> Result<Tre
         root_dir
     } else {
         root_dir.find_directory(&path).ok_or_else(|| {
-            radicle_surf::file_system::error::Error::Path(
-                radicle_surf::file_system::error::Path::Empty,
-            )
+            surf::file_system::error::Error::Path(surf::file_system::error::Path::Empty)
         })?
     };
     let mut prefix_contents = prefix_dir.list_directory();
@@ -315,8 +313,8 @@ pub fn tree(paths: &Paths, id: &str, revision: &str, prefix: &str) -> Result<Tre
             let mut entry_path = if path.is_root() {
                 let label_path =
                     nonempty::NonEmpty::from_slice(&[label.clone()]).ok_or_else(|| {
-                        radicle_surf::file_system::error::Error::Label(
-                            radicle_surf::file_system::error::Label::Empty,
+                        surf::file_system::error::Error::Label(
+                            surf::file_system::error::Label::Empty,
                         )
                     })?;
                 surf::file_system::Path(label_path)
@@ -354,7 +352,7 @@ pub fn tree(paths: &Paths, id: &str, revision: &str, prefix: &str) -> Result<Tre
     entries.sort_by(|a, b| a.info.object_type.cmp(&b.info.object_type));
 
     let last_commit = if path.is_root() {
-        Some(Commit::from(browser.get().0.first()))
+        Some(Commit::from(browser.get().first()))
     } else {
         let mut commit_path = surf::file_system::Path::root();
         commit_path.append(&mut path);

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -1,9 +1,9 @@
 //! Domain errors returned by the API.
 
 use librad::meta::common::url;
+use librad::surf;
+use librad::surf::git::git2;
 use radicle_registry_client::{DispatchError, Error as ProtocolError};
-use radicle_surf as surf;
-use radicle_surf::git::git2;
 use std::time::SystemTimeError;
 
 /// Project problems.
@@ -19,7 +19,7 @@ pub enum ProjectValidation {
 #[derive(Debug)]
 pub enum Error {
     /// FileSystem errors from interacting with code in repository.
-    FS(radicle_surf::file_system::error::Error),
+    FS(surf::file_system::error::Error),
     /// Originated from `radicle_surf`.
     Git(surf::git::error::Error),
     /// Originated from `radicle_surf::git::git2`.
@@ -46,8 +46,8 @@ pub enum Error {
     Time(SystemTimeError),
 }
 
-impl From<radicle_surf::file_system::error::Error> for Error {
-    fn from(fs_error: radicle_surf::file_system::error::Error) -> Self {
+impl From<surf::file_system::error::Error> for Error {
+    fn from(fs_error: surf::file_system::error::Error) -> Self {
         Self::FS(fs_error)
     }
 }

--- a/proxy/src/graphql/error.rs
+++ b/proxy/src/graphql/error.rs
@@ -1,6 +1,6 @@
 use librad::meta::common::url;
-use radicle_surf as surf;
-use radicle_surf::git::git2;
+use librad::surf;
+use librad::surf::git::git2;
 
 use crate::error;
 
@@ -53,15 +53,15 @@ impl juniper::IntoFieldError for error::Error {
 }
 
 /// Helper to convert `radicle_surf` `FileSystem` error to `juniper::FieldError`.
-fn convert_fs(error: &radicle_surf::file_system::error::Error) -> juniper::FieldError {
+fn convert_fs(error: &surf::file_system::error::Error) -> juniper::FieldError {
     let error_str = match &error {
-        radicle_surf::file_system::error::Error::Label(label_error) => match label_error {
-            radicle_surf::file_system::error::Label::ContainsSlash => "Label contains slashes",
-            radicle_surf::file_system::error::Label::Empty => "Label is empty",
-            radicle_surf::file_system::error::Label::InvalidUTF8 => "Label is not valid utf8",
+        surf::file_system::error::Error::Label(label_error) => match label_error {
+            surf::file_system::error::Label::ContainsSlash => "Label contains slashes",
+            surf::file_system::error::Label::Empty => "Label is empty",
+            surf::file_system::error::Label::InvalidUTF8 => "Label is not valid utf8",
         },
-        radicle_surf::file_system::error::Error::Path(path_error) => match path_error {
-            radicle_surf::file_system::error::Path::Empty => "Path is empty",
+        surf::file_system::error::Error::Path(path_error) => match path_error {
+            surf::file_system::error::Path::Empty => "Path is empty",
         },
     };
 

--- a/proxy/src/graphql/error.rs
+++ b/proxy/src/graphql/error.rs
@@ -86,22 +86,22 @@ fn convert_io(error: &std::io::Error) -> juniper::FieldError {
 /// Helper to convert a `radicle_surf` Git error to `juniper::FieldError`.
 fn convert_git(error: &surf::git::error::Error) -> juniper::FieldError {
     match error {
-        surf::git::error::Error::EmptyCommitHistory => juniper::FieldError::new(
-            "Repository has an empty commit history.",
-            graphql_value!({
-                "type": "GIT_EMPTY_COMMIT_HISTORY"
-            }),
-        ),
-        surf::git::error::Error::NotBranch => juniper::FieldError::new(
-            "Not a known branch.",
+        surf::git::error::Error::NotBranch(branch) => juniper::FieldError::new(
+            format!("branch '{}' not known", branch.name()),
             graphql_value!({
                 "type": "GIT_NOT_BRANCH"
             }),
         ),
-        surf::git::error::Error::NotTag => juniper::FieldError::new(
-            "Not a known tag.",
+        surf::git::error::Error::NotTag(tag) => juniper::FieldError::new(
+            format!("tag '{}' not known", tag.name()),
             graphql_value!({
                 "type": "GIT_NOT_TAG"
+            }),
+        ),
+        surf::git::error::Error::RevParseFailure(rev) => juniper::FieldError::new(
+            format!("revspec '{}' malformed", rev),
+            graphql_value!({
+                "type": "GIT_REV_PARSE"
             }),
         ),
         surf::git::error::Error::Utf8Error(_utf8_error) => juniper::FieldError::new(
@@ -111,13 +111,13 @@ fn convert_git(error: &surf::git::error::Error) -> juniper::FieldError {
             }),
         ),
         surf::git::error::Error::FileSystem(fs_error) => convert_fs(fs_error),
-        surf::git::error::Error::FileDiffException => juniper::FieldError::new(
-            "Diff failed.",
+        surf::git::error::Error::LastCommitException => juniper::FieldError::new(
+            "last commit failed",
             graphql_value!({
-                "type": "GIT_FILE_DIFF"
+                "type": "GIT_LAST_COMMIT"
             }),
         ),
-        surf::git::error::Error::Internal(error) => juniper::FieldError::new(
+        surf::git::error::Error::Git(error) => juniper::FieldError::new(
             format!("Internal Git error: {:?}", error),
             graphql_value!({
                 "type": "GIT_INTERNAL"

--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -1,9 +1,11 @@
-use librad::paths::Paths;
-use radicle_registry_client::ed25519;
-use radicle_surf as surf;
 use std::convert::From;
 use std::convert::TryFrom;
 use std::str::FromStr;
+
+use librad::paths::Paths;
+use librad::surf;
+use librad::surf::git::git2;
+use radicle_registry_client::ed25519;
 
 use super::project;
 use crate::coco;
@@ -328,9 +330,7 @@ impl registry::Transaction {
                 .duration_since(std::time::UNIX_EPOCH)?
                 .as_secs(),
         )?;
-        let git_time = radicle_surf::git::git2::Time::new(since_epoch, 0)
-            .seconds()
-            .to_string();
+        let git_time = git2::Time::new(since_epoch, 0).seconds().to_string();
 
         Ok(git_time)
     }

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -164,7 +164,7 @@ mod tests {
             &alice,
             "hello".into(),
             "world".into(),
-            Some(librad::git::ProjectId::new(radicle_surf::git::git2::Oid::zero()).into()),
+            Some(librad::git::ProjectId::new(librad::surf::git::git2::Oid::zero()).into()),
         ));
         assert!(result.is_ok());
         let project_domain = String32::from_string("hello".into()).unwrap();

--- a/proxy/tests/common/mod.rs
+++ b/proxy/tests/common/mod.rs
@@ -1,9 +1,9 @@
 use juniper::{DefaultScalarValue, ExecutionError, Value, Variables};
 use librad::git::ProjectId;
 use librad::paths::Paths;
-use radicle_surf as surf;
-use radicle_surf::git::git2;
+use librad::surf;
 use std::env;
+use surf::git::git2;
 use tempfile::{tempdir_in, TempDir};
 
 use proxy::coco;

--- a/proxy/tests/graphql_mutation.rs
+++ b/proxy/tests/graphql_mutation.rs
@@ -3,8 +3,8 @@ extern crate juniper;
 
 use indexmap::IndexMap;
 use juniper::{InputValue, Variables};
+use librad::surf::git::git2;
 use pretty_assertions::assert_eq;
-use radicle_surf::git::git2;
 
 mod common;
 use proxy::coco;


### PR DESCRIPTION
This avoids brittle chaining and is closer to the underlying git2 mechanisms.

Closes #139