### PR TITLE
chore(ui): remove avatars from commit authors

### DIFF
--- a/proxy/src/coco/source.rs
+++ b/proxy/src/coco/source.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::hash_map::DefaultHasher;
 use std::fmt;
-use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 use librad::peer;
@@ -54,8 +52,6 @@ pub struct Person {
     pub name: String,
     /// Email part of the commit signature.
     pub email: String,
-    /// Reference (url/uri) to a persons avatar image.
-    pub avatar: String,
 }
 
 /// Commit statistics.
@@ -108,29 +104,17 @@ impl CommitHeader {
 
 impl From<&git::Commit> for CommitHeader {
     fn from(commit: &git::Commit) -> Self {
-        let avatar = |input: &String| {
-            let mut s = DefaultHasher::new();
-            input.hash(&mut s);
-
-            format!(
-                "https://avatars.dicebear.com/v2/jdenticon/{}.svg",
-                s.finish().to_string()
-            )
-        };
-
         Self {
             sha1: commit.id,
             author: Person {
                 name: commit.author.name.clone(),
                 email: commit.author.email.clone(),
-                avatar: avatar(&commit.author.email),
             },
             summary: commit.summary.clone(),
             message: commit.message.clone(),
             committer: Person {
                 name: commit.committer.name.clone(),
                 email: commit.committer.email.clone(),
-                avatar: avatar(&commit.committer.email),
             },
             committer_time: commit.author.time,
         }

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -736,7 +736,6 @@ impl Serialize for coco::Person {
         let mut state = serializer.serialize_struct("Person", 3)?;
         state.serialize_field("name", &self.name)?;
         state.serialize_field("email", &self.email)?;
-        state.serialize_field("avatar", &self.avatar)?;
         state.end()
     }
 }
@@ -755,12 +754,6 @@ impl ToDocumentedType for coco::Person {
             document::string()
                 .description("Email part of the commit signature.")
                 .example("self@cloudhead.io"),
-        );
-        properties.insert(
-            "avatar".into(),
-            document::string()
-                .description("Reference (url/uri) to a persons avatar image.")
-                .example("https://avatars1.githubusercontent.com/u/40774"),
         );
 
         document::DocumentedType::from(properties).description("Person")
@@ -936,12 +929,10 @@ mod test {
                         "lastCommit": {
                             "sha1": "1e0206da8571ca71c51c91154e2fee376e09b4e7",
                             "author": {
-                                "avatar": "https://avatars.dicebear.com/v2/jdenticon/6579925199124505498.svg",
                                 "name": "Rūdolfs Ošiņš",
                                 "email": "rudolfs@osins.org",
                             },
                             "committer": {
-                                "avatar": "https://avatars.dicebear.com/v2/jdenticon/6579925199124505498.svg",
                                 "name": "Rūdolfs Ošiņš",
                                 "email": "rudolfs@osins.org",
                             },
@@ -993,12 +984,10 @@ mod test {
                         "lastCommit": {
                             "sha1": "19bec071db6474af89c866a1bd0e4b1ff76e2b97",
                             "author": {
-                                "avatar": "https://avatars.dicebear.com/v2/jdenticon/6579925199124505498.svg",
                                 "name": "Rūdolfs Ošiņš",
                                 "email": "rudolfs@osins.org",
                             },
                             "committer": {
-                                "avatar": "https://avatars.dicebear.com/v2/jdenticon/6579925199124505498.svg",
                                 "name": "Rūdolfs Ošiņš",
                                 "email": "rudolfs@osins.org",
                             },
@@ -1106,12 +1095,10 @@ mod test {
                 json!({
                     "sha1": sha1,
                     "author": {
-                        "avatar": "https://avatars.dicebear.com/v2/jdenticon/6367167426181048581.svg",
                         "name": "Fintan Halpenny",
                         "email": "fintan.halpenny@gmail.com",
                     },
                     "committer": {
-                        "avatar": "https://avatars.dicebear.com/v2/jdenticon/16701125315436463681.svg",
                         "email": "noreply@github.com",
                         "name": "GitHub",
                     },

--- a/ui/DesignSystem/Component/UserCard.svelte
+++ b/ui/DesignSystem/Component/UserCard.svelte
@@ -10,16 +10,8 @@
     display: flex;
     align-items: center;
   }
-
-  img {
-    width: 24px;
-    height: 24px;
-    border-radius: 12px;
-    margin-right: 8px;
-  }
 </style>
 
 <span class="user" {style}>
-  <img src={user.avatar} alt="user-avatar" />
   <Title>{user.username}</Title>
 </span>

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -66,7 +66,6 @@
 
   const user = {
     username: "Rudolfs Osins",
-    avatar: "https://avatars.dicebear.com/v2/jdenticon/two.svg",
   };
 
   const avatarFallback1 = {


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-upstream/issues/559.

Before:
<img width="50%" alt="Screenshot 2020-07-03 at 17 58 01" src="https://user-images.githubusercontent.com/158411/86485230-81c27d00-bd58-11ea-9f3c-8a1abacdc883.png">
<img width="50%" alt="Screenshot 2020-07-03 at 17 58 40" src="https://user-images.githubusercontent.com/158411/86485233-84bd6d80-bd58-11ea-8efd-b9ff341d7baf.png">

After:
<img width="50%" alt="Screenshot 2020-07-03 at 17 58 22" src="https://user-images.githubusercontent.com/158411/86485243-8a1ab800-bd58-11ea-96fb-8a47253308c1.png">
<img width="50%" alt="Screenshot 2020-07-03 at 17 58 30" src="https://user-images.githubusercontent.com/158411/86485247-8c7d1200-bd58-11ea-9dd2-9918d4bdb9d7.png">
