### PR TITLE
feat(ui): use Twitter svg emojis in Avatar component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 .DS_Store
 native/main.comp.js
 public/bundle.*
+public/twemoji
 cypress/videos
 cypress/screenshots
 cypress/fixtures/example.json

--- a/README.md
+++ b/README.md
@@ -19,11 +19,22 @@ If you have questions or would like to get in touch, check out
 [radicle.community][rc].
 
 
+### Attribution
+
+Upstream uses:
+  - [Twemoji by Twitter][tw]
+  - [The Inter typeface family by Rasmus Andersson][ra]
+  - [Source Code Pro font family by Adobe][so]
+
+
 [ba]: https://badge.buildkite.com/4fb43c6b471ab7cc26509eae235b0e4bbbaace11cc1848eae6.svg?branch=master
 [de]: DEVELOPMENT.md
 [pr]: proxy
+[ra]: https://rsms.me/inter
 [rc]: https://radicle.community
 [ru]: https://www.rust-lang.org
 [st]: https://buildkite.com/monadic/radicle-upstream
+[so]: https://adobe-fonts.github.io/source-code-pro
 [sv]: https://svelte.dev
+[tw]: https://twemoji.twitter.com
 [ui]: ui

--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -43,8 +43,6 @@ context("routing", () => {
             cy.location().should(loc => {
               expect(loc.hash).to.eq("#/search");
             });
-
-            cy.screenshot();
           });
         }
       );

--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -43,6 +43,8 @@ context("routing", () => {
             cy.location().should(loc => {
               expect(loc.hash).to.eq("#/search");
             });
+
+            cy.screenshot();
           });
         }
       );

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "hotkeys-js": "^3.7.3",
     "timeago.js": "^4.0.2",
     "twemoji": "^12.1.6",
+    "twemoji-svg-assets": "https://github.com/radicle-dev/twemoji-svg-assets.git#v12.1.6",
     "validate.js": "^0.13.1"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@types/qs": "^6.9.1",
     "hotkeys-js": "^3.7.3",
     "timeago.js": "^4.0.2",
+    "twemoji": "^12.1.6",
     "validate.js": "^0.13.1"
   },
   "husky": {

--- a/ui/DesignSystem/Primitive/Avatar.svelte
+++ b/ui/DesignSystem/Primitive/Avatar.svelte
@@ -83,6 +83,13 @@
   .square.big {
     width: 64px;
     height: 64px;
+    border-radius: 4px;
+  }
+
+  .square.huge {
+    width: 72px;
+    height: 72px;
+    border-radius: 4px;
   }
 
   .container {
@@ -150,7 +157,7 @@
   {/if}
 
   {#if title}
-    {#if size === 'big'}
+    {#if size === 'big' || size === 'huge'}
       <Title variant="big" style="white-space: nowrap; margin-left: 12px">
         {title}
       </Title>

--- a/ui/DesignSystem/Primitive/Avatar.svelte
+++ b/ui/DesignSystem/Primitive/Avatar.svelte
@@ -151,8 +151,8 @@
       style="background: {fmt(avatarFallback.background)}">
       {@html twemoji.parse(avatarFallback.emoji, {
         className: `emoji ${size}`,
-        folder: 'twemoji/assets/svg',
         base: '',
+        folder: 'twemoji/',
         ext: '.svg'
       })}
     </div>

--- a/ui/DesignSystem/Primitive/Avatar.svelte
+++ b/ui/DesignSystem/Primitive/Avatar.svelte
@@ -106,6 +106,12 @@
     user-select: none;
   }
 
+  .image {
+    width: 32px;
+    height: 32px;
+    border-radius: 16px;
+  }
+
   .avatar :global(.emoji.small) {
     height: 12px;
     width: 12px;
@@ -135,7 +141,7 @@
 <div class={`container ${size}`} {style}>
   {#if imageUrl}
     <img
-      class={avatarClass}
+      class={`image ${avatarClass}`}
       src={imageUrl}
       alt="user-avatar"
       onerror="this.style.display='none'" />

--- a/ui/DesignSystem/Primitive/Avatar.svelte
+++ b/ui/DesignSystem/Primitive/Avatar.svelte
@@ -1,4 +1,5 @@
 <script>
+  import twemoji from "twemoji";
   import Title from "./Title.svelte";
 
   export let style = null;
@@ -26,7 +27,6 @@
     border-radius: 16px;
   }
 
-  img,
   .circle.regular {
     width: 32px;
     height: 32px;
@@ -98,6 +98,31 @@
     align-items: center;
     user-select: none;
   }
+
+  .avatar :global(.emoji.small) {
+    height: 12px;
+    width: 12px;
+  }
+
+  .avatar :global(.emoji.regular) {
+    height: 16px;
+    width: 16px;
+  }
+
+  .avatar :global(.emoji.medium) {
+    height: 18px;
+    width: 18px;
+  }
+
+  .avatar :global(.emoji.big) {
+    height: 32px;
+    width: 32px;
+  }
+
+  .avatar :global(.emoji.huge) {
+    height: 36px;
+    width: 36px;
+  }
 </style>
 
 <div class={`container ${size}`} {style}>
@@ -111,9 +136,12 @@
     <div
       class={`avatar ${avatarClass}`}
       style="background: {fmt(avatarFallback.background)}">
-      <Title variant={size} style="min-width: 27px; text-align: end;">
-        {avatarFallback.emoji}
-      </Title>
+      {@html twemoji.parse(avatarFallback.emoji, {
+        className: `emoji ${size}`,
+        folder: 'twemoji/assets/svg',
+        base: '',
+        ext: '.svg'
+      })}
     </div>
   {:else}
     <div

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -71,12 +71,12 @@
   };
 
   const avatarFallback2 = {
-    emoji: "🛠",
     background: {
-      r: 181,
-      g: 25,
-      b: 111
-    }
+      r: 122,
+      g: 112,
+      b: 90
+    },
+    emoji: "💡"
   };
 
   const additionalActionsDropdownItems = [
@@ -570,25 +570,123 @@
     subTitle="User, project, etc avatars in various sizes and shapes.">
 
     <Swatch>
-      <Avatar avatarFallback={avatarFallback1} />
-      <Avatar size="big" avatarFallback={avatarFallback1} />
-      <Avatar imageUrl="https://avatars1.githubusercontent.com/u/40774" />
       <Avatar
-        imageUrl="https://avatars1.githubusercontent.com/u/40774"
-        size="big" />
+        style="margin-right: 16px"
+        size="small"
+        variant="circle"
+        avatarFallback={avatarFallback1} />
       <Avatar
-        imageUrl="https://avatars.dicebear.com/v2/jdenticon/one.svg"
-        variant="square" />
-      <Avatar
-        imageUrl="https://avatars.dicebear.com/v2/jdenticon/two.svg"
+        style="margin-right: 16px"
+        size="small"
         variant="square"
-        size="big" />
-      <Avatar size="huge" avatarFallback={avatarFallback2} />
+        avatarFallback={avatarFallback2} />
+      <Avatar
+        style="margin-right: 16px"
+        size="small"
+        variant="circle"
+        imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+      <Avatar
+        style="margin-right: 16px"
+        size="small"
+        variant="circle"
+        avatarFallback={avatarFallback1}
+        title="cloudhead" />
     </Swatch>
 
     <Swatch>
-      <Avatar title="My name" avatarFallback={avatarFallback2} />
-      <Avatar size="big" title="My name" avatarFallback={avatarFallback2} />
+      <Avatar
+        style="margin-right: 16px"
+        size="regular"
+        variant="circle"
+        avatarFallback={avatarFallback1} />
+      <Avatar
+        style="margin-right: 16px"
+        size="regular"
+        variant="square"
+        avatarFallback={avatarFallback2} />
+      <Avatar
+        style="margin-right: 16px"
+        size="regular"
+        variant="circle"
+        imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+      <Avatar
+        style="margin-right: 16px"
+        size="regular"
+        variant="circle"
+        avatarFallback={avatarFallback1}
+        title="cloudhead" />
+    </Swatch>
+
+    <Swatch>
+      <Avatar
+        style="margin-right: 16px"
+        size="medium"
+        variant="circle"
+        avatarFallback={avatarFallback1} />
+      <Avatar
+        style="margin-right: 16px"
+        size="medium"
+        variant="square"
+        avatarFallback={avatarFallback2} />
+      <Avatar
+        style="margin-right: 16px"
+        size="medium"
+        variant="circle"
+        imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+      <Avatar
+        style="margin-right: 16px"
+        size="medium"
+        variant="circle"
+        avatarFallback={avatarFallback1}
+        title="cloudhead" />
+    </Swatch>
+
+    <Swatch>
+      <Avatar
+        style="margin-right: 16px"
+        size="big"
+        variant="circle"
+        avatarFallback={avatarFallback1} />
+      <Avatar
+        style="margin-right: 16px"
+        size="big"
+        variant="square"
+        avatarFallback={avatarFallback2} />
+      <Avatar
+        style="margin-right: 16px"
+        size="big"
+        variant="circle"
+        imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+      <Avatar
+        style="margin-right: 16px"
+        size="big"
+        variant="circle"
+        avatarFallback={avatarFallback1}
+        title="cloudhead" />
+    </Swatch>
+
+    <Swatch>
+      <Avatar
+        style="margin-right: 16px"
+        size="huge"
+        variant="circle"
+        avatarFallback={avatarFallback1} />
+      <Avatar
+        style="margin-right: 16px"
+        size="huge"
+        variant="square"
+        avatarFallback={avatarFallback2} />
+      <Avatar
+        style="margin-right: 16px"
+        size="huge"
+        variant="circle"
+        imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+      <Avatar
+        style="margin-right: 16px"
+        size="huge"
+        variant="circle"
+        avatarFallback={avatarFallback1}
+        title="cloudhead" />
     </Swatch>
   </Section>
 

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -194,7 +194,7 @@
       variant: "avatar",
       value: "1",
       avatarProps: {
-        variant: "user",
+        variant: "circle",
         title: identity.metadata.handle,
         avatarFallback: identity.avatarFallback,
         imageUrl: identity.imageUrl
@@ -204,7 +204,7 @@
       variant: "avatar",
       value: "2",
       avatarProps: {
-        variant: "project",
+        variant: "square",
         title: orgs[0].metadata.name,
         avatarFallback: orgs[0].avatarFallback
       }
@@ -213,7 +213,7 @@
       variant: "avatar",
       value: "3",
       avatarProps: {
-        variant: "project",
+        variant: "square",
         title: orgs[1].metadata.name,
         avatarFallback: orgs[1].avatarFallback
       }

--- a/ui/Screen/DesignSystemGuide/Swatch.svelte
+++ b/ui/Screen/DesignSystemGuide/Swatch.svelte
@@ -2,7 +2,7 @@
   .swatch {
     display: flex;
     margin-bottom: 34px;
-    align-items: baseline;
+    align-items: flex-end;
   }
 </style>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,7 +2777,7 @@ fs-access@1.0.1:
   dependencies:
     null-check "^1.0.0"
 
-fs-extra@8.1.0, fs-extra@^8.1.0:
+fs-extra@8.1.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -3500,6 +3500,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-5.0.0.tgz#e6b718f73da420d612823996fdf14a03f6ff6922"
+  integrity sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==
+  dependencies:
+    universalify "^0.1.2"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -5640,6 +5649,21 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
+twemoji-parser@12.1.3:
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-12.1.3.tgz#916c0153e77bd5f1011e7a99cbeacf52e43c9371"
+  integrity sha512-ND4LZXF4X92/PFrzSgGkq6KPPg8swy/U0yRw1k/+izWRVmq1HYi3khPwV3XIB6FRudgVICAaBhJfW8e8G3HC7Q==
+
+twemoji@^12.1.6:
+  version "12.1.6"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-12.1.6.tgz#3425427627a38ab5cae24e7690cecb691022479f"
+  integrity sha512-FIKi9Jne5IiDGDWekoANJ1a8ltUKVbJLEIR8XUpbFRDMqIPgLWnYgjeWZ1KOrdiTztRCAa9x4v+5w5OuiJOGVw==
+  dependencies:
+    fs-extra "^8.0.1"
+    jsonfile "^5.0.0"
+    twemoji-parser "12.1.3"
+    universalify "^0.1.2"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -5711,7 +5735,7 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
-universalify@^0.1.0:
+universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5654,6 +5654,10 @@ twemoji-parser@12.1.3:
   resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-12.1.3.tgz#916c0153e77bd5f1011e7a99cbeacf52e43c9371"
   integrity sha512-ND4LZXF4X92/PFrzSgGkq6KPPg8swy/U0yRw1k/+izWRVmq1HYi3khPwV3XIB6FRudgVICAaBhJfW8e8G3HC7Q==
 
+"twemoji-svg-assets@https://github.com/radicle-dev/twemoji-svg-assets.git#v12.1.6":
+  version "12.1.6"
+  resolved "https://github.com/radicle-dev/twemoji-svg-assets.git#1e0592f51ed08159cda6b4eb12c94598345544ad"
+
 twemoji@^12.1.6:
   version "12.1.6"
   resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-12.1.6.tgz#3425427627a38ab5cae24e7690cecb691022479f"


### PR DESCRIPTION
I got tired of the emoji alignment issues.

The implementation is based on this discussion: https://github.com/radicle-dev/radicle-upstream/issues/231#issuecomment-604914935.

<img width="99" alt="Screenshot 2020-05-04 at 20 58 55" src="https://user-images.githubusercontent.com/158411/81002894-484dbe00-8e4a-11ea-970e-566228ce2416.png">
<img width="80%" alt="Screenshot 2020-05-04 at 20 59 09" src="https://user-images.githubusercontent.com/158411/81002898-497eeb00-8e4a-11ea-979e-59723b226d51.png">
<img width="50%" alt="Screenshot 2020-05-04 at 20 59 17" src="https://user-images.githubusercontent.com/158411/81002903-4b48ae80-8e4a-11ea-823e-1680f016739a.png">


Closes #231, #290.