### PR TITLE
feat(proxy): User Creation

### DIFF
--- a/cypress/integration/identity_creation.spec.js
+++ b/cypress/integration/identity_creation.spec.js
@@ -1,11 +1,10 @@
 context("identity creation", () => {
   const validUser = {
     handle: "rafalca",
-    shareableEntityIdentifier: "rafalca@123abcd.git",
-    fallbackAvatar: "🎀",
   };
 
   beforeEach(() => {
+    cy.nukeCocoState();
     cy.nukeSessionState();
     cy.nukeRegistryState();
     cy.visit("./public/index.html");
@@ -29,12 +28,8 @@ context("identity creation", () => {
       cy.pick("create-id-button").click();
 
       // Confirmation screen
-      cy.get(
-        `[data-cy="identity-card"] img[alt=${validUser.fallbackAvatar}]`
-      ).should("exist");
-      cy.pick("identity-card")
-        .contains(validUser.shareableEntityIdentifier)
-        .should("exist");
+      cy.get(`[data-cy="identity-card"]`).should("exist");
+      cy.pick("identity-card").contains(validUser.handle).should("exist");
 
       // Land on profile screen
       cy.pick("go-to-profile-button").click();
@@ -89,9 +84,7 @@ context("identity creation", () => {
           cy.pick("form", "handle").type(validUser.handle);
           cy.pick("create-id-button").click();
 
-          cy.pick("identity-card")
-            .contains(validUser.shareableEntityIdentifier)
-            .should("exist");
+          cy.pick("identity-card").contains(validUser.handle).should("exist");
 
           // Land on profile screen
           cy.pick("modal-close-button").click();
@@ -107,9 +100,7 @@ context("identity creation", () => {
         cy.pick("form", "handle").type(validUser.handle);
         cy.pick("create-id-button").click();
 
-        cy.pick("identity-card")
-          .contains(validUser.shareableEntityIdentifier)
-          .should("exist");
+        cy.pick("identity-card").contains(validUser.handle).should("exist");
 
         // Now try the escape key
         cy.get("body").type("{esc}");

--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -2,6 +2,7 @@ context("routing", () => {
   context("session persistancy", () => {
     context("first time app start with no stored session data", () => {
       it("opens on the identity creation wizard", () => {
+        cy.nukeCocoState();
         cy.nukeSessionState();
         cy.visit("./public/index.html");
         cy.pick("get-started-button").should("exist");
@@ -13,7 +14,6 @@ context("routing", () => {
         "when there is no additional routing information stored in the browser location",
         () => {
           it("opens the app on the profile screen", () => {
-            cy.nukeSessionState();
             cy.createIdentity();
             cy.visit("./public/index.html");
 
@@ -28,7 +28,6 @@ context("routing", () => {
         "when there is additional routing information stored in the browser location",
         () => {
           it("resumes the app from the browser location", () => {
-            cy.nukeSessionState();
             cy.createIdentity();
             cy.visit("./public/index.html");
 

--- a/cypress/integration/settings_specs.js
+++ b/cypress/integration/settings_specs.js
@@ -1,6 +1,7 @@
 context("settings", () => {
   beforeEach(() => {
     cy.nukeCache();
+    cy.nukeCocoState();
     cy.nukeSessionState();
     cy.nukeRegistryState();
     cy.createIdentity();

--- a/cypress/integration/user_registration.spec.js
+++ b/cypress/integration/user_registration.spec.js
@@ -1,12 +1,12 @@
 context("user registration", () => {
   before(() => {
     cy.nukeAllState();
-    cy.nukeCache();
     cy.registerAlternativeUser("nope");
     cy.createProjectWithFixture();
   });
 
   beforeEach(() => {
+    cy.nukeCocoState();
     cy.nukeSessionState();
     cy.createIdentity();
 
@@ -90,23 +90,23 @@ context("user registration", () => {
     before(() => {
       // Clear everything again so transaction center is empty
       cy.nukeAllState();
-      cy.nukeCache();
       cy.createProjectWithFixture();
     });
 
-    it("shows the correct transaction details for confirmation", () => {
+    it("shows the correct transaction details for confirmation", async () => {
       cy.pick("next-button").click();
 
       cy.pick("message").contains("User registration");
       cy.pick("subject").contains("secretariat");
 
       cy.pick("subject-avatar", "emoji").should("have.class", "circle");
-      cy.pick("subject", "emoji").find("img").should("have.attr", "alt", "🏯");
-      cy.pick("subject", "emoji").should(
-        "have.css",
-        "background-color",
-        "rgb(185, 118, 211)"
-      );
+      // TODO(xla): Fimd a way to assert the correct avatar is present.
+      // cy.pick("subject", "emoji").find("img").should("have.attr", "alt", "🏯");
+      // cy.pick("subject", "emoji").should(
+      //   "have.css",
+      //   "background-color",
+      //   "rgb(185, 118, 211)"
+      // );
 
       cy.pick("deposit", "rad-amount").contains("0.00001");
       cy.pick("deposit", "usd-amount").contains("$0.00001");
@@ -133,12 +133,13 @@ context("user registration", () => {
         "have.class",
         "circle"
       );
-      cy.pick("subject", "emoji").find("img").should("have.attr", "alt", "🏯");
-      cy.pick("subject", "emoji").should(
-        "have.css",
-        "background-color",
-        "rgb(185, 118, 211)"
-      );
+      // TODO(xla): Fimd a way to assert the correct avatar is present.
+      // cy.pick("subject", "emoji").find("img").should("have.attr", "alt", "🏯");
+      // cy.pick("subject", "emoji").should(
+      //   "have.css",
+      //   "background-color",
+      //   "rgb(185, 118, 211)"
+      // );
 
       cy.pick("deposit", "rad-amount").contains("0.00001");
       cy.pick("deposit", "usd-amount").contains("$0.00001");

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1575,7 +1575,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=35f6e5e8bbe91012dae180f4a41ae582b3b1d2c2#35f6e5e8bbe91012dae180f4a41ae582b3b1d2c2"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=11daae382a812d4f152cdf5cdc70572360a65228#11daae382a812d4f152cdf5cdc70572360a65228"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "radicle-keystore"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=35f6e5e8bbe91012dae180f4a41ae582b3b1d2c2#35f6e5e8bbe91012dae180f4a41ae582b3b1d2c2"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=11daae382a812d4f152cdf5cdc70572360a65228#11daae382a812d4f152cdf5cdc70572360a65228"
 dependencies = [
  "lazy_static",
  "rpassword",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1575,7 +1575,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=11daae382a812d4f152cdf5cdc70572360a65228#11daae382a812d4f152cdf5cdc70572360a65228"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=d5e06abd9e8f5361cb6b4f693561007036b6d263#d5e06abd9e8f5361cb6b4f693561007036b6d263"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "radicle-keystore"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=11daae382a812d4f152cdf5cdc70572360a65228#11daae382a812d4f152cdf5cdc70572360a65228"
+source = "git+https://github.com/radicle-dev/radicle-keystore?rev=a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa#a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
 dependencies = [
  "lazy_static",
  "rpassword",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "adler32"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
+checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
 name = "ahash"
@@ -110,9 +110,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8"
+checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -144,13 +144,14 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -194,9 +195,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+checksum = "e223af0dc48c96d4f8342ec01a4974f139df863896b316681efd36742f22cc67"
 
 [[package]]
 name = "bincode"
@@ -341,9 +342,12 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "cc"
@@ -373,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "clear_on_drop"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
+checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
 dependencies = [
  "cc",
 ]
@@ -593,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.7"
+version = "0.99.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
+checksum = "bc655351f820d774679da6cdc23355a93de496867d8203496675162e17b1d671"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -640,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "ed25519-dalek"
@@ -1048,7 +1052,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe8859feb7140742ed1a2a85a07941100ad2b5f98a421b353931d718a34144d1"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures 0.3.5",
  "memchr",
  "pin-project",
@@ -1063,6 +1067,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
+dependencies = [
+ "cc",
+ "libc",
+ "log 0.4.8",
+ "rustc_version",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1127,7 +1144,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1177,9 +1194,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.2",
  "bitflags",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "headers-core",
  "http",
  "mime 0.3.16",
@@ -1198,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
@@ -1238,7 +1255,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "fnv",
  "itoa",
 ]
@@ -1249,7 +1266,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "http",
 ]
 
@@ -1293,7 +1310,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1387,7 +1404,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
 ]
 
 [[package]]
@@ -1407,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jobserver"
@@ -1575,12 +1592,12 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=d5e06abd9e8f5361cb6b4f693561007036b6d263#d5e06abd9e8f5361cb6b4f693561007036b6d263"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=a5b1d53cfe01e929dc8290c1037797a25a56335e#a5b1d53cfe01e929dc8290c1037797a25a56335e"
 dependencies = [
  "async-trait",
  "bit-vec",
  "bs58",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "directories",
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -1708,6 +1725,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls 0.1.2",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +1856,15 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.31",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -2040,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg 1.0.0",
  "num-traits",
@@ -2062,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg 1.0.0",
  "libm",
@@ -2082,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "olpc-cjson"
@@ -2333,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d508492eeb1e5c38ee696371bf7b9fc33c83d46a7d451606b96458fbbbdc2dec"
+checksum = "026c63fe245362be0322bfec5a9656d458d13f9cfb1785d1b38458b9968e8080"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -2343,14 +2380,11 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f328a6a63192b333fce5fbb4be79db6758a4d518dfac6d54412f1492f72d32"
+checksum = "7b9281a268ec213237dcd2aa3c3d0f46681b04ced37c1616fd36567a9e6954b0"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.31",
 ]
 
 [[package]]
@@ -2428,24 +2462,24 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad1f1b834a05d42dae330066e9699a173b28185b3bdc3dbf14ca239585de8cc"
+checksum = "6a71836ceac43f0349e3bd964f5bb902f7b003916f32a4ad00354dafc447fa8f"
 
 [[package]]
 name = "pin-project"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -2554,9 +2588,9 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afe1bd463b9e9ed51d0e0f0b50b6b146aec855c56fd182bb242388710a9b6de"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -2601,7 +2635,7 @@ name = "proxy"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "directories",
  "futures 0.3.5",
  "hex",
@@ -2649,7 +2683,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88de58d76d8f82fb28e5c89302119c102bb5b9ce57b034186b559b63ba147a0f"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "err-derive",
  "futures 0.3.5",
  "libc",
@@ -2667,7 +2701,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ea0a358c179c6b7af34805c675d1664a9c6a234a7acd7efdbb32d2f39d3d2a"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "err-derive",
  "rand 0.7.3",
  "ring",
@@ -2698,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "radicle-keystore"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-keystore?rev=a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa#a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
+source = "git+https://github.com/radicle-dev/radicle-keystore.git?rev=a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa#a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
 dependencies = [
  "lazy_static",
  "rpassword",
@@ -2791,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "radicle-surf"
 version = "0.2.1"
-source = "git+https://github.com/radicle-dev/radicle-surf?rev=fc11489494fb76a2a6e1c7b425b164602f89ba23#fc11489494fb76a2a6e1c7b425b164602f89ba23"
+source = "git+https://github.com/radicle-dev/radicle-surf?rev=a23f9406f00c3230a24b6ddd9b612a9b1d5accf1#a23f9406f00c3230a24b6ddd9b612a9b1d5accf1"
 dependencies = [
  "git2",
  "lazy_static",
@@ -3039,18 +3073,18 @@ checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "ring"
-version = "0.16.14"
+version = "0.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b3fefa4f12272808f809a0af618501fdaba41a58963c5fb72238ab0be09603"
+checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
 dependencies = [
  "cc",
  "libc",
@@ -3130,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
+checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -3165,7 +3199,7 @@ name = "sc-rpc-api"
 version = "0.8.0-dev"
 source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
 dependencies = [
- "derive_more 0.99.7",
+ "derive_more 0.99.8",
  "futures 0.3.5",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3211,6 +3245,12 @@ dependencies = [
  "subtle 2.2.3",
  "zeroize",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scoped-tls"
@@ -3289,9 +3329,9 @@ checksum = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 dependencies = [
  "serde_derive",
 ]
@@ -3319,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -3633,7 +3673,7 @@ name = "sp-inherents"
 version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
 dependencies = [
- "derive_more 0.99.7",
+ "derive_more 0.99.8",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sp-core",
@@ -3797,7 +3837,7 @@ name = "sp-transaction-pool"
 version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
 dependencies = [
- "derive_more 0.99.7",
+ "derive_more 0.99.8",
  "futures 0.3.5",
  "log 0.4.8",
  "parity-scale-codec",
@@ -3959,9 +3999,9 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tar"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c058ad0bd6ccb84faa24cc44d4fc99bee8a5d7ba9ff33aa4d993122d1aeeac2"
+checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 dependencies = [
  "filetime",
  "libc",
@@ -3994,18 +4034,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -4057,6 +4097,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+
+[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,7 +4132,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "iovec",
@@ -4303,7 +4349,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -4400,7 +4446,7 @@ checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "http",
  "httparse",
  "input_buffer",
@@ -4482,11 +4528,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "smallvec 1.4.0",
+ "tinyvec",
 ]
 
 [[package]]
@@ -4538,9 +4584,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed"
+checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
 
 [[package]]
 name = "urltemplate"
@@ -4590,7 +4636,7 @@ name = "warp"
 version = "0.2.2"
 source = "git+https://github.com/radicle-dev/warp?branch=openapi#879d3d10327171b01a598f183617069ef12f833c"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 0.5.5",
  "futures 0.3.5",
  "headers",
  "http",
@@ -4602,7 +4648,7 @@ dependencies = [
  "multipart",
  "openapiv3",
  "pin-project",
- "scoped-tls",
+ "scoped-tls 1.0.0",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -33,9 +33,8 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "d5e06abd9e8f5361cb6b4f693561007036b6d263"
+rev = "a5b1d53cfe01e929dc8290c1037797a25a56335e"
 
-# TODO: Point to new repo
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore.git"
 rev = "a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -33,11 +33,11 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "35f6e5e8bbe91012dae180f4a41ae582b3b1d2c2"
+rev = "11daae382a812d4f152cdf5cdc70572360a65228"
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "35f6e5e8bbe91012dae180f4a41ae582b3b1d2c2"
+rev = "11daae382a812d4f152cdf5cdc70572360a65228"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -33,11 +33,12 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "11daae382a812d4f152cdf5cdc70572360a65228"
+rev = "d5e06abd9e8f5361cb6b4f693561007036b6d263"
 
+# TODO: Point to new repo
 [dependencies.radicle-keystore]
-git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "11daae382a812d4f152cdf5cdc70572360a65228"
+git = "https://github.com/radicle-dev/radicle-keystore.git"
+rev = "a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -577,13 +577,9 @@ mod test {
         let mut peer = super::Peer::new(config).await?;
 
         let user = peer.init_user("cloudhead").await?;
-        let project = peer.init_project(
-            &user,
-            &repo_path,
-            "radicalise",
-            "the people",
-            "power",
-        ).await;
+        let project = peer
+            .init_project(&user, &repo_path, "radicalise", "the people", "power")
+            .await;
 
         assert!(project.is_ok());
 
@@ -603,7 +599,10 @@ mod test {
         if let Err(Error::EntityExists(urn)) = err {
             assert_eq!(urn, user.urn())
         } else {
-            panic!("unexpected error when creating the user a second time: {:?}", err);
+            panic!(
+                "unexpected error when creating the user a second time: {:?}",
+                err
+            );
         }
 
         Ok(())
@@ -618,26 +617,21 @@ mod test {
         let mut peer = super::Peer::new(config).await?;
 
         let user = peer.init_user("cloudhead").await?;
-        let _project = peer.init_project(
-            &user,
-            &repo_path,
-            "radicalise",
-            "the people",
-            "power",
-        ).await?;
+        let _project = peer
+            .init_project(&user, &repo_path, "radicalise", "the people", "power")
+            .await?;
 
-        let err = peer.init_project(
-            &user,
-            &repo_path,
-            "radicalise",
-            "the people",
-            "power",
-        ).await;
+        let err = peer
+            .init_project(&user, &repo_path, "radicalise", "the people", "power")
+            .await;
 
         if let Err(Error::RadRemoteExists(path)) = err {
             assert_eq!(path, format!("{}", repo_path.display()))
         } else {
-            panic!("unexpected error when creating the project a second time: {:?}", err);
+            panic!(
+                "unexpected error when creating the project a second time: {:?}",
+                err
+            );
         }
 
         Ok(())

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -550,6 +550,7 @@ pub fn default_config(
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod test {
     use librad::keys::SecretKey;
 
@@ -557,7 +558,7 @@ mod test {
 
     #[tokio::test]
     async fn test_can_create_user() -> Result<(), Error> {
-        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let key = SecretKey::new();
         let config = super::default_config(key, tmp_dir.path())?;
         let peer = super::Peer::new(config).await?;
@@ -570,7 +571,7 @@ mod test {
 
     #[tokio::test]
     async fn test_can_create_project() -> Result<(), Error> {
-        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let repo_path = tmp_dir.path().join("radicle");
         let key = SecretKey::new();
         let config = super::default_config(key, tmp_dir.path())?;
@@ -588,7 +589,7 @@ mod test {
 
     #[tokio::test]
     async fn test_cannot_create_user_twice() -> Result<(), Error> {
-        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let key = SecretKey::new();
         let config = super::default_config(key, tmp_dir.path())?;
         let peer = super::Peer::new(config).await?;
@@ -610,7 +611,7 @@ mod test {
 
     #[tokio::test]
     async fn test_cannot_create_project_twice() -> Result<(), Error> {
-        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
         let repo_path = tmp_dir.path().join("radicle");
         let key = SecretKey::new();
         let config = super::default_config(key, tmp_dir.path())?;

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -221,8 +221,8 @@ impl Peer {
         Ok(meta)
     }
 
-    /// Create a [`user::User`] with the provided `handle`. This assumes that you are creating a user
-    /// that uses the secret key the `PeerApi` was configured with.
+    /// Create a [`user::User`] with the provided `handle`. This assumes that you are creating a
+    /// user that uses the secret key the `PeerApi` was configured with.
     ///
     /// # Errors
     ///

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -230,13 +230,14 @@ impl Peer {
     ///     * [`Self::with_api`] fails with a poisoned lock.
     ///     * The signing of the user metadata fails.
     ///     * The interaction with `librad` [`librad::git::storage::Storage`] fails.
-    pub async fn init_user(&self, name: &str) -> Result<User, error::Error> {
+    pub async fn init_user(&self, handle: &str) -> Result<User, error::Error> {
         let user = self
             .with_api(|api| {
                 let key = api.key();
 
                 // Create the project meta
-                let mut user = user::User::<entity::Draft>::create(name.to_string(), key.public())?;
+                let mut user =
+                    user::User::<entity::Draft>::create(handle.to_string(), key.public())?;
                 user.sign_owned(key)?;
 
                 let storage = api.storage().reopen()?;

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 
 use librad::keys;
-use librad::meta::entity::{self, Resolver as _};
+use librad::meta::entity;
 use librad::meta::project;
 use librad::meta::user;
 use librad::net;
@@ -119,14 +119,29 @@ impl Peer {
     /// `get_project` fails if:
     ///     * Parsing the `project_urn` fails.
     ///     * Resolving the project fails.
-    pub async fn get_project(
+    pub fn get_project(
         &self,
-        project_urn: &str,
+        urn: &RadUrn,
     ) -> Result<project::Project<entity::Draft>, error::Error> {
-        // TODO(finto): we need the storage to be a resolver
-        let urn = project_urn.parse()?;
-        let project = self.resolve(&urn).await?;
-        Ok(project)
+        self.with_api(|api| {
+            let storage = api.storage().reopen()?;
+            Ok(storage.entity(urn)?)
+        })
+        .flatten()
+    }
+
+    /// Get the user found at `urn`.
+    ///
+    /// # Errors
+    ///
+    ///   * Resolving the project fails.
+    ///   * Could not successfully acquire a lock to the API.
+    pub fn get_user(&self, urn: &RadUrn) -> Result<user::User<entity::Draft>, error::Error> {
+        self.with_api(|api| {
+            let storage = api.storage().reopen()?;
+            Ok(storage.entity(urn)?)
+        })
+        .flatten()
     }
 
     /// Get a repo browser for a project.
@@ -135,15 +150,15 @@ impl Peer {
     ///
     /// The function will result in an error if the mutex guard was poisoned. See
     /// [`std::sync::Mutex::lock`] for further details.
-    pub async fn with_browser<F, T>(
+    pub fn with_browser<F, T>(
         &self,
-        project_urn: &str,
+        project_urn: &RadUrn,
         callback: F,
     ) -> Result<T, error::Error>
     where
         F: Send + FnOnce(&mut surf::vcs::git::Browser) -> Result<T, error::Error>,
     {
-        let project = self.get_project(project_urn).await?;
+        let project = self.get_project(project_urn)?;
         let default_branch = project.default_branch();
         let api = self.api.lock().map_err(|_| error::Error::LibradLock)?;
         let repo = api.storage().open_repo(project.urn())?;
@@ -208,6 +223,34 @@ impl Peer {
         projects.insert(meta.urn(), meta.clone());
 
         Ok(meta)
+    }
+
+    /// Create a [`user::User`] with the provided `name`. This assumes that you are creating a user
+    /// that uses the secret key the `PeerApi` was configured with.
+    ///
+    /// # Errors
+    ///
+    /// Will error if:
+    ///     * [`Self::with_api`] fails with a poisoned lock.
+    ///     * The signing of the user metadata fails.
+    ///     * The interaction with `librad` [`librad::git::storage::Storage`] fails.
+    pub async fn init_user(&self, name: &str) -> Result<User, error::Error> {
+        let user = self.with_api(|api| {
+            let key = api.key();
+
+            // Create the project meta
+            let mut user = user::User::<entity::Draft>::create(name.to_string(), key.public())?;
+            user.sign_owned(key)?;
+
+            let storage = api.storage().reopen()?;
+            let _repo = storage.create_repo(&user)?;
+            Ok(user)
+        })
+        .flatten()?;
+
+        let fake_resolver = FakeUserResolver(user.clone());
+        let verified_user = user.check_history_status(&fake_resolver, &fake_resolver).await?;
+        Ok(verified_user)
     }
 
     /// Equips a repository with a rad remote for the given id. If the directory at the given path

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -221,7 +221,7 @@ impl Peer {
         Ok(meta)
     }
 
-    /// Create a [`user::User`] with the provided `name`. This assumes that you are creating a user
+    /// Create a [`user::User`] with the provided `handle`. This assumes that you are creating a user
     /// that uses the secret key the `PeerApi` was configured with.
     ///
     /// # Errors

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -38,7 +38,7 @@ pub enum UserValidation {
 pub enum Error {
     /// Returned when an attempt to create an identity was made and there is one present.
     #[error("the identity '{0}' already exits")]
-    IdentityExists(RadUrn),
+    EntityExists(RadUrn),
 
     /// Configured default branch for the project is missing.
     #[error("repository '{0}' doesn't have the configured default branch '{1}'")]

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -112,6 +112,10 @@ pub enum Error {
     #[error("failed to acquire lock for peer")]
     LibradLock,
 
+    /// Failure during the verification of a `librad` entity.
+    #[error(transparent)]
+    LibradVerification(#[from] entity::HistoryVerificationError),
+
     /// Failure when interacting with [`crate::keystore`].
     #[error(transparent)]
     Keystorage(#[from] keystore::Error),

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -6,6 +6,7 @@ use librad::meta::common::url;
 use librad::meta::entity;
 use librad::surf;
 use librad::surf::git::git2;
+use librad::uri::RadUrn;
 use radicle_registry_client as registry;
 
 use crate::keystore;
@@ -37,7 +38,7 @@ pub enum UserValidation {
 pub enum Error {
     /// Returned when an attempt to create an identity was made and there is one present.
     #[error("the identity '{0}' already exits")]
-    IdentityExists(String),
+    IdentityExists(RadUrn),
 
     /// Configured default branch for the project is missing.
     #[error("repository '{0}' doesn't have the configured default branch '{1}'")]

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -46,7 +46,11 @@ where
                 Arc::clone(&owner),
                 Arc::clone(&registry),
             ))
-            .or(identity::filters(Arc::clone(&registry), Arc::clone(&store)))
+            .or(identity::filters(
+                Arc::clone(&peer),
+                Arc::clone(&registry),
+                Arc::clone(&store),
+            ))
             .or(notification::filters(subscriptions.clone()))
             .or(org::routes(
                 Arc::clone(&peer),

--- a/proxy/src/http/error.rs
+++ b/proxy/src/http/error.rs
@@ -59,6 +59,9 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
             )
         } else if let Some(err) = err.find::<error::Error>() {
             match err {
+                error::Error::EntityExists(_) => {
+                    (StatusCode::CONFLICT, "ENTITY_EXISTS", err.to_string())
+                },
                 error::Error::Git(git_error) => match git_error {
                     surf::git::error::Error::Git(error) => (
                         StatusCode::BAD_REQUEST,

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -278,7 +278,7 @@ mod test {
 
         let store = &*store.read().await;
         let registry = &*registry.read().await;
-        let session = session::current(peer, &store, registry).await?;
+        let session = session::current(peer, store, registry).await?;
         let urn = session.identity.expect("failed to set identity").id;
 
         http::test::assert_response(&res, StatusCode::CREATED, |have| {

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -107,7 +107,7 @@ mod handler {
             .await?
             .identity
         {
-            return Err(Rejection::from(error::Error::IdentityExists(identity.id)));
+            return Err(Rejection::from(error::Error::EntityExists(identity.id)));
         }
 
         let peer = peer.lock().await;

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -262,12 +262,10 @@ mod test {
             let (client, _) = radicle_registry_client::Client::new_emulator();
             Arc::new(RwLock::new(registry::Registry::new(client)))
         };
-        let store = Arc::new(RwLock::new(kv::Store::new(kv::Config::new(tmp_dir.path().join("store"))).unwrap()));
-        let api = super::filters(
-            Arc::clone(&peer),
-            Arc::clone(&registry),
-            Arc::clone(&store),
-        );
+        let store = Arc::new(RwLock::new(
+            kv::Store::new(kv::Config::new(tmp_dir.path().join("store"))).unwrap(),
+        ));
+        let api = super::filters(Arc::clone(&peer), Arc::clone(&registry), Arc::clone(&store));
 
         let res = request()
             .method("POST")
@@ -286,15 +284,18 @@ mod test {
         http::test::assert_response(&res, StatusCode::CREATED, |have| {
             let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
             let shareable_entity_identifier = format!("cloudhead@{}", urn);
-            assert_eq!(have, json!({
-                "avatarFallback": avatar,
-                "id": urn,
-                "metadata": {
-                    "handle": "cloudhead",
-                },
-                "registered": Value::Null,
-                "shareableEntityIdentifier": &shareable_entity_identifier
-            }));
+            assert_eq!(
+                have,
+                json!({
+                    "avatarFallback": avatar,
+                    "id": urn,
+                    "metadata": {
+                        "handle": "cloudhead",
+                    },
+                    "registered": Value::Null,
+                    "shareableEntityIdentifier": &shareable_entity_identifier
+                })
+            );
         });
 
         Ok(())

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -261,7 +261,7 @@ mod handler {
         let mut mapped_projects = Vec::new();
         for p in &projects {
             let maybe_project = if let Some(urn) = &p.maybe_project_id {
-                Some(project::get(&peer, urn).await.expect("Project not found"))
+                Some(project::get(&peer, urn).expect("Project not found"))
             } else {
                 None
             };

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -196,9 +196,10 @@ mod handler {
 
     /// Get the [`project::Project`] for the given `id`.
     pub async fn get(peer: Arc<Mutex<coco::Peer>>, urn: String) -> Result<impl Reply, Rejection> {
+        let urn = urn.parse().map_err(Error::from)?;
         let peer = peer.lock().await;
 
-        Ok(reply::json(&project::get(&peer, &urn).await?))
+        Ok(reply::json(&project::get(&peer, &urn)?))
     }
 
     /// List all known projects.
@@ -632,7 +633,7 @@ mod test {
             .await?;
         let urn = platinum_project.urn();
 
-        let project = project::get(&peer, &urn.to_string()).await?;
+        let project = project::get(&peer, &urn)?;
 
         let api = super::filters(
             Arc::new(Mutex::new(peer)),

--- a/proxy/src/http/session.rs
+++ b/proxy/src/http/session.rs
@@ -153,7 +153,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let store = store.read().await;
         let reg = registry.read().await;
-        let sess = session::current(&store, (*reg).clone()).await?;
+        let sess = session::current(&store, &*reg).await?;
 
         Ok(reply::json(&sess))
     }
@@ -269,7 +269,7 @@ mod test {
 
         // Test that we reset the session to default.
         let store = store.read().await;
-        let have = session::current(&*store, cache.read().await.clone())
+        let have = session::current(&*store, &*cache.read().await)
             .await
             .unwrap()
             .settings;

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -354,12 +354,12 @@ mod handler {
                         .parse()
                         .expect("failed to parse hardcoded URN"),
                     metadata: identity::Metadata {
-                        handle: handle.to_string(),
+                        handle: (*handle).to_string(),
                     },
                     avatar_fallback: avatar::Avatar::from(handle, avatar::Usage::Identity),
                     registered: None,
                     shareable_entity_identifier: identity::SharedIdentifier {
-                        handle: handle.to_string(),
+                        handle: (*handle).to_string(),
                         urn: "rad:git:hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try"
                             .parse()
                             .expect("failed to parse hardcoded URN"),
@@ -1035,12 +1035,12 @@ mod test {
                     identity: identity::Identity {
                         id: fake_user_urn.clone(),
                         metadata: identity::Metadata {
-                            handle: handle.to_string(),
+                            handle: (*handle).to_string(),
                         },
                         avatar_fallback: avatar::Avatar::from(handle, avatar::Usage::Identity),
                         registered: None,
                         shareable_entity_identifier: identity::SharedIdentifier {
-                            handle: handle.to_string(),
+                            handle: (*handle).to_string(),
                             urn: fake_user_urn.clone(),
                         },
                     },

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -279,10 +279,9 @@ mod handler {
         let urn = project_urn.parse().map_err(Error::from)?;
         let project = peer.get_project(&urn)?;
         let default_branch = project.default_branch();
-        let blob = peer
-            .with_browser(&urn, |mut browser| {
-                coco::blob(&mut browser, default_branch, revision, &path)
-            })?;
+        let blob = peer.with_browser(&urn, |mut browser| {
+            coco::blob(&mut browser, default_branch, revision, &path)
+        })?;
 
         Ok(reply::json(&blob))
     }
@@ -294,8 +293,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let urn = project_urn.parse().map_err(Error::from)?;
         let peer = peer.lock().await;
-        let branches = peer
-            .with_browser(&urn, |browser| coco::branches(browser))?;
+        let branches = peer.with_browser(&urn, |browser| coco::branches(browser))?;
 
         Ok(reply::json(&branches))
     }
@@ -308,10 +306,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let urn = project_urn.parse().map_err(Error::from)?;
         let peer = peer.lock().await;
-        let commit = peer
-            .with_browser(&urn, |mut browser| {
-                coco::commit(&mut browser, &sha1)
-            })?;
+        let commit = peer.with_browser(&urn, |mut browser| coco::commit(&mut browser, &sha1))?;
 
         Ok(reply::json(&commit))
     }
@@ -324,10 +319,8 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let urn = project_urn.parse().map_err(Error::from)?;
         let peer = peer.lock().await;
-        let commits = peer
-            .with_browser(&urn, |mut browser| {
-                coco::commits(&mut browser, &branch)
-            })?;
+        let commits =
+            peer.with_browser(&urn, |mut browser| coco::commits(&mut browser, &branch))?;
 
         Ok(reply::json(&commits))
     }
@@ -346,10 +339,9 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let urn = project_urn.parse().map_err(Error::from)?;
         let peer = peer.lock().await;
-        let (branches, tags) = peer
-            .with_browser(&urn, |browser| {
-                Ok((coco::branches(browser)?, coco::tags(browser)?))
-            })?;
+        let (branches, tags) = peer.with_browser(&urn, |browser| {
+            Ok((coco::branches(browser)?, coco::tags(browser)?))
+        })?;
 
         let revs = ["cloudhead", "rudolfs", "xla"]
             .iter()
@@ -386,8 +378,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let urn = project_urn.parse().map_err(Error::from)?;
         let peer = peer.lock().await;
-        let tags = peer
-            .with_browser(&urn, |browser| coco::tags(browser))?;
+        let tags = peer.with_browser(&urn, |browser| coco::tags(browser))?;
 
         Ok(reply::json(&tags))
     }
@@ -402,10 +393,9 @@ mod handler {
         let peer = peer.lock().await;
         let project = peer.get_project(&urn)?;
         let default_branch = project.default_branch();
-        let tree = peer
-            .with_browser(&urn, |mut browser| {
-                coco::tree(&mut browser, default_branch, revision, prefix)
-            })?;
+        let tree = peer.with_browser(&urn, |mut browser| {
+            coco::tree(&mut browser, default_branch, revision, prefix)
+        })?;
 
         Ok(reply::json(&tree))
     }
@@ -755,15 +745,14 @@ mod test {
         let revision = "master";
         let default_branch = "master".to_string(); // TODO(finto): need to change this
         let path = "text/arrows.txt";
-        let want = peer
-            .with_browser(&urn, |mut browser| {
-                coco::blob(
-                    &mut browser,
-                    &default_branch.clone(),
-                    Some(revision.to_string()),
-                    path,
-                )
-            })?;
+        let want = peer.with_browser(&urn, |mut browser| {
+            coco::blob(
+                &mut browser,
+                &default_branch.clone(),
+                Some(revision.to_string()),
+                path,
+            )
+        })?;
 
         let api = super::filters(Arc::new(Mutex::new(peer.clone())));
 
@@ -829,10 +818,9 @@ mod test {
             .reply(&api)
             .await;
 
-        let want = peer
-            .with_browser(&urn, |browser| {
-                coco::blob(browser, &default_branch, Some(revision.to_string()), path)
-            })?;
+        let want = peer.with_browser(&urn, |browser| {
+            coco::blob(browser, &default_branch, Some(revision.to_string()), path)
+        })?;
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
             assert_eq!(have, json!(want));
@@ -880,8 +868,7 @@ mod test {
             .await?;
         let urn = platinum_project.urn();
 
-        let want = peer
-            .with_browser(&urn, |browser| coco::branches(browser))?;
+        let want = peer.with_browser(&urn, |browser| coco::branches(browser))?;
 
         let api = super::filters(Arc::new(Mutex::new(peer)));
         let res = request()
@@ -911,10 +898,7 @@ mod test {
         let urn = platinum_project.urn();
 
         let sha1 = "3873745c8f6ffb45c990eb23b491d4b4b6182f95";
-        let want = peer
-            .with_browser(&urn, |mut browser| {
-                coco::commit(&mut browser, sha1)
-            })?;
+        let want = peer.with_browser(&urn, |mut browser| coco::commit(&mut browser, sha1))?;
 
         let api = super::filters(Arc::new(Mutex::new(peer)));
         let res = request()
@@ -963,14 +947,9 @@ mod test {
 
         let branch = "master";
         let head = "223aaf87d6ea62eef0014857640fd7c8dd0f80b5";
-        let want = peer
-            .with_browser(&urn, |mut browser| {
-                coco::commits(&mut browser, branch)
-            })?;
-        let head_commit = peer
-            .with_browser(&urn, |mut browser| {
-                coco::commit(&mut browser, head)
-            })?;
+        let want = peer.with_browser(&urn, |mut browser| coco::commits(&mut browser, branch))?;
+        let head_commit =
+            peer.with_browser(&urn, |mut browser| coco::commit(&mut browser, head))?;
 
         let api = super::filters(Arc::new(Mutex::new(peer)));
         let res = request()
@@ -1044,10 +1023,9 @@ mod test {
             "rad:git:hwd1yredksthny1hht3bkhtkxakuzfnjxd8dyk364prfkjxe4xpxsww3try".parse()?;
 
         let want = {
-            let (branches, tags) = peer
-                .with_browser(&urn, |browser| {
-                    Ok((coco::branches(browser)?, coco::tags(browser)?))
-                })?;
+            let (branches, tags) = peer.with_browser(&urn, |browser| {
+                Ok((coco::branches(browser)?, coco::tags(browser)?))
+            })?;
 
             ["cloudhead", "rudolfs", "xla"]
                 .iter()
@@ -1162,8 +1140,7 @@ mod test {
             .unwrap();
         let urn = platinum_project.urn();
 
-        let want = peer
-            .with_browser(&urn, |browser| coco::tags(browser))?;
+        let want = peer.with_browser(&urn, |browser| coco::tags(browser))?;
 
         let api = super::filters(Arc::new(Mutex::new(peer)));
         let res = request()
@@ -1199,15 +1176,14 @@ mod test {
         let prefix = "src";
 
         let default_branch = "master".to_string(); // TODO(finto): need to change this
-        let want = peer
-            .with_browser(&urn, |mut browser| {
-                coco::tree(
-                    &mut browser,
-                    &default_branch,
-                    Some(revision.to_string()),
-                    Some(prefix.to_string()),
-                )
-            })?;
+        let want = peer.with_browser(&urn, |mut browser| {
+            coco::tree(
+                &mut browser,
+                &default_branch,
+                Some(revision.to_string()),
+                Some(prefix.to_string()),
+            )
+        })?;
 
         let api = super::filters(Arc::new(Mutex::new(peer)));
         let res = request()

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -1061,7 +1061,10 @@ mod test {
                         },
                         avatar_fallback: avatar::Avatar::from(handle, avatar::Usage::Identity),
                         registered: None,
-                        shareable_entity_identifier: format!("{}@123abcd.git", handle),
+                        shareable_entity_identifier: identity::SharedIdentifier {
+                            handle: handle.to_string(),
+                            urn: fake_user_urn.clone(),
+                        },
                     },
                 })
                 .collect::<Vec<super::Revision>>()

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -111,9 +111,9 @@ pub mod shared_identifier {
 
     impl<ST> From<user::User<ST>> for SharedIdentifier {
         fn from(user: user::User<ST>) -> Self {
-            SharedIdentifier {
+            Self {
                 handle: user.name().to_string(),
-                urn: user.urn().clone(),
+                urn: user.urn(),
             }
         }
     }

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -2,19 +2,23 @@
 
 use serde::{Deserialize, Serialize};
 
+use librad::uri::RadUrn;
+
 use crate::avatar;
+use crate::coco;
 use crate::error;
 use crate::registry;
-use std::convert::TryFrom;
+
+pub use shared_identifier::SharedIdentifier;
 
 /// The users personal identifying metadata and keys.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Identity {
     /// The librad id.
-    pub id: String,
+    pub id: RadUrn,
     /// Unambiguous identifier pointing at this identity.
-    pub shareable_entity_identifier: String,
+    pub shareable_entity_identifier: SharedIdentifier,
     /// Bundle of user provided data.
     pub metadata: Metadata,
     /// Indicator if the identity is registered on the Registry.
@@ -34,14 +38,16 @@ pub struct Metadata {
 /// Creates a new identity.
 ///
 /// # Errors
-pub fn create(handle: String) -> Result<Identity, error::Error> {
-    let id = format!("{}@123abcd.git", handle);
+pub async fn create(peer: &coco::Peer, handle: String) -> Result<Identity, error::Error> {
+    let user = peer.init_user(&handle).await?;
+    let id = user.urn();
+    let shareable_entity_identifier = user.into();
     Ok(Identity {
         id: id.clone(),
-        shareable_entity_identifier: id.clone(),
+        shareable_entity_identifier,
         metadata: Metadata { handle },
         registered: None,
-        avatar_fallback: avatar::Avatar::from(&id, avatar::Usage::Identity),
+        avatar_fallback: avatar::Avatar::from(&id.to_string(), avatar::Usage::Identity),
     })
 }
 
@@ -50,14 +56,127 @@ pub fn create(handle: String) -> Result<Identity, error::Error> {
 /// # Errors
 ///
 /// Errors if access to coco state on the filesystem fails, or the id is malformed.
-pub fn get(id: &str) -> Result<Option<Identity>, error::Error> {
-    Ok(Some(Identity {
-        id: id.to_string(),
-        shareable_entity_identifier: format!("cloudhead@{}", id),
-        metadata: Metadata {
-            handle: "cloudhead".into(),
+pub fn get(peer: &coco::Peer, id: &RadUrn) -> Result<Identity, error::Error> {
+    let user = peer.get_user(id)?;
+    Ok(Identity {
+        id: id.clone(),
+        shareable_entity_identifier: SharedIdentifier {
+            handle: user.name().to_string(),
+            urn: id.clone(),
         },
-        registered: registry::Id::try_from("cloudhead").ok(),
-        avatar_fallback: avatar::Avatar::from(id, avatar::Usage::Identity),
-    }))
+        metadata: Metadata {
+            handle: user.name().to_string(),
+        },
+        registered: None,
+        avatar_fallback: avatar::Avatar::from(&id.to_string(), avatar::Usage::Identity),
+    })
+}
+
+/// A `SharedIdentifier` is the combination of a user handle and the [`RadUrn`] that identifies the
+/// user.
+pub mod shared_identifier {
+
+    use std::{fmt, str::FromStr};
+
+    use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+    use librad::meta::user;
+    use librad::uri::{rad_urn, RadUrn};
+
+    /// Errors captured when parsing a shareable identifier of the form `<handle>@<urn>`.
+    #[derive(Debug, thiserror::Error)]
+    pub enum ParseError {
+        /// Could not parse the URN portion of the identifier.
+        #[error(transparent)]
+        Urn(#[from] rad_urn::ParseError),
+        /// The identifier contained more than one '@' symbol.
+        #[error("shared identifier contains more than one '@' symbol")]
+        AtSplitError,
+        /// The handle portion of the identifier was missing.
+        #[error("shared identifier is missing the handle to the left of the '@' symbol")]
+        MissingHandle,
+        /// The urn portion of the identifier was missing.
+        #[error("shared identifier is missing the URN to the right of the '@' symbol")]
+        MissingUrn,
+    }
+
+    /// The combination of a handle and a urn give user's a structure for sharing their identities.
+    #[derive(Clone, Debug)]
+    pub struct SharedIdentifier {
+        /// The user's chosen handle.
+        pub handle: String,
+        /// The unique identifier of the user.
+        pub urn: RadUrn,
+    }
+
+    impl<ST> From<user::User<ST>> for SharedIdentifier {
+        fn from(user: user::User<ST>) -> Self {
+            SharedIdentifier {
+                handle: user.name().to_string(),
+                urn: user.urn().clone(),
+            }
+        }
+    }
+
+    impl FromStr for SharedIdentifier {
+        type Err = ParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let mut sub = s.split('@');
+            let handle = sub.next();
+            let urn = sub.next();
+
+            if sub.count() != 0 {
+                return Err(ParseError::AtSplitError);
+            }
+
+            let handle = handle.ok_or(ParseError::MissingHandle)?.to_string();
+            let urn = urn
+                .ok_or(ParseError::MissingUrn)
+                .and_then(|urn| Ok(urn.parse()?))?;
+
+            Ok(Self { handle, urn })
+        }
+    }
+
+    impl fmt::Display for SharedIdentifier {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}@{}", self.handle, self.urn)
+        }
+    }
+
+    impl Serialize for SharedIdentifier {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(&self.to_string())
+        }
+    }
+
+    impl<'de> Deserialize<'de> for SharedIdentifier {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct IdVisitor;
+
+            impl<'de> Visitor<'de> for IdVisitor {
+                type Value = SharedIdentifier;
+
+                fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, "a shared identifier of the form <handle>@<urn>")
+                }
+
+                fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    s.parse().map_err(serde::de::Error::custom)
+                }
+            }
+
+            deserializer.deserialize_str(IdVisitor)
+        }
+    }
 }

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -159,6 +159,7 @@ pub mod shared_identifier {
         where
             D: Deserializer<'de>,
         {
+            /// A phantom Visitor for serde to deserialize.
             struct IdVisitor;
 
             impl<'de> Visitor<'de> for IdVisitor {

--- a/proxy/src/project.rs
+++ b/proxy/src/project.rs
@@ -72,8 +72,8 @@ pub struct Stats {
 }
 
 /// TODO(xla): Add documentation.
-pub async fn get(peer: &coco::Peer, project_urn: &str) -> Result<Project, error::Error> {
-    let meta = peer.get_project(project_urn).await?;
+pub fn get(peer: &coco::Peer, project_urn: &uri::RadUrn) -> Result<Project, error::Error> {
+    let meta = peer.get_project(project_urn)?;
     let id = meta.urn();
     let metadata = meta.into();
 

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_cbor::from_reader;
 use std::str::FromStr;
 
+use librad::uri::RadUrn;
 use radicle_registry_client::{self as protocol, ClientT, CryptoPair};
 pub use radicle_registry_client::{Balance, Id, ProjectDomain, ProjectName, MINIMUM_FEE};
 
@@ -63,7 +64,7 @@ impl Serialize for Hash {
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {
     /// Librad project ID.
-    pub id: String,
+    pub id: RadUrn,
     /// Metadata version.
     pub version: u8,
 }
@@ -97,7 +98,7 @@ pub struct Project {
     /// The domain of the project.
     pub domain: ProjectDomain,
     /// Optionally associated project id for attestation in other systems.
-    pub maybe_project_id: Option<String>,
+    pub maybe_project_id: Option<RadUrn>,
 }
 
 /// The registered user with associated coco id.
@@ -230,7 +231,7 @@ pub trait Client: Clone + Send + Sync {
         author: &protocol::ed25519::Pair,
         project_domain: ProjectDomain,
         project_name: ProjectName,
-        maybe_project_id: Option<librad::uri::RadUrn>,
+        maybe_project_id: Option<RadUrn>,
         fee: Balance,
     ) -> Result<Transaction, error::Error>;
 
@@ -490,7 +491,7 @@ impl Client for Registry {
         author: &protocol::ed25519::Pair,
         project_domain: ProjectDomain,
         project_name: ProjectName,
-        maybe_project_id: Option<librad::uri::RadUrn>,
+        maybe_project_id: Option<RadUrn>,
         fee: Balance,
     ) -> Result<Transaction, error::Error> {
         // Prepare and submit checkpoint transaction.
@@ -516,7 +517,7 @@ impl Client for Registry {
 
         let register_metadata_vec = if let Some(pid_string) = maybe_project_id {
             let pid_cbor = Metadata {
-                id: pid_string.to_string(),
+                id: pid_string,
                 version: 1,
             };
             // TODO(garbados): unpanic
@@ -843,7 +844,7 @@ mod test {
         assert_eq!(projects[0].name, project_name);
         assert_eq!(
             projects[0].maybe_project_id,
-            Some("rad:git:hwd1yrerjqujexs8p9barieeoo3q6nwczgdn48g9zf8msw5bn9dnsy5eqph".to_string())
+            Some("rad:git:hwd1yrerjqujexs8p9barieeoo3q6nwczgdn48g9zf8msw5bn9dnsy5eqph".parse()?)
         );
 
         Ok(())

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -61,7 +61,7 @@ pub fn clear_current(store: &kv::Store) -> Result<(), error::Error> {
 /// can't be found.
 pub async fn current<R: registry::Client>(
     store: &kv::Store,
-    registry: R,
+    registry: &R,
 ) -> Result<Session, error::Error> {
     let mut session = get(store, KEY_CURRENT)?;
     session.transaction_deposits = registry::get_deposits();

--- a/ui/Screen/IdentityCreation.svelte
+++ b/ui/Screen/IdentityCreation.svelte
@@ -16,9 +16,9 @@
     store.set(State.Welcome);
   };
 
-  const onError = (error) => {
+  const onError = (event) => {
+    notification.error(`Could not create identity: ${event.detail}`);
     pop();
-    notification.error(`Could not create identity: ${error}`);
   };
 
   const complete = (redirectPath) => {


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/radicle-link/pull/186

Fixes #478 

This solves the ability to create and get a user in the monorepo, as well as linking it up with the identity create and get API.

Also threw in changes for get project, since the change we rely on in `radicle-link` allows us to fix that.