### PR TITLE
style(ui): fix revision selector background

### DIFF
--- a/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
@@ -71,7 +71,7 @@
   }
   .revision-dropdown {
     position: relative;
-    background: white;
+    background: var(--color-background);
     border: 1px solid var(--color-foreground-level-3);
     border-radius: 4px;
     box-shadow: var(--elevation-medium),


### PR DESCRIPTION
Before:
<img width="50%" alt="Screenshot 2020-05-16 at 10 43 19" src="https://user-images.githubusercontent.com/158411/82183547-7b7e5b80-98e6-11ea-82fa-7cd6f754c1a0.png">

After:
<img width="50%" alt="Screenshot 2020-05-16 at 10 43 37" src="https://user-images.githubusercontent.com/158411/82183548-7d481f00-98e6-11ea-9c58-0ca6a0e98a8c.png">
<img width="50%" alt="Screenshot 2020-05-16 at 10 43 45" src="https://user-images.githubusercontent.com/158411/82183551-7e794c00-98e6-11ea-9979-fabc02b2c7bd.png">
