### PR TITLE
feat(proxy): extend identity with registered field

### DIFF
--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -68,6 +68,7 @@ impl Mutation {
                 display_name,
                 avatar_url,
             },
+            registered: None,
         })
     }
 
@@ -321,6 +322,7 @@ impl Query {
                 display_name: Some("Alexis Sellier".into()),
                 avatar_url: Some("https://avatars1.githubusercontent.com/u/40774".into()),
             },
+            registered: None,
         }))
     }
 
@@ -579,6 +581,12 @@ impl identity::Identity {
 
     fn metadata(&self) -> &identity::Metadata {
         &self.metadata
+    }
+
+    fn registered(&self) -> Option<juniper::ID> {
+        self.registered
+            .as_ref()
+            .map(|r| juniper::ID::new(r.to_string()))
     }
 
     fn avatar_fallback(&self) -> avatar::Avatar {

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -1,5 +1,7 @@
 //! Container to bundle and associate information around an identity.
 
+use radicle_registry_client::UserId;
+
 /// The users personal identifying metadata and keys.
 pub struct Identity {
     /// The librad id.
@@ -8,6 +10,8 @@ pub struct Identity {
     pub shareable_entity_identifier: String,
     /// Bundle of user provided data.
     pub metadata: Metadata,
+    /// Indicator if the identity is registered on the Registry.
+    pub registered: Option<UserId>,
 }
 
 /// User maintained information for an identity, which can evolve over time.

--- a/proxy/tests/graphql_mutation.rs
+++ b/proxy/tests/graphql_mutation.rs
@@ -29,6 +29,7 @@ fn create_identity() {
                         displayName
                         avatarUrl
                     }
+                    registered
                 }
             }";
 
@@ -45,6 +46,7 @@ fn create_identity() {
                             "displayName": "Alexis Sellier",
                             "avatarUrl": "https://avatars1.githubusercontent.com/u/40774",
                         },
+                        "registered": None,
                     },
                 })
             );

--- a/proxy/tests/graphql_query.rs
+++ b/proxy/tests/graphql_query.rs
@@ -669,6 +669,7 @@ fn identity() {
                         displayName
                         avatarUrl
                     }
+                    registered
                     avatarFallback {
                         emoji
                         background {
@@ -693,6 +694,7 @@ fn identity() {
                             "displayName": "Alexis Sellier",
                             "avatarUrl": "https://avatars1.githubusercontent.com/u/40774",
                         },
+                        "registered": None,
                         "avatarFallback": {
                             "emoji": "🚡",
                             "background": {


### PR DESCRIPTION
The Identity now carries a registered field which is an optional `UserId`, which is the id the user is registered with on the Registry.

Closes #255