### PR TITLE
refactor(proxy): improve api ergonomics around project registration

### DIFF
--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -27,7 +27,6 @@ mod project;
 mod session;
 mod source;
 mod transaction;
-
 mod user;
 
 /// Helper to combine the multiple filters together with Filter::or, possibly boxing the types in

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -1,9 +1,17 @@
 //! HTTP API delivering JSON over `RESTish` endpoints.
 
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
+use std::convert::TryFrom;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
-use warp::{path, Filter, Rejection, Reply};
+use warp::http::StatusCode;
+use warp::{
+    document::{self, ToDocumentedType},
+    path, reply, Filter, Rejection, Reply,
+};
 
 use crate::coco;
 use crate::registry;
@@ -19,6 +27,7 @@ mod project;
 mod session;
 mod source;
 mod transaction;
+
 mod user;
 
 /// Helper to combine the multiple filters together with Filter::or, possibly boxing the types in
@@ -154,6 +163,82 @@ pub fn with_subscriptions(
     subscriptions: crate::notification::Subscriptions,
 ) -> impl Filter<Extract = (crate::notification::Subscriptions,), Error = Infallible> + Clone {
     warp::any().map(move || crate::notification::Subscriptions::clone(&subscriptions))
+}
+
+/// Bundled input data for project registration, shared
+/// between users and orgs.
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterProjectInput {
+    /// User specified transaction fee.
+    transaction_fee: registry::Balance,
+    /// Optionally passed coco id to store for attestion.
+    maybe_coco_id: Option<String>,
+}
+
+impl ToDocumentedType for RegisterProjectInput {
+    fn document() -> document::DocumentedType {
+        let mut properties = HashMap::with_capacity(2);
+        properties.insert(
+            "transactionFee".into(),
+            document::string()
+                .description("User specified transaction fee")
+                .example(100),
+        );
+        properties.insert(
+            "maybeCocoId".into(),
+            document::string()
+                .description("Optionally passed coco id to store for attestion")
+                .example("ac1cac587b49612fbac39775a07fb05c6e5de08d.git"),
+        );
+
+        document::DocumentedType::from(properties).description("Input for Project registration")
+    }
+}
+
+/// Register a project in the registry under the given domain.
+///
+/// # Errors
+///
+/// Might return an http error
+pub async fn register_project<R: registry::Client>(
+    registry: Shared<R>,
+    subscriptions: crate::notification::Subscriptions,
+    domain_type: registry::DomainType,
+    domain_id_str: String,
+    project_name: String,
+    input: RegisterProjectInput,
+) -> Result<impl Reply, Rejection> {
+    // TODO(xla): Get keypair from persistent storage.
+    let fake_pair = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
+
+    let reg = registry.read().await;
+    let maybe_coco_id = input
+        .maybe_coco_id
+        .map(|id| librad::uri::RadUrn::from_str(&id).expect("Project RadUrn"));
+    let domain_id = registry::Id::try_from(domain_id_str).map_err(crate::error::Error::from)?;
+    let domain = match domain_type {
+        registry::DomainType::Org => registry::ProjectDomain::Org(domain_id),
+        registry::DomainType::User => registry::ProjectDomain::User(domain_id),
+    };
+    let project_name =
+        registry::ProjectName::try_from(project_name).map_err(crate::error::Error::from)?;
+
+    let tx = reg
+        .register_project(
+            &fake_pair,
+            domain,
+            project_name,
+            maybe_coco_id,
+            input.transaction_fee,
+        )
+        .await?;
+
+    subscriptions
+        .broadcast(crate::notification::Notification::Transaction(tx.clone()))
+        .await;
+
+    Ok(reply::with_status(reply::json(&tx), StatusCode::CREATED))
 }
 
 #[cfg(test)]

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -70,12 +70,7 @@ where
         Arc::clone(&registry),
         subscriptions.clone(),
     );
-    let project_filter = project::filters(
-        Arc::clone(&peer),
-        Arc::clone(&owner),
-        Arc::clone(&registry),
-        subscriptions.clone(),
-    );
+    let project_filter = project::filters(Arc::clone(&peer), Arc::clone(&owner));
     let session_filter =
         session::routes(Arc::clone(&peer), Arc::clone(&registry), Arc::clone(&store));
     let source_filter = source::routes(peer);

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -9,7 +9,7 @@ use warp::{path, Filter, Rejection, Reply};
 
 use crate::avatar;
 use crate::coco;
-use crate::http::{self, RegisterProjectInput};
+use crate::http;
 use crate::notification;
 use crate::project;
 use crate::registry;

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -114,7 +114,7 @@ fn register_project_filter<R: registry::Client>(
         )))
         .and(document::document(document::tag("Org")))
         .and(document::document(
-            document::body(RegisterProjectInput::document()).mime("application/json"),
+            document::body(http::RegisterProjectInput::document()).mime("application/json"),
         ))
         .and(document::document(
             document::response(

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -277,7 +277,7 @@ mod handler {
         subscriptions: notification::Subscriptions,
         org_id: String,
         project_name: String,
-        input: super::RegisterProjectInput,
+        input: http::RegisterProjectInput,
     ) -> Result<impl Reply, Rejection> {
         http::register_project(
             registry,

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -2,7 +2,6 @@
 
 use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize, Serializer};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use warp::document::{self, ToDocumentedType};
@@ -10,7 +9,7 @@ use warp::{path, Filter, Rejection, Reply};
 
 use crate::avatar;
 use crate::coco;
-use crate::http;
+use crate::http::{self, RegisterProjectInput};
 use crate::notification;
 use crate::project;
 use crate::registry;
@@ -248,7 +247,6 @@ fn register_member_filter<R: registry::Client>(
 /// Org handlers for conversion between core domain and http request fullfilment.
 mod handler {
     use std::convert::TryFrom;
-    use std::str::FromStr;
     use std::sync::Arc;
     use tokio::sync::Mutex;
     use warp::http::StatusCode;
@@ -281,32 +279,15 @@ mod handler {
         project_name: String,
         input: super::RegisterProjectInput,
     ) -> Result<impl Reply, Rejection> {
-        // TODO(xla): Get keypair from persistent storage.
-        let fake_pair = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
-
-        let reg = registry.read().await;
-        let maybe_coco_id = input
-            .maybe_coco_id
-            .map(|id| librad::uri::RadUrn::from_str(&id).expect("Project RadUrn"));
-        let domain_id = registry::Id::try_from(org_id).map_err(Error::from)?;
-        let domain = registry::ProjectDomain::Org(domain_id);
-        let project_name = registry::ProjectName::try_from(project_name).map_err(Error::from)?;
-
-        let tx = reg
-            .register_project(
-                &fake_pair,
-                domain,
-                project_name,
-                maybe_coco_id,
-                input.transaction_fee,
-            )
-            .await?;
-
-        subscriptions
-            .broadcast(notification::Notification::Transaction(tx.clone()))
-            .await;
-
-        Ok(reply::with_status(reply::json(&tx), StatusCode::CREATED))
+        http::register_project(
+            registry,
+            subscriptions,
+            registry::DomainType::Org,
+            org_id,
+            project_name,
+            input,
+        )
+        .await
     }
 
     /// Get the [`registry::Project`] under the given org id.
@@ -521,36 +502,6 @@ impl ToDocumentedType for RegisterInput {
         );
 
         document::DocumentedType::from(properties).description("Input for org registration")
-    }
-}
-
-/// Bundled input data for project registration.
-#[derive(Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RegisterProjectInput {
-    /// User specified transaction fee.
-    transaction_fee: registry::Balance,
-    /// Optionally passed coco id to store for attestion.
-    maybe_coco_id: Option<String>,
-}
-
-impl ToDocumentedType for RegisterProjectInput {
-    fn document() -> document::DocumentedType {
-        let mut properties = HashMap::with_capacity(2);
-        properties.insert(
-            "transactionFee".into(),
-            document::string()
-                .description("User specified transaction fee")
-                .example(100),
-        );
-        properties.insert(
-            "maybeCocoId".into(),
-            document::string()
-                .description("Optionally passed coco id to store for attestion")
-                .example("ac1cac587b49612fbac39775a07fb05c6e5de08d.git"),
-        );
-
-        document::DocumentedType::from(properties).description("Input for Project registration")
     }
 }
 

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -1,5 +1,4 @@
 //! Endpoints and serialisation for [`project::Project`] related types.
-
 use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
@@ -11,24 +10,19 @@ use warp::{path, Filter, Rejection, Reply};
 
 use crate::coco;
 use crate::http;
-use crate::notification;
 use crate::project;
 use crate::registry;
 
 /// Combination of all routes.
-pub fn filters<R>(
+pub fn filters(
     peer: Arc<Mutex<coco::Peer>>,
     owner: http::Shared<coco::User>,
-    registry: http::Shared<R>,
-    subscriptions: notification::Subscriptions,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
 where
-    R: registry::Client,
 {
     list_filter(Arc::clone(&peer))
         .or(create_filter(Arc::clone(&peer), owner))
         .or(get_filter(peer))
-        .or(register_filter(registry, subscriptions))
 }
 
 /// `POST /projects`
@@ -109,42 +103,9 @@ fn list_filter(
         .and_then(handler::list)
 }
 
-/// `POST /projects/register`
-fn register_filter<R: registry::Client>(
-    registry: http::Shared<R>,
-    subscriptions: notification::Subscriptions,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    path!("projects" / "register")
-        .and(warp::post())
-        .and(http::with_shared(registry))
-        .and(http::with_subscriptions(subscriptions))
-        .and(warp::body::json())
-        .and(document::document(document::description(
-            "Register a Project on the Registry",
-        )))
-        .and(document::document(document::tag("Project")))
-        .and(document::document(
-            document::body(RegisterInput::document()).mime("application/json"),
-        ))
-        .and(document::document(
-            document::response(
-                201,
-                document::body(
-                    document::array(registry::Transaction::document())
-                        .description("RegisterProject transaction"),
-                )
-                .mime("application/json"),
-            )
-            .description("Creation succeeded"),
-        ))
-        .and_then(handler::register)
-}
-
 /// Project handlers to implement conversion and translation between core domain and http request
 /// fullfilment.
 mod handler {
-    use std::convert::TryFrom;
-    use std::str::FromStr;
     use std::sync::Arc;
     use tokio::sync::Mutex;
     use warp::http::StatusCode;
@@ -153,9 +114,7 @@ mod handler {
     use crate::coco;
     use crate::error::Error;
     use crate::http;
-    use crate::notification;
     use crate::project;
-    use crate::registry;
 
     /// Create a new [`project::Project`].
     pub async fn create(
@@ -224,44 +183,6 @@ mod handler {
 
         Ok(reply::json(&projects))
     }
-
-    /// Register a project on the Registry.
-    pub async fn register<R: registry::Client>(
-        registry: http::Shared<R>,
-        subscriptions: notification::Subscriptions,
-        input: super::RegisterInput,
-    ) -> Result<impl Reply, Rejection> {
-        // TODO(xla): Get keypair from persistent storage.
-        let fake_pair = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
-
-        let reg = registry.read().await;
-        let maybe_coco_id = input
-            .maybe_coco_id
-            .map(|id| librad::uri::RadUrn::from_str(&id).expect("Project RadUrn"));
-        let domain_id = registry::Id::try_from(input.domain_id).map_err(Error::from)?;
-        let domain: registry::ProjectDomain = match input.domain_type.clone() {
-            registry::DomainType::Org => registry::ProjectDomain::Org(domain_id.clone()),
-            registry::DomainType::User => registry::ProjectDomain::User(domain_id.clone()),
-        };
-        let project_name =
-            registry::ProjectName::try_from(input.project_name).map_err(Error::from)?;
-
-        let tx = reg
-            .register_project(
-                &fake_pair,
-                domain,
-                project_name,
-                maybe_coco_id,
-                input.transaction_fee,
-            )
-            .await?;
-
-        subscriptions
-            .broadcast(notification::Notification::Transaction(tx.clone()))
-            .await;
-
-        Ok(reply::with_status(reply::json(&tx), StatusCode::CREATED))
-    }
 }
 
 impl Serialize for project::Project {
@@ -303,32 +224,6 @@ impl ToDocumentedType for project::Project {
 
         document::DocumentedType::from(properties)
             .description("Radicle project for sharing and collaborating")
-    }
-}
-
-impl ToDocumentedType for project::Metadata {
-    fn document() -> document::DocumentedType {
-        let mut properties = HashMap::with_capacity(3);
-        properties.insert(
-            "name".into(),
-            document::string()
-                .description("Project name")
-                .example("upstream"),
-        );
-        properties.insert(
-            "description".into(),
-            document::string()
-                .description("High-level description of the Project")
-                .example("Desktop client for radicle"),
-        );
-        properties.insert(
-            "defaultBranch".into(),
-            document::string()
-                .description("Default branch for checkouts, often used as mainline as well")
-                .example("master"),
-        );
-
-        document::DocumentedType::from(properties).description("Project metadata")
     }
 }
 
@@ -375,6 +270,32 @@ impl ToDocumentedType for project::Registration {
             .example(Self::Org(
                 registry::Id::try_from("monadic").expect("unable to parse org id"),
             ))
+    }
+}
+
+impl ToDocumentedType for project::Metadata {
+    fn document() -> document::DocumentedType {
+        let mut properties = HashMap::with_capacity(3);
+        properties.insert(
+            "name".into(),
+            document::string()
+                .description("Project name")
+                .example("upstream"),
+        );
+        properties.insert(
+            "description".into(),
+            document::string()
+                .description("High-level description of the Project")
+                .example("Desktop client for radicle"),
+        );
+        properties.insert(
+            "defaultBranch".into(),
+            document::string()
+                .description("Default branch for checkouts, often used as mainline as well")
+                .example("master"),
+        );
+
+        document::DocumentedType::from(properties).description("Project metadata")
     }
 }
 
@@ -482,66 +403,11 @@ impl ToDocumentedType for MetadataInput {
     }
 }
 
-/// Bundled input data for project registration.
-#[derive(Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RegisterInput {
-    /// The type of domain the project will be registered under.
-    domain_type: registry::DomainType,
-    /// Id of the domain the project will be registered under.
-    domain_id: String,
-    /// Unique name under Org of the project.
-    project_name: String,
-    /// User specified transaction fee.
-    transaction_fee: registry::Balance,
-    /// Optionally passed coco id to store for attestion.
-    maybe_coco_id: Option<String>,
-}
-
-impl ToDocumentedType for RegisterInput {
-    fn document() -> document::DocumentedType {
-        let mut properties = HashMap::with_capacity(3);
-        properties.insert(
-            "domainType".into(),
-            document::enum_string(vec!["org".into(), "user".into()])
-                .description("The type of domain the project will be registered under")
-                .example("org"),
-        );
-        properties.insert(
-            "domainId".into(),
-            document::string()
-                .description("ID of the domain the project will be registered under")
-                .example("monadic"),
-        );
-        properties.insert(
-            "projectName".into(),
-            document::string()
-                .description("Unique name under the Org of the project")
-                .example("upstream"),
-        );
-        properties.insert(
-            "transactionFee".into(),
-            document::string()
-                .description("User specified transaction fee")
-                .example(100),
-        );
-        properties.insert(
-            "maybeCocoId".into(),
-            document::string()
-                .description("Optionally passed coco id to store for attestion")
-                .example("ac1cac587b49612fbac39775a07fb05c6e5de08d.git"),
-        );
-
-        document::DocumentedType::from(properties).description("Input for Project registration")
-    }
-}
-
 #[allow(clippy::panic, clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
-    use std::convert::TryFrom;
     use std::sync::Arc;
     use tokio::sync::{Mutex, RwLock};
     use warp::http::StatusCode;
@@ -552,9 +418,7 @@ mod test {
     use crate::coco;
     use crate::error;
     use crate::http;
-    use crate::notification;
     use crate::project;
-    use crate::registry::{self, Cache as _, Client as _};
 
     #[tokio::test]
     async fn create() -> Result<(), error::Error> {
@@ -563,24 +427,13 @@ mod test {
         let config = coco::default_config(key, tmp_dir.path())?;
         let peer = coco::Peer::new(config).await?;
         let owner = Arc::new(RwLock::new(coco::fake_owner(&peer).await));
-        let registry = {
-            let (client, _) = radicle_registry_client::Client::new_emulator();
-            registry::Registry::new(client)
-        };
-        let subscriptions = notification::Subscriptions::default();
-
         let repos_dir = tempfile::tempdir_in(tmp_dir.path())?;
         let dir = tempfile::tempdir_in(repos_dir.path())?;
         let path = dir.path().to_str().unwrap();
 
         let peer = Arc::new(Mutex::new(peer));
 
-        let api = super::filters(
-            Arc::clone(&peer),
-            Arc::clone(&owner),
-            Arc::new(RwLock::new(registry)),
-            subscriptions,
-        );
+        let api = super::filters(Arc::clone(&peer), Arc::clone(&owner));
         let res = request()
             .method("POST")
             .path("/projects")
@@ -628,12 +481,6 @@ mod test {
         let config = coco::default_config(key, tmp_dir.path())?;
         let mut peer = coco::Peer::new(config).await?;
         let owner = coco::fake_owner(&peer).await;
-        let registry = {
-            let (client, _) = radicle_registry_client::Client::new_emulator();
-            registry::Registry::new(client)
-        };
-        let subscriptions = notification::Subscriptions::default();
-
         let platinum_project = peer
             .replicate_platinum(&owner, "git-platinum", "fixture data", "master")
             .await?;
@@ -641,12 +488,7 @@ mod test {
 
         let project = project::get(&peer, &urn)?;
 
-        let api = super::filters(
-            Arc::new(Mutex::new(peer)),
-            Arc::new(RwLock::new(owner)),
-            Arc::new(RwLock::new(registry)),
-            subscriptions,
-        );
+        let api = super::filters(Arc::new(Mutex::new(peer)), Arc::new(RwLock::new(owner)));
         let res = request()
             .method("GET")
             .path(&format!("/projects/{}", urn))
@@ -667,11 +509,6 @@ mod test {
         let config = coco::default_config(key, tmp_dir.path())?;
         let mut peer = coco::Peer::new(config).await?;
         let owner = coco::fake_owner(&peer).await;
-        let registry = {
-            let (client, _) = radicle_registry_client::Client::new_emulator();
-            registry::Registry::new(client)
-        };
-        let subscriptions = notification::Subscriptions::default();
 
         peer.setup_fixtures(&owner).await?;
 
@@ -691,179 +528,12 @@ mod test {
             })
             .collect::<Vec<project::Project>>();
 
-        let api = super::filters(
-            Arc::new(Mutex::new(peer)),
-            Arc::new(RwLock::new(owner)),
-            Arc::new(RwLock::new(registry)),
-            subscriptions,
-        );
+        let api = super::filters(Arc::new(Mutex::new(peer)), Arc::new(RwLock::new(owner)));
         let res = request().method("GET").path("/projects").reply(&api).await;
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
             assert_eq!(have, json!(projects));
         });
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn register_under_org() -> Result<(), error::Error> {
-        let tmp_dir = tempfile::tempdir()?;
-        let key = SecretKey::new();
-        let config = coco::default_config(key, tmp_dir.path())?;
-        let peer = coco::Peer::new(config).await?;
-        let owner = coco::fake_owner(&peer).await;
-        let registry = {
-            let (client, _) = radicle_registry_client::Client::new_emulator();
-            registry::Registry::new(client)
-        };
-        let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store")))?;
-        let cache = Arc::new(RwLock::new(registry::Cacher::new(registry, &store)));
-        let subscriptions = notification::Subscriptions::default();
-
-        let api = super::filters(
-            Arc::new(Mutex::new(peer)),
-            Arc::new(RwLock::new(owner.clone())),
-            Arc::clone(&cache),
-            subscriptions,
-        );
-        let author = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
-        let handle = registry::Id::try_from("alice")?;
-        let org_id = registry::Id::try_from("radicle")?;
-        let urn = librad::uri::RadUrn::new(
-            owner.root_hash().clone(),
-            librad::uri::Protocol::Git,
-            librad::uri::Path::new(),
-        );
-
-        // Register user.
-        cache
-            .read()
-            .await
-            .register_user(&author, handle, None, 10)
-            .await?;
-
-        // Register org.
-        cache
-            .read()
-            .await
-            .register_org(&author, org_id.clone(), 10)
-            .await?;
-
-        let res = request()
-            .method("POST")
-            .path("/projects/register")
-            .json(&super::RegisterInput {
-                domain_type: registry::DomainType::Org,
-                domain_id: org_id.to_string(),
-                project_name: "upstream".into(),
-                maybe_coco_id: Some(urn.to_string()),
-                transaction_fee: registry::MINIMUM_FEE,
-            })
-            .reply(&api)
-            .await;
-
-        assert_eq!(res.status(), StatusCode::CREATED);
-
-        let txs = cache.read().await.list_transactions(vec![])?;
-        let tx = txs.first().unwrap();
-
-        let have: Value = serde_json::from_slice(res.body()).unwrap();
-        assert_eq!(have, json!(tx));
-
-        let tx_msg = tx.messages.first().unwrap();
-        match tx_msg {
-            registry::Message::ProjectRegistration {
-                project_name,
-                domain_type,
-                domain_id,
-            } => {
-                assert_eq!(
-                    project_name.clone(),
-                    registry::ProjectName::try_from("upstream").unwrap()
-                );
-                assert_eq!(domain_type.clone(), registry::DomainType::Org);
-                assert_eq!(domain_id.clone(), org_id);
-            },
-            _ => panic!("The tx message is an unexpected variant."),
-        }
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn register_under_user() -> Result<(), error::Error> {
-        let tmp_dir = tempfile::tempdir()?;
-        let key = SecretKey::new();
-        let config = coco::default_config(key, tmp_dir.path())?;
-        let peer = coco::Peer::new(config).await?;
-        let owner = coco::fake_owner(&peer).await;
-        let registry = {
-            let (client, _) = radicle_registry_client::Client::new_emulator();
-            registry::Registry::new(client)
-        };
-        let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store")))?;
-        let cache = Arc::new(RwLock::new(registry::Cacher::new(registry, &store)));
-        let subscriptions = notification::Subscriptions::default();
-
-        let api = super::filters(
-            Arc::new(Mutex::new(peer)),
-            Arc::new(RwLock::new(owner)),
-            Arc::clone(&cache),
-            subscriptions,
-        );
-        let author = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
-        let handle = registry::Id::try_from("alice")?;
-        let urn = librad::uri::RadUrn::new(
-            librad::hash::Hash::hash(b"upstream"),
-            librad::uri::Protocol::Git,
-            librad::uri::Path::new(),
-        );
-
-        // Register user.
-        cache
-            .read()
-            .await
-            .register_user(&author, handle.clone(), None, 10)
-            .await?;
-
-        let res = request()
-            .method("POST")
-            .path("/projects/register")
-            .json(&super::RegisterInput {
-                domain_type: registry::DomainType::User,
-                domain_id: handle.to_string(),
-                project_name: "upstream".into(),
-                maybe_coco_id: Some(urn.to_string()),
-                transaction_fee: registry::MINIMUM_FEE,
-            })
-            .reply(&api)
-            .await;
-
-        assert_eq!(res.status(), StatusCode::CREATED);
-
-        let txs = cache.read().await.list_transactions(vec![])?;
-        let tx = txs.first().unwrap();
-
-        let have: Value = serde_json::from_slice(res.body()).unwrap();
-        assert_eq!(have, json!(tx));
-
-        let tx_msg = tx.messages.first().unwrap();
-        match tx_msg {
-            registry::Message::ProjectRegistration {
-                project_name,
-                domain_type,
-                domain_id,
-            } => {
-                assert_eq!(
-                    project_name.clone(),
-                    registry::ProjectName::try_from("upstream").unwrap()
-                );
-                assert_eq!(domain_type.clone(), registry::DomainType::User);
-                assert_eq!(domain_id.clone(), handle);
-            },
-            _ => panic!("The tx message is an unexpected variant."),
-        }
 
         Ok(())
     }

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -1,4 +1,5 @@
 //! Endpoints and serialisation for [`project::Project`] related types.
+
 use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLock;
 use warp::document::{self, ToDocumentedType};
 use warp::{path, Filter, Rejection, Reply};
 
-use crate::http::{self, RegisterProjectInput};
+use crate::http;
 use crate::notification;
 use crate::registry;
 

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -227,7 +227,7 @@ mod handler {
         subscriptions: notification::Subscriptions,
         handle: String,
         project_name: String,
-        input: super::RegisterProjectInput,
+        input: http::RegisterProjectInput,
     ) -> Result<impl Reply, Rejection> {
         http::register_project(
             registry,

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -140,7 +140,7 @@ fn register_project_filter<R: registry::Client>(
         )))
         .and(document::document(document::tag("User")))
         .and(document::document(
-            document::body(RegisterProjectInput::document()).mime("application/json"),
+            document::body(http::RegisterProjectInput::document()).mime("application/json"),
         ))
         .and(document::document(
             document::response(

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -18,13 +18,13 @@ pub fn routes<R: registry::Client>(
     subscriptions: notification::Subscriptions,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path("users").and(
-        register_filter(Arc::clone(&registry), store, subscriptions.clone())
+        list_orgs_filter(Arc::clone(&registry))
             .or(register_project_filter(
                 Arc::clone(&registry),
-                subscriptions,
+                subscriptions.clone(),
             ))
-            .or(list_orgs_filter(Arc::clone(&registry)))
-            .or(get_filter(registry)),
+            .or(get_filter(Arc::clone(&registry)))
+            .or(register_filter(registry, store, subscriptions)),
     )
 }
 

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -84,9 +84,6 @@ interface CreateInput {
 }
 
 interface RegisterInput {
-  domainType: Domain;
-  domainId: string;
-  projectName: string;
   transactionFee: currency.MicroRad;
   maybeCocoId?: string;
 }
@@ -138,6 +135,16 @@ export const getOrgProject = (
   return api.get<Registered>(`orgs/${orgId}/projects/${projectName}`);
 };
 
+// Resolve the api base for the given project domain
+const apiBase = (domain: Domain): string => {
+  switch (domain) {
+    case Domain.Org:
+      return "orgs";
+    case Domain.User:
+      return "users";
+  }
+};
+
 export const register = (
   domainType: Domain,
   domainId: string,
@@ -145,13 +152,14 @@ export const register = (
   transactionFee: currency.MicroRad,
   maybeCocoId?: string
 ): Promise<transaction.Transaction> => {
-  return api.post<RegisterInput, transaction.Transaction>(`projects/register`, {
-    domainType,
-    domainId,
-    projectName,
-    transactionFee,
-    maybeCocoId,
-  });
+  const base = apiBase(domainType);
+  return api.post<RegisterInput, transaction.Transaction>(
+    `${base}/${domainId}/projects/${projectName}`,
+    {
+      transactionFee,
+      maybeCocoId,
+    }
+  );
 };
 
 export const fetch = event.create<Kind, Msg>(Kind.Fetch, update);


### PR DESCRIPTION

Closes #474 

Moves away from `POST projects/register/` with an intertwined payload to have `POST users/<handle>/projects/<name>` and `POST orgs/<id>/projects/<name>`. The payload, `RegisterProjectInput` and the HTTP handler `register_project` are shared and DRY for both endpoints.

### Note

1. When I introduced the new endpoints under `/users`, I ran into this issue where the result of the request was a `500`:

```
'res is Response { status: 500, version: HTTP/1.1, headers: {"content-type": "text/plain; charset=utf-8"}, body: b"Request body consumed multiple times" }', src/http/user.rs:560:9
```

Searching for `Request body consumed multiple times` led me to https://github.com/seanmonstar/warp/issues/291. So, the order in which the endpoint "filters" are combined either makes it or breaks it. That's odd. Have you seen this before?

2. I noticed that if I try to register a project twice from the app, I get the same error as reported above. I have no clue why that would happen yet. The UI should not allow a user to register a project twice anyway.