### PR TITLE
fix(proxy): fix transaction subject for project registration

### DIFF
--- a/cypress/integration/project_registration.spec.js
+++ b/cypress/integration/project_registration.spec.js
@@ -131,9 +131,8 @@ context("project registration", () => {
   });
 
   context("summary screen", () => {
-    // TODO(sos): test this when we can actually register projects under users
     context("when registering under a user", () => {
-      it.skip("shows the selected subject and payer information", () => {
+      it("shows the selected subject and payer information", () => {
         cy.pick(`project-list-entry-${project1.name}`, "context-menu").click();
         cy.pick(`project-list-entry-${project1.name}`).click();
 
@@ -143,11 +142,7 @@ context("project registration", () => {
         cy.pick("project-registration-screen").should("exist");
         cy.pick("submit-button").click();
 
-        cy.get('[data-cy="subject-avatar"] img[alt="🐅"]').should("exist");
         cy.pick("subject-avatar").contains(`${user} / ${project1.name}`);
-
-        cy.get('[data-cy="payer-avatar"] img[alt="🐅"]').should("exist");
-        cy.pick("payer-avatar").contains(user);
       });
     });
 
@@ -168,10 +163,6 @@ context("project registration", () => {
 
         cy.get('[data-cy="subject-avatar"] img[alt="🥂"]').should("exist");
         cy.pick("subject-avatar").contains(`${org1} / ${project1.name}`);
-
-        // TODO(sos): test this when we can actually change transaction payer
-        // cy.get('[data-cy="payer-avatar"] img[alt="🥂"]').should("exist");
-        // cy.pick("payer-avatar").contains(org1);
       });
     });
   });
@@ -189,6 +180,8 @@ context("project registration", () => {
 
         // go to summary screen
         cy.pick("submit-button").click();
+
+        cy.pick("subject-avatar").contains(`${org1} / ${project1.name}`);
 
         cy.pick("deposit", "rad-amount").contains("0.00001");
         cy.pick("deposit", "usd-amount").contains("$0.00001");
@@ -222,6 +215,8 @@ context("project registration", () => {
         cy.pick("transaction-center", "transaction-item")
           .contains("Project registration")
           .click();
+
+        cy.pick("subject-avatar").contains(`${org1} / ${project1.name}`);
 
         cy.pick("deposit", "rad-amount").contains("0.00001");
         cy.pick("deposit", "usd-amount").contains("$0.00001");

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -530,8 +530,6 @@ mod test {
     use crate::project;
     use crate::registry::{self, Cache as _, Client as _};
 
-    use super::registry::DomainType;
-
     #[tokio::test]
     async fn create() {
         let tmp_dir = tempfile::tempdir().unwrap();

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -248,15 +248,6 @@ mod handler {
     }
 }
 
-impl From<(DomainType, registry::Id)> for registry::ProjectDomain {
-    fn from((domain, id): (DomainType, registry::Id)) -> Self {
-        match domain {
-            DomainType::Org => Self::Org(id),
-            DomainType::User => Self::User(id),
-        }
-    }
-}
-
 impl Serialize for project::Project {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -475,22 +466,12 @@ impl ToDocumentedType for MetadataInput {
     }
 }
 
-/// The domains we support under which a project can live.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum DomainType {
-    /// An Org
-    Org,
-    /// A User
-    User,
-}
-
 /// Bundled input data for project registration.
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterInput {
     /// The type of domain the project will be registered under.
-    domain_type: DomainType,
+    domain_type: registry::DomainType,
     /// Id of the domain the project will be registered under.
     domain_id: String,
     /// Unique name under Org of the project.
@@ -549,7 +530,7 @@ mod test {
     use crate::project;
     use crate::registry::{self, Cache as _, Client as _};
 
-    use super::DomainType;
+    use super::registry::DomainType;
 
     #[tokio::test]
     async fn create() {
@@ -723,7 +704,7 @@ mod test {
             .method("POST")
             .path("/projects/register")
             .json(&super::RegisterInput {
-                domain_type: DomainType::Org,
+                domain_type: registry::DomainType::Org,
                 domain_id: org_id.to_string(),
                 project_name: "upstream".into(),
                 maybe_coco_id: Some("1234.git".to_string()),
@@ -743,13 +724,15 @@ mod test {
         match tx_msg {
             registry::Message::ProjectRegistration {
                 project_name,
-                project_domain,
+                domain_type,
+                domain_id,
             } => {
                 assert_eq!(
                     project_name.clone(),
                     registry::ProjectName::try_from("upstream").unwrap()
                 );
-                assert_eq!(project_domain.clone(), registry::ProjectDomain::Org(org_id));
+                assert_eq!(domain_type.clone(), registry::DomainType::Org);
+                assert_eq!(domain_id.clone(), org_id);
             },
             _ => panic!("The tx message is an unexpected variant."),
         }
@@ -784,7 +767,7 @@ mod test {
             .method("POST")
             .path("/projects/register")
             .json(&super::RegisterInput {
-                domain_type: DomainType::User,
+                domain_type: registry::DomainType::User,
                 domain_id: handle.to_string(),
                 project_name: "upstream".into(),
                 maybe_coco_id: Some("1234.git".to_string()),
@@ -804,16 +787,15 @@ mod test {
         match tx_msg {
             registry::Message::ProjectRegistration {
                 project_name,
-                project_domain,
+                domain_type,
+                domain_id,
             } => {
                 assert_eq!(
                     project_name.clone(),
                     registry::ProjectName::try_from("upstream").unwrap()
                 );
-                assert_eq!(
-                    project_domain.clone(),
-                    registry::ProjectDomain::User(handle)
-                );
+                assert_eq!(domain_type.clone(), registry::DomainType::User);
+                assert_eq!(domain_id.clone(), handle);
             },
             _ => panic!("The tx message is an unexpected variant."),
         }

--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -233,13 +233,13 @@ mod test {
         let now = registry::Timestamp::now();
 
         let org_id = registry::Id::try_from("radicle").unwrap();
-        let project_domain = registry::ProjectDomain::Org(org_id);
 
         let tx = registry::Transaction {
             id: registry::Hash(radicle_registry_client::TxHash::random()),
             messages: vec![registry::Message::ProjectRegistration {
                 project_name: registry::ProjectName::try_from("upstream").unwrap(),
-                project_domain,
+                domain_type: registry::DomainType::Org,
+                domain_id: org_id,
             }],
             state: registry::State::Confirmed {
                 block: 1,

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -99,10 +99,12 @@ pub enum Message {
     /// Issue a new project registration with a given name under a given org.
     #[serde(rename_all = "camelCase")]
     ProjectRegistration {
-        /// Actual project name, unique for org.
+        /// Actual project name, unique under its domain.
         project_name: registry::ProjectName,
-        /// The domain in which to register the project.
-        project_domain: registry::ProjectDomain,
+        /// The type of domain in which to register the project.
+        domain_type: registry::DomainType,
+        /// The id of the domain in which to register the project
+        domain_id: registry::Id,
     },
 
     /// Issue a user registration for a given handle storing the corresponding identity id.
@@ -321,7 +323,6 @@ where
             }
         }
         txs.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-
         Ok(txs)
     }
 }

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -18,6 +18,8 @@ interface Timestamp {
   nanos: number;
 }
 
+// / Note: The schemas of each variant must correspond to
+// / their proxy > registry > Message variant counterpart.
 export enum MessageType {
   OrgRegistration = "orgRegistration",
   OrgUnregistration = "orgUnregistration",


### PR DESCRIPTION
Closes #481 

### The problem

The `ui > MessageType` and their corresponding `proxy > registry > Message` variants need to match in schema or else the UI will be missing out on information, which occurs now in the transaction details screen for a project registration, where `domain_id` is undefined.

More concretely, at the moment `Message::ProjectRegistration`, when serialized to the UI, includes `projectDomain { "User|Org": "id" }`, instead of `domainType` and `domainId`, as the UI counterpart expects, leading to the `undefined` we see.

 


