### PR TITLE
Fix CI

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -25,6 +25,9 @@ mkdir -p "$CACHE_FOLDER/yarn"
 mkdir -p "$CACHE_FOLDER/cargo"
 mkdir -p "$CACHE_FOLDER/rustup"
 
+# cypress npm install workaround
+mkdir -p "$CACHE_FOLDER/build"
+ln -s "$CACHE_FOLDER/build" /build
 
 export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
 export CARGO_HOME="$CACHE_FOLDER/cargo"

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -19,15 +19,19 @@ else
 
   echo "CACHE_FOLDER=$CACHE_FOLDER"
   echo "HOME=$HOME"
+
+  # When cypress is installed via yarn it runs a script that runs npm in a
+  # sub-command which in turn tries to install cypress in /build. Our linux CI
+  # host is configured to have free space only available in /cache.
+  # To work around this we're symlinking /build -> /cache/build
+  mkdir -p "$CACHE_FOLDER/build"
+  ln -s "$CACHE_FOLDER/build" /build
 fi
 
 mkdir -p "$CACHE_FOLDER/yarn"
 mkdir -p "$CACHE_FOLDER/cargo"
 mkdir -p "$CACHE_FOLDER/rustup"
 
-# cypress npm install workaround
-mkdir -p "$CACHE_FOLDER/build"
-ln -s "$CACHE_FOLDER/build" /build
 
 export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
 export CARGO_HOME="$CACHE_FOLDER/cargo"

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -21,13 +21,11 @@ else
   echo "HOME=$HOME"
 fi
 
-mkdir -p "$CACHE_FOLDER/npm"
 mkdir -p "$CACHE_FOLDER/yarn"
 mkdir -p "$CACHE_FOLDER/cargo"
 mkdir -p "$CACHE_FOLDER/rustup"
 
 
-export NPM_CONFIG_CACHE="$CACHE_FOLDER/npm"
 export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
 export CARGO_HOME="$CACHE_FOLDER/cargo"
 export RUSTUP_HOME="$CACHE_FOLDER/rustup"


### PR DESCRIPTION
Cypress tries to install itself outside of the `/cache` folder which fails on our Linux build host.
This PR attempts to address this issue.

```

Installing yarn dependencies | 53s
-- | --
  | yarn install v1.22.4
  | [1/4] Resolving packages...
  | [2/4] Fetching packages...
  | warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
  | [1/4] Resolving packages...
  | [2/4] Fetching packages...
  | error https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.12.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, stat '/cache/yarn/v6/npm-fsevents-1.2.12-db7e0d8ec3b0b45724fd4d83d43554a8f1f0de5c-integrity/node_modules/fsevents/node_modules/number-is-nan/readme.md'"
  | info fsevents@1.2.12: The platform "linux" is incompatible with this module.
  | info "fsevents@1.2.12" is an optional dependency and failed compatibility check. Excluding it from installation.
  | [3/4] Linking dependencies...
  | [4/4] Building fresh packages...
  | success Saved lockfile.
  | $ npm run build
  | npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1586436053393-0.8238545578502929/node but npm is using /usr/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
  |  
  | > prettier-plugin-svelte@0.7.0 build /cache/yarn/v6/.tmp/24e6be015d7a0ffe5c7f423514b3c385.e56c529d8d28757d46691330209625c18c2d6730.prepare
  | > rollup -c
  |  
  |  
  | src/index.ts → plugin.js...
  | created plugin.js in 867ms
  | info fsevents@2.1.2: The platform "linux" is incompatible with this module.
  | info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
  | [3/4] Linking dependencies...
  | warning " > svelte-apollo@0.3.0" has unmet peer dependency "apollo-client@^2.4.0".
  | warning "apollo > apollo-language-server > @endemolshinegroup/cosmiconfig-typescript-loader > ts-node@8.7.0" has unmet peer dependency "typescript@>=2.7".
  | warning " > rollup-plugin-livereload@1.0.4" has incorrect peer dependency "rollup@^1.0.0".
  | warning " > rollup-plugin-node-externals@2.1.3" has unmet peer dependency "builtin-modules@^3.1.0".
  | [4/4] Building fresh packages...
  | error /build/node_modules/cypress: Command failed.
  | Exit code: 1
  | Command: node index.js --exec install
  | Arguments:
  | Directory: /build/node_modules/cypress
  | Output:
  | Installing Cypress (version: 4.2.0)
  |  
  | [12:41:04]  Downloading Cypress     [started]
  | internal/streams/legacy.js:61
  | throw er; // Unhandled stream error in pipe.
  | ^
  |  
  | [Error: ENOSPC: no space left on device, write] {
  | errno: -28,
  | code: 'ENOSPC',
  | syscall: 'write'
  | }
  | info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
  | elapsed time: 52.041 (user: 45.526, system: 29.017)
  | 🚨 Error: The command exited with status 1
```