### PR TITLE
feat(proxy): add kind to transaction messages

### DIFF
--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -739,11 +739,13 @@ impl registry::Transaction {
             .map(|m| match m {
                 registry::Message::OrgRegistration(org_id) => {
                     Message::OrgRegistration(OrgRegistrationMessage {
+                        kind: MessageKind::OrgRegistration,
                         org_id: juniper::ID::new(org_id.to_string()),
                     })
                 },
                 registry::Message::OrgUnregistration(org_id) => {
                     Message::OrgUnregistration(OrgUnregistrationMessage {
+                        kind: MessageKind::OrgUnregistration,
                         org_id: juniper::ID::new(org_id.to_string()),
                     })
                 },
@@ -751,11 +753,13 @@ impl registry::Transaction {
                     project_name,
                     org_id,
                 } => Message::ProjectRegistration(ProjectRegistrationMessage {
+                    kind: MessageKind::ProjectRegistration,
                     project_name: juniper::ID::new(project_name.to_string()),
                     org_id: juniper::ID::new(org_id.to_string()),
                 }),
                 registry::Message::UserRegistration { handle, id } => {
                     Message::UserRegistration(UserRegistrationMessage {
+                        kind: MessageKind::UserRegistration,
                         handle: juniper::ID::new(handle.to_string()),
                         id: juniper::ID::new(id.to_string()),
                     })
@@ -799,6 +803,22 @@ enum Message {
     UserRegistration(UserRegistrationMessage),
 }
 
+/// Kind of the transaction message.
+#[derive(juniper::GraphQLEnum)]
+enum MessageKind {
+    /// Registration of a new org.
+    OrgRegistration,
+
+    /// Registration of a new org.
+    OrgUnregistration,
+
+    /// Registration of a new project.
+    ProjectRegistration,
+
+    /// Registration of a new user.
+    UserRegistration,
+}
+
 juniper::graphql_union!(Message: () where Scalar = <S> |&self| {
     instance_resolvers: |_| {
         &OrgRegistrationMessage => match *self {
@@ -823,6 +843,8 @@ juniper::graphql_union!(Message: () where Scalar = <S> |&self| {
 /// Contextual information for an org registration message.
 #[derive(juniper::GraphQLObject)]
 struct OrgRegistrationMessage {
+    /// Field to distinguish [`Message`] types.
+    kind: MessageKind,
     /// The ID of the org.
     org_id: juniper::ID,
 }
@@ -830,6 +852,8 @@ struct OrgRegistrationMessage {
 /// Contextual information for an org unregistration message.
 #[derive(juniper::GraphQLObject)]
 struct OrgUnregistrationMessage {
+    /// Field to distinguish [`Message`] types.
+    kind: MessageKind,
     /// The ID of the org.
     org_id: juniper::ID,
 }
@@ -837,6 +861,8 @@ struct OrgUnregistrationMessage {
 /// Contextual information for a project registration message.
 #[derive(juniper::GraphQLObject)]
 struct ProjectRegistrationMessage {
+    /// Field to distinguish [`Message`] types.
+    kind: MessageKind,
     /// Actual project name, unique under org.
     project_name: juniper::ID,
     /// The org under which to register the project.
@@ -846,6 +872,8 @@ struct ProjectRegistrationMessage {
 /// Payload of a user registration message.
 #[derive(juniper::GraphQLObject)]
 struct UserRegistrationMessage {
+    /// Field to distinguish [`Message`] types.
+    kind: MessageKind,
     /// The chosen unique handle to be registered.
     handle: juniper::ID,
     /// The id of the coco identity.

--- a/proxy/tests/graphql_query.rs
+++ b/proxy/tests/graphql_query.rs
@@ -557,6 +557,7 @@ async fn list_transactions() {
             listTransactions(ids: $ids) {
                 messages {
                     ... on ProjectRegistrationMessage {
+                        kind,
                         projectName,
                         orgId
                     }
@@ -581,6 +582,7 @@ async fn list_transactions() {
                 {
                     "messages": [
                         {
+                            "kind": "PROJECT_REGISTRATION",
                             "projectName": "upstream",
                             "orgId": "radicle",
                         },


### PR DESCRIPTION
In order to vary in the UI on the different messages in a transaction we introduce a kind enum exposed as a field on the messages.

Closes #253