### PR TITLE
chore(ui): fix diff line styling

### DIFF
--- a/ui/DesignSystem/Component/SourceBrowser/FileDiff.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/FileDiff.svelte
@@ -71,13 +71,13 @@
   td.diff-expand-action {
     text-align: center;
     user-select: none;
-    background: var(--color-foreground-level-2);
-    color: var(--color-foreground-level-6);
+    background: var(--color-background);
+    color: var(--color-foreground-level-4);
   }
   td.diff-expand-header {
     user-select: none;
-    background: var(--color-foreground-level-2);
-    color: var(--color-foreground-level-6);
+    background: var(--color-background);
+    color: var(--color-foreground-level-4);
   }
 
   td.diff-line-number {
@@ -116,7 +116,7 @@
           {/each}
         {:else}
           <tr class="diff-line">
-            <td colspan="2" class="diff-expand-action">...</td>
+            <td colspan="2" class="diff-expand-action" />
             <td colspan="2" class="diff-expand-header">{hunk.header}</td>
           </tr>
         {/if}


### PR DESCRIPTION
Just cleaning up some styling on the diff-expand-line

**old**
<img width="1066" alt="download-1" src="https://user-images.githubusercontent.com/2326909/81058828-86d98c00-8ecf-11ea-9388-719565709102.png">

**new**
<img width="1016" alt="download" src="https://user-images.githubusercontent.com/2326909/81058834-8a6d1300-8ecf-11ea-9835-7f8e66b2a84e.png">
