### PR TITLE
Pass registry runtime version explicitly

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d7f0f3c955e29eac19da94dc76dcf304866310a7#d7f0f3c955e29eac19da94dc76dcf304866310a7"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=7600bd1de70c1a0af1db75e0e311ec473dd94b58#7600bd1de70c1a0af1db75e0e311ec473dd94b58"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d7f0f3c955e29eac19da94dc76dcf304866310a7#d7f0f3c955e29eac19da94dc76dcf304866310a7"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=7600bd1de70c1a0af1db75e0e311ec473dd94b58#7600bd1de70c1a0af1db75e0e311ec473dd94b58"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -2794,8 +2794,8 @@ dependencies = [
 
 [[package]]
 name = "radicle-registry-runtime"
-version = "0.8.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d7f0f3c955e29eac19da94dc76dcf304866310a7#d7f0f3c955e29eac19da94dc76dcf304866310a7"
+version = "0.10.0"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=7600bd1de70c1a0af1db75e0e311ec473dd94b58#7600bd1de70c1a0af1db75e0e311ec473dd94b58"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -41,7 +41,7 @@ rev = "a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "d7f0f3c955e29eac19da94dc76dcf304866310a7"
+rev = "7600bd1de70c1a0af1db75e0e311ec473dd94b58"
 
 [dev-dependencies]
 bytes = "0.5"


### PR DESCRIPTION
This updates the registry client to a newer version that requires passing the runtime version explicitly. The APIs for these are subject to change but this serves as a proof-of-concept for setting the runtime version on the proxy side.