### PR TITLE
docs: add Linux dev dependencies to docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,8 +61,7 @@ On Linux:
   - [GNU M4](https://www.gnu.org/software/m4)
   - [Nettle](http://www.lysator.liu.se/~nisse/nettle)
   - [OpenSSL](https://www.openssl.org)
-
-On both platforms make sure to have [`yarn`][ya] installed.
+  - [Yarn](https://yarnpkg.com)
 
 1. Get Upstream: `git clone git@github.com:radicle-dev/radicle-upstream.git`.
 2. Install dependencies: `cd radicle-upstream && yarn install`.
@@ -464,4 +463,3 @@ Release v0.0.11 successfully completed! 👏 🎉 🚀
 [sv]: https://github.com/conventional-changelog/standard-version
 [tp]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [wa]: https://github.com/seanmonstar/warp
-[ya]: https://yarnpkg.com

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,10 +43,8 @@ make sure only properly formatted and lint-free code lands into master.
 
 ### Running Upstream
 
-You'll have to install some external dependencies to be able to compile
-the proxy as well as the UI.
-
-On both platforms make sure to have [`yarn`][ya] installed.
+You'll have to install some external dependencies to be able to compile the
+proxy as well as the UI.
 
 On macOS:
 ```
@@ -55,11 +53,16 @@ sudo xcodebuild -license
 brew install yarn pkgconfig nettle
 ```
 
-On Debian/Ubuntu:
-```
-# Install proxy dependencies
-sudo apt-get install libssl-dev libgmp3-dev m4 clang
-```
+On Linux:
+  - [Autoconf](https://www.gnu.org/software/autoconf)
+  - [Clang](https://clang.llvm.org)
+  - [Git](https://git-scm.com)
+  - [GMP](https://gmplib.org)
+  - [GNU M4](https://www.gnu.org/software/m4)
+  - [Nettle](http://www.lysator.liu.se/~nisse/nettle)
+  - [OpenSSL](https://www.openssl.org)
+
+On both platforms make sure to have [`yarn`][ya] installed.
 
 1. Get Upstream: `git clone git@github.com:radicle-dev/radicle-upstream.git`.
 2. Install dependencies: `cd radicle-upstream && yarn install`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,8 @@ make sure only properly formatted and lint-free code lands into master.
 You'll have to install some external dependencies to be able to compile
 the proxy as well as the UI.
 
+On both platforms make sure to have [`yarn`][ya] installed.
+
 On macOS:
 ```
 xcode-select --install
@@ -55,11 +57,6 @@ brew install yarn pkgconfig nettle
 
 On Debian/Ubuntu:
 ```
-# Install yarn (UI dependency):
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt update && sudo apt install yarn
-
 # Install proxy dependencies
 sudo apt-get install libssl-dev libgmp3-dev m4 clang
 ```
@@ -464,3 +461,4 @@ Release v0.0.11 successfully completed! 👏 🎉 🚀
 [sv]: https://github.com/conventional-changelog/standard-version
 [tp]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [wa]: https://github.com/seanmonstar/warp
+[ya]: https://yarnpkg.com

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,12 +43,22 @@ make sure only properly formatted and lint-free code lands into master.
 
 ### Running Upstream
 
-On macOS you'll have to install some external dependencies, to be able to
-compile everything:
+You'll have to install some external dependencies to be able to compile
+everything.
+
+On macOS:
 ```
 xcode-select --install
 sudo xcodebuild -license
 brew install pkgconfig nettle
+```
+
+On Debian/Ubuntu:
+```
+sudo apt-get install libssl-dev
+sudo apt-get install libgmp3-dev
+sudo apt-get install m4
+sudo apt-get install clang
 ```
 
 1. Get Upstream: `git clone git@github.com:radicle-dev/radicle-upstream.git`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,21 +44,24 @@ make sure only properly formatted and lint-free code lands into master.
 ### Running Upstream
 
 You'll have to install some external dependencies to be able to compile
-everything.
+the proxy as well as the UI.
 
 On macOS:
 ```
 xcode-select --install
 sudo xcodebuild -license
-brew install pkgconfig nettle
+brew install yarn pkgconfig nettle
 ```
 
 On Debian/Ubuntu:
 ```
-sudo apt-get install libssl-dev
-sudo apt-get install libgmp3-dev
-sudo apt-get install m4
-sudo apt-get install clang
+# Install yarn (UI dependency):
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt update && sudo apt install yarn
+
+# Install proxy dependencies
+sudo apt-get install libssl-dev libgmp3-dev m4 clang
 ```
 
 1. Get Upstream: `git clone git@github.com:radicle-dev/radicle-upstream.git`.
@@ -286,6 +289,9 @@ application package by [electron-builder][eb].
 
 
 ### Running the proxy in stand-alone mode
+
+To be able to build the proxy first install all required dependencies from the
+[Running Upstream](#running-upstream) section.
 
 To start the proxy binary, run: `cd proxy && cargo run -- --registry=emulator`.
 After that the API docs are served under `http://127.0.0.1:8080/docs`.


### PR DESCRIPTION
Noticed that we don't have all the dependencies listed when I was trying to build Upstream from scratch on Linux.