### PR TITLE
chore(ui): skip flaky test

### DIFF
--- a/cypress/integration/org_registration.spec.js
+++ b/cypress/integration/org_registration.spec.js
@@ -42,7 +42,8 @@ context("org registration", () => {
   });
 
   context("validations", () => {
-    it("prevents the user from registering an invalid org id", () => {
+    // TODO: Fix validation bug in https://github.com/radicle-dev/radicle-upstream/issues/492
+    it.skip("prevents the user from registering an invalid org id", () => {
       // no empty input
       cy.pick("input").type("a_name");
       cy.pick("input").clear();


### PR DESCRIPTION
This test fails most of our CI runs now that the CI server is more loaded and slower.

We should fix the underlying issue https://github.com/radicle-dev/radicle-upstream/issues/492 before we un-skip this test.