### PR TITLE
fix(ui): missing revision icon

### DIFF
--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -62,7 +62,7 @@
       looseActiveStateMatching: false,
     },
     {
-      icon: Icon.Revisions,
+      icon: Icon.Revision,
       title: "Revisions",
       href: path.projectRevisions(projectId),
       looseActiveStateMatching: false,
@@ -78,7 +78,7 @@
     },
     {
       title: "New revision",
-      icon: Icon.Revisions,
+      icon: Icon.Revision,
       event: () => console.log("event(new-revision)"),
     },
   ];

--- a/ui/Screen/Project/RevisionsMenu.svelte
+++ b/ui/Screen/Project/RevisionsMenu.svelte
@@ -4,7 +4,7 @@
 
 <Button
   variant="transparent"
-  icon={Icon.Revisions}
+  icon={Icon.Revision}
   on:click={() => console.log('event(new-revision)')}>
   New revision
 </Button>


### PR DESCRIPTION
Revision Icon was missing because of a rename in the icon-refresh-PR.