### PR TITLE
fix(proxy): add transactionFee to example inputs

### DIFF
--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -434,6 +434,12 @@ impl ToDocumentedType for RegisterInput {
                 .description("ID of the org")
                 .example("monadic"),
         );
+        properties.insert(
+            "transactionFee".into(),
+            document::string()
+                .description("User specified transaction fee")
+                .example(100),
+        );
 
         document::DocumentedType::from(properties).description("Input for org registration")
     }
@@ -457,6 +463,12 @@ impl ToDocumentedType for RegisterMemberInput {
             document::string()
                 .description("Handle of the user")
                 .example("cloudhead"),
+        );
+        properties.insert(
+            "transactionFee".into(),
+            document::string()
+                .description("User specified transaction fee")
+                .example(100),
         );
 
         document::DocumentedType::from(properties).description("Input for member registration")

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -519,6 +519,12 @@ impl ToDocumentedType for RegisterInput {
                 .example("upstream"),
         );
         properties.insert(
+            "transactionFee".into(),
+            document::string()
+                .description("User specified transaction fee")
+                .example(100),
+        );
+        properties.insert(
             "maybeCocoId".into(),
             document::string()
                 .description("Optionally passed coco id to store for attestion")

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -223,6 +223,12 @@ impl ToDocumentedType for RegisterInput {
                 .example("cloudhead"),
         );
         props.insert(
+            "transactionFee".into(),
+            document::string()
+                .description("User specified transaction fee")
+                .example(100),
+        );
+        props.insert(
             "maybeEntityId".into(),
             document::string()
                 .description("Exisiting project id for attestion")


### PR DESCRIPTION
The `transactionFee` was missing from the example inputs so that the registration requests in the playground failed.