### PR TITLE
Use stored identity for handle registration

### DIFF
--- a/cypress/integration/user_registration.spec.js
+++ b/cypress/integration/user_registration.spec.js
@@ -23,6 +23,7 @@ context("user registration", () => {
     it("moves through the views by pressing navigation buttons", () => {
       // 1 -> 2
       cy.get('[data-cy="register-user"] [data-cy="handle"]').should("exist");
+      cy.get('[data-cy="page"] [data-cy="handle"]').type("testy");
       cy.get('[data-cy="register-user"] [data-cy="next-button"]').click();
       cy.get('[data-cy="register-user"] [data-cy="tx-summary"]').should(
         "exist"

--- a/ui/Screen/Identity/IdentityCreationForm.svelte
+++ b/ui/Screen/Identity/IdentityCreationForm.svelte
@@ -8,6 +8,7 @@
     avatarFallbackStore,
     displayNameStore,
     handleStore,
+    idStore,
     shareableEntityIdentifierStore
   } from "../../store/identity.js";
 
@@ -130,6 +131,7 @@
 
       const responseData = response.data.createIdentity;
 
+      idStore.set(responseData.id);
       handleStore.set(responseData.metadata.handle);
       displayNameStore.set(responseData.metadata.displayName);
       avatarUrlStore.set(responseData.metadata.avatarUrl);

--- a/ui/Screen/UserRegistration.svelte
+++ b/ui/Screen/UserRegistration.svelte
@@ -3,6 +3,13 @@
   import { getClient, mutate } from "svelte-apollo";
   import { pop } from "svelte-spa-router";
 
+  import {
+    avatarUrlStore,
+    avatarFallbackStore,
+    handleStore,
+    idStore
+  } from "../store/identity.js";
+
   import { Text, Title } from "../DesignSystem/Primitive";
   import { ModalLayout, StepCounter } from "../DesignSystem/Component";
 
@@ -10,19 +17,11 @@
   import SubmitRegistrationStep from "./UserRegistration/SubmitRegistrationStep.svelte";
 
   let step = 1;
-  // TODO(merle): Get actual user profile (id, name, imageUrl, avatarFallback)
-  let handle = "cloudhead";
-  let avatarFallback = {
-    emoji: "📐",
-    background: {
-      r: 24,
-      g: 105,
-      b: 216
-    }
-  };
-  const imageUrl = null;
 
-  const id = "1234";
+  let handle = $handleStore;
+  let avatarFallback = $avatarFallbackStore;
+  const imageUrl = $avatarUrlStore;
+  const id = $idStore;
 
   const nextStep = () => {
     step += 1;

--- a/ui/store/identity.js
+++ b/ui/store/identity.js
@@ -4,4 +4,5 @@ export const avatarUrlStore = writable(null);
 export const avatarFallbackStore = writable(null);
 export const displayNameStore = writable(null);
 export const handleStore = writable(null);
+export const idStore = writable(null);
 export const shareableEntityIdentifierStore = writable(null);


### PR DESCRIPTION
Uses the identity store to fill in the handle, imageUrl and avatarFallback for the user registration and provided the stored id to the handle registration mutation.
This means that the identity creation flow has to be done before (separately) in order for the registration to succeed, as it is the only way currently to fill the identity store.