### PR TITLE
chore(proxy): update librad

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1573,7 +1573,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=e2e5b1ed4b1aa03f718da0c3b8c5cb414df1c328#e2e5b1ed4b1aa03f718da0c3b8c5cb414df1c328"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=79460f429e4d9ae9a49c9b389a2411fbc138ed0e#79460f429e4d9ae9a49c9b389a2411fbc138ed0e"
 dependencies = [
  "async-trait",
  "bit-vec",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -33,7 +33,7 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "e2e5b1ed4b1aa03f718da0c3b8c5cb414df1c328"
+rev = "79460f429e4d9ae9a49c9b389a2411fbc138ed0e"
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore.git"

--- a/proxy/src/coco/control.rs
+++ b/proxy/src/coco/control.rs
@@ -26,7 +26,11 @@ pub async fn fake_owner(key: keys::SecretKey) -> User {
 ///
 /// Will error if filesystem access is not granted or broken for the configured
 /// [`librad::paths::Paths`].
-pub fn setup_fixtures(peer: &PeerApi, owner: &User) -> Result<(), error::Error> {
+pub fn setup_fixtures(
+    peer: &PeerApi,
+    key: keys::SecretKey,
+    owner: &User,
+) -> Result<(), error::Error> {
     let infos = vec![
         ("monokel", "A looking glass into the future", "master"),
         (
@@ -49,7 +53,7 @@ pub fn setup_fixtures(peer: &PeerApi, owner: &User) -> Result<(), error::Error> 
     for info in infos {
         // let path = format!("{}/{}/{}", root, "repos", info.0);
         // std::fs::create_dir_all(path.clone())?;
-        replicate_platinum(peer, owner, info.0, info.1, info.2)?;
+        replicate_platinum(peer, key.clone(), owner, info.0, info.1, info.2)?;
     }
 
     Ok(())
@@ -64,6 +68,7 @@ pub fn setup_fixtures(peer: &PeerApi, owner: &User) -> Result<(), error::Error> 
 /// the coco project.
 pub fn replicate_platinum(
     peer: &PeerApi,
+    key: keys::SecretKey,
     owner: &User,
     name: &str,
     description: &str,
@@ -84,6 +89,7 @@ pub fn replicate_platinum(
 
     let meta = init_project(
         peer,
+        key,
         owner,
         platinum_into.clone(),
         name,

--- a/proxy/src/coco/control.rs
+++ b/proxy/src/coco/control.rs
@@ -3,22 +3,11 @@ use std::env;
 use librad::keys;
 use librad::meta::entity;
 use librad::meta::project;
-use librad::meta::user;
 use librad::net::peer::PeerApi;
 use radicle_surf::vcs::git::git2;
 
-use crate::coco::peer::{init_project, verify_user, User};
+use crate::coco::peer::{init_project, User};
 use crate::error;
-
-// TODO(finto): Should be fully removed where we use init_user instead.
-/// Constructs a fake user to be used as an owner of projects until we have more permanent key and
-/// user management.
-pub async fn fake_owner(key: keys::SecretKey) -> User {
-    let mut user = user::User::<entity::Draft>::create("cloudhead".into(), key.public())
-        .expect("unable to create user");
-    user.sign_owned(&key).expect("unable to sign user");
-    verify_user(user).await.expect("failed to verify user")
-}
 
 /// Creates a small set of projects in your peer.
 ///
@@ -26,6 +15,7 @@ pub async fn fake_owner(key: keys::SecretKey) -> User {
 ///
 /// Will error if filesystem access is not granted or broken for the configured
 /// [`librad::paths::Paths`].
+#[allow(clippy::needless_pass_by_value)] // We don't want to keep `SecretKey` in memory.
 pub fn setup_fixtures(
     peer: &PeerApi,
     key: keys::SecretKey,

--- a/proxy/src/coco/peer.rs
+++ b/proxy/src/coco/peer.rs
@@ -42,8 +42,8 @@ where
 /// The function will error if:
 ///   * The retrieving the project entities from the store fails.
 #[allow(
-    clippy::wildcard_enum_match_arm,
-    clippy::match_wildcard_for_single_variants
+    clippy::match_wildcard_for_single_variants,
+    clippy::wildcard_enum_match_arm
 )]
 pub fn list_projects(peer: &PeerApi) -> Result<Vec<project::Project<entity::Draft>>, error::Error> {
     let storage = peer.storage();
@@ -65,8 +65,8 @@ pub fn list_projects(peer: &PeerApi) -> Result<Vec<project::Project<entity::Draf
 /// The function will error if:
 ///   * The retrieving the project entities from the store fails.
 #[allow(
-    clippy::wildcard_enum_match_arm,
-    clippy::match_wildcard_for_single_variants
+    clippy::match_wildcard_for_single_variants,
+    clippy::wildcard_enum_match_arm
 )]
 pub fn list_users(peer: &PeerApi) -> Result<Vec<user::User<entity::Draft>>, error::Error> {
     let storage = peer.storage();
@@ -139,6 +139,7 @@ where
 /// Will error if:
 ///     * The signing of the project metadata fails.
 ///     * The interaction with `librad` [`librad::git::storage::Storage`] fails.
+#[allow(clippy::needless_pass_by_value)] // We don't want to keep `SecretKey` in memory.
 pub fn init_project(
     peer: &PeerApi,
     key: keys::SecretKey,
@@ -196,6 +197,7 @@ pub fn init_project(
 /// Will error if:
 ///     * The signing of the user metadata fails.
 ///     * The interaction with `librad` [`librad::git::storage::Storage`] fails.
+#[allow(clippy::needless_pass_by_value)] // We don't want to keep `SecretKey` in memory.
 pub fn init_user(
     peer: &PeerApi,
     key: keys::SecretKey,

--- a/proxy/src/coco/source.rs
+++ b/proxy/src/coco/source.rs
@@ -472,3 +472,38 @@ pub fn tree<'repo>(
         info,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use librad::keys::SecretKey;
+    use radicle_surf::vcs::git;
+
+    use crate::coco;
+    use crate::error;
+
+    #[tokio::test]
+    async fn browse_commit() -> Result<(), error::Error> {
+        let tmp_dir = tempfile::tempdir()?;
+        let key = SecretKey::new();
+        let config = coco::config::default(key.clone(), tmp_dir)?;
+        let peer = coco::create_peer_api(config).await?;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
+        let platinum_project = coco::control::replicate_platinum(
+            &peer,
+            key,
+            &owner,
+            "git-platinum",
+            "fixture data",
+            "master",
+        )?;
+        let urn = platinum_project.urn();
+        let sha = "91b69e00cd8e5a07e20942e9e4457d83ce7a3ff1";
+
+        let commit = coco::with_browser(&peer, &urn, |browser| super::commit_header(browser, sha))?;
+
+        assert_eq!(commit.sha1, git::Oid::from_str(sha)?);
+
+        Ok(())
+    }
+}

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -15,6 +15,7 @@ use warp::{
 };
 
 use crate::coco;
+use crate::keystore;
 use crate::registry;
 
 mod avatar;
@@ -51,6 +52,7 @@ macro_rules! combine {
 pub fn api<R>(
     peer: coco::PeerApi,
     owner: coco::User,
+    keystore: keystore::Keystorage,
     registry: R,
     store: kv::Store,
     enable_control: bool,
@@ -61,6 +63,7 @@ where
     let peer = Arc::new(Mutex::new(peer));
     // TODO(finto): The user should be read from rad/self
     let owner = Arc::new(RwLock::new(Some(owner)));
+    let keystore = Arc::new(RwLock::new(keystore));
     let registry = Arc::new(RwLock::new(registry));
     let store = Arc::new(RwLock::new(store));
     let subscriptions = crate::notification::Subscriptions::default();
@@ -69,18 +72,23 @@ where
     let control_filter = control::routes(
         enable_control,
         Arc::clone(&peer),
+        Arc::clone(&keystore),
         Arc::clone(&owner),
         Arc::clone(&registry),
     );
-    let identity_filter =
-        identity::filters(Arc::clone(&peer), Arc::clone(&registry), Arc::clone(&store));
+    let identity_filter = identity::filters(
+        Arc::clone(&peer),
+        Arc::clone(&keystore),
+        Arc::clone(&registry),
+        Arc::clone(&store),
+    );
     let notification_filter = notification::filters(subscriptions.clone());
     let org_filter = org::routes(
         Arc::clone(&peer),
         Arc::clone(&registry),
         subscriptions.clone(),
     );
-    let project_filter = project::filters(Arc::clone(&peer), Arc::clone(&owner));
+    let project_filter = project::filters(Arc::clone(&peer), keystore, Arc::clone(&owner));
     let session_filter =
         session::routes(Arc::clone(&peer), Arc::clone(&registry), Arc::clone(&store));
     let source_filter = source::routes(peer);

--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -193,10 +193,7 @@ mod handler {
         let mut new_keystore = keystore::Keystorage::new(&paths, pw);
         let key = new_keystore.init_librad_key().map_err(Error::from)?;
 
-        let config = coco::config::configure(
-            paths,
-            key.clone(),
-        );
+        let config = coco::config::configure(paths, key.clone());
 
         let new_peer = coco::create_peer_api(config).await?;
 
@@ -238,8 +235,8 @@ mod handler {
         use librad::paths;
 
         use crate::coco;
-        use crate::keystore;
         use crate::error;
+        use crate::keystore;
 
         #[tokio::test]
         async fn nuke_coco() -> Result<(), error::Error> {
@@ -258,7 +255,13 @@ mod handler {
                 (peer.paths().clone(), peer.peer_id().clone())
             };
 
-            super::nuke_coco(Arc::clone(&peer), Arc::new(RwLock::new(keystore)), Arc::new(RwLock::new(None))).await.unwrap();
+            super::nuke_coco(
+                Arc::clone(&peer),
+                Arc::new(RwLock::new(keystore)),
+                Arc::new(RwLock::new(None)),
+            )
+            .await
+            .unwrap();
 
             let (new_paths, new_peer_id) = {
                 let peer = peer.lock().await;

--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -7,12 +7,14 @@ use warp::{path, reject, Filter, Rejection, Reply};
 
 use crate::coco;
 use crate::http;
+use crate::keystore;
 use crate::registry;
 
 /// Prefixed control filters.
 pub fn routes<R>(
     enable: bool,
     peer: Arc<Mutex<coco::PeerApi>>,
+    keystore: http::Shared<keystore::Keystorage>,
     owner: http::Shared<Option<coco::User>>,
     registry: http::Shared<R>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
@@ -30,8 +32,8 @@ where
         })
         .untuple_one()
         .and(
-            create_project_filter(Arc::clone(&peer), owner)
-                .or(nuke_coco_filter(peer))
+            create_project_filter(Arc::clone(&peer), keystore, Arc::clone(&owner))
+                .or(nuke_coco_filter(peer, owner))
                 .or(nuke_registry_filter(Arc::clone(&registry)))
                 .or(register_user_filter(registry)),
         )
@@ -41,14 +43,15 @@ where
 #[allow(dead_code)]
 fn filters<R>(
     peer: Arc<Mutex<coco::PeerApi>>,
+    keystore: http::Shared<keystore::Keystorage>,
     owner: http::Shared<Option<coco::User>>,
     registry: http::Shared<R>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
 where
     R: registry::Client,
 {
-    create_project_filter(Arc::clone(&peer), owner)
-        .or(nuke_coco_filter(peer))
+    create_project_filter(Arc::clone(&peer), keystore, Arc::clone(&owner))
+        .or(nuke_coco_filter(peer, owner))
         .or(nuke_registry_filter(Arc::clone(&registry)))
         .or(register_user_filter(registry))
 }
@@ -56,10 +59,12 @@ where
 /// POST /create-project
 fn create_project_filter(
     peer: Arc<Mutex<coco::PeerApi>>,
+    keystore: http::Shared<keystore::Keystorage>,
     owner: http::Shared<Option<coco::User>>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("create-project")
         .and(super::with_peer(peer))
+        .and(super::with_shared(keystore))
         .and(super::with_owner_guard(owner))
         .and(warp::body::json())
         .and_then(handler::create_project)
@@ -78,9 +83,11 @@ fn register_user_filter<R: registry::Client>(
 /// GET /nuke/coco
 fn nuke_coco_filter(
     peer: Arc<Mutex<coco::PeerApi>>,
+    owner: http::Shared<Option<coco::User>>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("nuke" / "coco")
         .and(super::with_peer(peer))
+        .and(super::with_shared(owner))
         .and_then(handler::nuke_coco)
 }
 
@@ -106,19 +113,23 @@ mod handler {
     use crate::coco;
     use crate::error::Error;
     use crate::http;
+    use crate::keystore;
     use crate::project;
     use crate::registry;
 
     /// Create a project from the fixture repo.
     pub async fn create_project(
         peer: Arc<Mutex<coco::PeerApi>>,
+        keystore: http::Shared<keystore::Keystorage>,
         owner: coco::User,
         input: super::CreateInput,
     ) -> Result<impl Reply, Rejection> {
-        let peer = &*peer.lock().await;
+        let keystore = &*keystore.read().await;
 
+        let key = keystore.get_librad_key().map_err(Error::from)?;
         let meta = coco::control::replicate_platinum(
-            peer,
+            &*peer.lock().await,
+            key,
             &owner,
             &input.name,
             &input.description,
@@ -159,7 +170,10 @@ mod handler {
     }
 
     /// Reset the coco state by creating a new temporary directory for the librad paths.
-    pub async fn nuke_coco(peer: Arc<Mutex<coco::PeerApi>>) -> Result<impl Reply, Rejection> {
+    pub async fn nuke_coco(
+        peer: Arc<Mutex<coco::PeerApi>>,
+        owner: http::Shared<Option<coco::User>>,
+    ) -> Result<impl Reply, Rejection> {
         // TmpDir deletes the temporary directory once it DROPS.
         // This means our new directory goes missing, and future calls will fail.
         // The Peer creates the directory again.
@@ -170,13 +184,23 @@ mod handler {
             temp_dir.path().to_path_buf()
         };
 
-        let config = coco::config::default(
-            SecretKey::new(),
-            tmp_path.to_str().expect("path extraction failed"),
-        )?;
-        let mut peer = peer.lock().await;
+        let key = SecretKey::new();
 
+        let config = coco::config::default(
+            key.clone(),
+            tmp_path
+        )?;
         let new_peer = coco::create_peer_api(config).await?;
+        let mut owner = owner.write().await;
+        let new_owner = if let Some(old_owner) = &*owner {
+            let new_owner = coco::init_user(&new_peer, key, old_owner.name())?;
+            Some(coco::verify_user(new_owner).await?)
+        } else {
+            None
+        };
+
+        let mut peer = peer.lock().await;
+        *owner = new_owner;
         *peer = new_peer;
 
         Ok(reply::json(&true))
@@ -197,7 +221,7 @@ mod handler {
     mod test {
         use pretty_assertions::assert_ne;
         use std::sync::Arc;
-        use tokio::sync::Mutex;
+        use tokio::sync::{Mutex, RwLock};
 
         use crate::coco;
         use crate::error;
@@ -209,20 +233,19 @@ mod handler {
             let config = coco::config::default(key, tmp_dir)?;
             let peer = Arc::new(Mutex::new(coco::create_peer_api(config).await?));
 
-            let (old_paths, old_key, old_peer_id) = {
+            let (old_paths, old_peer_id) = {
                 let peer = peer.lock().await;
-                (peer.paths().clone(), peer.public_key(), peer.peer_id())
+                (peer.paths().clone(), peer.peer_id().clone())
             };
 
-            super::nuke_coco(Arc::clone(&peer)).await.unwrap();
+            super::nuke_coco(Arc::clone(&peer), Arc::new(RwLock::new(None))).await.unwrap();
 
-            let (new_paths, new_key, new_peer_id) = {
+            let (new_paths, new_peer_id) = {
                 let peer = peer.lock().await;
-                (peer.paths().clone(), peer.public_key(), peer.peer_id())
+                (peer.paths().clone(), peer.peer_id().clone())
             };
 
             assert_ne!(old_paths.all_dirs(), new_paths.all_dirs());
-            assert_ne!(old_key, new_key);
             assert_ne!(old_peer_id, new_peer_id);
 
             let can_open = {
@@ -266,18 +289,27 @@ mod test {
     use warp::http::StatusCode;
     use warp::test::request;
 
+    use librad::paths;
+
     use crate::coco;
     use crate::error;
     use crate::http;
+    use crate::keystore;
     use crate::registry;
 
     #[tokio::test]
     async fn create_project_after_nuke() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let key = librad::keys::SecretKey::new();
-        let config = coco::config::default(key, tmp_dir.path())?;
+        let paths = paths::Paths::from_root(tmp_dir.path())?;
+
+        let pw = keystore::SecUtf8::from("radicle-upstream");
+        let mut keystore = keystore::Keystorage::new(&paths, pw);
+        let key = keystore.init_librad_key()?;
+
+        let config = coco::config::default(key.clone(), tmp_dir.path())?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let registry = {
             let (client, _) = radicle_registry_client::Client::new_emulator();
             registry::Registry::new(client)
@@ -285,6 +317,7 @@ mod test {
 
         let api = super::filters(
             Arc::new(Mutex::new(peer)),
+            Arc::new(RwLock::new(keystore)),
             Arc::new(RwLock::new(Some(owner))),
             Arc::new(RwLock::new(registry)),
         );

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -620,7 +620,7 @@ mod test {
         let key = SecretKey::new();
         let config = coco::config::default(key.clone(), tmp_dir.path())?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(key).await;
+        let owner = coco::init_user(&peer, key, "cloudhead")?;
         let registry = {
             let (client, _) = radicle_registry_client::Client::new_emulator();
             registry::Registry::new(client)

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -618,9 +618,9 @@ mod test {
     async fn register_project() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir.path())?;
+        let config = coco::config::default(key.clone(), tmp_dir.path())?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::control::fake_owner(key).await;
         let registry = {
             let (client, _) = radicle_registry_client::Client::new_emulator();
             registry::Registry::new(client)
@@ -771,9 +771,10 @@ mod test {
     async fn get_projects() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir.path())?;
+        let config = coco::config::default(key.clone(), tmp_dir.path())?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let registry = {
             let (client, _) = radicle_registry_client::Client::new_emulator();
             Arc::new(RwLock::new(registry::Registry::new(client)))
@@ -786,6 +787,7 @@ mod test {
 
         let platinum_project = coco::control::replicate_platinum(
             &peer,
+            key,
             &owner,
             project_name,
             project_description,

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -507,8 +507,14 @@ mod test {
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
         let owner = coco::verify_user(owner).await?;
 
-        let platinum_project =
-            coco::control::replicate_platinum(&peer, key, &owner, "git-platinum", "fixture data", "master")?;
+        let platinum_project = coco::control::replicate_platinum(
+            &peer,
+            key,
+            &owner,
+            "git-platinum",
+            "fixture data",
+            "master",
+        )?;
         let urn = platinum_project.urn();
 
         let project = project::get(&peer, &urn)?;

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -11,27 +11,31 @@ use warp::{path, Filter, Rejection, Reply};
 
 use crate::coco;
 use crate::http;
+use crate::keystore;
 use crate::project;
 use crate::registry;
 
 /// Combination of all routes.
 pub fn filters(
     peer: Arc<Mutex<coco::PeerApi>>,
+    keystore: http::Shared<keystore::Keystorage>,
     owner: http::Shared<Option<coco::User>>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     list_filter(Arc::clone(&peer))
-        .or(create_filter(Arc::clone(&peer), owner))
+        .or(create_filter(Arc::clone(&peer), keystore, owner))
         .or(get_filter(peer))
 }
 
 /// `POST /projects`
 fn create_filter(
     peer: Arc<Mutex<coco::PeerApi>>,
+    keystore: http::Shared<keystore::Keystorage>,
     owner: http::Shared<Option<coco::User>>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("projects")
         .and(warp::post())
         .and(http::with_peer(peer))
+        .and(http::with_shared(keystore))
         .and(http::with_owner_guard(owner))
         .and(warp::body::json())
         .and(document::document(document::description(
@@ -112,18 +116,24 @@ mod handler {
 
     use crate::coco;
     use crate::error::Error;
+    use crate::http;
+    use crate::keystore;
     use crate::project;
 
     /// Create a new [`project::Project`].
     pub async fn create(
         peer: Arc<Mutex<coco::PeerApi>>,
+        keystore: http::Shared<keystore::Keystorage>,
         owner: coco::User,
         input: super::CreateInput,
     ) -> Result<impl Reply, Rejection> {
-        let peer = &*peer.lock().await;
+        let keystore = &*keystore.read().await;
+
+        let key = keystore.get_librad_key().map_err(Error::from)?;
 
         let meta = coco::init_project(
-            peer,
+            &*peer.lock().await,
+            key,
             &owner,
             &input.path,
             &input.metadata.name,
@@ -410,28 +420,39 @@ mod test {
     use warp::http::StatusCode;
     use warp::test::request;
 
-    use librad::keys::SecretKey;
+    use librad::paths;
 
     use crate::coco;
     use crate::error;
     use crate::http;
+    use crate::keystore;
     use crate::project;
 
     #[tokio::test]
     async fn create() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir.path())?;
+        let paths = paths::Paths::from_root(tmp_dir.path())?;
+
+        let pw = keystore::SecUtf8::from("radicle-upstream");
+        let mut keystore = keystore::Keystorage::new(&paths, pw);
+        let key = keystore.init_librad_key()?;
+
+        let config = coco::config::configure(paths, key.clone());
         let peer = coco::create_peer_api(config).await?;
-        let owner = Arc::new(RwLock::new(Some(
-            coco::control::fake_owner(peer.key().clone()).await,
-        )));
+        let owner = coco::init_user(&peer, key, "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
+        let owner = Arc::new(RwLock::new(Some(owner)));
+
         let repos_dir = tempfile::tempdir_in(tmp_dir.path())?;
         let dir = tempfile::tempdir_in(repos_dir.path())?;
         let path = dir.path().to_str().unwrap();
 
         let peer = Arc::new(Mutex::new(peer));
-        let api = super::filters(Arc::clone(&peer), Arc::clone(&owner));
+        let api = super::filters(
+            Arc::clone(&peer),
+            Arc::new(RwLock::new(keystore)),
+            Arc::clone(&owner),
+        );
         let res = request()
             .method("POST")
             .path("/projects")
@@ -475,23 +496,26 @@ mod test {
     #[tokio::test]
     async fn get() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir.path())?;
+        let paths = paths::Paths::from_root(tmp_dir.path())?;
+
+        let pw = keystore::SecUtf8::from("radicle-upstream");
+        let mut keystore = keystore::Keystorage::new(&paths, pw);
+        let key = keystore.init_librad_key()?;
+
+        let config = coco::config::configure(paths, key.clone());
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
-        let platinum_project = coco::control::replicate_platinum(
-            &peer,
-            &owner,
-            "git-platinum",
-            "fixture data",
-            "master",
-        )?;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
+
+        let platinum_project =
+            coco::control::replicate_platinum(&peer, key, &owner, "git-platinum", "fixture data", "master")?;
         let urn = platinum_project.urn();
 
         let project = project::get(&peer, &urn)?;
 
         let api = super::filters(
             Arc::new(Mutex::new(peer)),
+            Arc::new(RwLock::new(keystore)),
             Arc::new(RwLock::new(Some(owner))),
         );
 
@@ -511,12 +535,19 @@ mod test {
     #[tokio::test]
     async fn list() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir.path())?;
-        let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let paths = paths::Paths::from_root(tmp_dir.path())?;
 
-        coco::control::setup_fixtures(&peer, &owner)?;
+        let pw = keystore::SecUtf8::from("radicle-upstream");
+        let mut keystore = keystore::Keystorage::new(&paths, pw);
+        let key = keystore.init_librad_key()?;
+
+        let config = coco::config::configure(paths, key.clone());
+        let peer = coco::create_peer_api(config).await?;
+
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
+
+        coco::control::setup_fixtures(&peer, key, &owner)?;
 
         let projects = coco::list_projects(&peer)?
             .into_iter()
@@ -535,6 +566,7 @@ mod test {
 
         let api = super::filters(
             Arc::new(Mutex::new(peer)),
+            Arc::new(RwLock::new(keystore)),
             Arc::new(RwLock::new(Some(owner))),
         );
         let res = request().method("GET").path("/projects").reply(&api).await;

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -775,11 +775,13 @@ mod test {
     async fn blob() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = Arc::new(Mutex::new(coco::create_peer_api(config).await?));
-        let owner = coco::control::fake_owner(peer.lock().await.key().clone()).await;
+        let owner = coco::init_user(&*peer.lock().await, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let platinum_project = coco::control::replicate_platinum(
             &*peer.lock().await,
+            key,
             &owner,
             "git-platinum",
             "fixture data",
@@ -905,11 +907,13 @@ mod test {
     async fn branches() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
+            key,
             &owner,
             "git-platinum",
             "fixture data",
@@ -939,11 +943,14 @@ mod test {
     async fn commit() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
+
         let platinum_project = coco::control::replicate_platinum(
             &peer,
+            key,
             &owner,
             "git-platinum",
             "fixture data",
@@ -993,11 +1000,13 @@ mod test {
     async fn commits() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
+            key,
             &owner,
             "git-platinum",
             "fixture data",
@@ -1038,7 +1047,7 @@ mod test {
     async fn local_state() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
 
         let path = "../fixtures/git-platinum";
@@ -1072,11 +1081,13 @@ mod test {
     async fn revisions() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
+            key,
             &owner,
             "git-platinum",
             "fixture data",
@@ -1197,11 +1208,13 @@ mod test {
     async fn tags() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
+            key,
             &owner,
             "git-platinum",
             "fixture data",
@@ -1233,11 +1246,13 @@ mod test {
     async fn tree() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir)?;
+        let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+        let owner = coco::verify_user(owner).await?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
+            key,
             &owner,
             "git-platinum",
             "fixture data",

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -467,9 +467,9 @@ mod test {
     async fn register_project() -> Result<(), Error> {
         let tmp_dir = tempfile::tempdir()?;
         let key = SecretKey::new();
-        let config = coco::config::default(key, tmp_dir.path())?;
+        let config = coco::config::default(key.clone(), tmp_dir.path())?;
         let peer = coco::create_peer_api(config).await?;
-        let owner = coco::control::fake_owner(peer.key().clone()).await;
+        let owner = coco::init_user(&peer, key, "cloudhead")?;
         let registry = {
             let (client, _) = radicle_registry_client::Client::new_emulator();
             registry::Registry::new(client)

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
+use librad::keys;
 use librad::uri::RadUrn;
 
 use crate::avatar;
@@ -43,9 +44,10 @@ pub struct Metadata {
 /// # Errors
 pub async fn create(
     peer: Arc<Mutex<coco::PeerApi>>,
+    key: keys::SecretKey,
     handle: String,
 ) -> Result<Identity, error::Error> {
-    let user = coco::init_user(&*peer.lock().await, &handle)?;
+    let user = coco::init_user(&*peer.lock().await, key, &handle)?;
     let user = coco::verify_user(user).await?;
     let id = user.urn();
     let shareable_entity_identifier = user.into();

--- a/proxy/src/keystore.rs
+++ b/proxy/src/keystore.rs
@@ -5,11 +5,10 @@ use std::fmt;
 
 use librad::keys;
 use librad::paths;
+pub use radicle_keystore::pinentry::SecUtf8;
 use radicle_keystore::{
     crypto::{Pwhash, SecretBoxError},
-    file,
-    pinentry::SecUtf8,
-    FileStorage, Keystore, SecStr, SecretKeyExt,
+    file, FileStorage, Keystore, SecStr, SecretKeyExt,
 };
 use radicle_registry_client::{ed25519, CryptoError, CryptoPair};
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -63,15 +63,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let paths = paths::Paths::try_from(paths_config)?;
 
-    let mut store = keystore::Keystorage::new(&paths, pw);
-    let key = store.init_librad_key()?;
+    let mut keystore = keystore::Keystorage::new(&paths, pw);
+    let key = keystore.init_librad_key()?;
 
-    let config = coco::config::configure(paths, key);
+    let config = coco::config::configure(paths, key.clone());
     let peer = coco::create_peer_api(config).await?;
-    let owner = coco::control::fake_owner(peer.key().clone()).await;
+    let owner = coco::control::fake_owner(key.clone()).await;
 
     if args.test {
-        coco::control::setup_fixtures(&peer, &owner).expect("fixture creation failed");
+        coco::control::setup_fixtures(&peer, key, &owner).expect("fixture creation failed");
     }
 
     let store = {
@@ -89,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Starting API");
 
     let cache = registry::Cacher::new(registry::Registry::new(registry_client), &store);
-    let api = http::api(peer, owner, cache.clone(), store, args.test);
+    let api = http::api(peer, owner, keystore, cache.clone(), store, args.test);
 
     tokio::spawn(async move {
         cache.run().await.expect("cacher run failed");

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -68,7 +68,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = coco::config::configure(paths, key.clone());
     let peer = coco::create_peer_api(config).await?;
-    let owner = coco::control::fake_owner(key.clone()).await;
+    let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
+    let owner = coco::verify_user(owner).await?;
 
     if args.test {
         coco::control::setup_fixtures(&peer, key, &owner).expect("fixture creation failed");


### PR DESCRIPTION
Before integrating the `rad/self` feature we need to deal with the fact we're not able to get a `SecretKey` anymore from the `PeerApi`. This PR achieves that by adding the `SecretKey` as a parameter where needed. Then to get hold of the key we use the `Keystorage` to access it.

We need to have `User` in the monorepo when we create a project. This is so we can add the owner as a certifier, which _must_ be resolvable to an entity in the monorepo. This means we get rid of `fake_owner` and instead use `init_user` + `verify_user` instead.