### PR TITLE
fix: clippy CI

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -72,8 +72,6 @@ echo "--- Run cargo fmt"
 (cd proxy && time cargo fmt --all -- --check)
 
 echo "--- Run proxy lints"
-(cd proxy && time cargo check --all --all-features --all-targets)
-(cd proxy && time cargo clean)
 (cd proxy && time cargo clippy --all --all-features --all-targets)
 
 echo "--- Run proxy tests"

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -71,12 +71,13 @@ cat "$HOME/.gitconfig"
 echo "--- Run cargo fmt"
 (cd proxy && time cargo fmt --all -- --check)
 
-echo "--- Run proxy tests"
-(cd proxy && time cargo test --all --all-features --all-targets)
-
 echo "--- Run proxy lints"
 (cd proxy && time cargo check --all --all-features --all-targets)
+(cd proxy && time cargo clean)
 (cd proxy && time cargo clippy --all --all-features --all-targets)
+
+echo "--- Run proxy tests"
+(cd proxy && time cargo test --all --all-features --all-targets)
 
 echo "--- Run app eslint checks"
 time yarn lint

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::integer_arithmetic)]
 //! Abstractions and types to handle, persist and interact with transactions.
 
 use async_trait::async_trait;

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Abstractions and types to handle, persist and interact with transactions.
 
 use async_trait::async_trait;


### PR DESCRIPTION
As per workaround documented in: https://github.com/rust-lang/rust-clippy/issues/4612

This adds 11m to the build however : (
We should probably try to upgrade to the latest nightly version and try `-Zunstable-options`.

Closes #376.