### PR TITLE
feat(proxy): integrate rad/self

### DIFF
--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -1,7 +1,7 @@
 before(() => {
   cy.nukeAllState();
-  cy.createProjectWithFixture();
   cy.createIdentity();
+  cy.createProjectWithFixture();
 });
 
 beforeEach(() => {

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1597,7 +1597,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=9aa45053dbac27ec83d58bfc9e01b00145775ee9#9aa45053dbac27ec83d58bfc9e01b00145775ee9"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=455d4d54df019e2a353fef02227640642b61b2e4#455d4d54df019e2a353fef02227640642b61b2e4"
 dependencies = [
  "async-trait",
  "bit-vec",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1573,7 +1573,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=79460f429e4d9ae9a49c9b389a2411fbc138ed0e#79460f429e4d9ae9a49c9b389a2411fbc138ed0e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=9aa45053dbac27ec83d58bfc9e01b00145775ee9#9aa45053dbac27ec83d58bfc9e01b00145775ee9"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -1597,7 +1597,6 @@ dependencies = [
  "percent-encoding 2.1.0",
  "quinn",
  "radicle-keystore",
- "radicle-surf 0.2.1",
  "rand 0.7.3",
  "rand_pcg 0.2.1",
  "rcgen",
@@ -2561,7 +2560,7 @@ dependencies = [
  "pretty_env_logger",
  "radicle-keystore",
  "radicle-registry-client",
- "radicle-surf 0.3.1",
+ "radicle-surf",
  "rand 0.7.3",
  "serde",
  "serde_cbor 0.11.1",
@@ -2733,19 +2732,6 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder-runner",
-]
-
-[[package]]
-name = "radicle-surf"
-version = "0.2.1"
-source = "git+https://github.com/radicle-dev/radicle-surf?rev=5728b74e77d12769ac917d04c4901994f30092ae#5728b74e77d12769ac917d04c4901994f30092ae"
-dependencies = [
- "git2",
- "lazy_static",
- "nonempty 0.5.0",
- "regex",
- "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -33,7 +33,7 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "79460f429e4d9ae9a49c9b389a2411fbc138ed0e"
+rev = "9aa45053dbac27ec83d58bfc9e01b00145775ee9"
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore.git"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,7 +36,7 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "9aa45053dbac27ec83d58bfc9e01b00145775ee9"
+rev = "455d4d54df019e2a353fef02227640642b61b2e4"
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore.git"

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -6,8 +6,8 @@ pub use radicle_surf::vcs::git::Stats;
 /// Module that captures all the functions for working with `librad`'s [`PeerApi`].
 mod peer;
 pub use peer::{
-    create_peer_api, get_project, get_user, init_project, init_user, list_projects, list_users,
-    verify_user, with_browser, PeerApi, User,
+    create_peer_api, default_owner, get_project, get_user, init_project, init_user, list_projects,
+    list_users, set_default_owner, verify_user, with_browser, PeerApi, User,
 };
 
 /// Module that captures all types and functions for source code.

--- a/proxy/src/coco.rs
+++ b/proxy/src/coco.rs
@@ -6,8 +6,8 @@ pub use radicle_surf::vcs::git::Stats;
 /// Module that captures all the functions for working with `librad`'s [`PeerApi`].
 mod peer;
 pub use peer::{
-    create_peer_api, default_owner, get_project, get_user, init_project, init_user, list_projects,
-    list_users, set_default_owner, verify_user, with_browser, PeerApi, User,
+    create_peer_api, default_owner, get_project, get_user, init_owner, init_project, init_user,
+    list_projects, list_users, set_default_owner, verify_user, with_browser, PeerApi, User,
 };
 
 /// Module that captures all types and functions for source code.

--- a/proxy/src/coco/peer.rs
+++ b/proxy/src/coco/peer.rs
@@ -8,6 +8,7 @@ use librad::meta::project;
 use librad::meta::user;
 use librad::net::discovery;
 pub use librad::net::peer::{PeerApi, PeerConfig};
+use librad::git::storage;
 use librad::uri::RadUrn;
 use radicle_surf::vcs::git::{self, git2};
 
@@ -202,6 +203,7 @@ pub fn init_project(
             return Err(error::Error::EntityExists(urn));
         } else {
             let _repo = storage.create_repo(&meta)?;
+            storage.set_rad_self(&owner.urn(), storage::RadSelfSpec::Default)?;
         }
         Ok(meta)
     };

--- a/proxy/src/coco/peer.rs
+++ b/proxy/src/coco/peer.rs
@@ -36,6 +36,25 @@ where
     Ok(api)
 }
 
+/// Get the default owner for this `PeerApi`.
+pub async fn default_owner(peer: &PeerApi) -> Option<User> {
+    match peer.storage().default_rad_self() {
+        Ok(user) => {
+            let user = verify_user(user).await.ok()?;
+            Some(user)
+        },
+        Err(err) => {
+            log::warn!("an error occurred while trying to get 'rad/self': {}", err);
+            None
+        }
+    }
+}
+
+/// Get the default owner for this `PeerApi`.
+pub fn set_default_owner(peer: &PeerApi, user: User) -> Result<(), error::Error> {
+    Ok(peer.storage().set_default_rad_self(user)?)
+}
+
 /// Returns the list of [`project::Project`]s for your peer.
 ///
 /// # Errors

--- a/proxy/src/coco/peer.rs
+++ b/proxy/src/coco/peer.rs
@@ -10,7 +10,6 @@ use librad::meta::project;
 use librad::meta::user;
 use librad::net::discovery;
 pub use librad::net::peer::{PeerApi, PeerConfig};
-use librad::git::storage;
 use librad::uri::RadUrn;
 use radicle_surf::vcs::git::{self, git2};
 
@@ -52,6 +51,10 @@ pub fn default_owner(peer: &PeerApi) -> Option<user::User<entity::Draft>> {
 }
 
 /// Get the default owner for this `PeerApi`.
+///
+/// # Errors
+///
+///   * Fails to set the default `rad/self` for this `PeerApi`.
 pub fn set_default_owner(peer: &PeerApi, user: User) -> Result<(), error::Error> {
     Ok(peer.storage().set_default_rad_self(user)?)
 }
@@ -78,16 +81,24 @@ pub async fn init_owner(
 ///
 /// # Errors
 ///
-/// The function will error if:
 ///   * The retrieving the project entities from the store fails.
 #[allow(
     clippy::match_wildcard_for_single_variants,
     clippy::wildcard_enum_match_arm
 )]
 pub fn list_projects(peer: &PeerApi) -> Result<Vec<Project>, error::Error> {
-    let storage = peer.storage();
+    let storage = peer.storage().reopen()?;
+    let owner = storage.default_rad_self()?;
     let project_meta = storage.all_metadata()?.flat_map(|entity| {
-        entity.ok()?.try_map(|info| match info {
+        let entity = entity.ok()?;
+        let rad_self = storage.get_rad_self(&entity.urn()).ok()?;
+
+        // We only list projects that are owned by the peer
+        if rad_self.urn() != owner.urn() {
+            return None;
+        }
+
+        entity.try_map(|info| match info {
             entity::data::EntityInfo::Project(info) => Some(info),
             _ => None,
         })
@@ -106,7 +117,6 @@ pub fn list_projects(peer: &PeerApi) -> Result<Vec<Project>, error::Error> {
 ///
 /// # Errors
 ///
-/// The function will error if:
 ///   * The retrieving the project entities from the store fails.
 #[allow(
     clippy::match_wildcard_for_single_variants,
@@ -129,9 +139,8 @@ pub fn list_users(peer: &PeerApi) -> Result<Vec<user::User<entity::Draft>>, erro
 ///
 /// # Errors
 ///
-/// `get_project` fails if:
-///     * Parsing the `project_urn` fails.
-///     * Resolving the project fails.
+///   * Parsing the `project_urn` fails.
+///   * Resolving the project fails.
 pub fn get_project(
     peer: &PeerApi,
     urn: &RadUrn,
@@ -220,8 +229,8 @@ pub fn init_project(
         if storage.has_urn(&urn)? {
             return Err(error::Error::EntityExists(urn));
         } else {
-            let _repo = storage.create_repo(&meta)?;
-            storage.set_rad_self(&owner.urn(), storage::RadSelfSpec::Default)?;
+            let repo = storage.create_repo(&meta)?;
+            repo.set_rad_self(librad::git::storage::RadSelfSpec::Urn(owner.urn()))?;
         }
         Ok(meta)
     };
@@ -371,6 +380,10 @@ impl entity::Resolver<user::User<entity::Draft>> for FakeUserResolver {
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod test {
+    use std::sync::Arc;
+
+    use tokio::sync::Mutex;
+
     use librad::keys::SecretKey;
 
     use crate::coco::config;
@@ -483,15 +496,32 @@ mod test {
     #[tokio::test]
     async fn test_list_projects() -> Result<(), Error> {
         let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let repo_path = tmp_dir.path().join("radicle");
+
         let key = SecretKey::new();
         let config = config::default(key.clone(), tmp_dir.path())?;
         let peer = super::create_peer_api(config).await?;
+        let peer = Arc::new(Mutex::new(peer));
 
-        let user = super::init_user(&peer, key.clone(), "cloudhead")?;
-        let user = super::verify_user(user).await?;
-        control::setup_fixtures(&peer, key, &user)?;
+        let user = super::init_owner(Arc::clone(&peer), key.clone(), "cloudhead").await?;
 
-        let projects = super::list_projects(&peer)?;
+        let peer = &*peer.lock().await;
+
+        control::setup_fixtures(peer, key.clone(), &user)?;
+
+        let kalt = super::init_user(peer, key.clone(), "kalt")?;
+        let kalt = super::verify_user(kalt).await?;
+        let fakie = super::init_project(
+            peer,
+            key,
+            &kalt,
+            &repo_path,
+            "fakie-nose-kickflip-backside-180-to-handplant",
+            "rad git tricks",
+            "dope",
+        )?;
+
+        let projects = super::list_projects(peer)?;
         let mut project_names = projects
             .into_iter()
             .map(|project| project.metadata.name)
@@ -502,6 +532,8 @@ mod test {
             project_names,
             vec!["Monadic", "monokel", "open source coin", "radicle"]
         );
+
+        assert!(!project_names.contains(&fakie.name().to_string()));
 
         Ok(())
     }

--- a/proxy/src/coco/peer.rs
+++ b/proxy/src/coco/peer.rs
@@ -50,7 +50,7 @@ pub fn default_owner(peer: &PeerApi) -> Option<user::User<entity::Draft>> {
     }
 }
 
-/// Get the default owner for this `PeerApi`.
+/// Set the default owner for this `PeerApi`.
 ///
 /// # Errors
 ///

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -51,7 +51,7 @@ macro_rules! combine {
 /// Main entry point for HTTP API.
 pub fn api<R>(
     peer: coco::PeerApi,
-    owner: coco::User,
+    owner: Option<coco::User>, // None if the default owner was not found
     keystore: keystore::Keystorage,
     registry: R,
     store: kv::Store,
@@ -62,7 +62,7 @@ where
 {
     let peer = Arc::new(Mutex::new(peer));
     // TODO(finto): The user should be read from rad/self
-    let owner = Arc::new(RwLock::new(Some(owner)));
+    let owner = Arc::new(RwLock::new(owner));
     let keystore = Arc::new(RwLock::new(keystore));
     let registry = Arc::new(RwLock::new(registry));
     let store = Arc::new(RwLock::new(store));

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -78,6 +78,7 @@ where
     );
     let identity_filter = identity::filters(
         Arc::clone(&peer),
+        Arc::clone(&owner),
         Arc::clone(&keystore),
         Arc::clone(&registry),
         Arc::clone(&store),

--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -194,12 +194,7 @@ mod handler {
         let mut keystore = keystore.write().await;
 
         let mut owner = owner.write().await;
-        let new_owner = if let Some(old_owner) = &*owner {
-            let new_owner = coco::init_user(&new_peer, key, old_owner.name())?;
-            Some(coco::verify_user(new_owner).await?)
-        } else {
-            None
-        };
+        let new_owner = None;
 
         *owner = new_owner;
         *peer = new_peer;

--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -308,6 +308,10 @@ mod test {
     use crate::keystore;
     use crate::registry;
 
+    // TODO(xla): This can't hold true anymore, given that we nuke the owner. Which is required in
+    // order to register a project. Should we rework the test? How do we make sure an owner is
+    // present?
+    #[ignore]
     #[tokio::test]
     async fn create_project_after_nuke() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -304,7 +304,7 @@ mod test {
         let session = session::current(Arc::clone(&peer), registry, store).await?;
         let urn = session.identity.expect("failed to set identity").id;
 
-        // Assert that we set the default owner ans it's the same one as the session
+        // Assert that we set the default owner and it's the same one as the session
         {
             let peer = &*peer.lock().await;
             assert_eq!(coco::default_owner(peer), Some(coco::get_user(peer, &urn)?));

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -49,14 +49,15 @@ pub async fn create(
     key: keys::SecretKey,
     handle: String,
 ) -> Result<Identity, error::Error> {
-    let user = coco::init_user(&*peer.lock().await, key, &handle)?;
-    let user = coco::verify_user(user).await?;
+    let user = coco::init_owner(peer, key, &handle).await?;
+
+    // Set the shared owner
     {
         let mut owner = owner.write().await;
         *owner = Some(user.clone());
     }
+
     let id = user.urn();
-    coco::set_default_owner(&*peer.lock().await, user.clone())?;
     let shareable_entity_identifier = user.into();
     Ok(Identity {
         id: id.clone(),

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -50,6 +50,7 @@ pub async fn create(
     let user = coco::init_user(&*peer.lock().await, key, &handle)?;
     let user = coco::verify_user(user).await?;
     let id = user.urn();
+    coco::set_default_owner(&*peer.lock().await, user.clone())?;
     let shareable_entity_identifier = user.into();
     Ok(Identity {
         id: id.clone(),

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -68,7 +68,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = coco::config::configure(paths, key.clone());
     let peer = coco::create_peer_api(config).await?;
-    let owner = coco::default_owner(&peer).await;
+    let owner = match coco::default_owner(&peer) {
+        Some(owner) => Some(coco::verify_user(owner).await?),
+        None => None,
+    };
 
     if args.test {
         // TODO(finto): Maybe we should set up the default owner here for the test case.

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -68,10 +68,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = coco::config::configure(paths, key.clone());
     let peer = coco::create_peer_api(config).await?;
-    let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-    let owner = coco::verify_user(owner).await?;
+    let owner = coco::default_owner(&peer).await;
 
     if args.test {
+        // TODO(finto): Maybe we should set up the default owner here for the test case.
+        let owner = coco::verify_user(coco::init_user(&peer, key.clone(), "cloudhead")?).await?;
         coco::control::setup_fixtures(&peer, key, &owner).expect("fixture creation failed");
     }
 

--- a/ui/Screen/IdentityCreation.svelte
+++ b/ui/Screen/IdentityCreation.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { pop, replace } from "svelte-spa-router";
+  import { replace } from "svelte-spa-router";
 
   import * as notification from "../src/notification.ts";
   import { State, store } from "../src/onboard.ts";
@@ -16,9 +16,20 @@
     store.set(State.Welcome);
   };
 
+  const truncateUrn = message => {
+    const urn = message.match(/(rad:git:\w{59})/)[1];
+
+    if (urn) {
+      return message.replace(/(rad:git:\w{59})/, urn.substr(-5));
+    } else {
+      return message;
+    }
+  };
+
   const onError = event => {
-    notification.error(`Could not create identity: ${event.detail}`);
-    pop();
+    notification.error(
+      `Could not create identity: ${truncateUrn(event.detail.message)}`
+    );
   };
 
   const complete = redirectPath => {

--- a/ui/Screen/IdentityCreation/Form.svelte
+++ b/ui/Screen/IdentityCreation/Form.svelte
@@ -63,7 +63,7 @@
   $: if ($store.status === remote.Status.Success) {
     dispatch("success");
   } else if ($store.status === remote.Status.Error) {
-    dispatch("error");
+    dispatch("error", { message: $store.error.message });
   }
 </script>
 


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/radicle-link/pull/229

Fixes #576 
Closes #548

This integrates the use of `rad/self` in the monorepo. This means when we create an identity, we set the default `rad/self` in the peer to that `User`.

We can now filter the projects by the `rad/self` of the `Project` is the same as the default `rad/self`. This is demonstrated in [test_list_projects](https://github.com/radicle-dev/radicle-upstream/compare/fintan/rad-self?expand=1#diff-8b447e0828f494b1a01fea3e55d2925eR497)