### PR TITLE
chore(proxy): bump coco deps

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1597,7 +1597,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=455d4d54df019e2a353fef02227640642b61b2e4#455d4d54df019e2a353fef02227640642b61b2e4"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=f97ed83b9d1d4303407de038206c7da852cfe22e#f97ed83b9d1d4303407de038206c7da852cfe22e"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -1611,6 +1611,7 @@ dependencies = [
  "governor",
  "hex",
  "lazy_static",
+ "libc",
  "libgit2-sys",
  "log 0.4.8",
  "minicbor",
@@ -2724,8 +2725,10 @@ dependencies = [
 [[package]]
 name = "radicle-keystore"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-keystore.git?rev=a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa#a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
+source = "git+https://github.com/radicle-dev/radicle-keystore.git?rev=27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6#27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 dependencies = [
+ "async-trait",
+ "futures 0.3.5",
  "lazy_static",
  "rpassword",
  "secstr",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,11 +36,11 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "455d4d54df019e2a353fef02227640642b61b2e4"
+rev = "f97ed83b9d1d4303407de038206c7da852cfe22e"
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore.git"
-rev = "a04f4dbaec4d05be2c7a516a36b5bbec02ee32aa"
+rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"

--- a/proxy/src/coco/source.rs
+++ b/proxy/src/coco/source.rs
@@ -535,7 +535,7 @@ mod tests {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
             key,

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -163,7 +163,7 @@ where
                 if let Some(identity) = session.identity {
                     let api = api.lock().await;
                     let user = coco::get_user(&*api, &identity.id).expect("unable to get coco user");
-                    let user = coco::verify_user(user).await.expect("unable to verify user");
+                    let user = coco::verify_user(user).expect("unable to verify user");
 
                     Ok(user)
                 } else {

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -118,7 +118,7 @@ mod handler {
 
         let keystore = keystore.read().await;
         let key = keystore.get_librad_key().map_err(error::Error::from)?;
-        let id = identity::create(peer, key, input.handle.parse()?).await?;
+        let id = identity::create(&*peer.lock().await, key, input.handle.parse()?)?;
 
         session::set_identity(&store, id.clone())?;
 

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -774,7 +774,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir.path())?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let registry = {
             let (client, _) = radicle_registry_client::Client::new_emulator();
             Arc::new(RwLock::new(registry::Registry::new(client)))

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -432,7 +432,7 @@ mod test {
         let path = dir.path().to_str().unwrap();
 
         let handle = "cloudhead";
-        let id = identity::create(Arc::clone(&peer), key, handle.parse().unwrap()).await?;
+        let id = identity::create(&*peer.lock().await, key, handle.parse().unwrap())?;
 
         session::set_identity(&store, id.clone())?;
 
@@ -499,7 +499,7 @@ mod test {
         let config = coco::config::configure(paths, key.clone());
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
 
         let platinum_project = coco::control::replicate_platinum(
             &peer,
@@ -551,7 +551,7 @@ mod test {
         let peer = coco::create_peer_api(config).await?;
 
         let peer = Arc::new(Mutex::new(peer));
-        let owner = coco::init_owner(Arc::clone(&peer), key.clone(), "cloudhead").await?;
+        let owner = coco::init_owner(&*peer.lock().await, key.clone(), "cloudhead")?;
 
         coco::control::setup_fixtures(&*peer.lock().await, key, &owner)?;
 

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -866,7 +866,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = Arc::new(Mutex::new(coco::create_peer_api(config).await?));
         let owner = coco::init_user(&*peer.lock().await, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let platinum_project = coco::control::replicate_platinum(
             &*peer.lock().await,
             key,
@@ -1015,7 +1015,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
             key,
@@ -1060,7 +1060,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
 
         let platinum_project = coco::control::replicate_platinum(
             &peer,
@@ -1124,7 +1124,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
             key,
@@ -1223,7 +1223,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
             key,
@@ -1374,7 +1374,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
             key,
@@ -1421,7 +1421,7 @@ mod test {
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let peer = coco::create_peer_api(config).await?;
         let owner = coco::init_user(&peer, key.clone(), "cloudhead")?;
-        let owner = coco::verify_user(owner).await?;
+        let owner = coco::verify_user(owner)?;
         let platinum_project = coco::control::replicate_platinum(
             &peer,
             key,

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -1,9 +1,6 @@
 //! Container to bundle and associate information around an identity.
 
-use std::sync::Arc;
-
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
 
 use librad::keys;
 
@@ -41,12 +38,12 @@ pub struct Metadata {
 /// Creates a new identity.
 ///
 /// # Errors
-pub async fn create(
-    peer: Arc<Mutex<coco::PeerApi>>,
+pub fn create(
+    peer: &coco::PeerApi,
     key: keys::SecretKey,
     handle: String,
 ) -> Result<Identity, error::Error> {
-    let user = coco::init_owner(peer, key, &handle).await?;
+    let user = coco::init_owner(peer, key, &handle)?;
 
     let id = user.urn();
     let shareable_entity_identifier = user.into();

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -73,10 +73,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     if args.test {
-        // TODO(xla): GIven that we have proper ownership and user handling in coco, we should
+        // TODO(xla): Given that we have proper ownership and user handling in coco, we should
         // evaluate how meaningful these fixtures are.
-        let owner =
-            coco::verify_user(coco::init_user(&peer_api, key.clone(), "cloudhead")?).await?;
+        let owner = coco::verify_user(coco::init_user(&peer_api, key.clone(), "cloudhead")?)?;
         coco::control::setup_fixtures(&peer_api, key, &owner).expect("fixture creation failed");
     }
 


### PR DESCRIPTION
With the advent of sync resolvers we can simplify some of our internal
APIs and don't have to pass down ARGH mutexes.