### PR TITLE
Bump registry-client to fix project mutation

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2014,27 +2014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-aura"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-consensus-aura 0.8.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
 name = "pallet-balances"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
@@ -2049,40 +2028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-finality-tracker"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
-name = "pallet-grandpa"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
@@ -2093,24 +2038,6 @@ dependencies = [
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
-name = "pallet-session"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
 ]
 
 [[package]]
@@ -2502,7 +2429,7 @@ dependencies = [
  "pico-args 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd)",
+ "radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2559,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd#7a09917a7ec112c914a2a6981991fa9e67fa37dd"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148#ffa1e394775528503e8e3f37622106121e1f8148"
 dependencies = [
  "async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2574,8 +2501,8 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "radicle-registry-core 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd)",
- "radicle-registry-runtime 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd)",
+ "radicle-registry-core 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)",
+ "radicle-registry-runtime 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)",
  "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
@@ -2590,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd#7a09917a7ec112c914a2a6981991fa9e67fa37dd"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148#ffa1e394775528503e8e3f37622106121e1f8148"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2601,24 +2528,21 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd#7a09917a7ec112c914a2a6981991fa9e67fa37dd"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148#ffa1e394775528503e8e3f37622106121e1f8148"
 dependencies = [
  "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "radicle-registry-core 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd)",
+ "radicle-registry-core 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-consensus-aura 0.8.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
@@ -3200,20 +3124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-aura"
-version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
 name = "sp-core"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
@@ -3271,29 +3181,6 @@ dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
-name = "sp-finality-grandpa"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
-name = "sp-finality-tracker"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
 ]
 
 [[package]]
@@ -3406,16 +3293,6 @@ source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4f
 dependencies = [
  "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
-]
-
-[[package]]
-name = "sp-staking"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b#09abd3b436ea568a47ec4fc47f933728d8cf466b"
-dependencies = [
- "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
  "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)",
 ]
@@ -4522,12 +4399,8 @@ dependencies = [
 "checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
-"checksum pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
-"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
-"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
@@ -4574,9 +4447,9 @@ dependencies = [
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum radicle-keystore 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=4cedafaeb46deee4ec11d0e4b779a1a0d124d599)" = "<none>"
-"checksum radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd)" = "<none>"
-"checksum radicle-registry-core 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd)" = "<none>"
-"checksum radicle-registry-runtime 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=7a09917a7ec112c914a2a6981991fa9e67fa37dd)" = "<none>"
+"checksum radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)" = "<none>"
+"checksum radicle-registry-core 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)" = "<none>"
+"checksum radicle-registry-runtime 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)" = "<none>"
 "checksum radicle-surf 0.2.1 (git+https://github.com/radicle-dev/radicle-surf.git?rev=5c04b846cf53763a70bf0c168ce40293bbce0bd6)" = "<none>"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4640,12 +4513,9 @@ dependencies = [
 "checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
-"checksum sp-consensus-aura 0.8.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
-"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
-"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
@@ -4655,7 +4525,6 @@ dependencies = [
 "checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
-"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,7 +36,7 @@ rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "7a09917a7ec112c914a2a6981991fa9e67fa37dd"
+rev = "ffa1e394775528503e8e3f37622106121e1f8148"
 
 [dev-dependencies]
 indexmap = "1.3"


### PR DESCRIPTION
Fixes #167 

Currently, we can not register a project due to the registry client used
here in the upstream not being compatible with the registry runtime used
in the devnet. Here we bump the registry-client dependency to use the
latest revision which effectively fixes the issue.

As part of the review, read [Thoma's follow up](https://github.com/radicle-dev/radicle-upstream/issues/167#issuecomment-588870068) on this issue: 

> To prevent this issue in the future we should update the runtime version whenever something changes and have the client check the runtime version. I would also suggest that the devnet should not be used for local development for now since it is highly unstable and we’re experimenting a lot.