### PR TITLE
Register member endpoint

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1799de28e66a228d42b14386d8b43d9b62d1a0bc#1799de28e66a228d42b14386d8b43d9b62d1a0bc"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=9c9529a5ab6095eddcc48d835dbe3d0496e7d68b#9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -2717,6 +2717,7 @@ dependencies = [
  "jsonrpc-core-client",
  "lazy_static",
  "log 0.4.8",
+ "pallet-sudo",
  "parity-scale-codec",
  "radicle-registry-core",
  "radicle-registry-runtime",
@@ -2738,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1799de28e66a228d42b14386d8b43d9b62d1a0bc#1799de28e66a228d42b14386d8b43d9b62d1a0bc"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=9c9529a5ab6095eddcc48d835dbe3d0496e7d68b#9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -2751,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1799de28e66a228d42b14386d8b43d9b62d1a0bc#1799de28e66a228d42b14386d8b43d9b62d1a0bc"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=9c9529a5ab6095eddcc48d835dbe3d0496e7d68b#9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=80617f5964658b80cea71babb63f4e881ceff85c#80617f5964658b80cea71babb63f4e881ceff85c"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1799de28e66a228d42b14386d8b43d9b62d1a0bc#1799de28e66a228d42b14386d8b43d9b62d1a0bc"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=80617f5964658b80cea71babb63f4e881ceff85c#80617f5964658b80cea71babb63f4e881ceff85c"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1799de28e66a228d42b14386d8b43d9b62d1a0bc#1799de28e66a228d42b14386d8b43d9b62d1a0bc"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -2751,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=80617f5964658b80cea71babb63f4e881ceff85c#80617f5964658b80cea71babb63f4e881ceff85c"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=1799de28e66a228d42b14386d8b43d9b62d1a0bc#1799de28e66a228d42b14386d8b43d9b62d1a0bc"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=9c9529a5ab6095eddcc48d835dbe3d0496e7d68b#9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=a94b22bb5bcdc8d70d059d69c364f061d13e0741#a94b22bb5bcdc8d70d059d69c364f061d13e0741"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -2739,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=9c9529a5ab6095eddcc48d835dbe3d0496e7d68b#9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=a94b22bb5bcdc8d70d059d69c364f061d13e0741#a94b22bb5bcdc8d70d059d69c364f061d13e0741"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=9c9529a5ab6095eddcc48d835dbe3d0496e7d68b#9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=a94b22bb5bcdc8d70d059d69c364f061d13e0741#a94b22bb5bcdc8d70d059d69c364f061d13e0741"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,7 +36,7 @@ rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "80617f5964658b80cea71babb63f4e881ceff85c"
+rev = "1799de28e66a228d42b14386d8b43d9b62d1a0bc"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,7 +36,7 @@ rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
+rev = "a94b22bb5bcdc8d70d059d69c364f061d13e0741"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,7 +36,7 @@ rev = "4cedafaeb46deee4ec11d0e4b779a1a0d124d599"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "1799de28e66a228d42b14386d8b43d9b62d1a0bc"
+rev = "9c9529a5ab6095eddcc48d835dbe3d0496e7d68b"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -137,8 +137,8 @@ fn register_filter<R: registry::Client>(
     http::with_shared(registry)
         .and(http::with_subscriptions(subscriptions))
         .and(warp::post())
-        .and(warp::body::json())
         .and(path::end())
+        .and(warp::body::json())
         .and(document::document(document::description(
             "Register a new unique Org",
         )))
@@ -166,8 +166,8 @@ fn register_member_filter<R: registry::Client>(
     .and(warp::post())
     .and(document::param::<String>("id", "Unique ID of the Org"))
     .and(path("members"))
-    .and(warp::body::json())
     .and(path::end())
+    .and(warp::body::json())
     .and(document::document(document::description(
         "Register a member",
     )))

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -24,7 +24,8 @@ pub fn routes<R: registry::Client>(
         get_filter(Arc::clone(&registry))
             .or(get_project_filter(Arc::clone(&registry)))
             .or(get_projects_filter(paths, Arc::clone(&registry)))
-            .or(register_filter(registry, subscriptions)),
+            .or(register_filter(Arc::clone(&registry), subscriptions.clone()))
+            .or(register_member_filter(registry, subscriptions)),
     )
 }
 
@@ -38,7 +39,8 @@ fn filters<R: registry::Client>(
     get_filter(Arc::clone(&registry))
         .or(get_project_filter(Arc::clone(&registry)))
         .or(get_projects_filter(paths, Arc::clone(&registry)))
-        .or(register_filter(registry, subscriptions))
+        .or(register_filter(Arc::clone(&registry), subscriptions.clone()))
+        .or(register_member_filter(registry, subscriptions))
 }
 
 /// `GET /<id>`
@@ -154,6 +156,35 @@ fn register_filter<R: registry::Client>(
         .and_then(handler::register)
 }
 
+/// `POST /<id>/members`
+fn register_member_filter<R: registry::Client>(
+    registry:http::Shared<R>,
+    subscriptions: notification::Subscriptions,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    http::with_shared(registry)
+    .and(http::with_subscriptions(subscriptions))
+    .and(warp::post())
+    .and(document::param::<String>("id", "Unique ID of the Org"))
+    .and(path("members"))
+    .and(warp::body::json())
+    .and(path::end())
+    .and(document::document(document::description(
+        "Register a member",
+    )))
+    .and(document::document(document::tag("Org")))
+    .and(document::document(
+        document::body(RegisterMemberInput::document()).mime("application/json"),
+    ))
+    .and(document::document(
+        document::response(
+            201,
+            document::body(registry::Org::document()).mime("application/json"),
+        )
+        .description("Creation succeeded"),
+    ))
+    .and_then(handler::register_member)
+}
+
 /// Org handlers for conversion between core domain and http request fullfilment.
 mod handler {
     use librad::paths::Paths;
@@ -243,6 +274,30 @@ mod handler {
         let reg = registry.read().await;
         let org_id = registry::Id::try_from(input.id)?;
         let tx = reg.register_org(&fake_pair, org_id, fake_fee).await?;
+
+        subscriptions
+            .broadcast(notification::Notification::Transaction(tx.clone()))
+            .await;
+
+        Ok(reply::with_status(reply::json(&tx), StatusCode::CREATED))
+    }
+
+    /// Register a member under an org on the Registry.
+    pub async fn register_member<R: registry::Client>(
+        registry: http::Shared<R>,
+        subscriptions: notification::Subscriptions,
+        id: String,
+        input: super::RegisterMemberInput,
+    ) -> Result<impl Reply, Rejection> {
+        // TODO(xla): Get keypair from persistent storage.
+        let fake_pair = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
+        // TODO(xla): Use real fee defined by the user.
+        let fake_fee: Balance = 100;
+
+        let reg = registry.read().await;
+        let org_id = registry::Id::try_from(id)?;
+        let handle = registry::Id::try_from(input.handle)?;
+        let tx = reg.register_member(&fake_pair, org_id, handle, fake_fee).await?;
 
         subscriptions
             .broadcast(notification::Notification::Transaction(tx.clone()))
@@ -360,10 +415,33 @@ impl ToDocumentedType for RegisterInput {
     }
 }
 
+/// Bundled input data for member registration.
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterMemberInput {
+    /// Id of the User.
+    handle: String,
+}
+
+impl ToDocumentedType for RegisterMemberInput {
+    fn document() -> document::DocumentedType {
+        let mut properties = std::collections::HashMap::with_capacity(1);
+        properties.insert(
+            "handle".into(),
+            document::string()
+                .description("Handle of the user")
+                .example("cloudhead"),
+        );
+
+        document::DocumentedType::from(properties).description("Input for member registration")
+    }
+}
+
 #[allow(
     clippy::option_unwrap_used,
     clippy::result_unwrap_used,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::panic
 )]
 #[cfg(test)]
 mod test {
@@ -649,6 +727,75 @@ mod test {
         assert_eq!(res.status(), StatusCode::CREATED);
         assert_eq!(txs.len(), 2);
         assert_eq!(org.id, org_id);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn register_member() -> Result<(), error::Error> {
+        let tmp_dir = tempfile::tempdir()?;
+        let librad_paths = Paths::from_root(tmp_dir.path())?;
+        let registry = {
+            let (client, _) = radicle_registry_client::Client::new_emulator();
+            registry::Registry::new(client)
+        };
+        let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store")))?;
+        let cache = Arc::new(RwLock::new(registry::Cacher::new(registry, &store)));
+        let subscriptions = notification::Subscriptions::default();
+
+        let api = super::filters(
+            Arc::new(RwLock::new(librad_paths.clone())),
+            Arc::clone(&cache),
+            subscriptions,
+        );
+        let author = protocol::ed25519::Pair::from_legacy_string("//Alice", None);
+        let handle = registry::Id::try_from("alice")?;
+        let org_id = registry::Id::try_from("radicle")?;
+
+        // Register the user
+        cache
+            .write()
+            .await
+            .register_user(&author, handle.clone(), None, 10)
+            .await?;
+
+        // Register the org
+        cache
+            .write()
+            .await
+            .register_org(&author, org_id.clone(), 10)
+            .await?;
+
+        // Register a second user
+        let author2 = protocol::ed25519::Pair::from_legacy_string("//Bob", None);
+        let handle2 = registry::Id::try_from("bob")?;
+        cache
+            .write()
+            .await
+            .register_user(&author2, handle2.clone(), None, 10)
+            .await?;
+
+        // Register the second user as a member of the org
+        let res = request()
+            .method("POST")
+            .path(&format!("/{}/members", org_id.clone()))
+            .json(&super::RegisterMemberInput {
+                handle: handle2.clone().to_string(),
+            })
+            .reply(&api)
+            .await;
+
+        let txs = cache.write().await.list_transactions(vec![])?;
+
+        // Get the org and its members
+        let org = cache.read().await.get_org(org_id).await?.unwrap();
+        let member_handles: Vec<registry::Id> = org.members.iter().map(|user| user.handle.clone()).collect();
+
+        assert_eq!(res.status(), StatusCode::CREATED);
+        assert_eq!(txs.len(), 4);
+        assert_eq!(org.members.len(), 2);
+        assert!(member_handles.contains(&handle));
+        assert!(member_handles.contains(&handle2));
 
         Ok(())
     }

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -504,14 +504,6 @@ impl Client for Registry {
             Message::OrgRegistration { id: org_id.clone() },
         );
 
-        // TODO(xla): Remove automatic prepayment once we have proper balances.
-        let org = self
-            .client
-            .get_org(org_id.0)
-            .await?
-            .expect("org not present");
-        self.prepay_account(org.account_id, 1000).await?;
-
         Ok(tx)
     }
 

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -643,6 +643,8 @@ impl Client for Registry {
         id: Option<String>,
         fee: protocol::Balance,
     ) -> Result<Transaction, error::Error> {
+        // TODO(xla): Remove automatic prepayment once we have proper balances.
+        self.prepay_account(author.public(), 1000).await?;
         // Prepare and submit user registration transaction.
         let register_message = protocol::message::RegisterUser {
             user_id: handle.0.clone(),

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -362,7 +362,10 @@ where
         user_id: registry::Id,
         fee: protocol::Balance,
     ) -> Result<Transaction, error::Error> {
-        let tx = self.client.register_member(author, org_id, user_id, fee).await?;
+        let tx = self
+            .client
+            .register_member(author, org_id, user_id, fee)
+            .await?;
 
         self.cache_transaction(tx.clone())?;
 

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -355,6 +355,20 @@ where
         Ok(tx)
     }
 
+    async fn register_member(
+        &self,
+        author: &protocol::ed25519::Pair,
+        org_id: registry::Id,
+        user_id: registry::Id,
+        fee: protocol::Balance,
+    ) -> Result<Transaction, error::Error> {
+        let tx = self.client.register_member(author, org_id, user_id, fee).await?;
+
+        self.cache_transaction(tx.clone())?;
+
+        Ok(tx)
+    }
+
     async fn get_project(
         &self,
         org_id: registry::Id,


### PR DESCRIPTION
This implements the api endpoint to register a user as a member under an org. In a followup PR, it will be integrated in the ui and the transaction views will be adjusted to support the new transaction type.

part of #349 

**Note** This can't fully be tested via the api playground, as we use the same `author`/key_pair for all transactions. This means we currently can't register a second user handle to then register it as a member.