### PR TITLE
Run prettier and eslint checks on CI

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -73,6 +73,12 @@ echo "--- Run proxy lints"
 (cd proxy && time cargo check --all --all-features --all-targets)
 (cd proxy && time cargo clippy --all --all-features --all-targets)
 
+echo "--- Run app eslint checks"
+(cd app && time yarn lint)
+
+echo "--- Run app prettier checks"
+(cd app && time yarn prettier:check)
+
 echo "--- Starting proxy daemon and runing app tests"
 (cd app && time ELECTRON_ENABLE_LOGGING=1 yarn test)
 


### PR DESCRIPTION
We want to detect bad formatting and eslint errors on CI, since pre-commit hooks can be circumvented as pointed out in: https://github.com/radicle-dev/radicle-upstream/issues/131#issuecomment-586190148.