### PR TITLE
Remove joined date from member list

### DIFF
--- a/ui/Screen/Org/Members.svelte
+++ b/ui/Screen/Org/Members.svelte
@@ -71,9 +71,6 @@
           </Text>
         </div>
       {/if}
-      <Text style="color: var(--color-foreground-level-5); margin-right: 24px;">
-        {member.joined}
-      </Text>
       <AdditionalActionsDropdown menuItems={menuItems(member)} />
     </div>
   </div>

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -157,23 +157,20 @@ export const memberHandleValidationStore = (): validation.ValidationStore =>
 
 // MOCKS
 
-type MemberList = { handle: string; pending: boolean; joined: string }[]
+type MemberList = { handle: string; pending: boolean}[]
 
 // TODO(sos): replace with actual members
 export const mockMemberList: MemberList = [
   {
     handle: "eisenia_fetida",
-    pending: false,
-    joined: "06/2019"
+    pending: false
   },
   {
     handle: "eisenia_hortensis",
-    pending: true,
-    joined: "11/1992"
+    pending: true
   },
   {
     handle: "eisenia_andrei",
-    pending: false,
-    joined: "05/2020"
+    pending: false
   }
 ]


### PR DESCRIPTION
We decided to remove the joined date from the member list, as we would either have to store the date on chain or retrieve it from the transactions.