### PR TITLE
fix(ui): show ProfileProjects page on startup

### DIFF
--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -33,7 +33,6 @@
     "/identity/new": IdentityCreation,
     "/search": Search,
     "/settings": Settings,
-    "/profile": Profile,
     "/profile/*": Profile,
     "/orgs/register": OrgRegistration,
     "/orgs/:id/members/register": MemberRegistration,
@@ -60,7 +59,7 @@
         push(path.createIdentity());
       } else {
         if ($location === "/" || $location === "/identity/new") {
-          push(path.profile());
+          push(path.profileProjects());
         }
       }
       break;

--- a/ui/Screen/Profile.svelte
+++ b/ui/Screen/Profile.svelte
@@ -17,7 +17,6 @@
   import NotFound from "./NotFound.svelte";
 
   const screenRoutes = {
-    "/profile/": Projects,
     "/profile/projects": Projects,
     "/profile/wallet": Wallet,
     "*": NotFound,


### PR DESCRIPTION
This fixes a bug where the profile menu items wouldn't show up when the app is started.

Before:
<img width="60%" alt="Screenshot 2020-06-22 at 16 19 52" src="https://user-images.githubusercontent.com/158411/85298416-557b4680-b4a4-11ea-8dc6-86afc7badd7d.png">

After:
<img width="60%" alt="Screenshot 2020-06-22 at 16 20 18" src="https://user-images.githubusercontent.com/158411/85298428-59a76400-b4a4-11ea-9597-9405dc777b2d.png">