### PR TITLE
chore(ui): fix circular dependency

### DIFF
--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -4,7 +4,7 @@
 
   import * as path from "../../src/path.ts";
 
-  import { Tooltip } from "../Component";
+  import Tooltip from "./Tooltip.svelte";
   import { Avatar, Icon } from "../Primitive";
 
   import AddOrgButton from "./Sidebar/AddOrgButton.svelte";


### PR DESCRIPTION
Follow-up to: https://github.com/radicle-dev/radicle-upstream/pull/489.

Gets rid of warning:
```
(!) Circular dependency
ui/DesignSystem/Component/index.js -> ui/DesignSystem/Component/Sidebar.svelte -> ui/DesignSystem/Component/index.js
```

