### PR TITLE
refactor(ui): transaction list visual updates

### DIFF
--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { slide } from "svelte/transition";
   import { IconState, summaryIconState } from "../../../src/transaction.ts";
 
   import List from "./List.svelte";
@@ -9,74 +8,73 @@
   export let transactions = null;
 
   // Transaction center element. Set by the view.
-  let txList = null;
-  let hidden = true;
+  let element = null;
+  let expand = false;
+  let list = null;
 
-  const toggleList = () => {
-    hidden = !hidden;
-  };
-
-  const handleClick = ev => {
-    // Any click *outside* the elem should hide the elem.
-    if (txList !== ev.target && !txList.contains(ev.target) && !hidden) {
-      hidden = true;
+  const toggleList = ev => {
+    if ((element === ev.target || element.contains(ev.target)) && !expand) {
+      expand = true;
+    } else if (expand) {
+      expand = false;
     }
   };
 
   $: negative = summaryIconState(summary.counts) === IconState.Negative;
+  $: console.log(list && list.offsetHeight);
 </script>
 
 <style>
   .center {
     background: var(--color-background);
-    bottom: 0;
-    right: 0;
     border: 1px solid var(--color-foreground-level-2);
     border-radius: 8px;
     box-shadow: var(--elevation-medium);
     cursor: pointer;
+    height: 56px;
     min-width: 275px;
     overflow: hidden;
-    position: absolute;
+    transition: height 360ms ease;
     user-select: none;
-    z-index: 900;
   }
 
   .center:hover {
     background: var(--color-foreground-level-1);
   }
 
+  .center.expand {
+    height: calc(var(--list-height) - 56px);
+  }
+
   .negative {
     border: 1px solid var(--color-negative);
   }
 
-  .list-wrapper {
+  .list {
     max-height: 80vh;
     overflow-y: auto;
+    transform: translateY(calc(-1 * calc(100% - 56px)));
+    transition: transform 360ms ease;
   }
-  .list-wrapper::-webkit-scrollbar {
+  .list::-webkit-scrollbar {
     display: none; /* Chrome Safari */
   }
 
-  .hidden {
-    display: none;
+  .list.expand {
+    transform: translateY(0px);
   }
 </style>
 
-<svelte:window on:click={handleClick} />
+<svelte:window on:click={toggleList} />
 <div
-  bind:this={txList}
+  bind:this={element}
   class="center"
+  class:expand
   class:negative
-  data-cy="transaction-center">
-  {#if !hidden}
-    <div
-      class="list-wrapper"
-      class:hidden
-      in:slide={{ duration: 360 }}
-      out:slide={{ duration: 240 }}>
-      <List on:select {transactions} />
-    </div>
-  {/if}
-  <Summary on:click={toggleList} {summary} />
+  data-cy="transaction-center"
+  style="--list-height: {list && list.offsetHeight}px">
+  <div bind:this={list} class="list" class:expand>
+    <List on:select {transactions} />
+    <Summary {summary} />
+  </div>
 </div>

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -31,7 +31,7 @@
     bottom: 0;
     right: 0;
     border: 1px solid var(--color-foreground-level-2);
-    border-radius: 4px;
+    border-radius: 8px;
     box-shadow: var(--elevation-medium);
     cursor: pointer;
     min-width: 275px;

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -21,7 +21,6 @@
   };
 
   $: negative = summaryIconState(summary.counts) === IconState.Negative;
-  $: console.log(list && list.offsetHeight);
 </script>
 
 <style>

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -30,9 +30,9 @@
   .center {
     bottom: 0;
     right: 0;
-    border: 1px solid var(--color-foreground-level-3);
+    border: 1px solid var(--color-foreground-level-2);
     border-radius: 4px;
-    box-shadow: var(--elevation-low);
+    box-shadow: var(--elevation-medium);
     cursor: pointer;
     min-width: 275px;
     position: absolute;

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -28,6 +28,7 @@
 
 <style>
   .center {
+    background: var(--color-background);
     bottom: 0;
     right: 0;
     border: 1px solid var(--color-foreground-level-2);
@@ -35,9 +36,14 @@
     box-shadow: var(--elevation-medium);
     cursor: pointer;
     min-width: 275px;
+    overflow: hidden;
     position: absolute;
     user-select: none;
     z-index: 900;
+  }
+
+  .center:hover {
+    background: var(--color-foreground-level-1);
   }
 
   .negative {

--- a/ui/DesignSystem/Component/Transaction/Item.svelte
+++ b/ui/DesignSystem/Component/Transaction/Item.svelte
@@ -31,7 +31,7 @@
   }
 
   .icon {
-    margin: 12px;
+    margin: 6px 12px 0;
   }
 
   .carret {

--- a/ui/DesignSystem/Component/Transaction/Item.svelte
+++ b/ui/DesignSystem/Component/Transaction/Item.svelte
@@ -15,14 +15,15 @@
 <style>
   .item {
     align-items: center;
-    border-bottom: 1px solid var(--color-foreground-level-3);
+    background: var(--color-background);
+    border-bottom: 1px solid var(--color-foreground-level-2);
     display: flex;
     justify-content: space-between;
-    height: 64px;
+    height: 56px;
   }
 
   .item:hover {
-    background-color: var(--color-foreground-level-2);
+    background-color: var(--color-foreground-level-1);
   }
 
   .info {
@@ -30,7 +31,7 @@
   }
 
   .icon {
-    margin: 14px 14px 14px 18px;
+    margin: 12px;
   }
 
   .carret {

--- a/ui/DesignSystem/Component/Transaction/List.svelte
+++ b/ui/DesignSystem/Component/Transaction/List.svelte
@@ -12,7 +12,7 @@
 <style>
   .list {
     background-color: var(--color-foreground-level-1);
-    border-radius: 3px 3px 0 0;
+    border-radius: 7px 7px 0 0;
   }
 </style>
 

--- a/ui/DesignSystem/Component/Transaction/Summary.svelte
+++ b/ui/DesignSystem/Component/Transaction/Summary.svelte
@@ -13,8 +13,6 @@
 
 <style>
   .summary {
-    background-color: var(--color-background);
-    border-radius: 3px;
     height: 56px;
   }
 
@@ -30,7 +28,7 @@
         {progress}
         {rotate}
         {state}
-        style="margin: 12px 12px 12px 18px;" />
+        style="margin: 12px;" />
       <Text style="align-self: center; width: max-content;" variant="small">
         {text}
       </Text>

--- a/ui/DesignSystem/Component/Transaction/Summary.svelte
+++ b/ui/DesignSystem/Component/Transaction/Summary.svelte
@@ -28,7 +28,7 @@
         {progress}
         {rotate}
         {state}
-        style="margin: 12px;" />
+        style="margin: 11px 12px;" />
       <Text style="align-self: center; width: max-content;" variant="small">
         {text}
       </Text>


### PR DESCRIPTION
This will close #578 but there's still one more thing to do on it that I couldn't figure out:

- [x] when the list is expanded, hide the "Summary" row when the list is expanded. [Here's a prototype](https://www.figma.com/proto/HV5YDSx0FWFLs4qCSAiTL9/Transaction-expand-animation?node-id=1%3A72&viewport=318%2C696%2C0.5&scaling=min-zoom) of what I mean 

---

The changes to the text are being taken care of in #572.