### PR TITLE
feat(proxy): org project list endpoint

### DIFF
--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -18,6 +18,7 @@ pub fn routes(
     path("orgs").and(
         get_filter(Arc::clone(&registry))
             .or(get_project_filter(Arc::clone(&registry)))
+            .or(get_projects_filter(Arc::clone(&registry)))
             .or(register_filter(registry, subscriptions)),
     )
 }
@@ -30,6 +31,7 @@ fn filters(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     get_filter(Arc::clone(&registry))
         .or(get_project_filter(Arc::clone(&registry)))
+        .or(get_projects_filter(Arc::clone(&registry)))
         .or(register_filter(registry, subscriptions))
 }
 
@@ -94,6 +96,29 @@ fn get_project_filter(
         .and_then(handler::get_project)
 }
 
+/// `GET /<id>/projects`
+fn get_projects_filter(
+    registry: Arc<RwLock<registry::Registry>>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    super::with_registry(registry)
+        .and(warp::get())
+        .and(document::param::<String>("org_id", "Unique ID of the Org"))
+        .and(path("projects"))
+        .and(path::end())
+        .and(document::document(document::description(
+            "Lists all Projects of the Org",
+        )))
+        .and(document::document(document::tag("Org")))
+        .and(document::document(
+            document::response(
+                200,
+                document::body(registry::Project::document()).mime("application/json"),
+            )
+            .description("Successful retrieval"),
+        ))
+        .and_then(handler::get_projects)
+}
+
 /// `POST /`
 fn register_filter(
     registry: Arc<RwLock<registry::Registry>>,
@@ -153,6 +178,17 @@ mod handler {
         let project = reg.get_project(org_id, project_name).await?;
 
         Ok(reply::json(&project))
+    }
+
+    /// Get all projects under the given org id.
+    pub async fn get_projects(
+        registry: Arc<RwLock<registry::Registry>>,
+        org_id: String,
+    ) -> Result<impl Reply, Rejection> {
+        let reg = registry.read().await;
+        let projects = reg.list_org_projects(org_id).await?;
+
+        Ok(reply::json(&projects))
     }
 
     /// Register an org on the Registry.
@@ -369,6 +405,59 @@ mod test {
                 org_id: registry::Id::try_from(org_id).unwrap(),
                 maybe_project_id: None,
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn get_projects() {
+        let registry = Arc::new(RwLock::new(registry::Registry::new(
+            radicle_registry_client::Client::new_emulator(),
+        )));
+        let subscriptions = notification::Subscriptions::default();
+        let api = super::filters(Arc::clone(&registry), subscriptions);
+
+        let project_name = "upstream";
+        let org_id = "radicle";
+
+        // Register the org.
+        let alice = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
+        registry
+            .write()
+            .await
+            .register_org(&alice, org_id.to_string(), 10)
+            .await
+            .unwrap();
+
+        // Register the project.
+        registry
+            .write()
+            .await
+            .register_project(
+                &alice,
+                org_id.to_string(),
+                project_name.to_string(),
+                None,
+                10,
+            )
+            .await
+            .unwrap();
+
+        let res = request()
+            .method("GET")
+            .path(&format!("/{}/projects", org_id))
+            .reply(&api)
+            .await;
+
+        let have: Value = serde_json::from_slice(res.body()).unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            have,
+            json!([registry::Project {
+                name: registry::ProjectName::try_from(project_name).unwrap(),
+                org_id: registry::Id::try_from(org_id).unwrap(),
+                maybe_project_id: None,
+            }])
         );
     }
 

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -310,6 +310,7 @@ mod test {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
     use std::convert::TryFrom;
+    use std::str::FromStr;
     use std::sync::Arc;
     use tokio::sync::RwLock;
     use warp::http::StatusCode;
@@ -436,7 +437,12 @@ mod test {
                 &alice,
                 org_id.to_string(),
                 project_name.to_string(),
-                None,
+                Some(
+                    librad::project::ProjectId::from_str(
+                        "ac1cac587b49612fbac39775a07fb05c6e5de08d.git",
+                    )
+                    .expect("Project id"),
+                ),
                 10,
             )
             .await
@@ -456,7 +462,7 @@ mod test {
             json!([registry::Project {
                 name: registry::ProjectName::try_from(project_name).unwrap(),
                 org_id: registry::Id::try_from(org_id).unwrap(),
-                maybe_project_id: None,
+                maybe_project_id: Some("ac1cac587b49612fbac39775a07fb05c6e5de08d.git".to_string()),
             }])
         );
     }

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -224,10 +224,9 @@ mod handler {
         let fake_fee: Balance = 100;
 
         let mut reg = registry.write().await;
-        let maybe_coco_id = match input.maybe_coco_id {
-            Some(id) => Some(librad::project::ProjectId::from_str(&id).expect("Project id")),
-            None => None,
-        };
+        let maybe_coco_id = input
+            .maybe_coco_id
+            .map(|id| librad::project::ProjectId::from_str(&id).expect("Project id"));
         let tx = reg
             .register_project(
                 &fake_pair,

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -139,6 +139,7 @@ mod handler {
     use librad::paths::Paths;
     use librad::surf;
     use radicle_registry_client::Balance;
+    use std::str::FromStr;
     use std::sync::Arc;
     use tokio::sync::RwLock;
     use warp::http::StatusCode;
@@ -223,8 +224,18 @@ mod handler {
         let fake_fee: Balance = 100;
 
         let mut reg = registry.write().await;
+        let maybe_coco_id = match input.maybe_coco_id {
+            Some(id) => Some(librad::project::ProjectId::from_str(&id).expect("Project id")),
+            None => None,
+        };
         let tx = reg
-            .register_project(&fake_pair, input.org_id, input.project_name, None, fake_fee)
+            .register_project(
+                &fake_pair,
+                input.org_id,
+                input.project_name,
+                maybe_coco_id,
+                fake_fee,
+            )
             .await?;
 
         subscriptions
@@ -643,7 +654,7 @@ mod test {
             .json(&super::RegisterInput {
                 project_name: "upstream".into(),
                 org_id: "radicle".into(),
-                maybe_coco_id: None,
+                maybe_coco_id: Some("1234.git".to_string()),
             })
             .reply(&api)
             .await;

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -330,20 +330,17 @@ impl Registry {
     pub async fn list_org_projects(&self, id: String) -> Result<Vec<Project>, error::Error> {
         let org_id = Id::try_from(id.clone())?;
         let project_ids = self.client.list_projects().await?.into_iter();
-        Ok(project_ids
-            .filter_map(|project_id| {
-                if project_id.1 == org_id {
-                    Some(Project {
-                        name: project_id.0,
-                        org_id: project_id.1,
-                        // TODO(xla): Proper conversion of ProjectIds.
-                        maybe_project_id: None,
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect())
+        let mut projects = Vec::new();
+        for project_id in project_ids {
+            if project_id.1 == org_id {
+                projects.push(
+                    self.get_project(org_id.to_string(), project_id.0.to_string())
+                        .await?
+                        .expect("Get project"),
+                );
+            }
+        }
+        Ok(projects)
     }
 
     /// Try to retrieve project from the Registry by name for an id.

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -366,7 +366,7 @@ impl Registry {
                 Project {
                     name: project.name,
                     org_id: project.org_id,
-                    maybe_project_id: if let [] = metadata_vec[..] {
+                    maybe_project_id: if metadata_vec[..].is_empty() {
                         None
                     } else {
                         let maybe_metadata: Result<Metadata, serde_cbor::error::Error> =


### PR DESCRIPTION
Endpoint to return all projects registered under an org.
- [x] filter project list by org id
- [x] return `Project` instead of only the project name (*)
- [x] expose list in the api `GET orgs/<id>/projects`

(*) Open issue/dependency:
- when registering a project, currently `None` is always passed as the `maybe_project_id` in the proxy. In order to show any other info beside the name of the project, we need to pass the project id.

Solves part of #277 