### PR TITLE
feat(proxy): add thresholds to transaction list

### DIFF
--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -295,18 +295,21 @@ impl Query {
     fn list_transactions(
         ctx: &Context,
         ids: Vec<juniper::ID>,
-    ) -> Result<Vec<registry::Transaction>, error::Error> {
+    ) -> Result<ListTransactions, error::Error> {
         let tx_ids = ids
             .iter()
             .map(|id| radicle_registry_client::TxHash::from_slice(id.to_string().as_bytes()))
             .collect();
 
-        Ok(futures::executor::block_on(
-            ctx.registry
-                .read()
-                .expect("unable to acquire read lock")
-                .list_transactions(tx_ids),
-        )?)
+        Ok(ListTransactions {
+            transactions: futures::executor::block_on(
+                ctx.registry
+                    .read()
+                    .expect("unable to acquire read lock")
+                    .list_transactions(tx_ids),
+            )?,
+            thresholds: registry::Registry::thresholds(),
+        })
     }
 
     fn identity(
@@ -724,6 +727,36 @@ impl project::Stats {
 
     fn contributors(&self) -> i32 {
         i32::try_from(self.contributors).expect("unable to convert branches number")
+    }
+}
+
+/// Response wrapper for listTransactions query.
+struct ListTransactions {
+    /// The configured Registry thresholds for transaction acceptance stages.
+    thresholds: registry::Thresholds,
+    /// The known and cached transactions.
+    transactions: Vec<registry::Transaction>,
+}
+
+#[juniper::object]
+impl ListTransactions {
+    fn transactions(&self) -> &Vec<registry::Transaction> {
+        &self.transactions
+    }
+
+    fn thresholds(&self) -> &registry::Thresholds {
+        &self.thresholds
+    }
+}
+
+#[juniper::object]
+impl registry::Thresholds {
+    fn confirmation(&self) -> i32 {
+        i32::try_from(self.confirmation).expect("conversion failed")
+    }
+
+    fn settlement(&self) -> i32 {
+        i32::try_from(self.settlement).expect("conversion failed")
     }
 }
 

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -72,6 +72,14 @@ pub enum TransactionState {
     Applied(Hash),
 }
 
+/// Configured thresholds for acceptance criteria of transaction progress.
+pub struct Thresholds {
+    /// Number of blocks after which a [`Transaction`] is assumed to be confirmed.
+    pub confirmation: u64,
+    /// Number of blocks after which a [`Transaction`] is assumed to be settled.
+    pub settlement: u64,
+}
+
 /// Registry client wrapper.
 #[derive(Clone)]
 pub struct Registry {
@@ -351,6 +359,15 @@ impl Registry {
         self.cache_transaction(tx.clone()).await;
 
         Ok(tx)
+    }
+
+    /// Returns the configured thresholds for [`Transaction`] acceptance stages.
+    #[must_use]
+    pub const fn thresholds() -> Thresholds {
+        Thresholds {
+            confirmation: 3,
+            settlement: 9,
+        }
     }
 }
 

--- a/proxy/tests/graphql_query.rs
+++ b/proxy/tests/graphql_query.rs
@@ -555,12 +555,18 @@ async fn list_transactions() {
     vars.insert("ids".into(), InputValue::list(vec![]));
     let query = "query($ids: [ID!]!) {
             listTransactions(ids: $ids) {
-                messages {
-                    ... on ProjectRegistrationMessage {
-                        projectName,
-                        orgId
-                    }
-                },
+                transactions {
+                    messages {
+                        ... on ProjectRegistrationMessage {
+                            projectName,
+                            orgId
+                        }
+                    },
+                }
+                thresholds {
+                    confirmation
+                    settlement
+                }
             }
         }";
 
@@ -577,16 +583,22 @@ async fn list_transactions() {
     assert_eq!(
         res,
         graphql_value!({
-            "listTransactions": [
-                {
-                    "messages": [
-                        {
-                            "projectName": "upstream",
-                            "orgId": "radicle",
-                        },
-                    ],
-                }
-            ],
+            "listTransactions": {
+                "transactions": [
+                    {
+                        "messages": [
+                            {
+                                "projectName": "upstream",
+                                "orgId": "radicle",
+                            },
+                        ],
+                    }
+                ],
+                "thresholds": {
+                    "confirmation": 3,
+                    "settlement": 9,
+                },
+            },
         })
     );
 }


### PR DESCRIPTION
Embedds the thresholds in the listTransactions query response for now. We serve two fields: `confirmation` and `settlement`.

Closes #254