### PR TITLE
feat: improve dev ergonomics

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -493,7 +493,6 @@ yarn lint                 # Check UI code for linting errors
 yarn proxy:build          # Build the proxy binary
 yarn proxy:build:release  # Build the release version of the proxy, stripped of debug symbols
 yarn proxy:start          # Start only the proxy with its default configuration
-yarn proxy:start:test     # Start the proxy in test mode, where state is isolated and lives in memory or temporary directories
 ```
 
 ## CI setup

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   },
   "scripts": {
     "start": "run-p --race svelte:watch proxy:start electron:start",
-    "start:test": "run-p --race svelte:watch proxy:start:test electron:start",
     "test": "TZ='UTC' run-p --race proxy:start:test test:run",
     "test:debug": "TZ='UTC' run-p --race svelte:watch proxy:start:test cypress:open",
     "test:run": "wait-on tcp:8080 && yarn svelte:build && yarn cypress:run",

--- a/package.json
+++ b/package.json
@@ -88,9 +88,10 @@
   },
   "scripts": {
     "start": "run-p --race svelte:watch proxy:start electron:start",
-    "test": "TZ='UTC' run-p --race proxy:start:test test:run",
-    "test:debug": "TZ='UTC' run-p --race svelte:watch proxy:start:test cypress:open",
-    "test:run": "wait-on tcp:8080 && yarn svelte:build && yarn cypress:run",
+    "test": "TZ='UTC' run-p --race proxy:start:test wait:test",
+    "test:debug": "TZ='UTC' run-p --race svelte:watch proxy:start:test wait:debug",
+    "wait:test": "wait-on tcp:8080 && yarn svelte:build && yarn cypress:run",
+    "wait:debug": "wait-on tcp:8080 && yarn cypress:open",
     "dist": "rm -rf ./dist && mkdir ./dist && yarn svelte:clean && yarn svelte:build && yarn proxy:build:release && cp proxy/target/release/proxy dist && electron-builder --publish never",
     "electron:start": "wait-on ./public/bundle.js && wait-on ./native/main.comp.js && wait-on tcp:8080 && NODE_ENV=development electron .",
     "svelte:clean": "rm -rf public/bundle.*",

--- a/rollup.app.js
+++ b/rollup.app.js
@@ -55,6 +55,6 @@ export default {
     chokidar: {
       usePolling: true,
     },
-    clearScreen: true,
+    clearScreen: false,
   },
 };


### PR DESCRIPTION
- make proxy logs less verbose to de-clutter local console and CI
- make `yarn test:debug` wait for proxy to start up before launching debug console
- prevent rollup from swallowing logs

<img width="860" alt="Screenshot 2020-05-12 at 21 06 54" src="https://user-images.githubusercontent.com/158411/81734936-968b3e80-9494-11ea-8746-264fc71edce2.png">
