### PR TITLE
Fix stacking of dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "sirv-cli": "^0.4.5",
     "standard-version": "^7.1.0",
     "svelte": "^3.20.1",
-    "svelte-click-outside": "https://github.com/radicle-dev/svelte-click-outside#10e47e6359f943d45b72c2f3fc7ccc8036b60fac",
     "svelte-spa-router": "^2.1.0",
     "typescript": "3.8.3",
     "wait-on": "^4.0.1"

--- a/ui/DesignSystem/Component/AdditionalActionsDropdown.svelte
+++ b/ui/DesignSystem/Component/AdditionalActionsDropdown.svelte
@@ -1,5 +1,4 @@
 <script>
-  import ClickOutside from "svelte-click-outside";
   import { fade } from "svelte/transition";
 
   import { Icon, Text } from "../Primitive";
@@ -108,40 +107,39 @@
   }
 </style>
 
-<div data-cy={dataCy} class="container" {style} on:click|stopPropagation>
+<svelte:window on:click={hideModal} />
+<div data-cy={dataCy} class="container" {style}>
   <button bind:this={triggerEl} on:click|stopPropagation={toggleModal}>
     <svelte:component this={Icon.Ellipses} />
   </button>
-  <ClickOutside on:clickoutside={hideModal} exclude={[triggerEl]} useWindow>
-    {#if expanded}
-      <div out:fade={{ duration: 100 }} class="modal" hidden={!expanded}>
-        {#if headerTitle}
-          <Copyable {afterCopy}>
-            <div class="header">
-              <Text
-                style="white-space: nowrap; overflow: hidden; text-overflow:
-                ellipsis; max-width: 170px;">
-                {headerTitle}
-              </Text>
-              <svelte:component
-                this={copyIcon}
-                style="margin-left: 8px; min-width: 16px;" />
-            </div>
-          </Copyable>
-        {/if}
+  {#if expanded}
+    <div out:fade={{ duration: 100 }} class="modal" hidden={!expanded}>
+      {#if headerTitle}
+        <Copyable {afterCopy}>
+          <div class="header">
+            <Text
+              style="white-space: nowrap; overflow: hidden; text-overflow:
+              ellipsis; max-width: 170px;">
+              {headerTitle}
+            </Text>
+            <svelte:component
+              this={copyIcon}
+              style="margin-left: 8px; min-width: 16px;" />
+          </div>
+        </Copyable>
+      {/if}
 
-        <div class="menu" data-cy="dropdown-menu">
-          {#each menuItems as item, index}
-            <div
-              data-cy={item.dataCy}
-              class="menu-item"
-              on:click|stopPropagation={handleItemSelection(item)}>
-              <svelte:component this={item.icon} style="margin-right: 12px" />
-              <Text>{item.title}</Text>
-            </div>
-          {/each}
-        </div>
+      <div class="menu" data-cy="dropdown-menu">
+        {#each menuItems as item, index}
+          <div
+            data-cy={item.dataCy}
+            class="menu-item"
+            on:click|stopPropagation={handleItemSelection(item)}>
+            <svelte:component this={item.icon} style="margin-right: 12px" />
+            <Text>{item.title}</Text>
+          </div>
+        {/each}
       </div>
-    {/if}
-  </ClickOutside>
+    </div>
+  {/if}
 </div>

--- a/ui/DesignSystem/Component/Topbar.svelte
+++ b/ui/DesignSystem/Component/Topbar.svelte
@@ -13,6 +13,7 @@
     height: var(--topbar-height);
     left: var(--sidebar-width);
     border-bottom: 1px solid var(--color-foreground-level-3);
+    z-index: 1;
   }
 
   .left {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6610,10 +6610,6 @@ svelte-apollo@^0.3.0:
     apollo-utilities "^1.2.1"
     svelte-observable "^0.4.0"
 
-"svelte-click-outside@https://github.com/radicle-dev/svelte-click-outside#10e47e6359f943d45b72c2f3fc7ccc8036b60fac":
-  version "1.0.0"
-  resolved "https://github.com/radicle-dev/svelte-click-outside#10e47e6359f943d45b72c2f3fc7ccc8036b60fac"
-
 svelte-observable@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/svelte-observable/-/svelte-observable-0.4.0.tgz#74756e42fa3516c154d53f4244fa9cf691854224"


### PR DESCRIPTION
Because the dropdowns have `position:relative`, they create a new stacking context. By adding a `z-index` to the `Topbar`, we ensure its child dropdown stays on top:

Also, I removed the `svelte-click-outside` dependency so we'll have an easier time debugging and modifying the behavior of the `AdditionalActionsDropdown`.

![fix-zindex](https://user-images.githubusercontent.com/2712962/79820853-1ca6e000-8342-11ea-8065-41865c9b8ac2.gif)


Fixes part of #246 