### PR TITLE
refactor(ui): move all repository browsing state into store

### DIFF
--- a/ui/DesignSystem/Component/SourceBrowser/File.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/File.svelte
@@ -1,20 +1,8 @@
 <script>
-  import { link } from "svelte-spa-router";
-
-  import * as path from "../../../src/path.ts";
-  import {
-    currentPath,
-    currentRevision,
-    ObjectType,
-  } from "../../../src/source.ts";
-
   import { Icon } from "../../Primitive";
 
-  export let projectId = null;
-  export let filePath = null;
   export let name = null;
-
-  $: active = filePath === $currentPath;
+  export let active = false;
 </script>
 
 <style>
@@ -27,6 +15,14 @@
     line-height: 1.5em;
     flex: 1;
     width: 100%;
+    display: flex;
+    border-radius: 4px;
+    white-space: nowrap;
+    user-select: none;
+  }
+
+  .file:hover {
+    background-color: var(--color-foreground-level-1);
   }
 
   /* prevent icon from shrinking when the filename is long */
@@ -36,15 +32,6 @@
 
   .file-name {
     margin-left: 0.25rem;
-  }
-
-  a {
-    display: flex;
-    border-radius: 4px;
-  }
-
-  a:hover {
-    background-color: var(--color-foreground-level-1);
   }
 
   .active {
@@ -58,11 +45,7 @@
   }
 </style>
 
-<a
-  class="file"
-  class:active
-  href={path.projectSource(projectId, $currentRevision, ObjectType.Blob, filePath)}
-  use:link>
+<div class="file" class:active on:click>
   <Icon.File />
   <span class="file-name">{name}</span>
-</a>
+</div>

--- a/ui/DesignSystem/Component/SourceBrowser/Folder.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/Folder.svelte
@@ -3,6 +3,7 @@
     currentPath,
     currentRevision,
     tree,
+    updateParams,
     ObjectType,
   } from "../../../src/source.ts";
 
@@ -18,12 +19,20 @@
   export let expanded = false;
   export let toplevel = false;
 
-  const toggle = () => {
+  const toggleFolder = () => {
     expanded = !expanded;
   };
 
+  const onFileClick = filePath => {
+    updateParams({
+      path: filePath,
+      projectId: projectId,
+      revision: $currentRevision,
+      type: ObjectType.Blob,
+    });
+  };
+
   $: store = tree(projectId, $currentRevision, prefix);
-  $: active = prefix === $currentPath;
 </script>
 
 <style>
@@ -60,8 +69,8 @@
 
 <Remote {store} let:data={tree}>
   {#if !toplevel}
-    <div class="folder" on:click={toggle}>
-      <span class:expanded class:active style="height: 24px">
+    <div class="folder" on:click={toggleFolder}>
+      <span class:expanded style="height: 24px">
         <Icon.Chevron dataCy={`expand-${name}`} />
       </span>
       <span class="folder-name">{name}</span>
@@ -77,7 +86,12 @@
             name={entry.info.name}
             prefix={`${entry.path}/`} />
         {:else}
-          <File {projectId} filePath={entry.path} name={entry.info.name} />
+          <File
+            name={entry.info.name}
+            active={entry.path === $currentPath}
+            on:click={() => {
+              onFileClick(entry.path);
+            }} />
         {/if}
       {/each}
     {/if}

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -1,6 +1,6 @@
 <script>
   import { getContext } from "svelte";
-  import { location, link } from "svelte-spa-router";
+  import { link } from "svelte-spa-router";
   import { format } from "timeago.js";
 
   import * as path from "../../src/path.ts";
@@ -8,6 +8,7 @@
   import {
     currentPath,
     currentRevision,
+    currentObjectType,
     fetchRevisions,
     object as objectStore,
     ObjectType,
@@ -31,10 +32,10 @@
 
   const updateRevision = (projectId, revision) => {
     updateParams({
-      path: path.extractProjectSourceObjectPath($location),
+      path: getPath($currentPath),
       projectId: projectId,
       revision: revision,
-      type: path.extractProjectSourceObjectType($location),
+      type: getObjectType($currentObjectType),
     });
   };
 
@@ -53,15 +54,21 @@
     return current !== "" ? current : metadata.defaultBranch;
   };
 
-  $: readmeStore = readme(id, getRevision($currentRevision));
-  $: updateParams({
-    path: path.extractProjectSourceObjectPath($location),
-    projectId: id,
-    revision: getRevision($currentRevision),
-    type: path.extractProjectSourceObjectType($location),
-  });
+  const getPath = current => {
+    return current !== "" ? current : "";
+  };
 
+  const getObjectType = current => {
+    return current !== "" ? current : ObjectType.Tree;
+  };
+
+  $: readmeStore = readme(id, getRevision($currentRevision));
+
+  // Fetch users and revisions for repository selector
   fetchRevisions({ projectId: id });
+
+  // Set the initial routing information on page load
+  updateRevision(id, getRevision($currentRevision));
 </script>
 
 <style>

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -1,4 +1,3 @@
-export const DEFAULT_PROJECT_REVISION = "master";
 export const HIDDEN_BRANCHES = ["rad/contributor", "rad/project"];
 export const DEFAULT_BRANCH_FOR_NEW_PROJECTS = "master";
 export const NOTIFICATION_TIMEOUT = 5000; // ms

--- a/ui/src/path.ts
+++ b/ui/src/path.ts
@@ -1,12 +1,5 @@
 import regexparam from "regexparam";
 
-import * as config from "./config";
-import { ObjectType } from "./source";
-
-const PROJECT_SOURCE_PATH_MATCH = new RegExp(
-  `/source/(.*)/(${ObjectType.Blob}|${ObjectType.Tree})/(.*)`
-);
-
 export const search = (): string => "/search";
 export const settings = (): string => "/settings";
 
@@ -37,19 +30,8 @@ export const projectIssues = (id: string): string => `/projects/${id}/issues`;
 export const projectIssue = (id: string): string => `/projects/${id}/issue`;
 export const projectRevisions = (id: string): string =>
   `/projects/${id}/revisions`;
-export const projectSource = (
-  id: string,
-  revision: string,
-  objectType: string,
-  path: string
-): string => {
-  if (revision && path) {
-    return `/projects/${id}/source/${revision}/${objectType}/${
-      objectType === ObjectType.Tree ? `${path}/` : path
-    }`;
-  } else {
-    return `/projects/${id}/source`;
-  }
+export const projectSource = (id: string): string => {
+  return `/projects/${id}/source`;
 };
 export const projectCommit = (id: string, hash: string): string =>
   `/projects/${id}/commit/${hash}`;
@@ -67,19 +49,4 @@ export const active = (
   loose = false
 ): boolean => {
   return regexparam(path, loose).pattern.test(location);
-};
-
-export const extractProjectSourceRevision = (location: string): string => {
-  const rev = PROJECT_SOURCE_PATH_MATCH.exec(location);
-  return rev === null ? config.DEFAULT_PROJECT_REVISION : rev[1];
-};
-
-export const extractProjectSourceObjectPath = (location: string): string => {
-  const path = PROJECT_SOURCE_PATH_MATCH.exec(location);
-  return path === null ? "" : path[3];
-};
-
-export const extractProjectSourceObjectType = (location: string): string => {
-  const type = PROJECT_SOURCE_PATH_MATCH.exec(location);
-  return type === null ? ObjectType.Tree : type[2];
 };

--- a/ui/src/source.ts
+++ b/ui/src/source.ts
@@ -106,6 +106,12 @@ export const commits = commitsStore.readable;
 const currentPathStore = writable("");
 export const currentPath = derived(currentPathStore, $store => $store);
 
+const currentObjectTypeStore = writable("");
+export const currentObjectType = derived(
+  currentObjectTypeStore,
+  $store => $store
+);
+
 const currentRevisionStore = writable("");
 export const currentRevision = derived(currentRevisionStore, $store => $store);
 
@@ -220,6 +226,7 @@ const update = (msg: Msg): void => {
 
     case Kind.Update:
       currentPathStore.update(() => msg.path);
+      currentObjectTypeStore.update(() => msg.type);
       currentRevisionStore.update(() => msg.revision);
       objectStore.loading();
 


### PR DESCRIPTION
So far part of the source browsing state was in the router and another part in the global store. With this PR all the state will live in the Typescript/Svelte store.

We don't gain anything by having this state in the browser's window.location as it isn't presented to the user. And if we will want to present it to the user it's going to be easier to just grab it from the store.

This is in preparation of the UI changes for https://github.com/radicle-dev/radicle-upstream/issues/443.