### PR TITLE
Revert to latest version of git-platinum

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -21,10 +21,12 @@ else
   echo "HOME=$HOME"
 fi
 
+mkdir -p "$CACHE_FOLDER/npm"
 mkdir -p "$CACHE_FOLDER/yarn"
 mkdir -p "$CACHE_FOLDER/cargo"
 mkdir -p "$CACHE_FOLDER/rustup"
 
+npm config set cache $CACHE_FOLDER/npm --global
 export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
 export CARGO_HOME="$CACHE_FOLDER/cargo"
 export RUSTUP_HOME="$CACHE_FOLDER/rustup"

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -26,7 +26,8 @@ mkdir -p "$CACHE_FOLDER/yarn"
 mkdir -p "$CACHE_FOLDER/cargo"
 mkdir -p "$CACHE_FOLDER/rustup"
 
-npm config set cache $CACHE_FOLDER/npm --global
+
+export NPM_CONFIG_CACHE="$CACHE_FOLDER/npm"
 export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
 export CARGO_HOME="$CACHE_FOLDER/cargo"
 export RUSTUP_HOME="$CACHE_FOLDER/rustup"


### PR DESCRIPTION
I think this got downgraded in #267 by accident.

Also all builds stopped working with a bunch of weird errors.
Pointing npm to the right cache folder seems to fix this at least in this branch.

```
[4/4] Building fresh packages...
--
  | error /build/node_modules/cypress: Command failed.
  | Exit code: 1
  | Command: node index.js --exec install
  | Arguments:
  | Directory: /build/node_modules/cypress
  | Output:
  | Installing Cypress (version: 4.2.0)
  |  
  | [15:51:16]  Downloading Cypress     [started]
  | internal/streams/legacy.js:61
  | throw er; // Unhandled stream error in pipe.
  | ^
  |  
  | [Error: ENOSPC: no space left on device, write] {
  | errno: -28,
  | code: 'ENOSPC',
  | syscall: 'write'
  | }
  | info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
  | elapsed time: 73.627 (user: 26.917, system: 14.987)
  | 🚨 Error: The command exited with status 1
```

```

[2/4] Fetching packages...
--
  | error https://registry.yarnpkg.com/svelte/-/svelte-3.20.1.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, stat '/cache/yarn/v6/npm-svelte-3.20.1-8417fcd883a2f534b642a0737368272e651cf3ac-integrity/node_modules/svelte/motion/index.mjs'"
  | info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
  | elapsed time: 50.420 (user: 32.839, system: 16.833)
  | 🚨 Error: The command exited with status 1
```