### PR TITLE
fix(ui): open external links in default OS browser

### DIFF
--- a/native/main.js
+++ b/native/main.js
@@ -1,4 +1,11 @@
-import { app, BrowserWindow, ipcMain, dialog, clipboard } from "electron";
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  dialog,
+  clipboard,
+  shell,
+} from "electron";
 import path from "path";
 import * as ipc from "./ipc.js";
 
@@ -62,6 +69,16 @@ const createWindow = () => {
       mainWindow.reload();
     });
   }
+
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    event.preventDefault();
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      console.log(`Opening external URL: ${url}`);
+      shell.openExternal(url);
+    } else {
+      console.warn(`User tried opening URL with invalid URI scheme: ${url}`);
+    }
+  });
 
   mainWindow.loadURL(`file://${path.join(__dirname, "../public/index.html")}`);
   mainWindow.on("closed", () => {

--- a/native/main.js
+++ b/native/main.js
@@ -72,7 +72,10 @@ const createWindow = () => {
 
   mainWindow.webContents.on("will-navigate", (event, url) => {
     event.preventDefault();
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (
+      url.toLowerCase().startsWith("http://") ||
+      url.toLowerCase().startsWith("https://")
+    ) {
       console.log(`Opening external URL: ${url}`);
       shell.openExternal(url);
     } else {


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-upstream/issues/428.

We still need to figure out how to handle relative links that get rendered by the `marked` plugin.

![open](https://user-images.githubusercontent.com/158411/86487764-45464f80-bd5f-11ea-8dc8-6bca6c555acf.gif)
