### PR TITLE
Extend schema with avatar fallback

### DIFF
--- a/proxy/src/avatar.rs
+++ b/proxy/src/avatar.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::as_conversions, clippy::float_arithmetic)]
+
 //! Org and user avatar generation.
 
 use std::fmt;
@@ -5,6 +7,7 @@ use std::fmt;
 /// Emoji whitelist.
 ///
 /// Note that these are `str` and not `char` because an emoji can span multiple unicode scalars.
+#[allow(clippy::non_ascii_literal)]
 const EMOJIS: &[&str] = &[
     "⌚️", "📱", "📲", "💻", "⌨️", "💽", "💾", "💿", "📀", "📼", "📷", "📸", "📹", "🎥", "🎞", "📞",
     "☎️", "📟", "📠", "📺", "📻", "⏰", "🕰", "⌛️", "⏳", "📡", "🔋", "🔌", "💡", "🔦", "💸", "💵",
@@ -40,6 +43,7 @@ pub struct Avatar {
 
 impl Avatar {
     /// Generate an avatar from an input string.
+    #[must_use]
     pub fn from(input: &str) -> Self {
         Self {
             emoji: generate_emoji(input),
@@ -58,18 +62,20 @@ pub struct Color {
     /// The blue channel.
     pub b: u8,
 
-    // The alpha is here to facilitate working with `u32` values.
-    // We don't use it as part of the output.
+    /// The alpha is here to facilitate working with `u32` values.
+    /// We don't use it as part of the output.
     a: u8,
 }
 
 impl Color {
     /// Create a new color from individual channels.
-    pub fn new(r: u8, g: u8, b: u8) -> Self {
+    #[must_use]
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b, a: 0x0 }
     }
 
     /// Compute the lightness of a color.
+    #[must_use]
     pub fn lightness(&self) -> f32 {
         let r = self.r as f32;
         let g = self.g as f32;
@@ -142,11 +148,11 @@ fn compress_color(c: Color) -> Color {
 /// platforms.
 fn hash(input: &str) -> u64 {
     let bytes = input.bytes();
-    let mut hash: u64 = 0xcbf29ce484222325; // FNV offset basis.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325; // FNV offset basis.
 
     for byte in bytes {
-        hash = hash ^ (byte as u64);
-        hash = hash.wrapping_mul(0x100000001b3);
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
     }
 
     hash
@@ -169,7 +175,7 @@ mod test {
 
     #[test]
     fn test_avatar_hash() {
-        assert_eq!(hash("chongo was here!\n\0"), 0xc33bce57bef63eaf);
+        assert_eq!(hash("chongo was here!\n\0"), 0xc33b_ce57_bef6_3eaf);
     }
 
     #[test]

--- a/proxy/src/avatar.rs
+++ b/proxy/src/avatar.rs
@@ -19,7 +19,7 @@ const EMOJIS: &[&str] = &[
 
 /// An emoji.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Emoji(&'static str);
+pub struct Emoji(pub &'static str);
 
 /// An avatar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/proxy/src/avatar.rs
+++ b/proxy/src/avatar.rs
@@ -1,5 +1,7 @@
 //! Org and user avatar generation.
 
+use std::fmt;
+
 /// Emoji whitelist.
 ///
 /// Note that these are `str` and not `char` because an emoji can span multiple unicode scalars.
@@ -19,7 +21,13 @@ const EMOJIS: &[&str] = &[
 
 /// An emoji.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Emoji(pub &'static str);
+pub struct Emoji(&'static str);
+
+impl fmt::Display for Emoji {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// An avatar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -378,15 +378,15 @@ impl avatar::Avatar {
 #[juniper::object]
 impl avatar::Color {
     fn r() -> i32 {
-        self.r as i32
+        i32::from(self.r)
     }
 
     fn g() -> i32 {
-        self.g as i32
+        i32::from(self.g)
     }
 
     fn b() -> i32 {
-        self.b as i32
+        i32::from(self.b)
     }
 }
 

--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -517,6 +517,10 @@ impl identity::Identity {
     fn metadata(&self) -> &identity::Metadata {
         &self.metadata
     }
+
+    fn avatar_fallback(&self) -> avatar::Avatar {
+        avatar::Avatar::from(&self.metadata.handle)
+    }
 }
 
 #[juniper::object(name = "IdentityMetadata")]

--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -8,6 +8,7 @@ use librad::surf;
 use librad::surf::git::git2;
 use radicle_registry_client::ed25519;
 
+use crate::avatar;
 use crate::coco;
 use crate::error;
 use crate::identity;
@@ -147,6 +148,10 @@ pub struct Query;
 impl Query {
     fn apiVersion() -> &str {
         "1.0"
+    }
+
+    fn avatar(handle: juniper::ID) -> Result<avatar::Avatar, error::Error> {
+        Ok(avatar::Avatar::from(&handle.to_string()))
     }
 
     fn blob(
@@ -358,6 +363,32 @@ pub struct ControlQuery;
     description = "Queries to access raw proxy state.",
 )]
 impl ControlQuery {}
+
+#[juniper::object]
+impl avatar::Avatar {
+    fn background(&self) -> avatar::Color {
+        self.background
+    }
+
+    fn emoji(&self) -> &str {
+        &self.emoji.0
+    }
+}
+
+#[juniper::object]
+impl avatar::Color {
+    fn r() -> i32 {
+        self.r as i32
+    }
+
+    fn g() -> i32 {
+        self.g as i32
+    }
+
+    fn b() -> i32 {
+        self.b as i32
+    }
+}
 
 #[juniper::object]
 impl coco::Blob {

--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -370,8 +370,8 @@ impl avatar::Avatar {
         self.background
     }
 
-    fn emoji(&self) -> &str {
-        &self.emoji.0
+    fn emoji(&self) -> String {
+        self.emoji.to_string()
     }
 }
 

--- a/proxy/tests/graphql_query.rs
+++ b/proxy/tests/graphql_query.rs
@@ -22,6 +22,43 @@ fn api_version() {
 }
 
 #[test]
+fn avatar() {
+    with_fixtures(|librad_paths, _repos_dir, _platinum_id| {
+        let mut vars = Variables::new();
+
+        vars.insert("handle".into(), InputValue::scalar("cloudhead"));
+
+        let query = "query($handle: ID!) {
+            avatar(handle: $handle) {
+                emoji
+                background {
+                    r
+                    g
+                    b
+                }
+            }
+        }";
+
+        execute_query(librad_paths, query, &vars, |res, errors| {
+            assert_eq!(errors, []);
+            assert_eq!(
+                res,
+                graphql_value!({
+                    "avatar": {
+                        "emoji": "🧱",
+                        "background": {
+                            "r": 24,
+                            "g": 105,
+                            "b": 216,
+                        },
+                    }
+                })
+            );
+        });
+    })
+}
+
+#[test]
 fn blob() {
     with_fixtures(|librad_paths, _repos_dir, platinum_id| {
         let mut vars = Variables::new();

--- a/proxy/tests/graphql_query.rs
+++ b/proxy/tests/graphql_query.rs
@@ -593,6 +593,14 @@ fn identity() {
                         displayName
                         avatarUrl
                     }
+                    avatarFallback {
+                        emoji
+                        background {
+                            r
+                            g
+                            b
+                        }
+                    }
                 }
             }";
 
@@ -609,6 +617,14 @@ fn identity() {
                             "displayName": "Alexis Sellier",
                             "avatarUrl": "https://avatars1.githubusercontent.com/u/4077",
                         },
+                        "avatarFallback": {
+                            "emoji": "🧱",
+                            "background": {
+                                "r": 24,
+                                "g": 105,
+                                "b": 216,
+                            },
+                        }
                     },
                 })
             );


### PR DESCRIPTION
First follow up to #213 implementing the GraphQL query for getting an avatar given a handle as input.