### PR TITLE
feat: introduce session permissions

### DIFF
--- a/cypress/integration/user_registration.spec.js
+++ b/cypress/integration/user_registration.spec.js
@@ -139,7 +139,7 @@ context("user registration", () => {
       cy.nukeCache();
     });
 
-    it("can only register a handle once", () => {
+    it("only allows to register a handle once", () => {
       cy.pick("next-button").click();
       cy.pick("submit-button").click();
       cy.pick("profile-context-menu").click();

--- a/cypress/integration/user_registration.spec.js
+++ b/cypress/integration/user_registration.spec.js
@@ -2,7 +2,7 @@ context("user registration", () => {
   before(() => {
     cy.nukeAllState();
     cy.nukeCache();
-    cy.registerUser();
+    cy.registerAlternativeUser("nope");
     cy.createProjectWithFixture();
   });
 
@@ -130,6 +130,20 @@ context("user registration", () => {
         "background-color",
         "rgb(185, 118, 211)"
       );
+    });
+  });
+
+  context("permissions", () => {
+    before(() => {
+      cy.nukeAllState();
+      cy.nukeCache();
+    });
+
+    it("can only register a handle once", () => {
+      cy.pick("next-button").click();
+      cy.pick("submit-button").click();
+      cy.pick("profile-context-menu").click();
+      cy.pick("dropdown-menu", "register-handle").should("not.exist");
     });
   });
 });

--- a/proxy/src/http/session.rs
+++ b/proxy/src/http/session.rs
@@ -306,12 +306,17 @@ mod test {
                         "network": "emulator",
                     },
                 },
+                "permissions": {
+                    "registerHandle": false,
+                    "registerOrg": false,
+                    "registerProject": false,
+                },
             }),
         );
     }
 
     #[tokio::test]
-    async fn udpate_settings() {
+    async fn update_settings() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store"))).unwrap();
         let registry = {
@@ -347,6 +352,11 @@ mod test {
                     "registry": {
                         "network": "emulator",
                     },
+                },
+                "permissions": {
+                    "registerHandle": false,
+                    "registerOrg": false,
+                    "registerProject": false,
                 },
             }),
         );

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -62,9 +62,7 @@ pub async fn current<R: registry::Client>(
     let mut session = get(store, KEY_CURRENT)?;
 
     // Reset the permissions
-    session.permissions.register_handle = false;
-    session.permissions.register_org = false;
-    session.permissions.register_project = false;
+    session.permissions = Permissions::default();
 
     if let Some(mut id) = session.identity.clone() {
         if let Some(handle) = id.registered.clone() {

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -26,7 +26,7 @@ pub struct Session {
     pub settings: settings::Settings,
 }
 
-/// Permissions of the user
+/// Set of permitted actions the user can perform.
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Permissions {

--- a/ui/Screen/Profile.svelte
+++ b/ui/Screen/Profile.svelte
@@ -53,15 +53,17 @@
       icon: Icon.Plus,
       event: () => push(path.createProject()),
     },
-    {
+  ];
+
+  const session = getContext("session");
+  if (session.permissions.registerHandle) {
+    dropdownMenuItems.push({
       title: "Register handle",
       dataCy: "register-handle",
       icon: Icon.Register,
       event: () => push(path.registerUser()),
-    },
-  ];
-
-  const session = getContext("session");
+    });
+  }
 </script>
 
 <SidebarLayout

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -15,7 +15,14 @@ import * as transaction from "./transaction";
 export interface Session {
   identity?: identity.Identity;
   orgs: org.Org[];
+  permissions: Permissions;
   settings: Settings;
+}
+
+export interface Permissions {
+  registerHandle: boolean;
+  registerOrg: boolean;
+  registerProject: boolean;
 }
 
 // STATE
@@ -27,6 +34,16 @@ export const settings: Readable<Settings | null> = derived(
   (sess) => {
     if (sess.status === remote.Status.Success) {
       return sess.data.settings;
+    }
+    return null;
+  }
+);
+
+export const permissions: Readable<Permissions | null> = derived(
+  sessionStore,
+  (sess) => {
+    if (sess.status === remote.Status.Success) {
+      return sess.data.permissions;
     }
     return null;
   }


### PR DESCRIPTION
Implements permissions for registering handle/org/project added to the session API endpoint. The use of `registerHandle` in the ui is implemented to block the user from registering a handle a second time. More details can be found in #371. 
The use cases of the other permissions will be implemented in follow up PRs.