### PR TITLE
fix(ui): show the correct avatars in summary pages

### DIFF
--- a/ui/Screen/OrgRegistration.svelte
+++ b/ui/Screen/OrgRegistration.svelte
@@ -43,7 +43,7 @@
             ],
           };
           subject = formatSubject(
-            $session.data.identity,
+            { avatarFallback: avatarFallback, metadata: { avatarUrl: null } },
             transaction.messages[0]
           );
           payer = formatPayer($session.data.identity);

--- a/ui/Screen/ProjectRegistration/RegistrationDetailsStep.svelte
+++ b/ui/Screen/ProjectRegistration/RegistrationDetailsStep.svelte
@@ -43,7 +43,7 @@
       variant: "circle",
       title: session.identity.metadata.handle,
       avatarFallback: session.identity.avatarFallback,
-      imageUrl: session.identity.imageUrl,
+      imageUrl: session.identity.metadata.avatarUrl,
     },
   };
 

--- a/ui/Screen/ProjectRegistration/RegistrationDetailsStep.svelte
+++ b/ui/Screen/ProjectRegistration/RegistrationDetailsStep.svelte
@@ -5,6 +5,7 @@
 
   import * as notification from "../../src/notification.ts";
   import * as project from "../../src/project.ts";
+  import * as transaction from "../../src/transaction.ts";
 
   import { Text, Title, Input } from "../../DesignSystem/Primitive";
   import { Dropdown, NavigationButtons } from "../../DesignSystem/Component";
@@ -26,7 +27,10 @@
       registrarHandle: selectedRegistrar().avatarProps.title,
       registrarImageUrl: selectedRegistrar().avatarProps.imageUrl,
       registrarAvatarFallback: selectedRegistrar().avatarProps.avatarFallback,
-      registrarVariant: selectedRegistrar().avatarProps.variant,
+      registrarVariant:
+        selectedRegistrar().avatarProps.variant === "circle"
+          ? transaction.Variant.User
+          : transaction.Variant.Org,
     });
   };
 


### PR DESCRIPTION
- Register Org
subject: `org-emoji` `org-name`
paid by: `identity-emoji` `identity-name`
<img width="50%" alt="Screenshot 2020-05-15 at 18 12 21" src="https://user-images.githubusercontent.com/158411/82072256-b494b100-96d7-11ea-8867-137d738927c9.png">

- Register Project under User (with avatar URL)
subject: `identity-emoji` `identity-name` / `project-name`
paid by: `identity-emoji` `identity-name`
<img width="50%" alt="Screenshot 2020-05-15 at 18 10 29" src="https://user-images.githubusercontent.com/158411/82072252-b2325700-96d7-11ea-995d-1829ab9bf664.png">

- Register Project under User (without avatar URL)
subject: `identity-emoji` `identity-name` / `project-name`
paid by: `identity-emoji` `identity-name`
<img width="50%" alt="Screenshot 2020-05-15 at 18 11 41" src="https://user-images.githubusercontent.com/158411/82072253-b3638400-96d7-11ea-940b-626b72f0ab75.png">

- Register Project under Org
subject: `org-emoji` `org-name` / `project-name`
paid by: `identity-emoji` `identity-name`
<img width="50%" alt="Screenshot 2020-05-15 at 18 10 11" src="https://user-images.githubusercontent.com/158411/82072244-afcffd00-96d7-11ea-9929-4547e1fa5735.png">