### PR TITLE
feat(proxy): extend session with settings

### DIFF
--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -65,10 +65,7 @@ where
                 Arc::clone(&registry),
                 subscriptions.clone(),
             ))
-            .or(session::get_filter(
-                Arc::clone(&registry),
-                Arc::clone(&store),
-            ))
+            .or(session::routes(Arc::clone(&registry), Arc::clone(&store)))
             .or(source::routes(librad_paths))
             .or(transaction::filters(Arc::clone(&registry)))
             .or(user::routes(registry, store, subscriptions)),

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -14,7 +14,7 @@ use crate::notification;
 use crate::project;
 use crate::registry;
 
-/// Prefixed filters..
+/// Prefixed filters.
 pub fn routes<R: registry::Client>(
     paths: Arc<RwLock<Paths>>,
     registry: http::Shared<R>,

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -33,7 +33,7 @@ fn create_filter(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("projects")
         .and(warp::post())
-        .and(super::with_paths(paths))
+        .and(http::with_paths(paths))
         .and(warp::body::json())
         .and(document::document(document::description(
             "Create a new project",
@@ -58,7 +58,7 @@ fn get_filter(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path("projects")
         .and(warp::get())
-        .and(super::with_paths(paths))
+        .and(http::with_paths(paths))
         .and(document::param::<String>("id", "Project id"))
         .and(document::document(document::description(
             "Find Project by ID",
@@ -87,7 +87,7 @@ fn list_filter(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("projects")
         .and(warp::get())
-        .and(super::with_paths(paths))
+        .and(http::with_paths(paths))
         .and(document::document(document::description("List projects")))
         .and(document::document(document::tag("Project")))
         .and(document::document(

--- a/proxy/src/http/session.rs
+++ b/proxy/src/http/session.rs
@@ -1,5 +1,6 @@
 //! Endpoints and serialisation for [`session::Session`] related types.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use warp::document::{self, ToDocumentedType};
@@ -10,13 +11,30 @@ use crate::identity;
 use crate::registry;
 use crate::session;
 
+/// Prefixed fitlers.
+pub fn routes<R: registry::Client>(
+    registry: http::Shared<R>,
+    store: Arc<RwLock<kv::Store>>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path("session").and(get_filter(registry, Arc::clone(&store)).or(update_settings_filter(store)))
+}
+
+/// Combination of all session filters.
+#[cfg(test)]
+pub fn filters<R: registry::Client>(
+    registry: http::Shared<R>,
+    store: Arc<RwLock<kv::Store>>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    get_filter(registry, Arc::clone(&store)).or(update_settings_filter(store))
+}
+
 /// `GET /`
 pub fn get_filter<R: registry::Client>(
     registry: http::Shared<R>,
     store: Arc<RwLock<kv::Store>>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    path("session")
-        .and(warp::get())
+    warp::get()
+        .and(path::end())
         .and(http::with_shared(registry))
         .and(http::with_store(store))
         .and(document::document(document::description(
@@ -33,10 +51,28 @@ pub fn get_filter<R: registry::Client>(
         .and_then(handler::get)
 }
 
+/// `Post /settings`
+pub fn update_settings_filter(
+    store: Arc<RwLock<kv::Store>>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path("settings")
+        .and(warp::post())
+        .and(path::end())
+        .and(http::with_store(store))
+        .and(warp::body::json())
+        .and(document::document(document::description("Update settings")))
+        .and(document::document(document::tag("Session")))
+        .and(document::document(
+            document::response(204, None).description("Settings successfully updated"),
+        ))
+        .and_then(handler::update_settings)
+}
+
 /// Session handlers for conversion between core domain and HTTP request fullfilment.
 mod handler {
     use std::sync::Arc;
     use tokio::sync::RwLock;
+    use warp::http::StatusCode;
     use warp::{reply, Rejection, Reply};
 
     use crate::http;
@@ -54,18 +90,77 @@ mod handler {
 
         Ok(reply::json(&sess))
     }
+
+    /// Set the [`session::settings::Settings`] to the passed value.
+    pub async fn update_settings(
+        store: Arc<RwLock<kv::Store>>,
+        settings: session::settings::Settings,
+    ) -> Result<impl Reply, Rejection> {
+        let store = store.read().await;
+        session::set_settings(&store, settings)?;
+
+        Ok(reply::with_status(reply(), StatusCode::NO_CONTENT))
+    }
 }
 
 impl ToDocumentedType for session::Session {
     fn document() -> document::DocumentedType {
-        let mut properties = std::collections::HashMap::with_capacity(1);
+        let mut properties = HashMap::with_capacity(1);
         properties.insert(
             "identity".into(),
             identity::Identity::document().nullable(true),
         );
         properties.insert("orgs".into(), document::array(registry::Org::document()));
+        properties.insert("settings".into(), session::settings::Settings::document());
 
         document::DocumentedType::from(properties).description("Session")
+    }
+}
+
+impl ToDocumentedType for session::settings::Settings {
+    fn document() -> document::DocumentedType {
+        let mut properties = HashMap::with_capacity(2);
+        properties.insert(
+            "appearance".into(),
+            session::settings::Appearance::document(),
+        );
+        properties.insert("registry".into(), session::settings::Registry::document());
+
+        document::DocumentedType::from(properties).description("Settings")
+    }
+}
+
+impl ToDocumentedType for session::settings::Appearance {
+    fn document() -> document::DocumentedType {
+        let mut properties = HashMap::with_capacity(1);
+        properties.insert("theme".into(), session::settings::Theme::document());
+
+        document::DocumentedType::from(properties).description("Appearance")
+    }
+}
+
+impl ToDocumentedType for session::settings::Theme {
+    fn document() -> document::DocumentedType {
+        document::enum_string(vec!["dark".into(), "light".into()])
+            .description("Variants for possible color schemes.")
+            .example("dark")
+    }
+}
+
+impl ToDocumentedType for session::settings::Registry {
+    fn document() -> document::DocumentedType {
+        let mut properties = HashMap::with_capacity(1);
+        properties.insert("network".into(), session::settings::Network::document());
+
+        document::DocumentedType::from(properties).description("Registry")
+    }
+}
+
+impl ToDocumentedType for session::settings::Network {
+    fn document() -> document::DocumentedType {
+        document::enum_string(vec!["emulator".into(), "ffnet".into(), "testnet".into()])
+            .description("Variants for possible networks of the Registry to connect to.")
+            .example("testnet")
     }
 }
 
@@ -80,18 +175,19 @@ mod test {
     use warp::test::request;
 
     use crate::registry;
+    use crate::session;
 
     #[tokio::test]
     async fn get() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let registry = registry::Registry::new(radicle_registry_client::Client::new_emulator());
         let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store"))).unwrap();
-        let api = super::get_filter(
+        let api = super::filters(
             Arc::new(RwLock::new(registry)),
             Arc::new(RwLock::new(store)),
         );
 
-        let res = request().method("GET").path("/session").reply(&api).await;
+        let res = request().method("GET").path("/").reply(&api).await;
 
         let have: Value = serde_json::from_slice(res.body()).unwrap();
 
@@ -101,6 +197,55 @@ mod test {
             json!({
                 "identity": Value::Null,
                 "orgs": [],
+                "settings": {
+                    "appearance": {
+                        "theme": "light",
+                    },
+                    "registry": {
+                        "network": "emulator",
+                    },
+                },
+            }),
+        );
+    }
+
+    #[tokio::test]
+    async fn udpate_settings() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let registry = registry::Registry::new(radicle_registry_client::Client::new_emulator());
+        let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store"))).unwrap();
+        let api = super::filters(
+            Arc::new(RwLock::new(registry)),
+            Arc::new(RwLock::new(store)),
+        );
+
+        let mut settings = session::settings::Settings::default();
+        settings.appearance.theme = session::settings::Theme::Dark;
+
+        let res = request()
+            .method("POST")
+            .path("/settings")
+            .json(&settings)
+            .reply(&api)
+            .await;
+
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+        let res = request().method("GET").path("/").reply(&api).await;
+        let have: Value = serde_json::from_slice(res.body()).unwrap();
+        assert_eq!(
+            have,
+            json!({
+                "identity": Value::Null,
+                "orgs": [],
+                "settings": {
+                    "appearance": {
+                        "theme": "dark",
+                    },
+                    "registry": {
+                        "network": "emulator",
+                    },
+                },
             }),
         );
     }

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -43,7 +43,7 @@
       break;
 
     case remote.Status.Error:
-      console.log($store.error);
+      console.error($store.error);
       notification.error("Session could not be fetched");
       break;
   }

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -3,11 +3,14 @@ import * as event from "./event";
 import * as identity from "./identity";
 import * as org from "./org";
 import * as remote from "./remote";
+import * as settings from "./settings";
 
 // TYPES
+
 export interface Session {
   identity?: identity.Identity;
   orgs: org.Org[];
+  settings: settings.Settings;
 }
 
 // STATE

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -1,0 +1,23 @@
+export enum Theme {
+  Dark = "dark",
+  Light = "light",
+}
+
+export interface Appearance {
+  theme: Theme;
+}
+
+export enum Network {
+  Emulator = "emulator",
+  FFnet = "ffnet",
+  Testnet = "testnet",
+}
+
+export interface Registry {
+  network: Network;
+}
+
+export interface Settings {
+  appearance: Appearance;
+  registry: Registry;
+}


### PR DESCRIPTION
In preparation of a range of user controlled parameters this change
extends the session with settings and the ability to update said
settings. Currently we only accept the entire settings struct to be
updated. In the future we'll likely allow more granular updates.

* add `Settings` to session
* add endpoint to update settings

Ref #128 
Ref #375