### PR TITLE
fix(proxy): merge fix

### DIFF
--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -127,10 +127,11 @@ mod handler {
         input: super::CreateInput,
     ) -> Result<impl Reply, Rejection> {
         let keystore = &*keystore.read().await;
+        let peer = &*peer.lock().await;
 
         let key = keystore.get_librad_key().map_err(Error::from)?;
         let meta = coco::control::replicate_platinum(
-            &*peer.lock().await,
+            peer,
             key,
             &owner,
             &input.name,

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -130,9 +130,10 @@ mod handler {
         let keystore = &*keystore.read().await;
 
         let key = keystore.get_librad_key().map_err(Error::from)?;
+        let peer = &*peer.lock().await;
 
         let meta = coco::init_project(
-            &*peer.lock().await,
+            peer,
             key,
             &owner,
             &input.path,


### PR DESCRIPTION
While merging to our main branch, the code was clean but it caused an issue when the `peer` variable wasn't defined in scope to get the `stats` of the project. This PR fixes this by doing `let peer` again.