### PR TITLE
test(ui): improve identity creation test coverage

### DIFF
--- a/cypress/integration/identity_creation.spec.js
+++ b/cypress/integration/identity_creation.spec.js
@@ -68,6 +68,9 @@ context("identity creation", () => {
 
           // Now try to close the modal via the "x" button
           cy.get('[data-cy="modal-close-button"]').click();
+
+          // We should land back on the intro screen
+          cy.get('[data-cy="get-started-button"]').should("exist");
         });
       }
     );

--- a/cypress/integration/identity_creation.spec.js
+++ b/cypress/integration/identity_creation.spec.js
@@ -12,6 +12,89 @@ context("identity creation", () => {
     });
   });
 
+  context("navigation", () => {
+    it("is possible to step through the identity creation flow", () => {
+      // Intro screen
+      cy.get('[data-cy="get-started-button"]').click();
+
+      // Enter details screen
+      cy.get('[data-cy="form"] [data-cy="handle"]').type("rafalca");
+      cy.get('[data-cy="form"] [data-cy="display-name"]').type(
+        "Rafalca Romney"
+      );
+      cy.get('[data-cy="create-id-button"]').click();
+
+      // Confirmation screen
+      // TODO(rudolfs): change the emoji once the backend returns the right one
+      cy.get('[data-cy="identity-card"] img[alt="🐽"]').should("exist");
+      cy.get('[data-cy="identity-card"]')
+        .contains("Rafalca Romney")
+        .should("exist");
+      cy.get('[data-cy="identity-card"]')
+        .contains("rafalca@123abcd.git")
+        .should("exist");
+
+      // Land on profile screen
+      cy.get('[data-cy="go-to-profile-button"]').click();
+      // TODO(rudolfs): change this to the actual handle that we
+      // just created once the backend is wired up
+      cy.get('[data-cy="profile-avatar"]').contains("cloudhead");
+    });
+
+    it("is possible to directly register your identity after creating it", () => {
+      cy.get('[data-cy="get-started-button"]').click();
+
+      cy.get('[data-cy="form"] [data-cy="handle"]').type("rafalca");
+      cy.get('[data-cy="create-id-button"]').click();
+      cy.get('[data-cy="register-identity-link"]').click();
+
+      cy.contains("Register your handle").should("exist");
+
+      cy.get('[data-cy="cancel-button"]').click();
+      // TODO(rudolfs): change this to the actual handle that we
+      // just created once the backend is wired up
+      cy.get('[data-cy="profile-avatar"]').contains("cloudhead");
+    });
+
+    context(
+      "when clicking cancel or modal close button before the identity is created",
+      () => {
+        it("sends the user back to the intro screen", () => {
+          cy.get('[data-cy="get-started-button"]').click();
+          cy.get('[data-cy="cancel-button"]').click();
+
+          // We should land back on the intro screen
+          cy.get('[data-cy="get-started-button"]').click();
+
+          // Now try to close the modal via the "x" button
+          cy.get('[data-cy="modal-close-button"]').click();
+        });
+      }
+    );
+
+    context(
+      "when clicking the modal close button on the success screen",
+      () => {
+        it("lands the user on the profile screen", () => {
+          cy.get('[data-cy="get-started-button"]').click();
+
+          cy.get('[data-cy="form"] [data-cy="handle"]').type("rafalca");
+          cy.get('[data-cy="create-id-button"]').click();
+
+          cy.get('[data-cy="identity-card"]')
+            .contains("rafalca@123abcd.git")
+            .should("exist");
+
+          // Land on profile screen
+          cy.get('[data-cy="modal-close-button"]').click();
+          // TODO(rudolfs): change this to the actual handle that we
+          // just created once the backend is wired up
+          cy.get('[data-cy="profile-avatar"]').contains("cloudhead");
+        });
+      }
+    );
+  });
+
   context("validations", () => {
     beforeEach(() => {
       cy.get('[data-cy="get-started-button"]').click();

--- a/ui/DesignSystem/Component/ModalLayout.svelte
+++ b/ui/DesignSystem/Component/ModalLayout.svelte
@@ -28,7 +28,7 @@
 </style>
 
 {#if !hideCloseButton}
-  <div class="close">
+  <div data-cy="modal-close-button" class="close">
     <Icon.CrossBig on:click={onClose} />
   </div>
 {/if}

--- a/ui/DesignSystem/Primitive/Avatar.svelte
+++ b/ui/DesignSystem/Primitive/Avatar.svelte
@@ -3,6 +3,7 @@
   import Title from "./Title.svelte";
 
   export let style = null;
+  export let dataCy = null;
 
   // the hierarchy of usage for the following avatars is:
   // imageUrl > avatarFallback
@@ -138,7 +139,7 @@
   }
 </style>
 
-<div class={`container ${size}`} {style}>
+<div data-cy={dataCy} class={`container ${size}`} {style}>
   {#if imageUrl}
     <img
       class={`image ${avatarClass}`}

--- a/ui/Screen/Identity/IdentityCreationForm.svelte
+++ b/ui/Screen/Identity/IdentityCreationForm.svelte
@@ -132,6 +132,7 @@
       validation={avatarUrlValidation} />
     <div class="buttons">
       <Button
+        dataCy="cancel-button"
         variant="transparent"
         style="margin-right: 16px;"
         on:click={() => dispatch('cancel')}>

--- a/ui/Screen/Identity/IdentityCreationSuccess.svelte
+++ b/ui/Screen/Identity/IdentityCreationSuccess.svelte
@@ -68,12 +68,15 @@
     <Text style="margin: 20px 0; color: var(--color-foreground-level-5);">
       This is your peer-to-peer identity. Even though your radicleID is unique,
       your handle isn't. To get a unique handle, you have to
-      <span class="registration-link" on:click={() => dispatch('register')}>
+      <span
+        data-cy="register-identity-link"
+        class="registration-link"
+        on:click={() => dispatch('register')}>
         register it.
       </span>
     </Text>
     <Remote {store} let:data={identity}>
-      <div class="identity-card">
+      <div class="identity-card" data-cy="identity-card">
         <Avatar
           size="huge"
           imageUrl={identity.metadata.avatarUrl}
@@ -97,6 +100,8 @@
       </div>
     </Remote>
 
-    <Button on:click={() => dispatch('close')}>Go to profile</Button>
+    <Button dataCy="go-to-profile-button" on:click={() => dispatch('close')}>
+      Go to profile
+    </Button>
   </div>
 </div>

--- a/ui/Screen/IdentityCreation.svelte
+++ b/ui/Screen/IdentityCreation.svelte
@@ -13,7 +13,7 @@
   import IdentityCreationSuccess from "./Identity/IdentityCreationSuccess.svelte";
 
   const returnToWelcomeStep = () => {
-    $store.set(State.Welcome);
+    store.set(State.Welcome);
   };
 
   const onError = (error) => {

--- a/ui/Screen/Profile.svelte
+++ b/ui/Screen/Profile.svelte
@@ -92,6 +92,7 @@
       <!-- TODO(xla): Handle other states -->
       <div class="profile-avatar">
         <Avatar
+          dataCy="profile-avatar"
           avatarFallback={session.identity.avatarFallback}
           imageUrl={session.identity.metadata.avatarUrl}
           variant="circle"


### PR DESCRIPTION
Discovered a regression: when hitting `Cancel` or the modal close `x` button on the identity form screen there's an exception.

```
Uncaught TypeError: $store.set is not a function
    at IdentityCreationForm.returnToWelcomeStep (IdentityCreation.svelte:16)
    at index.mjs:620
    at Array.forEach (<anonymous>)
    at index.mjs:619
    at click_handler (IdentityCreationForm.svelte:138)
    at index.mjs:637
    at Array.forEach (<anonymous>)
    at bubble (index.mjs:637)
    at HTMLButtonElement.click_handler (Button.svelte:12)
```

Fixed in: https://github.com/radicle-dev/radicle-upstream/pull/359/commits/ec651d0c91b3d454cc76e03b5f0e58e248449c67.