### PR TITLE
feat: shareable entity identifiers

### DIFF
--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -116,7 +116,8 @@ mod handler {
 
         Ok(reply::with_status(
             reply::json(&project::Project {
-                id: librad::project::ProjectId::from(id),
+                id: librad::project::ProjectId::from(id.clone()),
+                shareable_entity_identifier: format!("%{}", id),
                 metadata: meta.into(),
                 registration: None,
                 stats: project::Stats {

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -146,7 +146,7 @@ impl ToDocumentedType for identity::Identity {
             "shareableEntityIdentifier".into(),
             document::string()
                 .description("Unique identifier that can be shared and looked up")
-                .example("upstream://coco/identity/cloudhead@123abcd.git"),
+                .example("cloudhead@123abcd.git"),
         );
 
         document::DocumentedType::from(properties).description("Unique identity")

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -211,7 +211,11 @@ mod handler {
             let org_project = super::Project {
                 name: p.name.to_string(),
                 org_id: p.org_id.to_string(),
-                shareable_entity_identifier: format!("%{}/{}", p.org_id.to_string(), p.name.to_string()),
+                shareable_entity_identifier: format!(
+                    "%{}/{}",
+                    p.org_id.to_string(),
+                    p.name.to_string()
+                ),
                 maybe_project,
             };
             mapped_projects.push(org_project);

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -211,6 +211,7 @@ mod handler {
             let org_project = super::Project {
                 name: p.name.to_string(),
                 org_id: p.org_id.to_string(),
+                shareable_entity_identifier: format!("%{}/{}", p.org_id.to_string(), p.name.to_string()),
                 maybe_project,
             };
             mapped_projects.push(org_project);
@@ -252,6 +253,12 @@ impl ToDocumentedType for registry::Org {
                 .example("monadic"),
         );
         properties.insert(
+            "shareableEntityIdentifier".into(),
+            document::string()
+                .description("Unique identifier that can be shared and looked up")
+                .example("%monadic"),
+        );
+        properties.insert(
             "members".into(),
             document::array(registry::User::document()),
         );
@@ -290,6 +297,12 @@ impl ToDocumentedType for registry::Project {
                 .example("radicle"),
         );
         properties.insert(
+            "shareableEntityIdentifier".into(),
+            document::string()
+                .description("Unique identifier that can be shared and looked up")
+                .example("%monadic/radicle-link"),
+        );
+        properties.insert(
             "maybeProjectId".into(),
             document::string()
                 .description("The id project attested in coco")
@@ -307,6 +320,8 @@ impl ToDocumentedType for registry::Project {
 pub struct Project {
     /// Id of the Org.
     org_id: String,
+    /// Unambiguous identifier pointing at this identity.
+    shareable_entity_identifier: String,
     /// Name of the project.
     name: String,
     /// Associated CoCo project.
@@ -413,6 +428,7 @@ mod test {
             have,
             json!(registry::Org {
                 id: "monadic".to_string(),
+                shareable_entity_identifier: "%monadic".to_string(),
                 avatar_fallback: avatar::Avatar::from("monadic", avatar::Usage::Org),
                 members: vec![user]
             })
@@ -566,6 +582,7 @@ mod test {
         let want = json!([{
             "name": project_name.to_string(),
             "orgId": org_id.to_string(),
+            "shareableEntityIdentifier": format!("%{}/{}", org_id.to_string(), project_name.to_string()),
             "maybeProject": {
                 "id": project_id.to_string(),
                 "metadata": {
@@ -574,6 +591,7 @@ mod test {
                     "name": project_name.to_string(),
                 },
                 "registration": Value::Null,
+                "shareableEntityIdentifier": format!("%{}", project_id.to_string()),
                 "stats": {
                     "branches": 11,
                     "commits": 267,

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -256,7 +256,10 @@ impl Serialize for project::Project {
     {
         let mut state = serializer.serialize_struct("Project", 4)?;
         state.serialize_field("id", &self.id.to_string())?;
-        state.serialize_field("shareableEntityIdentifier", &self.shareable_entity_identifier.to_string())?;
+        state.serialize_field(
+            "shareableEntityIdentifier",
+            &self.shareable_entity_identifier.to_string(),
+        )?;
         state.serialize_field("metadata", &self.metadata)?;
         state.serialize_field("registration", &self.registration)?;
         state.serialize_field("stats", &self.stats)?;
@@ -621,7 +624,7 @@ mod test {
         let projects = coco::list_projects(&librad_paths)
             .into_iter()
             .map(|(id, meta)| project::Project {
-                id:id.clone(),
+                id: id.clone(),
                 shareable_entity_identifier: format!("%{}", id),
                 metadata: meta.into(),
                 registration: None,

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -172,7 +172,8 @@ mod handler {
 
         Ok(reply::with_status(
             reply::json(&project::Project {
-                id: librad::project::ProjectId::from(id),
+                id: librad::project::ProjectId::from(id.clone()),
+                shareable_entity_identifier: format!("%{}", id),
                 metadata: meta.into(),
                 registration: None,
                 stats: project::Stats {
@@ -200,7 +201,8 @@ mod handler {
         let projects = coco::list_projects(&paths)
             .into_iter()
             .map(|(id, meta)| project::Project {
-                id,
+                id: id.clone(),
+                shareable_entity_identifier: format!("%{}", id),
                 metadata: meta.into(),
                 registration: None,
                 stats: project::Stats {
@@ -254,6 +256,7 @@ impl Serialize for project::Project {
     {
         let mut state = serializer.serialize_struct("Project", 4)?;
         state.serialize_field("id", &self.id.to_string())?;
+        state.serialize_field("shareableEntityIdentifier", &self.shareable_entity_identifier.to_string())?;
         state.serialize_field("metadata", &self.metadata)?;
         state.serialize_field("registration", &self.registration)?;
         state.serialize_field("stats", &self.stats)?;
@@ -269,6 +272,12 @@ impl ToDocumentedType for project::Project {
             document::string()
                 .description("ID of the project")
                 .example("ac1cac587b49612fbac39775a07fb05c6e5de08d.git"),
+        );
+        properties.insert(
+            "shareableEntityIdentifier".into(),
+            document::string()
+                .description("Unique identifier that can be shared and looked up")
+                .example("%123abcd.git"),
         );
         properties.insert("metadata".into(), project::Metadata::document());
         properties.insert("registration".into(), project::Registration::document());
@@ -551,6 +560,7 @@ mod test {
                 "name": "Upstream",
             },
             "registration": Value::Null,
+            "shareableEntityIdentifier": format!("%{}", id.to_string()),
             "stats": {
                 "branches": 11,
                 "commits": 267,
@@ -611,7 +621,8 @@ mod test {
         let projects = coco::list_projects(&librad_paths)
             .into_iter()
             .map(|(id, meta)| project::Project {
-                id,
+                id:id.clone(),
+                shareable_entity_identifier: format!("%{}", id),
                 metadata: meta.into(),
                 registration: None,
                 stats: project::Stats {

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -338,6 +338,7 @@ mod test {
             have,
             json!([registry::Org {
                 id: "monadic".to_string(),
+                shareable_entity_identifier: "%monadic".to_string(),
                 avatar_fallback: avatar::Avatar::from("monadic", avatar::Usage::Org),
                 members: vec![user]
             }])

--- a/proxy/src/project.rs
+++ b/proxy/src/project.rs
@@ -36,6 +36,8 @@ impl From<meta::Project> for Metadata {
 pub struct Project {
     /// Unique identifier of the project in the network.
     pub id: project::ProjectId,
+    /// Unambiguous identifier pointing at this identity.
+    pub shareable_entity_identifier: String,
     /// Attached metadata, mostly for human pleasure.
     pub metadata: Metadata,
     /// Informs if the project is present in the Registry and under what top-level entity it can be
@@ -70,6 +72,7 @@ pub async fn get(paths: &librad::paths::Paths, id: &str) -> Result<Project, erro
 
     Ok(Project {
         id: librad::project::ProjectId::from_str(id)?,
+        shareable_entity_identifier: format!("%{}", id),
         metadata: meta.into(),
         registration: None,
         stats: Stats {

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -173,6 +173,8 @@ pub struct Thresholds {
 pub struct Org {
     /// The unique identifier of the org
     pub id: String,
+    /// Unambiguous identifier pointing at this identity.
+    pub shareable_entity_identifier: String,
     /// Generated fallback avatar
     pub avatar_fallback: avatar::Avatar,
     /// List of members of the org
@@ -355,6 +357,7 @@ impl Client for Registry {
             }
             Ok(Some(Org {
                 id: id.clone(),
+                shareable_entity_identifier: format!("%{}", id.clone()),
                 avatar_fallback: avatar::Avatar::from(&id, avatar::Usage::Org),
                 members,
             }))

--- a/ui/Screen/Org.svelte
+++ b/ui/Screen/Org.svelte
@@ -102,7 +102,7 @@
         <AdditionalActionsDropdown
           dataCy="context-menu"
           style="margin: 0 24px 0 16px"
-          headerTitle={params.id}
+          headerTitle={org.shareableEntityIdentifier}
           menuItems={dropdownMenuItems} />
       </div>
     </Topbar>

--- a/ui/Screen/Org/Projects.svelte
+++ b/ui/Screen/Org/Projects.svelte
@@ -65,7 +65,8 @@
 
           <div slot="right" style="display: flex; align-items: center;">
             <Stats stats={statsProps(orgProject.maybeProject.stats)} />
-            <AdditionalActionsDropdown headerTitle={orgProject.name} />
+            <AdditionalActionsDropdown
+              headerTitle={orgProject.shareableEntityIdentifier} />
           </div>
         </Flex>
       {:else}
@@ -76,7 +77,8 @@
             <ProjectCard {...projectCardProps(orgProject)} />
           </div>
           <div slot="right" style="display: flex; align-items: center;">
-            <AdditionalActionsDropdown headerTitle={orgProject.name} />
+            <AdditionalActionsDropdown
+              headerTitle={orgProject.shareableEntityIdentifier} />
           </div>
         </Flex>
       {/if}

--- a/ui/Screen/Profile/Projects.svelte
+++ b/ui/Screen/Profile/Projects.svelte
@@ -83,7 +83,7 @@
           <Stats stats={statsProps(project.stats)} />
           <AdditionalActionsDropdown
             dataCy="context-menu"
-            headerTitle={project.id}
+            headerTitle={project.shareableEntityIdentifier}
             menuItems={contextMenuItems(project.id, session)} />
         </div>
       </Flex>

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -130,7 +130,7 @@
         <AdditionalActionsDropdown
           dataCy="context-menu"
           style="margin: 0 24px 0 16px"
-          headerTitle={params.id}
+          headerTitle={project.shareableEntityIdentifier}
           menuItems={dropdownMenuItems} />
       </div>
     </Topbar>

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -145,7 +145,7 @@
     <div class="project-id">
       <Code>
         <Copyable {afterCopy}>
-          %{project.id}
+          {project.shareableEntityIdentifier}
           <svelte:component this={copyIcon} style="vertical-align: bottom" />
         </Copyable>
       </Code>

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -10,12 +10,14 @@ import * as user from "./user";
 // Types
 export interface Org {
   name: string;
+  shareableEntityIdentifier: string;
   avatarFallback: avatar.EmojiAvatar;
 }
 
 export interface Project {
   name: string;
   orgId: string;
+  shareableEntityIdentifier: string;
   maybeProject: project.Project;
 }
 

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -20,6 +20,7 @@ interface Stats {
 
 export interface Project {
   id: string;
+  shareableEntityIdentifier: string;
   metadata: Metadata;
   registration: string; // TODO(rudolfs): what will this type be?
   stats: Stats;


### PR DESCRIPTION
This adds the shareable entity identifiers to all endpoints.

Refs: #175, #270

- profile projects screen (for unregistered projects)
<img width="50%" alt="Screenshot 2020-05-14 at 18 06 42" src="https://user-images.githubusercontent.com/158411/81958422-46d08280-960e-11ea-8e13-4e2f2c3b1e82.png">

- project screen (for unregistered project)
<img width="50%" alt="Screenshot 2020-05-14 at 18 06 54" src="https://user-images.githubusercontent.com/158411/81958427-489a4600-960e-11ea-8563-944a74cf3f13.png">

- org screen
<img width="50%" alt="Screenshot 2020-05-14 at 18 07 35" src="https://user-images.githubusercontent.com/158411/81958429-49cb7300-960e-11ea-852e-b4423418c2aa.png">

- org projects screen
<img width="50%" alt="Screenshot 2020-05-14 at 18 07 52" src="https://user-images.githubusercontent.com/158411/81958430-49cb7300-960e-11ea-8ecf-594b17fb3350.png">

