### PR TITLE
chore(ui): skip another flaky test

### DIFF
--- a/cypress/integration/org_registration.spec.js
+++ b/cypress/integration/org_registration.spec.js
@@ -107,7 +107,8 @@ context("org registration", () => {
       cy.pick("submit-button").should("be.disabled");
     });
 
-    it("prevents the user from registering an unavailable org id", () => {
+    // TODO: Fix validation bug in https://github.com/radicle-dev/radicle-upstream/issues/492
+    it.skip("prevents the user from registering an unavailable org id", () => {
       cy.registerOrg("coolname");
 
       cy.pick("org-reg-modal", "input").type("coolname");


### PR DESCRIPTION
Same as https://github.com/radicle-dev/radicle-upstream/pull/501.

This test fails most of our CI runs now that the CI server is more loaded and slower.
We should fix the underlying issue #492 before we un-skip this test.

https://buildkite.com/monadic/radicle-upstream/builds/2807