### PR TITLE
chore(ci): Improve build times

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -86,5 +86,7 @@ time yarn prettier:check
 echo "--- Starting proxy daemon and runing app tests"
 time ELECTRON_ENABLE_LOGGING=1 yarn test
 
-echo "--- Packaging and uploading app binaries"
-time yarn dist
+if [[ "${BUILDKITE_BRANCH:-}" == "master" ]]; then
+  echo "--- Packaging and uploading app binaries"
+  time yarn dist
+fi


### PR DESCRIPTION
Build binaries only on master, shaves off 15min of CI build times.

We're not using the binaries on feature branches yet. Checking the binary after a release should be enough for now.