### PR TITLE
feat(proxy): demo rest api

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -917,6 +917,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1338,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "input_buffer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1540,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazycell"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1795,6 +1835,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1962,23 @@ dependencies = [
 name = "nonempty"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fsevent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2491,6 +2559,7 @@ dependencies = [
  "radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2857,6 +2926,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocket_contrib"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rocket_http"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,6 +3015,14 @@ dependencies = [
 name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "sc-rpc-api"
@@ -4168,6 +4257,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,6 +4558,8 @@ dependencies = [
 "checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
+"checksum fsevent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+"checksum fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -4503,6 +4604,8 @@ dependencies = [
 "checksum impl-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
 "checksum impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 "checksum indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
+"checksum inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
+"checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 "checksum integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ea155abb3ba6f382a75f1418988c05fe82959ed9ce727de427f9cfd425b0c903"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -4523,6 +4626,7 @@ dependencies = [
 "checksum lalrpop-util 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c277d18683b36349ab5cd030158b54856fca6bb2d5dc5263b06288f486958b7c"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
 "checksum libgit2-sys 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4870c781f6063efb83150cd22c1ddf6ecf58531419e7570cdcced46970f64a16"
@@ -4552,6 +4656,7 @@ dependencies = [
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+"checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
@@ -4564,6 +4669,7 @@ dependencies = [
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum nonempty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6954982ece17426b038f84895b4a6771c541299dc7141fab20ee676b19d9d97f"
+"checksum notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
 "checksum num-bigint 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f115de20ad793e857f76da2563ff4a09fbcfd6fe93cca0c5d996ab5f3ee38d"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-rational 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "da4dc79f9e6c81bef96148c8f6b8e72ad4541caa4a24373e900a36da07de03a3"
@@ -4659,6 +4765,7 @@ dependencies = [
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 "checksum rocket 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e20afbad214b001cabbe31dd270b48b3be980a7153ee2ed8392e241f856d651b"
 "checksum rocket_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2108b35e2c3a35759d3f16cc3002ece05523191d884d3ad6523693fd43324dde"
+"checksum rocket_contrib 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a10e7471279bc2d4a21b6fddd9589016bb119e6fbb547b216dd54ef237f28341"
 "checksum rocket_http 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce8ca76247376ea21cf271af0f95e3f2014596e3e4c7cc04e44ee6242a40ff2"
 "checksum rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
@@ -4669,6 +4776,7 @@ dependencies = [
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f7bf422d23a88c16d5090d455f182bc99c60af4df6a345c63428acf5129e347"
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
@@ -4792,6 +4900,7 @@ dependencies = [
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 "checksum warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce153bc4ad61ed81c255cad4f1bf2474a1d284b482b20eecaefb152d0675fb1b"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -431,6 +431,17 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cookie"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +588,35 @@ dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "devise"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "devise_codegen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "devise_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "devise_codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "devise_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "devise_core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2236,6 +2276,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pear_codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2490,7 @@ dependencies = [
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "radicle-registry-client 0.0.0 (git+https://github.com/radicle-dev/radicle-registry.git?rev=ffa1e394775528503e8e3f37622106121e1f8148)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2746,9 +2807,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rocket"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rocket_codegen"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rocket_http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rpassword"
@@ -3397,6 +3519,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "state"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3802,6 +3929,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3966,6 +4101,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "untrusted"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -4181,6 +4321,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "yansi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "zeroize"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,6 +4408,7 @@ dependencies = [
 "checksum const-random 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7b641a8c9867e341f3295564203b1c250eb8ce6cb6126e007941f78c4d2ed7fe"
 "checksum const-random-macro 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c750ec12b83377637110d5a57f5ae08e895b06c4b16e2bdbf1a94ef717428c59"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+"checksum cookie 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9fac5e7bdefb6160fb181ee0eaa6f96704b625c70e6d61c465cb35750a4ea12"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
@@ -4274,6 +4425,9 @@ dependencies = [
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
+"checksum devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e04ba2d03c5fa0d954c061fc8c9c288badadffc272ebb87679a89846de3ed3"
+"checksum devise_codegen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "066ceb7928ca93a9bedc6d0e612a8a0424048b0ab1f75971b203d01420c055d7"
+"checksum devise_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf41c59b22b5e3ec0ea55c7847e5f358d340f3a8d6d53a5cf4f1564967f96487"
 "checksum diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -4446,6 +4600,8 @@ dependencies = [
 "checksum paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "423a519e1c6e828f1e73b720f9d9ed2fa643dce8a7737fb43235ce0b41eeaa49"
 "checksum paste-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
+"checksum pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c26d2b92e47063ffce70d3e3b1bd097af121a9e0db07ca38a6cc1cf0cc85ff25"
+"checksum pear_codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "336db4a192cc7f54efeb0c4e11a9245394824cc3bcbd37ba3ff51240c35d7a6e"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -4499,7 +4655,11 @@ dependencies = [
 "checksum regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
 "checksum regex-syntax 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+"checksum rocket 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e20afbad214b001cabbe31dd270b48b3be980a7153ee2ed8392e241f856d651b"
+"checksum rocket_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2108b35e2c3a35759d3f16cc3002ece05523191d884d3ad6523693fd43324dde"
+"checksum rocket_http 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce8ca76247376ea21cf271af0f95e3f2014596e3e4c7cc04e44ee6242a40ff2"
 "checksum rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -4561,6 +4721,7 @@ dependencies = [
 "checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
 "checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?rev=09abd3b436ea568a47ec4fc47f933728d8cf466b)" = "<none>"
+"checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum string_cache 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "89c058a82f9fd69b1becf8c274f412281038877c553182f1d02eb027045a2d67"
 "checksum string_cache_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f45ed1b65bf9a4bf2f7b7dc59212d1926e9eaf00fa998988e420fd124467c6"
@@ -4599,6 +4760,7 @@ dependencies = [
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e213bd24252abeb86a0b7060e02df677d367ce6cb772cef17e9214b8390a8d3"
@@ -4620,6 +4782,7 @@ dependencies = [
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed"
@@ -4644,6 +4807,8 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+"checksum yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d60c3b48c9cdec42fb06b3b84b5b087405e1fa1c644a1af3930e4dfafe93de48"
+"checksum yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
 "checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -20,14 +20,15 @@ nonempty = "0.2"
 pico-args = "0.3"
 pretty_env_logger = "0.3"
 rand = "0.7"
+rocket = "0.4.4"
 serde = "1.0"
 serde_cbor = "0.11.1"
 serde_derive = "1.0"
 serde_json = "1.0"
 tempfile = "3.1"
 tokio = { version = "0.2", features = [ "macros" ] }
-url17 = { package = "url", version = "1.7" }
 url = "2.1"
+url17 = { package = "url", version = "1.7" }
 warp = "0.2"
 
 [dependencies.librad]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -39,6 +39,11 @@ rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 git = "https://github.com/radicle-dev/radicle-registry.git"
 rev = "ffa1e394775528503e8e3f37622106121e1f8148"
 
+[dependencies.rocket_contrib]
+version = "0.4.4"
+default-features = false
+features = ["json"]
+
 [dev-dependencies]
 indexmap = "1.3"
 pretty_assertions = "0.6"

--- a/proxy/Rocket.toml
+++ b/proxy/Rocket.toml
@@ -1,0 +1,26 @@
+# docs: https://rocket.rs/v0.4/guide/configuration/
+# params: https://api.rocket.rs/v0.4/rocket/config/struct.ConfigBuilder.html
+
+[development]
+address = "localhost"
+port = 8000
+workers = 2
+keep_alive = 5
+log = "debug"
+limits = { forms = 32768 }
+
+[staging]
+address = "localhost"
+port = 8000
+workers = 2
+keep_alive = 5
+log = "normal"
+limits = { forms = 32768 }
+
+[production]
+address = "localhost"
+port = 8000
+workers = 2
+keep_alive = 5
+log = "critical"
+limits = { forms = 32768 }

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -438,7 +438,7 @@ pub fn init_project(
     Ok((id, meta))
 }
 
-/// Initialize a [`radicle_surf::git::git2::Repository`] at the given path.
+/// Initialize a (FIXME: add type) at the given path.
 ///
 /// # Errors
 ///

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -22,9 +22,12 @@
     clippy::result_expect_used,
     clippy::unseparated_literal_suffix
 )]
+#![feature(proc_macro_hygiene, decl_macro)]
 
 #[macro_use]
 extern crate juniper;
+#[macro_use]
+extern crate rocket;
 
 pub mod avatar;
 pub mod coco;
@@ -35,3 +38,4 @@ mod identity;
 mod project;
 /// Intergrations on the Regstriy.
 mod registry;
+pub mod rest;

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -3,6 +3,7 @@ extern crate log;
 
 use proxy::coco;
 use proxy::env;
+use proxy::graphql;
 use proxy::rest;
 
 /// Flags accepted by the proxy binary.
@@ -51,6 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     info!("Starting GraphQL HTTP API");
+    graphql::api::run(librad_paths, registry_client, args.test).await;
     rest::run(librad_paths, registry_client);
 
     Ok(())

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -3,7 +3,7 @@ extern crate log;
 
 use proxy::coco;
 use proxy::env;
-use proxy::graphql;
+use proxy::rest;
 
 /// Flags accepted by the proxy binary.
 struct Args {
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     info!("Starting GraphQL HTTP API");
-    graphql::api::run(librad_paths, registry_client, args.test).await;
+    rest::run();
 
     Ok(())
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     info!("Starting GraphQL HTTP API");
-    rest::run();
+    rest::run(librad_paths, registry_client);
 
     Ok(())
 }

--- a/proxy/src/project.rs
+++ b/proxy/src/project.rs
@@ -3,11 +3,13 @@
 
 use librad::meta;
 use librad::project;
+use serde::{Deserialize, Serialize};
 
 /// Metadata key used to store an image url for a project.
 const IMG_URL_LABEL: &str = "img_url";
 
 /// Object the API returns for project metadata.
+#[derive(Serialize)]
 pub struct Metadata {
     /// Project name.
     pub name: String,

--- a/proxy/src/rest.rs
+++ b/proxy/src/rest.rs
@@ -2,14 +2,24 @@
 
 /// Route handlers for the Org entity.
 mod orgs;
+mod projects;
+
+use crate::registry::Registry;
 
 /// Start the API server.
-pub fn run() {
+pub fn run(
+    librad_paths: librad::paths::Paths,
+    registry_client: radicle_registry_client::Client,
+) {
+    let client = Registry::new(registry_client);
     let mut router = routes![];
     // add entity modules one by one
     router.extend(orgs::router());
+    router.extend(projects::router());
     // mount the api endpoint
     rocket::ignite()
+        .manage(librad_paths)
+        .manage(client)
         .mount("/api/v1", router)
         // and if we ever need to make a new API version...
         // .mount("/api/v2", routes![])

--- a/proxy/src/rest.rs
+++ b/proxy/src/rest.rs
@@ -1,8 +1,14 @@
 //! Defines the proxy's REST API.
 
+/// REST API utilities.
+mod lib;
+
 /// Route handlers for the Org entity.
+mod branches;
+mod commits;
 mod orgs;
 mod projects;
+mod users;
 
 use crate::registry::Registry;
 
@@ -14,8 +20,11 @@ pub fn run(
     let client = Registry::new(registry_client);
     let mut router = routes![];
     // add entity modules one by one
+    router.extend(branches::router());
+    router.extend(commits::router());
     router.extend(orgs::router());
     router.extend(projects::router());
+    router.extend(users::router());
     // mount the api endpoint
     rocket::ignite()
         .manage(librad_paths)

--- a/proxy/src/rest.rs
+++ b/proxy/src/rest.rs
@@ -1,0 +1,17 @@
+//! Defines the proxy's REST API.
+
+/// Route handlers for the Org entity.
+mod orgs;
+
+/// Start the API server.
+pub fn run() {
+    let mut router = routes![];
+    // add entity modules one by one
+    router.extend(orgs::router());
+    // mount the api endpoint
+    rocket::ignite()
+        .mount("/api/v1", router)
+        // and if we ever need to make a new API version...
+        // .mount("/api/v2", routes![])
+        .launch();
+}

--- a/proxy/src/rest/branches.rs
+++ b/proxy/src/rest/branches.rs
@@ -1,0 +1,47 @@
+use rocket::http;
+use rocket::response;
+use rocket::State;
+use rocket_contrib::json::Json;
+use serde::{Deserialize, Serialize};
+
+#[get("/project/<project_id>/branches")]
+/// TODO
+fn get_project_branches (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+#[get("/project/<project_id>/tags")]
+/// TODO
+fn get_project_tags (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+#[get("/project/<project_id>/tree/<revspec>")]
+/// TODO
+fn get_project_tree (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+#[get("/project/<project_id>/trees")]
+/// TODO
+fn get_project_trees (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+/// TODO
+pub fn router() -> Vec<rocket::Route> {
+    routes![
+        get_project_branches,
+        get_project_tags,
+        get_project_tree,
+        get_project_trees
+    ]
+}

--- a/proxy/src/rest/commits.rs
+++ b/proxy/src/rest/commits.rs
@@ -1,0 +1,38 @@
+use rocket::http;
+use rocket::response;
+use rocket::State;
+use rocket_contrib::json::Json;
+use serde::{Deserialize, Serialize};
+
+#[get("/project/<project_id>/commits")]
+/// TODO
+fn get_project_commits (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+#[get("/project/<project_id>/commit/<hash>")]
+/// TODO
+fn get_project_commit (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+#[get("/project/<project_id>/commit/<hash>/blob/<path>")]
+/// TODO
+fn get_project_commit_blob (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+/// TODO
+pub fn router() -> Vec<rocket::Route> {
+    routes![
+        get_project_commit_blob,
+        get_project_commit,
+        get_project_commits,
+    ]
+}

--- a/proxy/src/rest/lib.rs
+++ b/proxy/src/rest/lib.rs
@@ -1,0 +1,13 @@
+use serde::{Serialize};
+
+#[derive(Serialize)]
+/// standard 200 { ok: true } reply
+pub struct Ok {
+    ok: bool,
+}
+
+impl Ok {
+    pub fn new () -> Ok {
+        Ok { ok: true }
+    }
+}

--- a/proxy/src/rest/orgs.rs
+++ b/proxy/src/rest/orgs.rs
@@ -1,0 +1,50 @@
+#[get("/orgs")]
+/// TODO
+fn get_orgs() -> &'static str {
+    "org 1, org 2, org 3"
+}
+
+#[post("/orgs")]
+/// TODO
+fn create_org() -> &'static str {
+    // TODO parse body for org params
+    "new org"
+}
+
+#[get("/org/<org_id>")]
+/// TODO
+fn get_org(org_id: String) -> String {
+    format!("org {}", org_id)
+}
+
+#[post("/org/<org_id>/register")]
+/// TODO
+fn register_org(org_id: String) -> String {
+    format!("org {} registered", org_id)
+}
+
+#[post("/org/<org_id>/unregister")]
+/// TODO
+fn unregister_org(org_id: String) -> String {
+    format!("org {} unregistered", org_id)
+}
+
+/// TODO
+pub fn router() -> Vec<rocket::Route> {
+    routes![create_org, get_org, get_orgs, register_org, unregister_org]
+}
+
+#[cfg(test)]
+mod test {
+    use rocket::http::Status;
+    use rocket::local::Client;
+
+    #[test]
+    fn hello_world() {
+        let rocket = rocket::ignite().mount("/", crate::rest::orgs::router());
+        let client = Client::new(rocket).expect("valid rocket instance");
+        let mut response = client.get("/orgs").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.body_string(), Some("org 1, org 2, org 3".into()));
+    }
+}

--- a/proxy/src/rest/projects.rs
+++ b/proxy/src/rest/projects.rs
@@ -1,44 +1,92 @@
+use librad::paths::Paths;
+use librad::project;
+use librad::surf;
+use librad::surf::git::git2;
 use radicle_registry_client::ed25519;
+use rocket::http;
+use rocket::response;
 use rocket::State;
 use rocket_contrib::json::Json;
 use serde::{Deserialize, Serialize};
 
 use crate::registry::Registry;
-
-#[derive(Serialize)]
-/// standard 200 { ok: true } reply
-struct Ok {
-    ok: bool,
-}
+use crate::rest::lib::Ok;
 
 #[get("/projects")]
 /// TODO
-fn get_projects() -> &'static str {
-    "project 1, project 2, project 3"
+fn get_projects() -> Json<Ok> {
+    // TODO
+    Json(Ok::new())
 }
 
-#[post("/projects")]
-/// TODO
-fn create_project() -> &'static str {
-    // TODO parse body for project params
-    "new project"
+#[derive(Deserialize)]
+struct ProjectCreationForm {
+    path: String,
+    publish: bool,
+    name: String,
+    description: String,
+    default_branch: String,
+    img_url: String,
 }
+
+#[derive(Serialize)]
+struct ProjectJson {
+    id: String,
+
+}
+
+// #[post("/projects", format = "json", data = "<form>")]
+// /// TODO
+// fn create_project(
+//     librad_paths: State<Paths>,
+//     form: Json<ProjectRegistrationForm>,
+// ) -> Json<ProjectJson> {
+//     // TODO parse body for project params
+//     if surf::git::git2::Repository::open(form.path.clone()).is_err() {
+//         coco::init_repo(form.path.clone())?;
+//     };
+//
+//     let (id, meta) = coco::init_project(
+//         librad_paths.read().expect("unable to acquire read lock"),
+//         &form.path,
+//         &form.name,
+//         &form.description,
+//         &form.default_branch,
+//         &form.img_url,
+//     )?;
+//
+//     Json(ProjectJson { project: project::Project::Git {
+//         id: librad::project::ProjectId::from(id),
+//         metadata: meta.into(),
+//     }})
+// }
 
 #[get("/project/<project_id>")]
 /// TODO
 fn get_project(project_id: String) -> String {
-    format!("project {}", project_id)
+    let meta = coco::get_project_meta(
+        &ctx.librad_paths
+            .read()
+            .expect("unable to acquire read lock"),
+        &id.to_string(),
+    ).expect("could not retrieve project meta");
+
+
+    Json(NewProject({ project: project::Project {
+        id: librad::project::ProjectId::from(id),
+        metadata: meta.into(),
+    }}))
 }
 
 #[derive(Deserialize)]
 /// Form data structure
 struct ProjectRegistrationForm {
     org_id: String,
-    librad_id: Option<String>,
+    librad_id: String
 }
 
 #[post("/project/<project_id>/register", format = "json", data = "<form>")]
-/// TODO
+/// Register a project by adding it to the Registry.
 fn register_project(
     project_id: String,
     registry: State<Registry>,
@@ -47,17 +95,17 @@ fn register_project(
     // TODO(xla): Get keypair from persistent storage.
     let fake_pair = ed25519::Pair::from_legacy_string("//Robot", None);
     // TODO(garbados): convert string to `librad::project::ProjectId`.
-    let librad_id = form
-        .librad_id
-        .map(|id| librad::project::ProjectId::from_str(&id.to_string()));
+    let librad_id = form.librad_id.map(|id| {
+        project::ProjectId::from_str(&id)
+    });
     registry.register_project(&fake_pair, project_id, form.org_id, librad_id);
-    Json(Ok { ok: true })
+    Json(Ok::new())
 }
 
 #[post("/project/<project_id>/unregister")]
 /// TODO
-fn unregister_project(project_id: String) -> String {
-    format!("project {} unregistered", project_id)
+fn unregister_project(project_id: String) -> http::Status {
+    http::Status::new(501, "Not implemented.")
 }
 
 /// TODO

--- a/proxy/src/rest/projects.rs
+++ b/proxy/src/rest/projects.rs
@@ -1,0 +1,90 @@
+use radicle_registry_client::ed25519;
+use rocket::State;
+use rocket_contrib::json::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::registry::Registry;
+
+#[derive(Serialize)]
+/// standard 200 { ok: true } reply
+struct Ok {
+    ok: bool,
+}
+
+#[get("/projects")]
+/// TODO
+fn get_projects() -> &'static str {
+    "project 1, project 2, project 3"
+}
+
+#[post("/projects")]
+/// TODO
+fn create_project() -> &'static str {
+    // TODO parse body for project params
+    "new project"
+}
+
+#[get("/project/<project_id>")]
+/// TODO
+fn get_project(project_id: String) -> String {
+    format!("project {}", project_id)
+}
+
+#[derive(Deserialize)]
+/// Form data structure
+struct ProjectRegistrationForm {
+    org_id: String,
+    librad_id: Option<String>,
+}
+
+#[post("/project/<project_id>/register", format = "json", data = "<form>")]
+/// TODO
+fn register_project(
+    project_id: String,
+    registry: State<Registry>,
+    form: Json<ProjectRegistrationForm>,
+) -> Json<Ok> {
+    // TODO(xla): Get keypair from persistent storage.
+    let fake_pair = ed25519::Pair::from_legacy_string("//Robot", None);
+    // TODO(garbados): convert string to `librad::project::ProjectId`.
+    let librad_id = form
+        .librad_id
+        .map(|id| librad::project::ProjectId::from_str(&id.to_string()));
+    registry.register_project(&fake_pair, project_id, form.org_id, librad_id);
+    Json(Ok { ok: true })
+}
+
+#[post("/project/<project_id>/unregister")]
+/// TODO
+fn unregister_project(project_id: String) -> String {
+    format!("project {} unregistered", project_id)
+}
+
+/// TODO
+pub fn router() -> Vec<rocket::Route> {
+    routes![
+        create_project,
+        get_project,
+        get_projects,
+        register_project,
+        unregister_project
+    ]
+}
+
+#[cfg(test)]
+mod test {
+    use rocket::http::Status;
+    use rocket::local::Client;
+
+    #[test]
+    fn hello_world() {
+        let rocket = rocket::ignite().mount("/", crate::rest::projects::router());
+        let client = Client::new(rocket).expect("valid rocket instance");
+        let mut response = client.get("/projects").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(
+            response.body_string(),
+            Some("project 1, project 2, project 3".into())
+        );
+    }
+}

--- a/proxy/src/rest/users.rs
+++ b/proxy/src/rest/users.rs
@@ -1,0 +1,38 @@
+use rocket::http;
+use rocket::response;
+use rocket::State;
+use rocket_contrib::json::Json;
+use serde::{Deserialize, Serialize};
+
+#[get("/project/<project_id>/commits")]
+/// TODO
+fn get_project_commits (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+#[get("/project/<project_id>/commit/<hash>")]
+/// TODO
+fn get_project_commit (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+#[get("/project/<project_id>/commit/<hash>/blob/<path>")]
+/// TODO
+fn get_project_commit_blob (
+    // TODO
+) -> &'static str {
+    // TODO
+}
+
+/// TODO
+pub fn router() -> Vec<rocket::Route> {
+    routes![
+        get_project_commit_blob,
+        get_project_commit,
+        get_project_commits,
+    ]
+}


### PR DESCRIPTION
This PR follows up on https://github.com/radicle-dev/radicle-upstream/issues/220 by implementing a demo REST API. This implementation is incomplete, and currently only intended to demonstrate the flow of writing routes.

This PR adds this file organization for its REST API:

```
src/
  rest/
    <entity>.rs
  rest.rs
```

Endpoints are divided by entity (ex: Org, User, Commit) and tied together in `rest.rs`, which `main.rs` invokes to start the server.

Although the proxy currently uses the [Warp](https://docs.rs/warp/0.2.2/warp/) HTTP framework, Warp is ill-suited to writing a large API for debugging reasons. It is very difficult to determine what filter has or hasn't caught, and what routes are actually exposed at any given time. Instead I chose to use [Rocket](https://rocket.rs/), which inherits the norms of frameworks like [Rails](https://rubyonrails.org/) and [Flask](https://flask.palletsprojects.com/en/1.1.x/).

This API demonstrates writing simple routes and simple tests, but a production API must also manage Librad and Registry clients. For that, Rocket exposes a [State](https://rocket.rs/v0.4/guide/state/#state) system so that routes can safely access shared objects.

This PR is incomplete but, should we decide to pursue a REST API over GraphQL, it will be expanded to encompass operations and queries with all Radicle entities.