### PR TITLE
feat(proxy): improve session

### DIFF
--- a/cypress/integration/identity_creation.spec.js
+++ b/cypress/integration/identity_creation.spec.js
@@ -26,7 +26,7 @@ context("identity creation", () => {
 
       // Confirmation screen
       // TODO(rudolfs): change the emoji once the backend returns the right one
-      cy.get('[data-cy="identity-card"] img[alt="🐽"]').should("exist");
+      cy.get('[data-cy="identity-card"] img[alt="🥌"]').should("exist");
       cy.get('[data-cy="identity-card"]')
         .contains("Rafalca Romney")
         .should("exist");
@@ -38,7 +38,7 @@ context("identity creation", () => {
       cy.get('[data-cy="go-to-profile-button"]').click();
       // TODO(rudolfs): change this to the actual handle that we
       // just created once the backend is wired up
-      cy.get('[data-cy="profile-avatar"]').contains("cloudhead");
+      cy.get('[data-cy="profile-avatar"]').contains("rafalca");
     });
 
     it("is possible to directly register your identity after creating it", () => {
@@ -51,9 +51,7 @@ context("identity creation", () => {
       cy.contains("Register your handle").should("exist");
 
       cy.get('[data-cy="cancel-button"]').click();
-      // TODO(rudolfs): change this to the actual handle that we
-      // just created once the backend is wired up
-      cy.get('[data-cy="profile-avatar"]').contains("cloudhead");
+      cy.get('[data-cy="profile-avatar"]').contains("rafalca");
     });
 
     context(
@@ -96,9 +94,7 @@ context("identity creation", () => {
 
           // Land on profile screen
           cy.get('[data-cy="modal-close-button"]').click();
-          // TODO(rudolfs): change this to the actual handle that we
-          // just created once the backend is wired up
-          cy.get('[data-cy="profile-avatar"]').contains("cloudhead");
+          cy.get('[data-cy="profile-avatar"]').contains("rafalca");
         });
       }
     );
@@ -118,9 +114,7 @@ context("identity creation", () => {
         cy.get("body").type("{esc}");
 
         // Land on profile screen
-        // TODO(rudolfs): change this to the actual handle that we
-        // just created once the backend is wired up
-        cy.get('[data-cy="profile-avatar"]').contains("cloudhead");
+        cy.get('[data-cy="profile-avatar"]').contains("rafalca");
       });
     });
   });

--- a/proxy/src/avatar.rs
+++ b/proxy/src/avatar.rs
@@ -9,6 +9,7 @@
 
 //! Org and user avatar generation.
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Emoji whitelist for all usages.
@@ -59,7 +60,7 @@ const EMOJIS_USER: &[&str] = &[
 ];
 
 /// An emoji.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Emoji(&'static str);
 
 impl fmt::Display for Emoji {
@@ -69,7 +70,8 @@ impl fmt::Display for Emoji {
 }
 
 /// Avatar usage.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Usage {
     /// A generic avatar.
     Any,
@@ -80,10 +82,11 @@ pub enum Usage {
 }
 
 /// An avatar.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Avatar {
     /// The emoji component.
-    pub emoji: Emoji,
+    pub emoji: String,
     /// The background color component.
     pub background: Color,
 }
@@ -93,14 +96,15 @@ impl Avatar {
     #[must_use]
     pub fn from(input: &str, usage: Usage) -> Self {
         Self {
-            emoji: generate_emoji(input, usage),
+            emoji: generate_emoji(input, usage).to_string(),
             background: compress_color(generate_color(input)),
         }
     }
 }
 
 /// A 32-bit RGBA color.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Color {
     /// The red channel.
     pub r: u8,
@@ -111,6 +115,7 @@ pub struct Color {
 
     /// The alpha is here to facilitate working with `u32` values.
     /// We don't use it as part of the output.
+    #[serde(skip)]
     a: u8,
 }
 
@@ -234,7 +239,7 @@ mod test {
         assert_eq!(
             Avatar::from("cloudhead", Usage::Identity),
             Avatar {
-                emoji: Emoji("🏍"),
+                emoji: "🏍".to_string(),
                 background: Color::new(24, 105, 216)
             }
         );

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -65,10 +65,13 @@ where
                 Arc::clone(&registry),
                 subscriptions.clone(),
             ))
-            .or(session::get_filter(Arc::clone(&registry), store))
+            .or(session::get_filter(
+                Arc::clone(&registry),
+                Arc::clone(&store),
+            ))
             .or(source::routes(librad_paths))
             .or(transaction::filters(Arc::clone(&registry)))
-            .or(user::routes(registry, subscriptions)),
+            .or(user::routes(registry, store, subscriptions)),
     );
     // let docs = path("docs").and(doc::filters(&api));
     let docs = path("docs").and(doc::index_filter().or(doc::describe_filter(&api)));

--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -156,7 +156,7 @@ mod handler {
     /// Reset the session state by clearing all buckets of the underlying store.
     pub async fn nuke_session(store: Arc<RwLock<Store>>) -> Result<impl Reply, Rejection> {
         let store = store.read().await;
-        session::clear(&store)?;
+        session::clear_current(&store)?;
 
         Ok(reply::json(&true))
     }

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -1,7 +1,6 @@
 //! Endpoints and serialisation for [`identity::Identity`] related types.
 
-use serde::ser::SerializeStruct as _;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use warp::document::{self, ToDocumentedType};
@@ -96,19 +95,13 @@ mod handler {
         let reg = registry.read().await;
         let store = store.read().await;
 
-        if let Some(identity) = session::get((*reg).clone(), &store).await?.identity {
+        if let Some(identity) = session::current(&store, (*reg).clone()).await?.identity {
             return Err(Rejection::from(error::Error::IdentityExists(identity.id)));
         }
 
         let id = identity::create(input.handle, input.display_name, input.avatar_url)?;
 
-        session::set(
-            &store,
-            session::Session {
-                identity: Some(id.clone()),
-                orgs: vec![],
-            },
-        )?;
+        session::set_identity(&store, id.clone())?;
 
         Ok(reply::with_status(reply::json(&id), StatusCode::CREATED))
     }
@@ -128,28 +121,6 @@ mod handler {
         };
 
         Ok(reply::json(&id))
-    }
-}
-
-impl Serialize for identity::Identity {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Identity", 4)?;
-        state.serialize_field("id", &self.id)?;
-        state.serialize_field(
-            "shareableEntityIdentifier",
-            &self.shareable_entity_identifier,
-        )?;
-        state.serialize_field("metadata", &self.metadata)?;
-        state.serialize_field(
-            "registered",
-            &self.registered.as_ref().map(ToString::to_string),
-        )?;
-        state.serialize_field("avatarFallback", &self.avatar_fallback)?;
-
-        state.end()
     }
 }
 
@@ -182,20 +153,6 @@ impl ToDocumentedType for identity::Identity {
     }
 }
 
-impl Serialize for identity::Metadata {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Metadata", 3)?;
-        state.serialize_field("handle", &self.handle)?;
-        state.serialize_field("displayName", &self.display_name)?;
-        state.serialize_field("avatarUrl", &self.avatar_url)?;
-
-        state.end()
-    }
-}
-
 impl ToDocumentedType for identity::Metadata {
     fn document() -> document::DocumentedType {
         let mut properties = std::collections::HashMap::with_capacity(3);
@@ -225,19 +182,6 @@ impl ToDocumentedType for identity::Metadata {
     }
 }
 
-impl Serialize for avatar::Avatar {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Avatar", 2)?;
-        state.serialize_field("background", &self.background)?;
-        state.serialize_field("emoji", &self.emoji.to_string())?;
-
-        state.end()
-    }
-}
-
 #[allow(clippy::non_ascii_literal)]
 impl ToDocumentedType for avatar::Avatar {
     fn document() -> document::DocumentedType {
@@ -252,20 +196,6 @@ impl ToDocumentedType for avatar::Avatar {
 
         document::DocumentedType::from(properties)
             .description("Generated avatar based on unique information")
-    }
-}
-
-impl Serialize for avatar::Color {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Color", 3)?;
-        state.serialize_field("r", &self.r)?;
-        state.serialize_field("g", &self.g)?;
-        state.serialize_field("b", &self.b)?;
-
-        state.end()
     }
 }
 
@@ -373,13 +303,13 @@ mod test {
         let want = json!({
             "avatarFallback": {
                 "background": {
-                    "r": 122,
-                    "g": 112,
-                    "b": 90,
+                    "r": 52,
+                    "g": 124,
+                    "b": 239,
                 },
-                "emoji": "🐽",
+                "emoji": "🍝",
             },
-            "id": "123abcd.git",
+            "id": "cloudhead@123abcd.git",
             "metadata": {
                 "avatarUrl": "https://avatars1.githubusercontent.com/u/40774",
                 "displayName": "Alexis Sellier",

--- a/proxy/src/http/session.rs
+++ b/proxy/src/http/session.rs
@@ -1,7 +1,5 @@
 //! Endpoints and serialisation for [`session::Session`] related types.
 
-use serde::ser::SerializeStruct as _;
-use serde::{Serialize, Serializer};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use warp::document::{self, ToDocumentedType};
@@ -52,22 +50,9 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let store = store.read().await;
         let reg = registry.read().await;
-        let sess = session::get((*reg).clone(), &store).await?;
+        let sess = session::current(&store, (*reg).clone()).await?;
 
         Ok(reply::json(&sess))
-    }
-}
-
-impl Serialize for session::Session {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Session", 1)?;
-        state.serialize_field("identity", &self.identity)?;
-        state.serialize_field("orgs", &self.orgs)?;
-
-        state.end()
     }
 }
 

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -1,12 +1,15 @@
 //! Container to bundle and associate information around an identity.
 
+use serde::{Deserialize, Serialize};
+
 use crate::avatar;
 use crate::error;
 use crate::registry;
 use std::convert::TryFrom;
 
 /// The users personal identifying metadata and keys.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Identity {
     /// The librad id.
     pub id: String,
@@ -21,7 +24,8 @@ pub struct Identity {
 }
 
 /// User maintained information for an identity, which can evolve over time.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Metadata {
     /// Similar to a nickname, the users chosen short identifier.
     pub handle: String,
@@ -39,17 +43,17 @@ pub fn create(
     display_name: Option<String>,
     avatar_url: Option<String>,
 ) -> Result<Identity, error::Error> {
-    let id = "123abcd.git";
+    let id = format!("{}@123abcd.git", handle);
     Ok(Identity {
-        id: id.into(),
-        shareable_entity_identifier: format!("{}@123abcd.git", handle),
+        id: id.clone(),
+        shareable_entity_identifier: id.clone(),
         metadata: Metadata {
             handle,
             display_name,
             avatar_url,
         },
         registered: None,
-        avatar_fallback: avatar::Avatar::from(id, avatar::Usage::Identity),
+        avatar_fallback: avatar::Avatar::from(&id, avatar::Usage::Identity),
     })
 }
 

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -164,8 +164,8 @@ where
         self.client.get_org(id).await
     }
 
-    async fn list_orgs(&self, user_id: String) -> Result<Vec<registry::Org>, error::Error> {
-        self.client.list_orgs(user_id).await
+    async fn list_orgs(&self, handle: registry::Id) -> Result<Vec<registry::Org>, error::Error> {
+        self.client.list_orgs(handle).await
     }
 
     async fn register_org(
@@ -228,14 +228,14 @@ where
         Ok(tx)
     }
 
-    async fn get_user(&self, handle: String) -> Result<Option<registry::User>, error::Error> {
+    async fn get_user(&self, handle: registry::Id) -> Result<Option<registry::User>, error::Error> {
         self.client.get_user(handle).await
     }
 
     async fn register_user(
         &mut self,
         author: &protocol::ed25519::Pair,
-        handle: String,
+        handle: registry::Id,
         id: Option<String>,
         fee: protocol::Balance,
     ) -> Result<Transaction, error::Error> {

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -1,15 +1,20 @@
 //! Management of local session state like the currently used identity, wallet related data and
 //! configuration of all sorts.
 
+use serde::{Deserialize, Serialize};
+
 use crate::error;
 use crate::identity;
 use crate::registry;
 
 /// Name for the storage bucket used for all session data.
 const BUCKET_NAME: &str = "session";
+/// Name of the item used for the currently active session.
+const KEY_CURRENT: &str = "current";
 
 /// Container for all local state.
-#[derive(Debug)]
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Session {
     /// The currently used [`identity::Identity`].
     pub identity: Option<identity::Identity>,
@@ -22,10 +27,10 @@ pub struct Session {
 /// # Errors
 ///
 /// Errors if the state on disk can't be accessed.
-pub fn clear(store: &kv::Store) -> Result<(), error::Error> {
+pub fn clear_current(store: &kv::Store) -> Result<(), error::Error> {
     Ok(store
-        .bucket::<kv::Raw, String>(Some(BUCKET_NAME))?
-        .clear()?)
+        .bucket::<&str, kv::Json<Session>>(Some(BUCKET_NAME))?
+        .remove(KEY_CURRENT)?)
 }
 
 /// Reads the current session.
@@ -34,33 +39,70 @@ pub fn clear(store: &kv::Store) -> Result<(), error::Error> {
 ///
 /// Errors if access to the session state fails, or associated data like the [`identity::Identity`]
 /// can't be found.
-pub async fn get<R: registry::Client>(
-    registry: R,
+pub async fn current<R: registry::Client>(
     store: &kv::Store,
+    registry: R,
 ) -> Result<Session, error::Error> {
-    let bucket = store.bucket::<&str, String>(Some(BUCKET_NAME))?;
+    let mut session = get(store, KEY_CURRENT)?;
 
-    let identity = bucket
-        .get("identity")?
-        .and_then(|id| identity::get(id.as_ref()).expect("unable to retrieve identity"));
-    // TODO(xla): Get actual attested handle from identity metadata. Alternatively use the stored
-    // keypair of the current session to find the associated user and look it up that way.
-    let orgs = registry.list_orgs("".to_string()).await?;
+    if let Some(mut id) = session.identity.clone() {
+        if let Some(handle) = id.registered.clone() {
+            if registry.get_user(handle.clone()).await?.is_some() {
+                session.orgs = registry.list_orgs(handle).await?;
+            } else {
+                id.registered = None;
+                session.identity = Some(id);
+            }
+        }
+    }
 
-    Ok(Session { identity, orgs })
+    Ok(session)
 }
 
-/// Stores the Session in its entirety.
+/// Stores the [`registry::Id`] for the registered user handle in the current session.
 ///
 /// # Errors
 ///
 /// Errors if access to the session state fails.
-pub fn set(store: &kv::Store, sess: Session) -> Result<(), error::Error> {
-    let bucket = store.bucket::<&str, String>(Some(BUCKET_NAME))?;
+pub fn set_handle(store: &kv::Store, handle: registry::Id) -> Result<(), error::Error> {
+    let sess = get(store, KEY_CURRENT)?;
+    let registered = sess.identity.map(|mut id| {
+        id.registered = Some(handle);
+        id
+    });
 
-    if let Some(identity) = sess.identity {
-        bucket.set("identity", identity.id)?;
+    if let Some(id) = registered {
+        set_identity(store, id)
+    } else {
+        Ok(())
     }
+}
 
-    Ok(())
+/// Stores the [`identity::Identity`] in the current session.
+///
+/// # Errors
+///
+/// Errors if access to the session state fails, or associated data like the [`identity::Identity`]
+/// can't be found.
+pub fn set_identity(store: &kv::Store, id: identity::Identity) -> Result<(), error::Error> {
+    let mut sess = get(store, KEY_CURRENT)?;
+    sess.identity = Some(id);
+
+    set(store, KEY_CURRENT, sess)
+}
+
+/// Fetches the session for the given item key.
+fn get(store: &kv::Store, key: &str) -> Result<Session, error::Error> {
+    Ok(store
+        .bucket::<&str, kv::Json<Session>>(Some(BUCKET_NAME))?
+        .get(key)?
+        .map(kv::Codec::to_inner)
+        .unwrap_or_default())
+}
+
+/// Stores the session for the given item key.
+fn set(store: &kv::Store, key: &str, sess: Session) -> Result<(), error::Error> {
+    Ok(store
+        .bucket::<&str, kv::Json<Session>>(Some(BUCKET_NAME))?
+        .set(key, kv::Json(sess))?)
 }

--- a/ui/Screen/UserRegistration.svelte
+++ b/ui/Screen/UserRegistration.svelte
@@ -4,6 +4,7 @@
 
   import { fallback } from "../src/identity.ts";
   import * as notification from "../src/notification.ts";
+  import * as session from "../src/session.ts";
   import * as user from "../src/user.ts";
 
   import { ModalLayout, StepCounter } from "../DesignSystem/Component";
@@ -12,19 +13,13 @@
   import PickHandleStep from "./UserRegistration/PickHandleStep.svelte";
   import SubmitRegistrationStep from "./UserRegistration/SubmitRegistrationStep.svelte";
 
-  const session = getContext("session");
+  let { identity } = getContext("session");
+
+  let handle = identity ? identity.metadata.handle : null;
+  const id = identity ? identity.id : null;
+  identity = identity ? identity : fallback;
 
   let step = 1;
-
-  let identity = fallback;
-  let handle = null;
-  let id = null;
-
-  if (session.identity !== null) {
-    identity = session.identity;
-    handle = session.identity.metadata.handle;
-    id = session.identity.id;
-  }
 
   const nextStep = () => {
     step += 1;
@@ -37,6 +32,7 @@
   const registerUser = async () => {
     try {
       await user.register(handle, id);
+      await session.fetch();
     } catch (error) {
       notification.error(`Could not register user: ${error}`);
     } finally {


### PR DESCRIPTION
Addresses the sub-optimal session handling, by actually serialising the
object itself into the store. This allows us to also keep the user
handle that was registered around and feed it to the org listing. That
means that all workflows that require local understanding of what
Registry entities are associated with the current session should work.

* serialise session object into store
* store registered user handle in session
* use user handle to query session org list
* improve internal registry API type coherence
* put a bunch of serialisations in the right place

Fixes #378