### PR TITLE
ci: prevent skipped tests from being committed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "es6": true,
     "node": true
   },
+  "plugins": ["no-only-tests"],
   "extends": ["eslint:recommended"],
   "parserOptions": {
     "ecmaVersion": 2017,
@@ -35,6 +36,7 @@
     }
   ],
   "rules": {
+    "no-only-tests/no-only-tests": "error",
     // Disallow Unused Variables
     // https://eslint.org/docs/rules/no-unused-vars
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,9 +95,6 @@ context("a bazillion tests in this context", () => {
 Then, to execute just this single test, fire up the Cypress GUI:
 `yarn test:debug` and choose the respective `.spec.js` file from the list.
 
-💡 *Don't forget to remove all `.only` methods from the tests before
-committing changes, otherwise these tests will be skipped on CI.*
-
 
 ### Design System
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "electron-builder": "^22.6.0",
     "eslint": "^6.8.0",
     "eslint-plugin-cypress": "^2.10.3",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-svelte3": "^2.7.3",
     "husky": ">=4.2.3",
     "lint-staged": "^10.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2590,6 +2590,11 @@ eslint-plugin-cypress@^2.10.3:
   dependencies:
     globals "^11.12.0"
 
+eslint-plugin-no-only-tests@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
+  integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
+
 eslint-plugin-svelte3@^2.7.3:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-svelte3/-/eslint-plugin-svelte3-2.7.3.tgz#e793b646b848e717674fe668c21b909cfa025eb3"


### PR DESCRIPTION
Closes: #131

Husky:
```
work/radicle-upstream » git commit

husky > pre-commit (node v11.11.0)
✔ Preparing...
⚠ Running tasks...
  ✔ Running tasks for *.{js,css,json,html}
  ❯ Running tasks for *.js
    ✖ eslint --fix [FAILED]
  ↓ No staged files match *.svelte [SKIPPED]
  ↓ No staged files match *.ts [SKIPPED]
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up...

✖ eslint --fix:

/Users/rudolfs/work/radicle-upstream/cypress/integration/identity_creation.spec.js
  47:8  error  it.only not permitted  no-only-tests/no-only-tests

✖ 1 problem (1 error, 0 warnings)
```

If a skipped tests slips by husky, it'll error out on CI as part of the lint build step.
```
work/radicle-upstream » yarn lint
yarn run v1.22.4
$ eslint . --ignore-path .gitignore --ext .js,.svelte,.ts

/Users/rudolfs/work/radicle-upstream/cypress/integration/settings_specs.js
  23:8  error  it.only not permitted  no-only-tests/no-only-tests

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```