### PR TITLE
chore(proxy): Drop duplicated registry types

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=ff04d829a5e6e3746a4147605a4639db0d390e2c#ff04d829a5e6e3746a4147605a4639db0d390e2c"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=353d5707bf3bcb725556039e144dde48a0703e4f#353d5707bf3bcb725556039e144dde48a0703e4f"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -2727,11 +2727,12 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=ff04d829a5e6e3746a4147605a4639db0d390e2c#ff04d829a5e6e3746a4147605a4639db0d390e2c"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=353d5707bf3bcb725556039e144dde48a0703e4f#353d5707bf3bcb725556039e144dde48a0703e4f"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
  "rand 0.7.3",
+ "serde",
  "sp-core",
  "sp-runtime",
  "thiserror",
@@ -2739,8 +2740,8 @@ dependencies = [
 
 [[package]]
 name = "radicle-registry-runtime"
-version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=ff04d829a5e6e3746a4147605a4639db0d390e2c#ff04d829a5e6e3746a4147605a4639db0d390e2c"
+version = "0.8.0"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=353d5707bf3bcb725556039e144dde48a0703e4f#353d5707bf3bcb725556039e144dde48a0703e4f"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -37,7 +37,7 @@ rev = "d2c75eab89e831f639a3618d081c9ce29c7f59a6"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "ff04d829a5e6e3746a4147605a4639db0d390e2c"
+rev = "353d5707bf3bcb725556039e144dde48a0703e4f"
 
 [dev-dependencies]
 bytes = "0.5"

--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -104,6 +104,7 @@ mod handler {
     use librad::keys::SecretKey;
 
     use crate::coco;
+    use crate::error::Error;
     use crate::http;
     use crate::project;
     use crate::registry;
@@ -150,7 +151,7 @@ mod handler {
         let fake_pair =
             radicle_registry_client::ed25519::Pair::from_legacy_string(&input.handle, None);
 
-        let handle = registry::Id::try_from(input.handle)?;
+        let handle = registry::Id::try_from(input.handle).map_err(Error::from)?;
         let reg = registry.write().await;
         reg.register_user(&fake_pair, handle.clone(), None, input.transaction_fee)
             .await

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -212,6 +212,7 @@ mod handler {
     use warp::{reply, Rejection, Reply};
 
     use crate::coco;
+    use crate::error::Error;
     use crate::http;
     use crate::notification;
     use crate::project;
@@ -223,7 +224,7 @@ mod handler {
         org_id: String,
     ) -> Result<impl Reply, Rejection> {
         let reg = registry.read().await;
-        let org_id = registry::Id::try_from(org_id)?;
+        let org_id = registry::Id::try_from(org_id).map_err(Error::from)?;
         let org = reg.get_org(org_id).await?;
 
         Ok(reply::json(&org))
@@ -236,9 +237,9 @@ mod handler {
         project_name: String,
     ) -> Result<impl Reply, Rejection> {
         let reg = registry.read().await;
-        let org_id = registry::Id::try_from(org_id)?;
+        let org_id = registry::Id::try_from(org_id).map_err(Error::from)?;
         let project_domain = registry::ProjectDomain::Org(org_id);
-        let project_name = registry::ProjectName::try_from(project_name)?;
+        let project_name = registry::ProjectName::try_from(project_name).map_err(Error::from)?;
         let project = reg.get_project(project_domain, project_name).await?;
 
         Ok(reply::json(&project))
@@ -254,7 +255,7 @@ mod handler {
         R: registry::Client,
     {
         let reg = registry.read().await;
-        let org_id = registry::Id::try_from(org_id)?;
+        let org_id = registry::Id::try_from(org_id).map_err(Error::from)?;
         let projects = reg.list_org_projects(org_id).await?;
         let peer = peer.lock().await;
         let mut mapped_projects = Vec::new();
@@ -291,7 +292,7 @@ mod handler {
         let fake_pair = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
 
         let reg = registry.read().await;
-        let org_id = registry::Id::try_from(input.id)?;
+        let org_id = registry::Id::try_from(input.id).map_err(Error::from)?;
         let tx = reg
             .register_org(&fake_pair, org_id, input.transaction_fee)
             .await?;
@@ -314,8 +315,8 @@ mod handler {
         let fake_pair = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
 
         let reg = registry.read().await;
-        let org_id = registry::Id::try_from(id)?;
-        let handle = registry::Id::try_from(input.handle)?;
+        let org_id = registry::Id::try_from(id).map_err(Error::from)?;
+        let handle = registry::Id::try_from(input.handle).map_err(Error::from)?;
         let tx = reg
             .register_member(&fake_pair, org_id, handle, input.transaction_fee)
             .await?;


### PR DESCRIPTION
Closes #470, expect the `Hash` type which is handled in #https://github.com/radicle-dev/radicle-upstream/pull/493

Drops the duplicated registry types by moving their trait implementations to the respective types in the registry.