### PR TITLE
Add a section about retrieving our GraphQL schema

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,18 @@ We don't keep around a copy of an SDL schema file as they tend to get outdated
 quickly and it is way easier to explore the API via introspection. You can read
 more on that in the [GraphiQL Explorer](#graphiql-explorer) section below.
 
+If you need the schema to guide you writing new queries or mutations, you can
+get the latest version by querying the proxy via `apollo`:
+
+```sh
+# This installs apollo globally, we don't want to pull in all the extra
+# dependencies just for the off chance it is needed.
+yarn global add apollo
+
+yarn proxy:start
+apollo client:download-schema schema.gql --endpoint=http://127.0.0.1:8080/graphql
+```
+
 
 ## UI
 


### PR DESCRIPTION
I added a small section on how to retrieve the GraphQL API schema from our proxy. It can be helpful when extending the schema with new endpoints.