### PR TITLE
chore(ui): run prettier on *.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "cypress:open": "yarn run cypress open",
     "release": "babel-node --presets \"@babel/env\" scripts/release.js",
     "release:finalize": "babel-node --presets \"@babel/env\" scripts/release.js --finalize",
-    "prettier": "prettier \"**/*.@(js|json|svelte|css|html)\" --ignore-path .gitignore",
+    "prettier": "prettier \"**/*.@(js|ts|json|svelte|css|html)\" --ignore-path .gitignore",
     "prettier:check": "yarn prettier --check",
     "prettier:write": "yarn prettier --write",
     "lint": "eslint . --ignore-path .gitignore --ext .js,.svelte,.ts"
@@ -153,6 +153,7 @@
       "eslint --fix"
     ],
     "*.ts": [
+      "prettier --write",
       "eslint --fix"
     ]
   }

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -2,7 +2,7 @@ import App from "./App.svelte";
 
 const app = new App({
   target: document.body,
-  props: {}
+  props: {},
 });
 
 export default app;

--- a/ui/src/__mocks__/api.ts
+++ b/ui/src/__mocks__/api.ts
@@ -1,38 +1,40 @@
-import { Org } from "../org"
-import { User } from "../user"
+import { Org } from "../org";
+import { User } from "../user";
 
-type MockedResponse = Org | User | null
+type MockedResponse = Org | User | null;
 
 // just to give an idea of how we'd stub the api with other endpoints
 const userMock: User = {
-  handle: "rafalca"
-}
+  handle: "rafalca",
+};
 
 const radicleMock: Org = {
   id: "radicle",
   shareableEntityIdentifier: "radicle@123abcd.git",
   avatarFallback: {
     background: {
-      r: 255, g: 67, b: 34
+      r: 255,
+      g: 67,
+      b: 34,
     },
-    emoji: "🔥"
+    emoji: "🔥",
   },
-  members: [userMock]
-}
+  members: [userMock],
+};
 
 export const get = async (endpoint: string): Promise<MockedResponse> => {
-  const [prefix, param] = endpoint.split("/")
+  const [prefix, param] = endpoint.split("/");
 
-  let response: MockedResponse
+  let response: MockedResponse;
 
   switch (prefix) {
     case "orgs":
-      response = param === "radicle" ? radicleMock : null
+      response = param === "radicle" ? radicleMock : null;
       break;
     case "user":
-      response = userMock
+      response = userMock;
       break;
   }
 
-  return new Promise((resolve) => resolve(response))
-}
+  return new Promise((resolve) => resolve(response));
+};

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -16,15 +16,13 @@ const request = (endpoint: string, init?: Init): Request => {
     endpoint = `${endpoint}?${qs.stringify(init.query)}`;
   }
 
-  return new Request(
-      `http://localhost:8080/v1/${endpoint}`,
-      {
-        headers: {
-          "Content-Type": "application/json"
-        },
-        ...init,
-    });
-}
+  return new Request(`http://localhost:8080/v1/${endpoint}`, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    ...init,
+  });
+};
 
 const http = async <T>(req: RequestInfo): Promise<T> => {
   const res = await fetch(req);
@@ -36,7 +34,7 @@ const http = async <T>(req: RequestInfo): Promise<T> => {
   }
 
   return body;
-}
+};
 
 const noContent = async (req: RequestInfo): Promise<null> => {
   const res = await fetch(req);
@@ -47,7 +45,7 @@ const noContent = async (req: RequestInfo): Promise<null> => {
   }
 
   return null;
-}
+};
 
 export const del = async (endpoint: string, options?: Options): Promise<null> =>
   noContent(request(endpoint, { method: "DELETE", ...options }));
@@ -55,16 +53,28 @@ export const del = async (endpoint: string, options?: Options): Promise<null> =>
 export const get = async <T>(endpoint: string, options?: Options): Promise<T> =>
   http<T>(request(endpoint, { method: "GET", ...options }));
 
-export const post = async <I, D>(endpoint: string, body: I, options?: Options): Promise<D> =>
-  http<D>(request(endpoint, {
-    method: "POST",
-    body: JSON.stringify(body),
-    ...options,
-  }));
+export const post = async <I, D>(
+  endpoint: string,
+  body: I,
+  options?: Options
+): Promise<D> =>
+  http<D>(
+    request(endpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+      ...options,
+    })
+  );
 
-export const set = async <T>(endpoint: string, body: T, options?: Options): Promise<null> =>
- noContent(request(endpoint, {
-    method: "POST",
-    body: JSON.stringify(body),
-    ...options,
-  }));
+export const set = async <T>(
+  endpoint: string,
+  body: T,
+  options?: Options
+): Promise<null> =>
+  noContent(
+    request(endpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+      ...options,
+    })
+  );

--- a/ui/src/avatar.ts
+++ b/ui/src/avatar.ts
@@ -14,7 +14,7 @@ export interface RemoteAvatar {
   url: string;
 }
 
-export type Avatar = EmojiAvatar | RemoteAvatar
+export type Avatar = EmojiAvatar | RemoteAvatar;
 
 export enum Usage {
   Any = "any",

--- a/ui/src/commitMocks.ts
+++ b/ui/src/commitMocks.ts
@@ -1,7 +1,7 @@
 export const mockChangeset = {
   summary: {
     additions: 32,
-    deletions: 24
+    deletions: 24,
   },
   files: [
     {
@@ -16,28 +16,26 @@ export const mockChangeset = {
             {
               num: [195, null],
               type: "-",
-              content:
-                "Server.prototype.hello = function (req, contentType) {"
+              content: "Server.prototype.hello = function (req, contentType) {",
             },
             {
               num: [null, 195],
               type: "+",
-              content:
-                "Server.prototype.hello = function (req, contentType) {"
+              content: "Server.prototype.hello = function (req, contentType) {",
             },
             {
               num: [196, 196],
               type: "",
-              content: "    var enable = this.options.gzip;"
+              content: "    var enable = this.options.gzip;",
             },
             {
               num: [197, 197],
               type: "",
-              content: "    if (enable && (typeof enable === 'boolean' ||"
-            }
-          ]
-        }
-      ]
+              content: "    if (enable && (typeof enable === 'boolean' ||",
+            },
+          ],
+        },
+      ],
     },
     {
       path: "core/server.js",
@@ -49,39 +47,38 @@ export const mockChangeset = {
               num: [192, 192],
               type: "",
               content:
-                "/* Check if we should consider sending a gzip version of the file based on the"
+                "/* Check if we should consider sending a gzip version of the file based on the",
             },
             {
               num: [193, 193],
               type: "",
               content:
-                " * file content type and client's Accept-Encoding header value."
+                " * file content type and client's Accept-Encoding header value.",
             },
             { num: [194, 194], type: "", content: " */" },
             {
               num: [195, null],
               type: "-",
-              content:
-                "Server.prototype.ok = function (req, contentType) {"
+              content: "Server.prototype.ok = function (req, contentType) {",
             },
             {
               num: [null, 195],
               type: "+",
               content:
-                "Server.prototype.gzipOk = function (req, contentType) {"
+                "Server.prototype.gzipOk = function (req, contentType) {",
             },
             {
               num: [196, 196],
               type: "",
-              content: "    var enable = this.options.gzip;"
+              content: "    var enable = this.options.gzip;",
             },
             { num: [197, 197], type: "", content: "    if (enable &&" },
             {
               num: [198, 198],
               type: "",
-              content: "        (typeof enable === 'boolean' ||"
-            }
-          ]
+              content: "        (typeof enable === 'boolean' ||",
+            },
+          ],
         },
         {
           expanded: false,
@@ -92,24 +89,25 @@ export const mockChangeset = {
               num: [199, 199],
               type: "",
               content:
-                "            (contentType && (enable instanceof RegExp) && enable.test(contentType)))) {"
+                "            (contentType && (enable instanceof RegExp) && enable.test(contentType)))) {",
             },
             {
               num: [200, 200],
               type: "",
               content:
-                "        var acceptEncoding = req.headers['accept-encoding'];"
+                "        var acceptEncoding = req.headers['accept-encoding'];",
             },
             {
               num: [201, 201],
               type: "",
               content:
-                "        return acceptEncoding && acceptEncoding.indexOf('gzip') >= 0;"
+                "        return acceptEncoding && acceptEncoding.indexOf('gzip') >= 0;",
             },
-            { num: [202, 202], type: "", content: "    }" }, { num: [203, 203], type: "", content: "    return false;" },
+            { num: [202, 202], type: "", content: "    }" },
+            { num: [203, 203], type: "", content: "    return false;" },
             { num: [204, 204], type: "", content: "}" },
-            { num: [205, 205], type: "", content: "" }
-          ]
+            { num: [205, 205], type: "", content: "" },
+          ],
         },
         {
           expanded: true,
@@ -118,108 +116,107 @@ export const mockChangeset = {
               num: [206, null],
               type: "-",
               content:
-                "Server.prototype.respond = function (pathname, status, contentType, _headers, files, stat, req, res, finish) {"
+                "Server.prototype.respond = function (pathname, status, contentType, _headers, files, stat, req, res, finish) {",
             },
             {
               num: [null, 206],
               type: "+",
               content:
-                "/* Send a gzipped version of the file if the options and the client indicate gzip is enabled and"
+                "/* Send a gzipped version of the file if the options and the client indicate gzip is enabled and",
             },
             {
               num: [null, 207],
               type: "+",
               content:
-                " * we find a .gz file mathing the static resource requested."
+                " * we find a .gz file mathing the static resource requested.",
             },
             { num: [null, 208], type: "+", content: " */" },
             {
               num: [null, 209],
               type: "+",
               content:
-                "Server.prototype.respondGzip = function (pathname, status, contentType, _headers, files, stat, req, res, finish) {"
+                "Server.prototype.respondGzip = function (pathname, status, contentType, _headers, files, stat, req, res, finish) {",
             },
             {
               num: [207, 210],
               type: "",
-              content: "    var that = this;"
+              content: "    var that = this;",
             },
             {
               num: [208, 211],
               type: "",
               content:
-                "    if (files.length == 1 && this.gzipOk(req, contentType)) {"
+                "    if (files.length == 1 && this.gzipOk(req, contentType)) {",
             },
             {
               num: [209, 212],
               type: "",
-              content: "        var gzFile = files[0] + '.gz';"
+              content: "        var gzFile = files[0] + '.gz';",
             },
             {
               num: [210, 213],
               type: "",
-              content: "        fs.stat(gzFile, function (e, gzStat) {"
+              content: "        fs.stat(gzFile, function (e, gzStat) {",
             },
             {
               num: [211, 214],
               type: "",
-              content: "            if (!e && gzStat.isFile()) {"
+              content: "            if (!e && gzStat.isFile()) {",
             },
             {
               num: [212, 215],
               type: "",
-              content: "                var vary = _headers['Vary'];"
+              content: "                var vary = _headers['Vary'];",
             },
             {
               num: [213, null],
               type: "-",
               content:
-                "                _headers['Vary'] = (vary && vary != 'Accept-Encoding'?vary+', ':'')+'Accept-Encoding';"
+                "                _headers['Vary'] = (vary && vary != 'Accept-Encoding'?vary+', ':'')+'Accept-Encoding';",
             },
             {
               num: [null, 216],
               type: "+",
               content:
-                "                _headers['Vary'] = (vary && vary != 'Accept-Encoding' ? vary + ', ' : '') + 'Accept-Encoding';"
+                "                _headers['Vary'] = (vary && vary != 'Accept-Encoding' ? vary + ', ' : '') + 'Accept-Encoding';",
             },
             {
               num: [214, 217],
               type: "",
-              content:
-                "                _headers['Content-Encoding'] = 'gzip';"
+              content: "                _headers['Content-Encoding'] = 'gzip';",
             },
             {
               num: [215, 218],
               type: "",
-              content: "                stat.size = gzStat.size;"
+              content: "                stat.size = gzStat.size;",
             },
             {
               num: [216, 219],
               type: "",
-              content: "                files = [gzFile];"
+              content: "                files = [gzFile];",
             },
             {
               num: [217, null],
               type: "-",
-              content: "            } else {"
+              content: "            } else {",
             },
             {
               num: [218, null],
               type: "-",
               content:
-                "                console.log('gzip file not found or error finding it', gzFile, String(e), stat.isFile());"
+                "                console.log('gzip file not found or error finding it', gzFile, String(e), stat.isFile());",
             },
             { num: [219, 220], type: "", content: "            }" },
             {
               num: [220, 221],
               type: "",
               content:
-                "            that.respondNoGzip(pathname, status, contentType, _headers, files, stat, req, res, finish);"
+                "            that.respondNoGzip(pathname, status, contentType, _headers, files, stat, req, res, finish);",
             },
-            { num: [221, 222], type: "", content: "        });" }
-          ]
-        }
-      ]
-    }
-  ]
+            { num: [221, 222], type: "", content: "        });" },
+          ],
+        },
+      ],
+    },
+  ],
 };

--- a/ui/src/event.ts
+++ b/ui/src/event.ts
@@ -1,12 +1,17 @@
 export type Event<K> = {
   kind: K;
-}
+};
 
 type Msg = object | null;
 
 declare type callback<K, M extends Event<K>> = (event: M) => void;
 declare type call = (msg?: Msg) => void;
 
-export function create<K, M extends Event<K>>(kind: K, cb: callback<K, M>): call {
-  return (msg?: Msg): void => { cb({ kind: kind, ...msg } as M) }
+export function create<K, M extends Event<K>>(
+  kind: K,
+  cb: callback<K, M>
+): call {
+  return (msg?: Msg): void => {
+    cb({ kind: kind, ...msg } as M);
+  };
 }

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -23,7 +23,6 @@ export interface Identity {
   avatarFallback: Avatar;
 }
 
-
 // STATE
 const creationStore = remote.createStore<Identity>();
 export const store = creationStore.readable;
@@ -53,15 +52,16 @@ function update(msg: Msg): void {
   switch (msg.kind) {
     case Kind.Create:
       creationStore.loading();
-      api.post<CreateInput, Identity>("identities", {
-        handle: msg.handle,
-        displayName: msg.displayName,
-        avatarUrl: msg.avatarUrl
-      })
-        .then(id => {
+      api
+        .post<CreateInput, Identity>("identities", {
+          handle: msg.handle,
+          displayName: msg.displayName,
+          avatarUrl: msg.avatarUrl,
+        })
+        .then((id) => {
           creationStore.success(id);
         })
-        .catch(creationStore.error)
+        .catch(creationStore.error);
 
       break;
   }

--- a/ui/src/notification.ts
+++ b/ui/src/notification.ts
@@ -17,7 +17,7 @@ interface Notification {
   message: string;
 }
 
-type Notifications = Notification[]
+type Notifications = Notification[];
 
 // STATE
 let notifications: Notifications = [];
@@ -50,7 +50,7 @@ type Msg = Remove | ShowError | ShowInfo;
 const filter = (id: ID): void => {
   notifications = notifications.filter((n) => n.id !== id);
   store.set(notifications);
-}
+};
 
 const show = (level: Level, message: string): void => {
   const id = Math.random();
@@ -60,14 +60,14 @@ const show = (level: Level, message: string): void => {
       id,
       level,
       message,
-    }
+    },
   ];
   store.set(notifications);
 
   setTimeout(() => {
     filter(id);
   }, config.NOTIFICATION_TIMEOUT);
-}
+};
 
 const update = (msg: Msg): void => {
   switch (msg.kind) {
@@ -86,7 +86,7 @@ const update = (msg: Msg): void => {
 
       break;
   }
-}
+};
 
 export const error = (message: string): void =>
   event.create<Kind, Msg>(Kind.ShowError, update)({ message });

--- a/ui/src/onboard.ts
+++ b/ui/src/onboard.ts
@@ -1,10 +1,10 @@
-import { writable } from "svelte/store"
+import { writable } from "svelte/store";
 
 export enum State {
   Welcome = "WELCOME",
   Form = "FORM",
   SuccessView = "SUCCESS_VIEW",
-  Complete = "COMPLETE"
+  Complete = "COMPLETE",
 }
 
-export const store = writable(State.Welcome)
+export const store = writable(State.Welcome);

--- a/ui/src/org.test.ts
+++ b/ui/src/org.test.ts
@@ -1,92 +1,99 @@
-import { getOrg, orgIdValidationStore } from "./org"
-import { ValidationStatus } from './validation'
-import { get } from 'svelte/store'
+import { getOrg, orgIdValidationStore } from "./org";
+import { ValidationStatus } from "./validation";
+import { get } from "svelte/store";
 
-jest.mock("./api")
+jest.mock("./api");
 
 describe("fetching an org", () => {
   it("returns an org", async () => {
-
-    const promise = await getOrg("radicle")
+    const promise = await getOrg("radicle");
     expect(promise).toEqual({
       id: "radicle",
       shareableEntityIdentifier: "radicle@123abcd.git",
       avatarFallback: {
         background: {
-          r: 255, g: 67, b: 34
+          r: 255,
+          g: 67,
+          b: 34,
         },
-        emoji: "🔥"
+        emoji: "🔥",
       },
-      members: [{handle: "rafalca"}]
-    })
-  })
-})
+      members: [{ handle: "rafalca" }],
+    });
+  });
+});
 
 describe("validation", () => {
   it("properly initializes a store", () => {
-    const validation = orgIdValidationStore()
-    validation.subscribe(state =>
+    const validation = orgIdValidationStore();
+    validation.subscribe((state) =>
       expect(state).toEqual({ status: ValidationStatus.NotStarted })
-    )
-  })
+    );
+  });
 
   it("updates the store correctly", () => {
-    const validation = orgIdValidationStore()
+    const validation = orgIdValidationStore();
 
-    validation.validate("notradicle")
+    validation.validate("notradicle");
 
-    expect(get(validation)).toEqual({ status: ValidationStatus.Loading, input: "notradicle" })
+    expect(get(validation)).toEqual({
+      status: ValidationStatus.Loading,
+      input: "notradicle",
+    });
 
     process.nextTick(() => {
-      expect(get(validation)).toEqual({ status: ValidationStatus.Success })
-    })
-  })
+      expect(get(validation)).toEqual({ status: ValidationStatus.Success });
+    });
+  });
 
   it("rejects ids of the wrong format", () => {
-    const validation = orgIdValidationStore()
+    const validation = orgIdValidationStore();
 
     // no empty input
-    validation.validate("")
-    expect(get(validation)).toEqual({ status: ValidationStatus.Error, message: "Org id is required" })
+    validation.validate("");
+    expect(get(validation)).toEqual({
+      status: ValidationStatus.Error,
+      message: "Org id is required",
+    });
 
     // no spaces
-    validation.validate("no spaces")
+    validation.validate("no spaces");
     expect(get(validation)).toEqual({
       status: ValidationStatus.Error,
-      message: "Org id should match [a-z0-9][a-z0-9_-]+"
-    })
+      message: "Org id should match [a-z0-9][a-z0-9_-]+",
+    });
 
     // no special characters
-    validation.validate("^^^inVaLiD***")
+    validation.validate("^^^inVaLiD***");
     expect(get(validation)).toEqual({
       status: ValidationStatus.Error,
-      message: "Org id should match [a-z0-9][a-z0-9_-]+"
-    })
+      message: "Org id should match [a-z0-9][a-z0-9_-]+",
+    });
 
     // no starting with an underscore or dash
-    validation.validate("_nVaLiD")
+    validation.validate("_nVaLiD");
     expect(get(validation)).toEqual({
       status: ValidationStatus.Error,
-      message: "Org id should match [a-z0-9][a-z0-9_-]+"
-    })
+      message: "Org id should match [a-z0-9][a-z0-9_-]+",
+    });
 
     // must meet minimum length
-    validation.validate("x")
+    validation.validate("x");
     expect(get(validation)).toEqual({
       status: ValidationStatus.Error,
-      message: "Org id should match [a-z0-9][a-z0-9_-]+"
-    })
-  })
+      message: "Org id should match [a-z0-9][a-z0-9_-]+",
+    });
+  });
 
   it("doesn't allow you to register an existing org id", () => {
-    const validation = orgIdValidationStore()
+    const validation = orgIdValidationStore();
 
-    validation.validate("radicle")
+    validation.validate("radicle");
     process.nextTick(() => {
       expect(get(validation)).toEqual({
         status: ValidationStatus.Error,
-        message: "Sorry, this id is already taken"
-      })
-    })
-  })
-})
+        message: "Sorry, this id is already taken",
+      });
+    });
+  });
+});

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -26,7 +26,7 @@ type Projects = Project[];
 
 export enum RegistrationFlowState {
   Preparation,
-  Confirmation
+  Confirmation,
 }
 
 // State
@@ -39,14 +39,14 @@ export const projects = projectsStore.readable;
 // Api
 export const getOrg = (id: string): Promise<Org> => api.get<Org>(`orgs/${id}`);
 export const getIdAvailability = (id: string): Promise<boolean> =>
-  getOrg(id).then(org => !org);
+  getOrg(id).then((org) => !org);
 const validateUserExistence = (handle: string): Promise<boolean> =>
-  user.get(handle).then(user => !!user);
+  user.get(handle).then((user) => !!user);
 
 // Events
 enum Kind {
   Fetch = "FETCH",
-  FetchProjectList = "FETCH_PROJECT_LIST"
+  FetchProjectList = "FETCH_PROJECT_LIST",
 }
 
 interface Fetch extends event.Event<Kind> {
@@ -90,16 +90,13 @@ const update = (msg: Msg): void => {
   }
 };
 
-export const registerMemberTransaction = (
-  orgId: string,
-  handle: string
-) => ({
+export const registerMemberTransaction = (orgId: string, handle: string) => ({
   messages: [
     {
       type: transaction.MessageType.MemberRegistration,
       orgId,
-      handle
-    }
+      handle,
+    },
   ],
   state: {
     type: transaction.StateType.Confirmed,
@@ -109,12 +106,12 @@ export const registerMemberTransaction = (
     timestamp: {
       secs: 1,
       nanos: 1,
-    }
+    },
   },
   timestamp: {
     secs: 1,
     nanos: 1,
-  }
+  },
 });
 
 export const fetch = event.create<Kind, Msg>(Kind.Fetch, update);
@@ -124,39 +121,44 @@ export const fetchProjectList = event.create<Kind, Msg>(
 );
 export const register = (id: string): Promise<transaction.Transaction> =>
   api.post<RegisterInput, transaction.Transaction>(`orgs`, { id });
-export const registerMember = (orgId: string, handle: string): Promise<transaction.Transaction> =>
-  api.post<RegisterMemberInput, transaction.Transaction>(`orgs/${orgId}/members`, { handle });
+export const registerMember = (
+  orgId: string,
+  handle: string
+): Promise<transaction.Transaction> =>
+  api.post<RegisterMemberInput, transaction.Transaction>(
+    `orgs/${orgId}/members`,
+    { handle }
+  );
 
 // ID validation
 const VALID_ID_MATCH = new RegExp("^[a-z0-9][a-z0-9]+$");
 export const idConstraints = {
   presence: {
     message: `Org id is required`,
-    allowEmpty: false
+    allowEmpty: false,
   },
   format: {
     pattern: VALID_ID_MATCH,
-    message: `Org id should match [a-z0-9][a-z0-9_-]+`
-  }
+    message: `Org id should match [a-z0-9][a-z0-9_-]+`,
+  },
 };
 
 // Make sure we make a new one every time
 export const orgIdValidationStore = (): validation.ValidationStore =>
   validation.createValidationStore(idConstraints, {
     promise: getIdAvailability,
-    validationMessage: "Sorry, this id is already taken"
+    validationMessage: "Sorry, this id is already taken",
   });
 
 const memberHandleConstraints = {
   presence: {
     message: "Member handle is required",
-    allowEmpty: false
-  }
+    allowEmpty: false,
+  },
 };
 
 export const memberHandleValidationStore = (): validation.ValidationStore =>
   validation.createValidationStore(memberHandleConstraints, {
     promise: validateUserExistence,
-    validationMessage: "Cannot find this user"
+    validationMessage: "Cannot find this user",
   });
-

--- a/ui/src/path.ts
+++ b/ui/src/path.ts
@@ -23,29 +23,30 @@ export const orgRegistration = (): string => `/orgs/register`;
 export const orgProjects = (id: string): string => `/orgs/${id}/projects`;
 export const orgFund = (id: string): string => `/orgs/${id}/fund`;
 export const orgMembers = (id: string): string => `/orgs/${id}/members`;
-export const memberRegistration = (id: string): string => `/orgs/${id}/members/register`;
+export const memberRegistration = (id: string): string =>
+  `/orgs/${id}/members/register`;
 
 export const createProject = (): string => "/projects/new";
 export const registerProject = (domainId: string): string =>
   `/projects/register/${domainId}`;
 export const registerExistingProject = (
   projectId: string,
-  domainId: string,
-): string =>
-  `/projects/${projectId}/register/${domainId}`;
+  domainId: string
+): string => `/projects/${projectId}/register/${domainId}`;
 export const projectIssues = (id: string): string => `/projects/${id}/issues`;
 export const projectIssue = (id: string): string => `/projects/${id}/issue`;
-export const projectRevisions = (id: string): string => `/projects/${id}/revisions`;
+export const projectRevisions = (id: string): string =>
+  `/projects/${id}/revisions`;
 export const projectSource = (
   id: string,
   revision: string,
   objectType: string,
-  path: string,
+  path: string
 ): string => {
   if (revision && path) {
     return `/projects/${id}/source/${revision}/${objectType}/${
       objectType === ObjectType.Tree ? `${path}/` : path
-      }`;
+    }`;
   } else {
     return `/projects/${id}/source`;
   }
@@ -60,7 +61,11 @@ export const transactions = (id: string): string => `/transactions/${id}`;
 export const designSystemGuide = (): string => "/design-system-guide";
 export const help = (): string => "/help";
 
-export const active = (path: string, location: string, loose = false): boolean => {
+export const active = (
+  path: string,
+  location: string,
+  loose = false
+): boolean => {
   return regexparam(path, loose).pattern.test(location);
 };
 

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -26,12 +26,12 @@ export interface Project {
   stats: Stats;
 }
 
-type Projects = Project[]
+type Projects = Project[];
 
 // The domain under which a registered project falls
 export enum Domain {
   User = "user",
-  Org = "org"
+  Org = "org",
 }
 export interface Registered {
   name: string;
@@ -90,48 +90,48 @@ const update = (msg: Msg): void => {
   switch (msg.kind) {
     case Kind.Create:
       creationStore.loading();
-      api.post<CreateInput, Project>(`projects`, {
-        metadata: msg.metadata,
-        path: msg.path,
-      })
+      api
+        .post<CreateInput, Project>(`projects`, {
+          metadata: msg.metadata,
+          path: msg.path,
+        })
         .then(creationStore.success)
         .catch(creationStore.error);
 
       break;
     case Kind.Fetch:
       projectStore.loading();
-      api.get<Project>(`projects/${msg.id}`)
+      api
+        .get<Project>(`projects/${msg.id}`)
         .then(projectStore.success)
-        .catch(projectStore.error)
+        .catch(projectStore.error);
 
       break;
 
     case Kind.FetchList:
-      projectsStore.loading()
-      api.get<Projects>("projects")
+      projectsStore.loading();
+      api
+        .get<Projects>("projects")
         .then(projectsStore.success)
         .catch(projectsStore.error);
 
       break;
   }
-}
+};
 
-export const create = (
-  metadata: Metadata,
-  path: string,
-): Promise<Project> => {
+export const create = (metadata: Metadata, path: string): Promise<Project> => {
   return api.post<CreateInput, Project>(`projects`, {
     metadata,
     path,
-  })
-}
+  });
+};
 
 export const getOrgProject = (
   orgId: string,
-  projectName: string,
+  projectName: string
 ): Promise<Registered> => {
-  return api.get<Registered>(`orgs/${orgId}/projects/${projectName}`)
-}
+  return api.get<Registered>(`orgs/${orgId}/projects/${projectName}`);
+};
 
 export const register = (
   orgId: string,
@@ -141,9 +141,9 @@ export const register = (
   return api.post<RegisterInput, transaction.Transaction>(`projects/register`, {
     orgId,
     projectName,
-    maybeCocoId
+    maybeCocoId,
   });
-}
+};
 
 export const fetch = event.create<Kind, Msg>(Kind.Fetch, update);
 const fetchList = event.create<Kind, Msg>(Kind.FetchList, update);

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -28,7 +28,7 @@ interface Option {
   title: string;
 }
 
-export  const networkOptions: Option[] = [
+export const networkOptions: Option[] = [
   {
     value: Network.Emulator,
     title: "Emulator",

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -2,10 +2,10 @@ import { Readable, Writable, get, derived, writable } from "svelte/store";
 import * as timeago from "timeago.js";
 
 import * as api from "./api";
-import { Avatar, getAvatar, Usage, EmojiAvatar } from "./avatar"
+import { Avatar, getAvatar, Usage, EmojiAvatar } from "./avatar";
 import * as event from "./event";
 import { Identity } from "./identity";
-import { Domain } from "./project"
+import { Domain } from "./project";
 import * as remote from "./remote";
 
 const POLL_INTERVAL = 10000;
@@ -65,8 +65,8 @@ interface UserRegistration {
   id: string;
 }
 
-type Message
-  = OrgRegistration
+type Message =
+  | OrgRegistration
   | OrgUnregistration
   | MemberRegistration
   | MemberUnregistration
@@ -131,30 +131,33 @@ interface Summary {
 }
 
 export const summarizeTransactions = (txs: Transactions): Summary =>
-  txs.reduce((acc, tx): Summary => {
-    acc.counts.sum += 1;
-    acc.counts[tx.state.type] += 1;
+  txs.reduce(
+    (acc, tx): Summary => {
+      acc.counts.sum += 1;
+      acc.counts[tx.state.type] += 1;
 
-    if (tx.state.type === StateType.Confirmed) {
-      acc.confirmations += tx.state.confirmations;
-      acc.minConfirmations = tx.state.minConfirmations;
-    } else if (tx.state.type === StateType.Settled) {
-      acc.confirmations += tx.state.minConfirmations;
-      acc.minConfirmations = tx.state.minConfirmations;
-    }
+      if (tx.state.type === StateType.Confirmed) {
+        acc.confirmations += tx.state.confirmations;
+        acc.minConfirmations = tx.state.minConfirmations;
+      } else if (tx.state.type === StateType.Settled) {
+        acc.confirmations += tx.state.minConfirmations;
+        acc.minConfirmations = tx.state.minConfirmations;
+      }
 
-    return acc;
-  }, {
-    confirmations: 0,
-    minConfirmations: 0,
-    counts: {
-      confirmed: 0,
-      failed: 0,
-      pending: 0,
-      settled: 0,
-      sum: 0,
+      return acc;
     },
-  });
+    {
+      confirmations: 0,
+      minConfirmations: 0,
+      counts: {
+        confirmed: 0,
+        failed: 0,
+        pending: 0,
+        settled: 0,
+        sum: 0,
+      },
+    }
+  );
 
 const transactionsStore = remote.createStore<Transactions>();
 export const transactions = transactionsStore.readable;
@@ -162,7 +165,7 @@ export const transactions = transactionsStore.readable;
 const summaryStore: Writable<Summary | null> = writable(null);
 export const summary = derived(transactionsStore, (store) => {
   if (store.status === remote.Status.Success) {
-    const updated = summarizeTransactions(store.data)
+    const updated = summarizeTransactions(store.data);
 
     summaryStore.set(updated);
 
@@ -197,33 +200,38 @@ const update = (msg: Msg): void => {
   switch (msg.kind) {
     case Kind.FetchList:
       transactionsStore.loading();
-      api.post<ListInput, Transactions>("transactions", { ids: msg.ids })
+      api
+        .post<ListInput, Transactions>("transactions", { ids: msg.ids })
         .then(transactionsStore.success)
         .catch(transactionsStore.error);
 
       break;
 
     case Kind.RefetchList:
-      api.post<ListInput, Transactions>("transactions", { ids: [] })
+      api
+        .post<ListInput, Transactions>("transactions", { ids: [] })
         .then(transactionsStore.success)
         .catch(transactionsStore.error);
 
       break;
   }
-}
+};
 
 export const fetchList = (ids?: Array<string>): void =>
   event.create<Kind, Msg>(Kind.FetchList, update)({ ids: ids || [] });
 
-export const fetch = (id: string): Readable<remote.Data<Transaction | null>> => {
+export const fetch = (
+  id: string
+): Readable<remote.Data<Transaction | null>> => {
   const store = remote.createStore<Transaction | null>();
 
-  api.post<ListInput, Transactions>("transactions", { ids: [id] })
-    .then(txs => store.success(txs.length === 1 ? txs[0] : null))
+  api
+    .post<ListInput, Transactions>("transactions", { ids: [id] })
+    .then((txs) => store.success(txs.length === 1 ? txs[0] : null))
     .catch(store.error);
 
   return store;
-}
+};
 export const refetchList = event.create<Kind, Msg>(Kind.RefetchList, update);
 
 // Fetch initial list when the store has been subcribed to for the first time.
@@ -244,10 +252,10 @@ export const formatMessage = (msg: Message): string => {
       return "Org unregistration";
 
     case MessageType.MemberRegistration:
-      return "Org member registration"
+      return "Org member registration";
 
     case MessageType.MemberUnregistration:
-      return "Org member unregistration"
+      return "Org member unregistration";
 
     case MessageType.ProjectRegistration:
       return "Project registration";
@@ -263,18 +271,19 @@ export const format = (tx: Transaction): object => {
     id: tx.id,
     message: formatMessage(tx.messages[0]),
     state: "pending",
-    progress: 0
-  }
-}
+    progress: 0,
+  };
+};
 
-export const formatStake = (msg: Message): string => `${formatMessage(msg)} deposit`;
+export const formatStake = (msg: Message): string =>
+  `${formatMessage(msg)} deposit`;
 
-// Having both enums & interfaces here is somewhat verbose; the reason we do this 
-// is so we have compatibility with non-TS svelte components while still enjoying 
+// Having both enums & interfaces here is somewhat verbose; the reason we do this
+// is so we have compatibility with non-TS svelte components while still enjoying
 // some type strictness
 export enum PayerType {
   Org = "org",
-  User = "user"
+  User = "user",
 }
 
 // TODO(sos): coordinate payer shape with proxy/registry
@@ -285,19 +294,20 @@ interface Payer {
   imageUrl?: string;
 }
 
-export const formatPayer = (identity: Identity): Payer => (identity && {
-  name: identity.metadata.displayName || identity.metadata.handle,
-  type: PayerType.User,
-  avatarFallback: identity.avatarFallback,
-  imageUrl: identity.metadata.avatarUrl
-});
+export const formatPayer = (identity: Identity): Payer =>
+  identity && {
+    name: identity.metadata.displayName || identity.metadata.handle,
+    type: PayerType.User,
+    avatarFallback: identity.avatarFallback,
+    imageUrl: identity.metadata.avatarUrl,
+  };
 
 export enum SubjectType {
   User = "user",
   OrgProject = "org_project",
   UserProject = "user_project",
   Org = "org",
-  Member = "member"
+  Member = "member",
 }
 
 interface Subject {
@@ -307,32 +317,32 @@ interface Subject {
 }
 
 export const formatSubject = (msg: Message): Subject => {
-  let avatarSource, name, type
+  let avatarSource, name, type;
 
   switch (msg.type) {
     case MessageType.OrgRegistration:
       name = msg.id;
-      type = SubjectType.Org
-      avatarSource = getAvatar(Usage.Org, msg.id)
+      type = SubjectType.Org;
+      avatarSource = getAvatar(Usage.Org, msg.id);
       break;
 
     case MessageType.OrgUnregistration:
       name = msg.id;
-      type = SubjectType.Org
-      avatarSource = getAvatar(Usage.Org, msg.id)
+      type = SubjectType.Org;
+      avatarSource = getAvatar(Usage.Org, msg.id);
       break;
 
     // TODO(sos): replace with actual avatar lookup for the identity associated with
     // the member, should it exist
     case MessageType.MemberRegistration:
       name = msg.handle;
-      type = SubjectType.Member
+      type = SubjectType.Member;
       // avatarSource = getAvatar(Usage.Identity, msg.handle)
       break;
 
     case MessageType.MemberUnregistration:
       name = msg.handle;
-      type = SubjectType.Member
+      type = SubjectType.Member;
       // avatarSource = getAvatar(Usage.Identity, msg.handle)
       break;
 
@@ -340,36 +350,39 @@ export const formatSubject = (msg: Message): Subject => {
     // the user, should it exist
     case MessageType.UserRegistration:
       name = msg.handle;
-      type = SubjectType.User
-      avatarSource = getAvatar(Usage.Identity, msg.id)
+      type = SubjectType.User;
+      avatarSource = getAvatar(Usage.Identity, msg.id);
       break;
 
     // TODO(sos): replace with associated identity handle for user, should it exist
     // TODO(sos): once we can register projects to users, accommodate circle avatars
     case MessageType.ProjectRegistration:
-      name = `${msg.orgId} / ${msg.projectName}`
-      type = SubjectType.OrgProject
-      avatarSource = getAvatar(msg.domain === Domain.User ? Usage.Identity : Usage.Org, msg.orgId)
+      name = `${msg.orgId} / ${msg.projectName}`;
+      type = SubjectType.OrgProject;
+      avatarSource = getAvatar(
+        msg.domain === Domain.User ? Usage.Identity : Usage.Org,
+        msg.orgId
+      );
       break;
   }
 
   return {
     name,
     type,
-    avatarSource
-  }
-}
+    avatarSource,
+  };
+};
 
 export const iconProgress = (state: State): number => {
   switch (state.type) {
     case StateType.Confirmed:
-      return state.confirmations / state.minConfirmations * 100;
+      return (state.confirmations / state.minConfirmations) * 100;
     case StateType.Settled:
       return 100;
     default:
       return 0;
   }
-}
+};
 
 export enum IconState {
   Caution = "caution",
@@ -386,7 +399,7 @@ export const iconState = (state: State): IconState => {
     default:
       return IconState.Caution;
   }
-}
+};
 
 export const statusText = (state: State): string => {
   const timestamp = timeago.format(state.timestamp.secs * 1000);
@@ -404,20 +417,28 @@ export const statusText = (state: State): string => {
     case StateType.Settled:
       return `Transaction settled ${timestamp}`;
   }
-}
+};
 
 export const summaryIconProgress = (summary: Summary): number => {
-  const sum = summary.counts[StateType.Confirmed] + summary.counts[StateType.Settled];
-  if (sum === 0) { return 0; }
+  const sum =
+    summary.counts[StateType.Confirmed] + summary.counts[StateType.Settled];
+  if (sum === 0) {
+    return 0;
+  }
 
   const progress = summary.confirmations / (summary.minConfirmations * sum);
 
   return progress !== 0 ? progress * 100 : 15;
-}
+};
 
 export const summaryIconRotate = (counts: SummaryCounts): boolean => {
-  return (counts.failed > 0 && counts.pending > 0) && (counts.confirmed === 0 && counts.settled === 0);
-}
+  return (
+    counts.failed > 0 &&
+    counts.pending > 0 &&
+    counts.confirmed === 0 &&
+    counts.settled === 0
+  );
+};
 
 export const summaryIconState = (counts: SummaryCounts): IconState => {
   if (counts.failed > 0) {
@@ -427,7 +448,7 @@ export const summaryIconState = (counts: SummaryCounts): IconState => {
   }
 
   return IconState.Positive;
-}
+};
 
 export const summaryText = (counts: SummaryCounts): string => {
   let sum = 0;
@@ -442,7 +463,7 @@ export const summaryText = (counts: SummaryCounts): string => {
   }
   if (counts[StateType.Confirmed] > 0 || counts[StateType.Pending] > 0) {
     sum = counts[StateType.Confirmed] + counts[StateType.Pending];
-    state = StateType.Pending
+    state = StateType.Pending;
   }
 
   if (sum > 1) {
@@ -450,4 +471,4 @@ export const summaryText = (counts: SummaryCounts): string => {
   }
 
   return `transaction ${state}`;
-}
+};

--- a/ui/src/user.ts
+++ b/ui/src/user.ts
@@ -14,17 +14,16 @@ interface RegisterInput {
   maybeEntityId?: string;
 }
 
-export const get = (
-  handle: string,
-): Promise<User | null> => {
+export const get = (handle: string): Promise<User | null> => {
   return api.get<User>(`users/${handle}`);
-}
+};
 
 export const register = (
   handle: string,
-  maybeEntityId?: string,
+  maybeEntityId?: string
 ): Promise<transaction.Transaction> => {
   return api.post<RegisterInput, transaction.Transaction>(`users`, {
-    handle, maybeEntityId
+    handle,
+    maybeEntityId,
   });
-}
+};

--- a/ui/src/validation.ts
+++ b/ui/src/validation.ts
@@ -1,18 +1,18 @@
-import validatejs from "validate.js"
-import { writable, Writable, Readable, get } from "svelte/store"
+import validatejs from "validate.js";
+import { writable, Writable, Readable, get } from "svelte/store";
 
 export enum ValidationStatus {
   NotStarted = "NOT_STARTED",
   Loading = "LOADING",
   Error = "ERROR",
-  Success = "SUCCESS"
+  Success = "SUCCESS",
 }
 
 type ValidationState =
-  { status: ValidationStatus.NotStarted } |
-  { status: ValidationStatus.Loading } |
-  { status: ValidationStatus.Error; message: string } |
-  { status: ValidationStatus.Success }
+  | { status: ValidationStatus.NotStarted }
+  | { status: ValidationStatus.Loading }
+  | { status: ValidationStatus.Error; message: string }
+  | { status: ValidationStatus.Success };
 
 export interface ValidationStore extends Readable<ValidationState> {
   validate: (input: string) => void;
@@ -20,16 +20,19 @@ export interface ValidationStore extends Readable<ValidationState> {
 
 // TODO(sos): While we're figuring out consistent validations, this method makes
 // it easier to derive a ValidationState from an existing validatejs response
-export const getValidationState = (entity: string, validationErrors: { [key: string]: string[] }): ValidationState => {
+export const getValidationState = (
+  entity: string,
+  validationErrors: { [key: string]: string[] }
+): ValidationState => {
   if (validationErrors && validationErrors[entity]) {
     return {
       status: ValidationStatus.Error,
-      message: validationErrors[entity][0]
+      message: validationErrors[entity][0],
     };
   }
 
   return { status: ValidationStatus.Success };
-}
+};
 
 interface RemoteValidation {
   promise: (input: string) => Promise<boolean>;
@@ -47,63 +50,82 @@ interface FormatConstraints {
   };
 }
 
-export const createValidationStore = (constraints: FormatConstraints, remoteValidation?: RemoteValidation): ValidationStore => {
-  const initialState = { status: ValidationStatus.NotStarted } as ValidationState
-  const internalStore = writable(initialState)
-  const { subscribe, update } = internalStore
-  let inputStore: Writable<string> | undefined = undefined
+export const createValidationStore = (
+  constraints: FormatConstraints,
+  remoteValidation?: RemoteValidation
+): ValidationStore => {
+  const initialState = {
+    status: ValidationStatus.NotStarted,
+  } as ValidationState;
+  const internalStore = writable(initialState);
+  const { subscribe, update } = internalStore;
+  let inputStore: Writable<string> | undefined = undefined;
 
   const runValidations = async (input: string): Promise<void> => {
     // Always start with Loading
-    update(() => { return { status: ValidationStatus.Loading, input: input } })
+    update(() => {
+      return { status: ValidationStatus.Loading, input: input };
+    });
 
     // Check for errors
-    const errors = validatejs({ input: input }, { input: constraints }, { fullMessages: false })
+    const errors = validatejs(
+      { input: input },
+      { input: constraints },
+      { fullMessages: false }
+    );
 
     if (errors) {
-      update(() => { return { status: ValidationStatus.Error, message: errors.input[0] } })
-      return
+      update(() => {
+        return { status: ValidationStatus.Error, message: errors.input[0] };
+      });
+      return;
     }
 
     // Check remote validation
     if (remoteValidation) {
       try {
-        const valid = await remoteValidation.promise(input)
+        const valid = await remoteValidation.promise(input);
 
         update((store) => {
           // If the input has changed since this request was fired off, don't update
-          if (get(inputStore) !== input) return store
-          return valid ?
-            { status: ValidationStatus.Success } :
-            { status: ValidationStatus.Error, message: remoteValidation.validationMessage }
-        })
-
+          if (get(inputStore) !== input) return store;
+          return valid
+            ? { status: ValidationStatus.Success }
+            : {
+                status: ValidationStatus.Error,
+                message: remoteValidation.validationMessage,
+              };
+        });
       } catch (error) {
         update(() => {
           return {
             status: ValidationStatus.Error,
-            message: `Cannot validate "${input}": ${error.message}`
-          }
-        })
+            message: `Cannot validate "${input}": ${error.message}`,
+          };
+        });
       }
-      return
+      return;
     }
 
     // If we made it here, it's valid
-    update(() => { return { status: ValidationStatus.Success } })
-  }
+    update(() => {
+      return { status: ValidationStatus.Success };
+    });
+  };
 
   const validate = (input: string): void => {
     if (!inputStore) {
-      inputStore = writable(input)
-      inputStore.subscribe((input: string) => { runValidations(input) })
-      return
+      inputStore = writable(input);
+      inputStore.subscribe((input: string) => {
+        runValidations(input);
+      });
+      return;
     }
-    inputStore.set(input)
-  }
+    inputStore.set(input);
+  };
 
   return {
     subscribe,
-    validate
-  }
-}
+    validate,
+  };
+};


### PR DESCRIPTION
We format everything with prettier, this PR makes sure that `*.ts` files also conform to prettier formatting:
  - enforce prettier formatted `*.ts` files via CI
  - automatically format `*.ts` files on commit via husky
  - fix formatting in all existing `*.ts` files.