### PR TITLE
chore(proxy): depend on radicle-surf directly

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "quinn",
  "radicle-keystore",
- "radicle-surf",
+ "radicle-surf 0.2.1",
  "rand 0.7.3",
  "rand_pcg 0.2.1",
  "rcgen",
@@ -2561,6 +2561,7 @@ dependencies = [
  "pretty_env_logger",
  "radicle-keystore",
  "radicle-registry-client",
+ "radicle-surf 0.3.1",
  "rand 0.7.3",
  "serde",
  "serde_cbor 0.11.1",
@@ -2738,6 +2739,20 @@ dependencies = [
 name = "radicle-surf"
 version = "0.2.1"
 source = "git+https://github.com/radicle-dev/radicle-surf?rev=5728b74e77d12769ac917d04c4901994f30092ae#5728b74e77d12769ac917d04c4901994f30092ae"
+dependencies = [
+ "git2",
+ "lazy_static",
+ "nonempty 0.5.0",
+ "regex",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "radicle-surf"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610d2ee2cdebe9dc47a1f693770107c2bec667ce17433b7caf93f73f9bc6ad35"
 dependencies = [
  "git2",
  "lazy_static",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -43,6 +43,10 @@ rev = "a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
 git = "https://github.com/radicle-dev/radicle-registry.git"
 rev = "114f78b357aa4615bc0e389ab62ad0029243583c"
 
+[dependencies.radicle-surf]
+version = "0.3.1"
+features = ["serialize"]
+
 [dev-dependencies]
 bytes = "0.5"
 http = "0.2"

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -14,18 +14,21 @@ use librad::net;
 use librad::net::discovery;
 use librad::paths;
 use librad::peer;
-use radicle_surf::{diff, vcs::git::{self, git2}};
 use librad::uri::RadUrn;
+use radicle_surf::{
+    diff,
+    vcs::git::{self, git2},
+};
 
 use crate::error;
 
 /// Module that captures all types and functions for source code.
 mod source;
+pub use diff::{Diff, FileDiff};
 pub use source::{
     blob, branches, commit, commit_header, commits, local_state, tags, tree, Blob, BlobContent,
     Branch, Commit, CommitHeader, Info, ObjectType, Person, Tag, Tree, TreeEntry,
 };
-pub use diff::{Diff, FileDiff};
 
 pub mod config;
 

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -14,8 +14,7 @@ use librad::net;
 use librad::net::discovery;
 use librad::paths;
 use librad::peer;
-use librad::surf;
-use librad::surf::vcs::git::git2;
+use radicle_surf::{diff, vcs::git::{self, git2}};
 use librad::uri::RadUrn;
 
 use crate::error;
@@ -26,7 +25,7 @@ pub use source::{
     blob, branches, commit, commit_header, commits, local_state, tags, tree, Blob, BlobContent,
     Branch, Commit, CommitHeader, Info, ObjectType, Person, Tag, Tree, TreeEntry,
 };
-pub use surf::diff::{Diff, FileDiff};
+pub use diff::{Diff, FileDiff};
 
 pub mod config;
 
@@ -170,13 +169,15 @@ impl Peer {
     /// [`std::sync::Mutex::lock`] for further details.
     pub fn with_browser<F, T>(&self, project_urn: &RadUrn, callback: F) -> Result<T, error::Error>
     where
-        F: Send + FnOnce(&mut surf::vcs::git::Browser) -> Result<T, error::Error>,
+        F: Send + FnOnce(&mut git::Browser) -> Result<T, error::Error>,
     {
         let project = self.get_project(project_urn)?;
         let default_branch = project.default_branch();
         let api = self.api.lock().map_err(|_| error::Error::LibradLock)?;
-        let repo = api.storage().open_repo(project.urn())?;
-        let mut browser = repo.browser(default_branch)?;
+        let git_dir = api.paths().git_dir();
+        let repo = git::Repository::new(git_dir)?;
+        let namespace = git::Namespace::from(project.urn().id.to_string().as_str());
+        let mut browser = git::Browser::new_with_namespace(&repo, &namespace, default_branch)?;
         callback(&mut browser)
     }
 

--- a/proxy/src/coco/source.rs
+++ b/proxy/src/coco/source.rs
@@ -328,7 +328,7 @@ pub fn commit<'repo>(browser: &mut Browser<'repo>, sha1: &str) -> Result<Commit,
                     match line {
                         diff::LineDiff::Addition { .. } => additions += 1,
                         diff::LineDiff::Deletion { .. } => deletions += 1,
-                        _ => {}
+                        _ => {},
                     }
                 }
             }

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -4,10 +4,10 @@ use std::time::SystemTimeError;
 
 use librad::meta::common::url;
 use librad::meta::entity;
-use librad::surf;
-use librad::surf::git::git2;
 use librad::uri::RadUrn;
 use radicle_registry_client as registry;
+use radicle_surf as surf;
+use radicle_surf::git::git2;
 
 use crate::keystore;
 

--- a/proxy/src/http/error.rs
+++ b/proxy/src/http/error.rs
@@ -1,13 +1,14 @@
 //! Recovery and conversion of [`error::Error`] to proper JSON responses, which expose variants
 //! for API consumers to act on.
 
-use librad::surf;
 use serde::Serialize;
 use std::convert::Infallible;
 use std::fmt;
 use warp::document::{self, ToDocumentedType};
 use warp::http::StatusCode;
 use warp::{reject, reply, Rejection, Reply};
+
+use radicle_surf as surf;
 
 use crate::error;
 


### PR DESCRIPTION
We have begun to publish radicle-surf to crates.io again. In this change
we use this method for retrieving radicle-surf rather than through
librad. This is because librad will not re-export surf soon: https://github.com/radicle-dev/radicle-link/pull/224.

The major difference here is that we can't simply create a Browser from
the Storage/Repo anymore. Instead, we must use the Paths to get the
git_dir and setup the Browser that way -- also calculating the Namespace
for the Project's RadUrn.