### PR TITLE
fix(ui): fix repository selector regressions

### DIFF
--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -86,7 +86,7 @@ context("source code browsing", () => {
     });
   });
 
-  context("when the 'source' section is selected in project sidebar", () => {
+  context("when the Source menu item is selected in project top-bar", () => {
     it("expands a tree starting at the root of the repo", () => {
       cy.pick("source-tree").within(() => {
         cy.contains("src").should("exist");
@@ -224,19 +224,49 @@ context("source code browsing", () => {
       });
     });
 
-    context("when clicking on folder names", () => {
-      it("allows diving deep into directory structures", () => {
-        cy.pick("source-tree").within(() => {
-          cy.pick("expand-this").click();
-          cy.pick("expand-is").click();
-          cy.pick("expand-a").click();
-          cy.pick("expand-really").click();
-          cy.pick("expand-deeply").click();
-          cy.pick("expand-nested").click();
-          cy.pick("expand-directory").click();
-          cy.pick("expand-tree").click();
-          cy.contains(".gitkeep").should("exist");
-        });
+    it("doesn't interfere with the top-bar menu item active state", () => {
+      cy.pick("topbar", "horizontal-menu", "Source")
+        .get("p")
+        .should("have.class", "active");
+
+      cy.pick("source-tree").within(() => {
+        cy.pick("expand-text").click();
+        cy.contains("arrows.txt").click();
+        cy.contains("arrows.txt").should("have.class", "active");
+      });
+
+      cy.pick("topbar", "horizontal-menu", "Source")
+        .get("p")
+        .should("have.class", "active");
+
+      cy.pick("file-source", "file-header").contains("platinum").click();
+
+      cy.pick("topbar", "horizontal-menu", "Source")
+        .get("p")
+        .should("have.class", "active");
+    });
+
+    it("allows navigating the tree structure", () => {
+      cy.pick("source-tree").within(() => {
+        // Traverse deeply nested folders.
+        cy.pick("expand-this").click();
+        cy.pick("expand-is").click();
+        cy.pick("expand-a").click();
+        cy.pick("expand-really").click();
+        cy.pick("expand-deeply").click();
+        cy.pick("expand-nested").click();
+        cy.pick("expand-directory").click();
+        cy.pick("expand-tree").click();
+
+        // Open a file within nested folders.
+        cy.contains(".gitkeep").click();
+        cy.contains(".gitkeep").should("have.class", "active");
+
+        // Preserve expanded folder state when selecting a different file.
+        cy.pick("expand-text").click();
+        cy.contains("arrows.txt").click();
+        cy.contains("arrows.txt").should("have.class", "active");
+        cy.contains(".gitkeep").should("not.have.class", "active");
       });
     });
 

--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -240,6 +240,14 @@ context("source code browsing", () => {
       });
     });
 
+    it("highlights the selected file", () => {
+      cy.pick("source-tree").within(() => {
+        cy.contains(".i-am-well-hidden").should("not.have.class", "active");
+        cy.contains(".i-am-well-hidden").click();
+        cy.contains(".i-am-well-hidden").should("have.class", "active");
+      });
+    });
+
     context("when clicking on a file name", () => {
       context("for non-binary files", () => {
         it("shows the contents of the file", () => {

--- a/ui/DesignSystem/Component/SourceBrowser/FileSource.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/FileSource.svelte
@@ -74,7 +74,7 @@
 
 <div class="file-source" data-cy="file-source">
   <header>
-    <div class="file-header">
+    <div class="file-header" data-cy="file-header">
       <Icon.File />
       <span class="file-name">
         <a href={rootPath} use:link>{projectName}</a>

--- a/ui/DesignSystem/Component/SourceBrowser/Folder.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/Folder.svelte
@@ -11,7 +11,7 @@
   export let projectId = null;
 
   export let currentRevision = null;
-  export let currentPath = null;
+  export let currentObjectPath = null;
   export let currentPeerId = null;
 
   export let expanded = false;
@@ -27,7 +27,9 @@
   };
 
   $: store = tree(projectId, currentPeerId, currentRevision, prefix);
-  $: active = prefix === currentPath;
+  $: active = prefix === currentObjectPath;
+
+  $: console.log(currentObjectPath, prefix);
 </script>
 
 <style>
@@ -78,14 +80,14 @@
         {#if entry.info.objectType === ObjectType.Tree}
           <svelte:self
             {projectId}
-            {currentPath}
+            {currentObjectPath}
             {currentRevision}
             {currentPeerId}
             name={entry.info.name}
             prefix={`${entry.path}/`} />
         {:else}
           <File
-            active={entry.path === currentPath}
+            active={entry.path === currentObjectPath}
             href={path.projectSource(projectId, currentPeerId, currentRevision, ObjectType.Blob, entry.path)}
             name={entry.info.name} />
         {/if}

--- a/ui/DesignSystem/Component/SourceBrowser/Folder.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/Folder.svelte
@@ -28,8 +28,6 @@
 
   $: store = tree(projectId, currentPeerId, currentRevision, prefix);
   $: active = prefix === currentObjectPath;
-
-  $: console.log(currentObjectPath, prefix);
 </script>
 
 <style>

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -34,7 +34,13 @@
     currentRevision,
     currentObjectType,
     currentObjectPath,
-  } = path.parseProjectSourceLocation($querystring, metadata.defaultBranch));
+  } = path.parseProjectSourceLocation(
+    $querystring,
+    null,
+    metadata.defaultBranch,
+    ObjectType.Tree,
+    null
+  ));
 
   const updateRevision = (projectId, revision, peerId) => {
     push(

--- a/ui/src/path.ts
+++ b/ui/src/path.ts
@@ -37,7 +37,7 @@ export const projectSource = (
   projectId: string,
   peerId?: string,
   revision?: string,
-  objectType: string = ObjectType.Tree,
+  objectType?: string,
   objectPath?: string
 ): string => {
   return `/projects/${projectId}/source?${stringify({
@@ -50,14 +50,17 @@ export const projectSource = (
 
 export const parseProjectSourceLocation = (
   querystring: string,
-  defaultRevision: string
+  defaultPeerId: string,
+  defaultRevision: string,
+  defaultObjectType: string,
+  defaultObjectPath: string
 ) => {
   const parsed = parse(querystring);
   return {
-    currentPeerId: parsed.peerId,
+    currentPeerId: parsed.peerId || defaultPeerId,
     currentRevision: parsed.revision || defaultRevision,
-    currentObjectType: parsed.objectType,
-    currentObjectPath: parsed.objectPath,
+    currentObjectType: parsed.objectType || defaultObjectType,
+    currentObjectPath: parsed.objectPath || defaultObjectPath,
   };
 };
 


### PR DESCRIPTION
Fixes regressions introduced in https://github.com/radicle-dev/radicle-upstream/pull/620:
- source tree file highlighting
- topbar `Source` menu item active state
- source tree expanded state persistance

Adds tests for all the regressions.