### PR TITLE
style(ui): replace html dropdown with custom one

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -270,11 +270,6 @@ overrides, components expose a `style` prop:
 
 ```html
   <Rad amount={200} style="margin-right: 24px" size="big" />
-
-  <Input.Dropdown
-    items={localBranches}
-    bind:value={defaultBranch}
-    style="min-width: 240px; --focus-outline-color: var(--color-primary)" />
 ```
 
 For very common alignment cases we have a helper primitive called `<Flex>`.

--- a/ui/DesignSystem/Primitive/Input/index.js
+++ b/ui/DesignSystem/Primitive/Input/index.js
@@ -1,11 +1,9 @@
 import Checkbox from "./Checkbox.svelte";
 import Directory from "./Directory.svelte";
-import Dropdown from "./Dropdown.svelte";
 import Text from "./Text.svelte";
 
 export default {
   Checkbox,
   Directory,
-  Dropdown,
   Text,
 };

--- a/ui/Screen/CreateProject.svelte
+++ b/ui/Screen/CreateProject.svelte
@@ -9,7 +9,6 @@
   import { getLocalBranches } from "../src/source.ts";
   import { getValidationState } from "../src/validation.ts";
 
-  import { ModalLayout, RadioOption } from "../DesignSystem/Component";
   import {
     Button,
     Flex,
@@ -18,6 +17,11 @@
     Text,
     Title,
   } from "../DesignSystem/Primitive";
+  import {
+    Dropdown,
+    ModalLayout,
+    RadioOption,
+  } from "../DesignSystem/Component";
 
   let currentSelection;
 
@@ -314,16 +318,16 @@
                 Select the default branch
               </Text>
               {#if localBranches.length > 0}
-                <Input.Dropdown
-                  items={localBranches}
-                  bind:value={defaultBranch}
-                  style="min-width: 240px; --focus-outline-color:
-                  var(--color-primary)" />
+                <Dropdown
+                  options={localBranches.map((branch) => {
+                    return { variant: 'text', value: branch, textProps: { title: branch } };
+                  })}
+                  bind:value={defaultBranch} />
               {:else}
-                <Input.Dropdown
-                  items={[DEFAULT_BRANCH_FOR_NEW_PROJECTS]}
-                  disabled
-                  style="min-width: 240px" />
+                <Dropdown
+                  placeholder={[DEFAULT_BRANCH_FOR_NEW_PROJECTS]}
+                  options={[]}
+                  disabled />
               {/if}
             </div>
           </div>

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -533,14 +533,6 @@
     </Swatch>
 
     <Swatch>
-      <Input.Dropdown items={['master', 'dev']} value={'dev'} />
-    </Swatch>
-
-    <Swatch>
-      <Input.Dropdown disabled items={['master', 'dev']} value={'dev'} />
-    </Swatch>
-
-    <Swatch>
       <Input.Checkbox>How about a checkbox?</Input.Checkbox>
     </Swatch>
 


### PR DESCRIPTION
Now that we have a custom dropdown that matches our style guide we should use it everywhere.