### PR TITLE
Remove avatar fallback query from user registration

### DIFF
--- a/ui/Screen/UserRegistration.svelte
+++ b/ui/Screen/UserRegistration.svelte
@@ -3,12 +3,7 @@
   import { getClient, mutate } from "svelte-apollo";
   import { pop } from "svelte-spa-router";
 
-  import {
-    identityAvatarUrlStore,
-    identityAvatarFallbackStore,
-    identityHandleStore,
-    identityIdStore
-  } from "../store/identity.js";
+  import { identityHandleStore, identityIdStore } from "../store/identity.js";
   import { showNotification } from "../store/notification.js";
 
   import { Text, Title } from "../DesignSystem/Primitive";
@@ -20,8 +15,6 @@
   let step = 1;
 
   let handle = $identityHandleStore;
-  let avatarFallback = $identityAvatarFallbackStore;
-  const imageUrl = $identityAvatarUrlStore;
   const id = $identityIdStore;
 
   const nextStep = () => {
@@ -99,20 +92,14 @@
           Registering your handle makes it unique and allows others to easily
           find you.
         </Text>
-        <PickHandleStep
-          bind:avatarFallback
-          {imageUrl}
-          bind:handle
-          onNextStep={nextStep} />
+        <PickHandleStep bind:handle onNextStep={nextStep} />
       {/if}
 
       {#if step === 2}
         <SubmitRegistrationStep
           onNextStep={registerUser}
           onPreviousStep={previousStep}
-          {handle}
-          {avatarFallback}
-          {imageUrl} />
+          {handle} />
       {/if}
     </div>
   </div>

--- a/ui/Screen/UserRegistration/SubmitRegistrationStep.svelte
+++ b/ui/Screen/UserRegistration/SubmitRegistrationStep.svelte
@@ -1,10 +1,12 @@
 <script>
+  import {
+    identityAvatarUrlStore,
+    identityAvatarFallbackStore
+  } from "../../store/identity.js";
   import { Button, Flex } from "../../DesignSystem/Primitive";
   import { Transaction } from "../../DesignSystem/Component";
 
   export let handle = null;
-  export let avatarFallback = null;
-  export let imageUrl = null;
 
   export let onNextStep = null;
   export let onPreviousStep = null;
@@ -15,14 +17,14 @@
     subject: {
       name: handle,
       kind: "user",
-      avatarFallback: avatarFallback,
-      imageUrl: imageUrl
+      avatarFallback: $identityAvatarFallbackStore,
+      imageUrl: $identityAvatarUrlStore
     },
     payer: {
       name: handle,
       kind: "user",
-      avatarFallback: avatarFallback,
-      imageUrl: imageUrl
+      avatarFallback: $identityAvatarFallbackStore,
+      imageUrl: $identityAvatarUrlStore
     }
   };
 </script>


### PR DESCRIPTION
The avatar fallback is now dependant on the id (not the handle as before). Therefor the query can be removed from the user registration flow and the identity store can be used.

Note that the avatar query will be needed for the org registration. The implementation of the flow and querying will look very similar to the user registration flow.