### PR TITLE
Adjust project creation UX according to new designs

### DIFF
--- a/cypress/integration/project_creation.spec.js
+++ b/cypress/integration/project_creation.spec.js
@@ -107,7 +107,7 @@ context("project creation", () => {
 
         // shows a validation message when existing project path is empty
         cy.get('[data-cy="page"] [data-cy="existing-project"]')
-          .contains("Pick an existing repository for the new project")
+          .contains("Pick a directory with an existing repository")
           .should("exist");
 
         // TODO(rudolfs): test empty directory validation
@@ -125,7 +125,7 @@ context("project creation", () => {
         cy.get('[data-cy="page"] [data-cy="existing-project"]').click();
         // shows a validation message when existing project path is empty
         cy.get('[data-cy="page"] [data-cy="existing-project"]')
-          .contains("Pick an existing repository for the new project")
+          .contains("Pick a directory with an existing repository")
           .should("exist");
       });
     });

--- a/cypress/integration/project_creation.spec.js
+++ b/cypress/integration/project_creation.spec.js
@@ -82,14 +82,6 @@ context("project creation", () => {
       });
     });
 
-    context("avatar url", () => {
-      it("prevents user from submitting an invalid avatar URL", () => {
-        // shows a validation message when avatar URL is not a valid URL
-        cy.get('[data-cy="page"] [data-cy="avatar-url"]').type("htttp");
-        cy.get('[data-cy="page"]').contains("Not a valid avatar URL");
-      });
-    });
-
     context("new repository", () => {
       it("prevents the user from picking an invalid directory", () => {
         // shows a validation message when new project path is empty

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -42,29 +42,25 @@ Cypress.Commands.add(
   (
     name = "Monadic",
     description = "Monadic is currently supporting radicle.",
-    defaultBranch = "master",
-    imgUrl = "https://res.cloudinary.com/juliendonck/image/upload/v1549554598/monadic-icon_myhdjk.svg"
+    defaultBranch = "master"
   ) => {
     client.mutate({
       variables: {
         name: name,
         description: description,
-        defaultBranch: defaultBranch,
-        imgUrl: imgUrl
+        defaultBranch: defaultBranch
       },
       mutation: gql`
         mutation CreateProjectWithFixture(
           $name: String!
           $description: String!
           $defaultBranch: String!
-          $imgUrl: String!
         ) {
           createProjectWithFixture(
             metadata: {
               name: $name
               description: $description
               defaultBranch: $defaultBranch
-              imgUrl: $imgUrl
             }
           ) {
             id

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use librad::git;
 use librad::keys;
-use librad::meta::{self};
+use librad::meta;
 use librad::paths::Paths;
 use librad::peer;
 use librad::project;

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -555,27 +555,23 @@ pub fn replicate_platinum(
 /// [`librad::paths::Paths`].
 pub fn setup_fixtures(librad_paths: &Paths, root: &str) -> Result<(), error::Error> {
     let infos = vec![
-            (
-                "monokel",
-                "A looking glass into the future",
-                "master",
-            ),
-            (
-                "Monadic",
-                "Open source organization of amazing things.",
-                "master",
-            ),
-            (
-                "open source coin",
-                "Research for the sustainability of the open source community.",
-                "master",
-            ),
-            (
-                "radicle",
-                "Decentralized open source collaboration",
-                "master",
-            ),
-        ];
+        ("monokel", "A looking glass into the future", "master"),
+        (
+            "Monadic",
+            "Open source organization of amazing things.",
+            "master",
+        ),
+        (
+            "open source coin",
+            "Research for the sustainability of the open source community.",
+            "master",
+        ),
+        (
+            "radicle",
+            "Decentralized open source collaboration",
+            "master",
+        ),
+    ];
 
     for info in infos {
         let path = format!("{}/{}/{}", root, "repos", info.0);

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use librad::git;
 use librad::keys;
-use librad::meta::{self, common::Url};
+use librad::meta::{self};
 use librad::paths::Paths;
 use librad::peer;
 use librad::project;
@@ -420,18 +420,15 @@ pub fn init_project(
     name: &str,
     description: &str,
     default_branch: &str,
-    img_url: &str,
 ) -> Result<(git::ProjectId, meta::Project), error::Error> {
     let key = keys::device::Key::new();
     let peer_id = peer::PeerId::from(key.public());
     let founder = meta::contributor::Contributor::new();
     let sources = git2::Repository::open(std::path::Path::new(path))?;
-    let img = Url::parse(img_url)?;
     let mut meta = meta::Project::new(name, &peer_id);
 
     meta.description = Some(description.to_string());
     meta.default_branch = default_branch.to_string();
-    meta.add_rel(meta::Relation::Url("img_url".to_string(), img));
 
     let id = git::GitProject::init(librad_paths, &key, &sources, meta.clone(), founder)?;
 
@@ -477,7 +474,6 @@ pub fn replicate_platinum(
     name: &str,
     description: &str,
     default_branch: &str,
-    img_url: &str,
 ) -> Result<(git::ProjectId, meta::Project), error::Error> {
     // Craft the absolute path to git-platinum fixtures.
     let mut platinum_path = env::current_dir()?;
@@ -540,7 +536,6 @@ pub fn replicate_platinum(
         name,
         description,
         default_branch,
-        img_url,
     )?;
     let mut rad_remote = platinum_repo.find_remote("rad")?;
 
@@ -564,25 +559,21 @@ pub fn setup_fixtures(librad_paths: &Paths, root: &str) -> Result<(), error::Err
                 "monokel",
                 "A looking glass into the future",
                 "master",
-                "https://res.cloudinary.com/juliendonck/image/upload/v1557488019/Frame_2_bhz6eq.svg",
             ),
             (
                 "Monadic",
                 "Open source organization of amazing things.",
                 "master",
-                "https://res.cloudinary.com/juliendonck/image/upload/v1549554598/monadic-icon_myhdjk.svg",
             ),
             (
                 "open source coin",
                 "Research for the sustainability of the open source community.",
                 "master",
-                "https://avatars0.githubusercontent.com/u/31632242",
             ),
             (
                 "radicle",
                 "Decentralized open source collaboration",
                 "master",
-                "https://avatars0.githubusercontent.com/u/48290027",
             ),
         ];
 
@@ -591,7 +582,7 @@ pub fn setup_fixtures(librad_paths: &Paths, root: &str) -> Result<(), error::Err
         std::fs::create_dir_all(path.clone())?;
 
         init_repo(path.clone())?;
-        init_project(librad_paths, &path, info.0, info.1, info.2, info.3)?;
+        init_project(librad_paths, &path, info.0, info.1, info.2)?;
     }
 
     Ok(())

--- a/proxy/src/graphql/schema.rs
+++ b/proxy/src/graphql/schema.rs
@@ -90,7 +90,6 @@ impl Mutation {
             &metadata.name,
             &metadata.description,
             &metadata.default_branch,
-            &metadata.img_url,
         )?;
 
         Ok(project::Project {
@@ -373,7 +372,6 @@ impl ControlMutation {
             &metadata.name,
             &metadata.description,
             &metadata.default_branch,
-            &metadata.img_url,
         )?;
 
         Ok(project::Project {
@@ -622,8 +620,6 @@ pub struct ProjectMetadataInput {
     pub description: String,
     /// Default branch for checkouts, often used as mainline as well.
     pub default_branch: String,
-    /// Image url for the project.
-    pub img_url: String,
 }
 
 #[juniper::object]
@@ -671,10 +667,6 @@ impl project::Metadata {
 
     fn description(&self) -> &str {
         &self.description
-    }
-
-    fn img_url(&self) -> &str {
-        &self.img_url
     }
 
     fn name(&self) -> &str {

--- a/proxy/src/project.rs
+++ b/proxy/src/project.rs
@@ -5,9 +5,6 @@ use librad::meta;
 use librad::project;
 use radicle_registry_client as registry;
 
-/// Metadata key used to store an image url for a project.
-const IMG_URL_LABEL: &str = "img_url";
-
 /// Object the API returns for project metadata.
 pub struct Metadata {
     /// Project name.
@@ -16,36 +13,14 @@ pub struct Metadata {
     pub description: String,
     /// Default branch for checkouts, often used as mainline as well.
     pub default_branch: String,
-    /// Image url for the project.
-    pub img_url: String,
 }
 
 impl From<meta::Project> for Metadata {
     fn from(project_meta: meta::Project) -> Self {
-        let img_url = project_meta
-            .rel
-            .into_iter()
-            .filter_map(|r| {
-                if let meta::Relation::Url(label, url) = r {
-                    Some((label, url))
-                } else {
-                    None
-                }
-            })
-            .find_map(|(label, url)| {
-                if *label == *IMG_URL_LABEL {
-                    Some(url.to_string())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| "".to_string());
-
         Self {
             name: project_meta.name.unwrap_or_else(|| "name unknown".into()),
             description: project_meta.description.unwrap_or_else(|| "".into()),
             default_branch: project_meta.default_branch,
-            img_url,
         }
     }
 }

--- a/proxy/tests/common/mod.rs
+++ b/proxy/tests/common/mod.rs
@@ -20,7 +20,6 @@ where
         "git-platinum",
         "fixture data",
         "master",
-        "https://avatars0.githubusercontent.com/u/48290027",
     )
     .unwrap();
 

--- a/proxy/tests/graphql_mutation.rs
+++ b/proxy/tests/graphql_mutation.rs
@@ -71,7 +71,6 @@ fn create_project_existing_repo() {
             InputValue::scalar("Code collaboration without intermediates."),
         );
         metadata_input.insert("defaultBranch".into(), InputValue::scalar("master"));
-        metadata_input.insert("imgUrl".into(), InputValue::scalar("https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/app/public/icon.png"));
 
         let mut vars = Variables::new();
         vars.insert("metadata".into(), InputValue::object(metadata_input));
@@ -85,7 +84,6 @@ fn create_project_existing_repo() {
                         name
                         description
                         defaultBranch
-                        imgUrl
                     }
                 }
             }";
@@ -100,7 +98,6 @@ fn create_project_existing_repo() {
                             "name": "upstream",
                             "description": "Code collaboration without intermediates.",
                             "defaultBranch": "master",
-                            "imgUrl": "https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/app/public/icon.png",
                         },
                     },
                 })
@@ -126,7 +123,6 @@ fn create_project() {
             InputValue::scalar("Code collaboration without intermediates."),
         );
         metadata_input.insert("defaultBranch".into(), InputValue::scalar("master"));
-        metadata_input.insert("imgUrl".into(), InputValue::scalar("https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/app/public/icon.png"));
 
         let mut vars = Variables::new();
         vars.insert("metadata".into(), InputValue::object(metadata_input));
@@ -140,7 +136,6 @@ fn create_project() {
                         name
                         description
                         defaultBranch
-                        imgUrl
                     }
                     registered {
                         ... on OrgRegistration {
@@ -168,7 +163,6 @@ fn create_project() {
                             "name": "upstream",
                             "description": "Code collaboration without intermediates.",
                             "defaultBranch": "master",
-                            "imgUrl": "https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/app/public/icon.png",
                         },
                         "registered": None,
                         "stats": {

--- a/proxy/tests/graphql_query.rs
+++ b/proxy/tests/graphql_query.rs
@@ -612,15 +612,14 @@ fn project() {
         let path = repo_dir.path().to_str().expect("repo path").to_string();
         coco::init_repo(path.clone()).expect("repo init failed");
 
-        let (project_id, _project_meta) =
-                    coco::init_project(
-                        &librad_paths,
-                        &path,
-                        "upstream",
-                        "Code collaboration without intermediates.",
-                        "master",
-                    )
-                    .expect("project init failed");
+        let (project_id, _project_meta) = coco::init_project(
+            &librad_paths,
+            &path,
+            "upstream",
+            "Code collaboration without intermediates.",
+            "master",
+        )
+        .expect("project init failed");
 
         let id = project_id.to_string();
         let mut vars = Variables::new();

--- a/proxy/tests/graphql_query.rs
+++ b/proxy/tests/graphql_query.rs
@@ -619,7 +619,6 @@ fn project() {
                         "upstream",
                         "Code collaboration without intermediates.",
                         "master",
-                        "https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/app/public/icon.png",
                     )
                     .expect("project init failed");
 
@@ -634,7 +633,6 @@ fn project() {
                             name
                             description
                             defaultBranch
-                            imgUrl
                         }
                         registered {
                             ... on OrgRegistration {
@@ -658,7 +656,6 @@ fn project() {
                             "name": "upstream",
                             "description": "Code collaboration without intermediates.",
                             "defaultBranch": "master",
-                            "imgUrl": "https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/app/public/icon.png",
                         },
                         "registered": None,
                     },
@@ -751,7 +748,6 @@ fn user() {
 //                     name
 //                     description
 //                     defaultBranch
-//                     imgUrl
 //                 }
 //             }
 //         }";
@@ -767,7 +763,6 @@ fn user() {
 //                                 "name": "Monadic",
 //                                 "description": "Open source organization of amazing
 // things.",                                 "defaultBranch": "stable",
-//                                 "imgUrl": "https://res.cloudinary.com/juliendonck/image/upload/v1549554598/monadic-icon_myhdjk.svg",
 //                             },
 //                         },
 //                         {
@@ -775,7 +770,6 @@ fn user() {
 //                                 "name": "monokel",
 //                                 "description": "A looking glass into the future",
 //                                 "defaultBranch": "master",
-//                                 "imgUrl": "https://res.cloudinary.com/juliendonck/image/upload/v1557488019/Frame_2_bhz6eq.svg",
 //                             },
 //                         },
 //                         {
@@ -783,7 +777,6 @@ fn user() {
 //                                 "name": "open source coin",
 //                                 "description": "Research for the sustainability of the
 // open source community.",                                 "defaultBranch":
-// "master",                                 "imgUrl": "https://avatars0.githubusercontent.com/u/31632242",
 //                             },
 //                         },
 //                         {
@@ -791,7 +784,6 @@ fn user() {
 //                                 "name": "radicle",
 //                                 "description": "Decentralized open source collaboration",
 //                                 "defaultBranch": "dev",
-//                                 "imgUrl": "https://avatars0.githubusercontent.com/u/48290027",
 //                             },
 //                         },
 //                     ],

--- a/ui/DesignSystem/Component/ProjectList.svelte
+++ b/ui/DesignSystem/Component/ProjectList.svelte
@@ -16,7 +16,6 @@
         id
         metadata {
           defaultBranch
-          imgUrl
           description
           name
         }

--- a/ui/DesignSystem/Primitive/Input/Text.svelte
+++ b/ui/DesignSystem/Primitive/Input/Text.svelte
@@ -99,7 +99,9 @@
       style="fill: var(--color-negative); justify-content: flex-start; position:
       absolute; top: 12px; right: 10px;" />
     <div class="validation-row">
-      <Text style="color: var(--color-negative);">{validationMessage}</Text>
+      <Text style="color: var(--color-negative); text-align: left;">
+        {validationMessage}
+      </Text>
     </div>
   {/if}
 </div>

--- a/ui/Screen/CreateProject.svelte
+++ b/ui/Screen/CreateProject.svelte
@@ -390,7 +390,7 @@
               disabled={!(name && currentSelection)}
               variant="primary"
               on:click={createProject}>
-              Publish project
+              Create project
             </Button>
           </div>
         </div>

--- a/ui/Screen/CreateProject.svelte
+++ b/ui/Screen/CreateProject.svelte
@@ -64,7 +64,7 @@
     }
 
     if (!localBranchesError.match("could not find repository")) {
-      return "The directory should not contain an existing repository";
+      return "The directory should be empty";
     }
   };
 
@@ -79,11 +79,11 @@
     }
 
     if (validatejs.isEmpty(value)) {
-      return "Pick an existing repository for the new project";
+      return "Pick a directory with an existing repository";
     }
 
     if (localBranchesError.match("could not find repository")) {
-      return "The directory should contain a valid git repository";
+      return "The directory should contain a git repository";
     }
 
     if (

--- a/ui/Screen/CreateProject.svelte
+++ b/ui/Screen/CreateProject.svelte
@@ -32,7 +32,6 @@
   let name;
   let description = "";
   let defaultBranch = DEFAULT_BRANCH_FOR_NEW_PROJECTS;
-  let publish = true;
   let newRepositoryPath = "";
   let existingRepositoryPath = "";
   let imageUrl = "";
@@ -204,7 +203,7 @@
             defaultBranch: defaultBranch
           },
           path: isNew ? newRepositoryPath : existingRepositoryPath,
-          publish: isNew ? true : publish
+          publish: true
         }
       });
 
@@ -286,12 +285,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 24px;
-  }
-
-  .publish-row {
-    display: flex;
-    align-items: center;
+    margin-top: 16px;
   }
 
   .validation-row {
@@ -369,7 +363,7 @@
               valid={!(validations && validations.existingRepositoryPath)}
               validationMessage={validations && validations.existingRepositoryPath && validations.existingRepositoryPath[0]}
               bind:path={existingRepositoryPath} />
-            <div class="default-branch-row" style="margin-top: 16px">
+            <div class="default-branch-row">
               <Text style="color: var(--color-foreground-level-6)">
                 Select the default branch
               </Text>
@@ -385,11 +379,6 @@
                   disabled
                   style="min-width: 240px" />
               {/if}
-            </div>
-            <div class="publish-row">
-              <Input.Checkbox bind:checked={publish}>
-                Publish the {defaultBranch} branch to the network
-              </Input.Checkbox>
             </div>
           </div>
         </RadioOption>
@@ -427,7 +416,7 @@
               disabled={!(name && currentSelection)}
               variant="primary"
               on:click={createProject}>
-              Create project
+              Publish project
             </Button>
           </div>
         </div>

--- a/ui/Screen/CreateProject.svelte
+++ b/ui/Screen/CreateProject.svelte
@@ -6,7 +6,6 @@
 
   import { showNotification } from "../store/notification.js";
   import * as path from "../lib/path.js";
-  import { hash } from "../lib/hash.js";
   import { DEFAULT_BRANCH_FOR_NEW_PROJECTS } from "../config.js";
 
   import {
@@ -34,7 +33,6 @@
   let defaultBranch = DEFAULT_BRANCH_FOR_NEW_PROJECTS;
   let newRepositoryPath = "";
   let existingRepositoryPath = "";
-  let imageUrl = "";
 
   let validations = false;
   let beginValidation = false;
@@ -105,15 +103,6 @@
         message: `Project name should match ${projectNameMatch}`
       }
     },
-    imageUrl: {
-      optional: {
-        url: {
-          schemes: ["http", "https"],
-          message: "Not a valid avatar URL",
-          allowLocal: false
-        }
-      }
-    },
     currentSelection: {
       presence: {
         message:
@@ -136,7 +125,6 @@
     validations = validatejs(
       {
         name: name,
-        imageUrl: imageUrl,
         currentSelection: currentSelection,
         newRepositoryPath: newRepositoryPath,
         existingRepositoryPath: existingRepositoryPath
@@ -149,7 +137,6 @@
   // only needed to make the function reactive to when they're changed.
   $: validate(
     name,
-    imageUrl,
     currentSelection,
     newRepositoryPath,
     existingRepositoryPath
@@ -195,11 +182,6 @@
           metadata: {
             name: name,
             description: description,
-            imgUrl:
-              imageUrl ||
-              `https://avatars.dicebear.com/v2/jdenticon/${hash(
-                name + description
-              )}.svg`,
             defaultBranch: defaultBranch
           },
           path: isNew ? newRepositoryPath : existingRepositoryPath,
@@ -314,14 +296,6 @@
         var(--color-primary)"
         placeholder="Project description"
         bind:value={description} />
-
-      <Input.Text
-        dataCy="avatar-url"
-        style="--focus-outline-color: var(--color-primary)"
-        placeholder="http://my-project-website.com/project-avatar.png"
-        bind:value={imageUrl}
-        valid={!(validations && validations.imageUrl)}
-        validationMessage={validations && validations.imageUrl && validations.imageUrl[0]} />
 
       <Title style="margin: 16px 0 12px 16px; text-align: left">
         Select one:

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -58,7 +58,6 @@
         metadata {
           defaultBranch
           description
-          imgUrl
           name
         }
         registered {

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -13,7 +13,6 @@
         metadata {
           name
           description
-          imgUrl
         }
       }
     }


### PR DESCRIPTION
Following up on the discussions with the #product team, we decided to:
- remove project avatar images entirely
- publish projects by default (remove "publish" checkbox from existing project option)
- ~~rename button `Create project` -> `Publish project`~~
- fix validation message alignment (if the text exceeds the component width, it gets broken into two lines and centered)

<img width="848" alt="Screenshot 2020-04-01 at 18 31 57" src="https://user-images.githubusercontent.com/158411/78162399-1dd1a500-7447-11ea-9f36-616b95b4c084.png">
