### PR TITLE
fix(ui): fix error display

### DIFF
--- a/ui/DesignSystem/Component/Error.svelte
+++ b/ui/DesignSystem/Component/Error.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { Text, Icon } from "../../DesignSystem/Primitive";
+
+  export let message = null;
+</script>
+
+<style>
+  .error {
+    color: white;
+    background-color: var(--color-negative-level-2);
+    vertical-align: middle;
+    margin: 1rem;
+    padding: 1rem;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: left;
+  }
+</style>
+
+<div class="error">
+  <Icon.Important variant="big" style="fill: white" />
+  <Text style="padding-left: 0.5rem">Error: {message}</Text>
+</div>

--- a/ui/DesignSystem/Component/index.js
+++ b/ui/DesignSystem/Component/index.js
@@ -3,6 +3,7 @@ import Comment from "./Comment.svelte";
 import Copyable from "./Copyable.svelte";
 import Dropdown from "./Dropdown.svelte";
 import EmptyState from "./EmptyState.svelte";
+import Error from "./Error.svelte";
 import Header from "./Header";
 import HorizontalMenu from "./HorizontalMenu.svelte";
 import Label from "./Label.svelte";
@@ -40,6 +41,7 @@ export {
   Copyable,
   Dropdown,
   EmptyState,
+  Error,
   Header,
   HorizontalMenu,
   Label,

--- a/ui/Screen/Org/Projects.svelte
+++ b/ui/Screen/Org/Projects.svelte
@@ -5,10 +5,11 @@
   import { projects as store, fetchProjectList } from "../../src/org.ts";
   import * as path from "../../src/path.ts";
 
-  import { Flex, Text } from "../../DesignSystem/Primitive";
+  import { Flex } from "../../DesignSystem/Primitive";
   import {
     AdditionalActionsDropdown,
     EmptyState,
+    Error,
     List,
     ProjectCard,
     Remote,
@@ -94,6 +95,6 @@
   {/if}
 
   <div slot="error" let:error>
-    <Text>{error}</Text>
+    <Error message={error.message} />
   </div>
 </Remote>

--- a/ui/Screen/Profile/Projects.svelte
+++ b/ui/Screen/Profile/Projects.svelte
@@ -5,10 +5,11 @@
   import * as path from "../../src/path.ts";
   import { projects as projectsStore } from "../../src/project.ts";
 
-  import { Flex, Icon, Text } from "../../DesignSystem/Primitive";
+  import { Flex, Icon } from "../../DesignSystem/Primitive";
   import {
     AdditionalActionsDropdown,
     EmptyState,
+    Error,
     List,
     ProjectCard,
     Remote,
@@ -105,6 +106,6 @@
   {/if}
 
   <div slot="error" let:error>
-    <Text>{error}</Text>
+    <Error message={error.message} />
   </div>
 </Remote>


### PR DESCRIPTION
Introduce `Error` component for displaying full-width error messages.

Before:
![2020-06-30-124737_1074x706_scrot](https://user-images.githubusercontent.com/40774/86117814-fdf65f80-bacf-11ea-8247-887b962c2ef9.png)

After:
![2020-06-30-124345_766x706_scrot](https://user-images.githubusercontent.com/40774/86117823-00f15000-bad0-11ea-9118-3abed450a384.png)
