### PR TITLE
chore(proxy): Drop the custom Hash struct

### DIFF
--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -58,18 +58,13 @@ mod handler {
         input: super::ListInput,
     ) -> Result<impl Reply, Rejection> {
         // TODO(xla): Don't panic when trying to convert ids.
-        println!("handler::list input.ids {:?}", input.ids.clone());
         let tx_ids = input
             .ids
             .iter()
             .map(|id| {
-                println!("handler::list will try to convert id {}", id);
                 let string = format!("\"{}\"", id);
-                println!("handler::list wrapped id with quotes: {}", string);
-                let deserialized = serde_json::from_str::<registry::Hash>(&string)
-                    .expect("unable to get hash from string");
-                println!("handler::list id now deserialized {:?}", deserialized);
-                deserialized
+                serde_json::from_str::<registry::Hash>(&string)
+                    .expect("unable to get hash from string")
             })
             .collect();
         let txs = cache.read().await.list_transactions(tx_ids)?;
@@ -259,10 +254,10 @@ mod test {
 
         cache.cache_transaction(tx.clone()).unwrap();
 
-        let input_ids = vec![tx.id.clone()];
+        let input_ids = vec![tx.id];
         let serialized_ids = input_ids
             .iter()
-            .map(|h| serde_json::to_string(h).expect("Fail 1"))
+            .map(|h| serde_json::to_string(h).expect("Failed to serialize ids"))
             .collect();
 
         let transactions = cache.list_transactions(input_ids).unwrap();
@@ -281,6 +276,5 @@ mod test {
 
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(have, json!(transactions));
-        assert_eq!(transactions.first().unwrap().id, tx.id);
     }
 }

--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -62,10 +62,7 @@ mod handler {
         let tx_ids = input
             .ids
             .iter()
-            .map(|id| {
-                radicle_registry_client::TxHash::from_str(id)
-                    .expect("unable to get hash from string")
-            })
+            .map(|id| registry::Hash::from_str(id).expect("unable to get hash from string"))
             .collect();
         let txs = cache.read().await.list_transactions(tx_ids)?;
 

--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -252,7 +252,7 @@ mod test {
 
         cache.cache_transaction(tx.clone()).unwrap();
 
-        let transactions = cache.list_transactions(vec![]).unwrap();
+        let transactions = cache.list_transactions(vec![tx.id.clone()]).unwrap();
 
         let api = super::filters(Arc::new(RwLock::new(cache)));
         let res = request()
@@ -266,5 +266,6 @@ mod test {
 
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(have, json!(transactions));
+        assert_eq!(transactions.first().unwrap().id, tx.id);
     }
 }

--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -236,7 +236,7 @@ mod test {
         let org_id = registry::Id::try_from("radicle").unwrap();
 
         let tx = registry::Transaction {
-            id: registry::Hash(radicle_registry_client::TxHash::random()),
+            id: registry::Hash::random(),
             messages: vec![registry::Message::ProjectRegistration {
                 project_name: registry::ProjectName::try_from("upstream").unwrap(),
                 domain_type: registry::DomainType::Org,

--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -47,7 +47,6 @@ fn list_filter<C: registry::Cache>(
 /// Transaction handlers to implement conversion and translation between core domain and http
 /// request fullfilment.
 mod handler {
-    use std::str::FromStr;
     use warp::{reply, Rejection, Reply};
 
     use crate::http;
@@ -62,7 +61,9 @@ mod handler {
         let tx_ids = input
             .ids
             .iter()
-            .map(|id| registry::Hash::from_str(id).expect("unable to get hash from string"))
+            .map(|id| {
+                serde_json::from_str::<registry::Hash>(id).expect("unable to get hash from string")
+            })
             .collect();
         let txs = cache.read().await.list_transactions(tx_ids)?;
 

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -1099,12 +1099,12 @@ mod test {
     #[tokio::test]
     async fn deserialize_failing_str() -> Result<(), error::Error> {
         let deserialized = serde_json::from_str::<protocol::Hash>(
-            &"0x6d8ccfd2b4fcf295af8cc51b3491f49893e4e55af0cf975bccbe264b080b2adf",
+            "0x6d8ccfd2b4fcf295af8cc51b3491f49893e4e55af0cf975bccbe264b080b2adf",
         );
         assert!(deserialized.is_err());
 
         let deserialized_2 = serde_json::from_str::<protocol::Hash>(
-            &"\"0x88788f187f40a12f88aad8e3dd6ba494452305ed0ced83367c9dcd997dd026c2\"",
+            "\"0x88788f187f40a12f88aad8e3dd6ba494452305ed0ced83367c9dcd997dd026c2\"",
         ); //.expect("failed");
         assert!(deserialized_2.is_ok());
 

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -1082,4 +1082,17 @@ mod test {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn deserialize_after_serialize() -> Result<(), error::Error> {
+        let hash = protocol::Hash::random();
+
+        let serialized = serde_json::to_string(&hash).expect("should work");
+        let deserialized =
+            serde_json::from_str::<protocol::Hash>(&serialized).expect("Should work 2");
+
+        assert_eq!(deserialized, hash);
+
+        Ok(())
+    }
 }

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 use std::fmt;
 
 use radicle_registry_client::{self as protocol, ClientT, CryptoPair};
-pub use radicle_registry_client::{Balance, MINIMUM_FEE};
+pub use radicle_registry_client::{Balance, Hash, MINIMUM_FEE};
 
 use crate::avatar;
 use crate::error;
@@ -115,9 +115,6 @@ impl TryFrom<&str> for ProjectName {
         Ok(Self(protocol::ProjectName::try_from(input)?))
     }
 }
-
-/// The registry Hash type
-pub type Hash = protocol::Hash;
 
 /// `ProjectID` wrapper for serde de/serialization
 #[derive(Serialize, Deserialize)]

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -1095,4 +1095,19 @@ mod test {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn deserialize_failing_str() -> Result<(), error::Error> {
+        let deserialized = serde_json::from_str::<protocol::Hash>(
+            &"0x6d8ccfd2b4fcf295af8cc51b3491f49893e4e55af0cf975bccbe264b080b2adf",
+        );
+        assert!(deserialized.is_err());
+
+        let deserialized_2 = serde_json::from_str::<protocol::Hash>(
+            &"\"0x88788f187f40a12f88aad8e3dd6ba494452305ed0ced83367c9dcd997dd026c2\"",
+        ); //.expect("failed");
+        assert!(deserialized_2.is_ok());
+
+        Ok(())
+    }
 }

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -329,9 +329,7 @@ where
 
     /// Caches a transaction locally in the Registry.
     fn cache_transaction(&self, tx: Transaction) -> Result<(), error::Error> {
-        println!("cache_transaction tx.id {:?}", tx.id);
         let key = serde_json::to_string(&tx.id).expect("Couldn't serialize registry Hash");
-        println!("cache_transaction tx.id serialized {:?}", key);
 
         self.transactions.set(key.as_str(), kv::Json(tx))?;
 

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -329,7 +329,10 @@ where
 
     /// Caches a transaction locally in the Registry.
     fn cache_transaction(&self, tx: Transaction) -> Result<(), error::Error> {
+        println!("cache_transaction tx.id {:?}", tx.id);
         let key = serde_json::to_string(&tx.id).expect("Couldn't serialize registry Hash");
+        println!("cache_transaction tx.id serialized {:?}", key);
+
         self.transactions.set(key.as_str(), kv::Json(tx))?;
 
         Ok(())

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -2,7 +2,6 @@
 //! Abstractions and types to handle, persist and interact with transactions.
 
 use async_trait::async_trait;
-use hex::ToHex;
 use kv::Codec as _;
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize, Serializer};
@@ -330,7 +329,7 @@ where
 
     /// Caches a transaction locally in the Registry.
     fn cache_transaction(&self, tx: Transaction) -> Result<(), error::Error> {
-        let key = tx.id.encode_hex::<String>();
+        let key = serde_json::to_string(&tx.id).expect("Couldn't serialize registry Hash");
         self.transactions.set(key.as_str(), kv::Json(tx))?;
 
         Ok(())


### PR DESCRIPTION
In https://github.com/radicle-dev/radicle-registry/issues/512,  we considered moving the `struct Hash` defined in this repo into the registry and adopting it client-side. We have [a draft PR](https://github.com/radicle-dev/radicle-registry/pull/517) introducing this change.

However, by implementing these changes the question became whether it's worth introducing it all. The registry hash type already implements `Serialize` and `Deserialize`, so the custom struct wrapper only serves to implement the custom implementation that hex encodes the hash. 

Comparing the output of the default implementation with the custom, hex-encoded implementation reveals that it's not really worth it:

- Default impl / with `#[derive(Serialize, Deserialize]`

```
0xc6e42491b3497438bd559219bbea2cc1badd7340393ce3231a553f750759dfd9
```

- Custom impl / with hex encode

```
c6e42491b3497438bd559219bbea2cc1badd7340393ce3231a553f750759dfd9
```

The only difference being the `0x` prefix. I and @geigerzaehler agree that the simplest approach, as of now, is to drop this `struct Hash` altogether and use the underlying type directly. In the UI, the `0x` prefix is ignored.

