### PR TITLE
feat(proxy): Return the member list for an Org

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2703,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=f05517c470e426d2f59c9f873845b5e1019b57b4#f05517c470e426d2f59c9f873845b5e1019b57b4"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1b044c0c408adafb4956760178c10d4779d087d4#1b044c0c408adafb4956760178c10d4779d087d4"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=f05517c470e426d2f59c9f873845b5e1019b57b4#f05517c470e426d2f59c9f873845b5e1019b57b4"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1b044c0c408adafb4956760178c10d4779d087d4#1b044c0c408adafb4956760178c10d4779d087d4"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -2750,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=f05517c470e426d2f59c9f873845b5e1019b57b4#f05517c470e426d2f59c9f873845b5e1019b57b4"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1b044c0c408adafb4956760178c10d4779d087d4#1b044c0c408adafb4956760178c10d4779d087d4"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,7 +36,7 @@ rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "f05517c470e426d2f59c9f873845b5e1019b57b4"
+rev = "1b044c0c408adafb4956760178c10d4779d087d4"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -290,9 +290,17 @@ mod test {
         )));
         let subscriptions = notification::Subscriptions::default();
         let api = super::filters(Arc::clone(&registry), subscriptions);
+        let alice = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
+
+        // Register the user
+        registry
+            .write()
+            .await
+            .register_user(&alice, "alice".to_string(), None, 10)
+            .await
+            .unwrap();
 
         // Register the org
-        let alice = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
         let fee: radicle_registry_client::Balance = 100;
         registry
             .write()
@@ -326,12 +334,20 @@ mod test {
         )));
         let subscriptions = notification::Subscriptions::default();
         let api = super::filters(Arc::clone(&registry), subscriptions);
+        let alice = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
 
         let project_name = "upstream";
         let org_id = "radicle";
 
+        // Register the user
+        registry
+            .write()
+            .await
+            .register_user(&alice, "alice".to_string(), None, 10)
+            .await
+            .unwrap();
+
         // Register the org.
-        let alice = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
         registry
             .write()
             .await
@@ -380,6 +396,15 @@ mod test {
         let subscriptions = notification::Subscriptions::default();
 
         let api = super::filters(Arc::clone(&registry), subscriptions);
+        let alice = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
+
+        // Register the user
+        registry
+            .write()
+            .await
+            .register_user(&alice, "alice".to_string(), None, 10)
+            .await
+            .unwrap();
 
         let res = request()
             .method("POST")

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -182,9 +182,10 @@ impl Serialize for registry::Org {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("Org", 2)?;
+        let mut state = serializer.serialize_struct("Org", 3)?;
         state.serialize_field("id", &self.id)?;
         state.serialize_field("avatarFallback", &self.avatar_fallback)?;
+        state.serialize_field("members", &self.members)?;
 
         state.end()
     }
@@ -192,13 +193,17 @@ impl Serialize for registry::Org {
 
 impl ToDocumentedType for registry::Org {
     fn document() -> document::DocumentedType {
-        let mut properties = std::collections::HashMap::with_capacity(2);
+        let mut properties = std::collections::HashMap::with_capacity(3);
         properties.insert("avatarFallback".into(), avatar::Avatar::document());
         properties.insert(
             "id".into(),
             document::string()
                 .description("The id of the org")
                 .example("monadic"),
+        );
+        properties.insert(
+            "members".into(),
+            document::array(registry::User::document()),
         );
 
         document::DocumentedType::from(properties).description("Org")
@@ -268,7 +273,11 @@ impl ToDocumentedType for RegisterInput {
     }
 }
 
-#[allow(clippy::option_unwrap_used, clippy::result_unwrap_used)]
+#[allow(
+    clippy::option_unwrap_used,
+    clippy::result_unwrap_used,
+    clippy::indexing_slicing
+)]
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
@@ -300,6 +309,14 @@ mod test {
             .await
             .unwrap();
 
+        let user = registry
+            .read()
+            .await
+            .get_user("alice".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+
         // Register the org
         let fee: radicle_registry_client::Balance = 100;
         registry
@@ -323,6 +340,7 @@ mod test {
             json!(registry::Org {
                 id: "monadic".to_string(),
                 avatar_fallback: avatar::Avatar::from("monadic", avatar::Usage::Org),
+                members: vec![user]
             })
         );
     }
@@ -421,11 +439,18 @@ mod test {
             .list_transactions(vec![])
             .await
             .unwrap();
-        let tx = txs.first().unwrap();
 
-        let have: Value = serde_json::from_slice(res.body()).unwrap();
+        // Get the registered org
+        let org = registry
+            .read()
+            .await
+            .get_org("monadic".to_string())
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(res.status(), StatusCode::CREATED);
-        assert_eq!(have, json!(tx));
+        assert_eq!(txs.len(), 2);
+        assert_eq!(org.id, "monadic")
     }
 }

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -190,7 +190,7 @@ impl ToDocumentedType for registry::User {
         );
 
         document::DocumentedType::from(props)
-            .description("Input for Uesr registration")
+            .description("Input for User registration")
             .nullable(true)
     }
 }
@@ -290,6 +290,14 @@ mod test {
             .await
             .unwrap();
 
+        let user = registry
+            .read()
+            .await
+            .get_user("alice".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+
         // Register the org
         let fee: radicle_registry_client::Balance = 100;
         registry
@@ -313,6 +321,7 @@ mod test {
             json!([registry::Org {
                 id: "monadic".to_string(),
                 avatar_fallback: avatar::Avatar::from("monadic", avatar::Usage::Org),
+                members: vec![user]
             }])
         );
     }


### PR DESCRIPTION
The `get_org` and `list_org` endpoints should return the list of members.

For this radicle-registry needs to based off of [the upstream branch](https://github.com/radicle-dev/radicle-registry/commit/1b044c0c408adafb4956760178c10d4779d087d4)

Part of #349 