### PR TITLE
chore(proxy): Bump registry client

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -79,6 +79,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +119,61 @@ name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
+name = "asn1_der"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fce6b6a0ffdafebd82c87e79e3f40e8d2c523e5fea5566ff6b90509bf98d638"
+dependencies = [
+ "asn1_der_derive",
+]
+
+[[package]]
+name = "asn1_der_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
+dependencies = [
+ "quote 1.0.7",
+ "syn 1.0.31",
+]
+
+[[package]]
+name = "async-std"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
+dependencies = [
+ "async-task",
+ "broadcaster",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "futures-core",
+ "futures-io",
+ "futures-timer 2.0.2",
+ "kv-log-macro",
+ "log 0.4.8",
+ "memchr",
+ "mio",
+ "mio-uds",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "async-task"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac2c016b079e771204030951c366db398864f5026f84a44dafb0ff20f02085d"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "async-trait"
@@ -297,6 +358,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "broadcaster"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "parking_lot 0.10.2",
+ "slab",
+]
+
+[[package]]
 name = "bs58"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +513,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -761,6 +846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
 name = "flate2"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,8 +886,8 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -812,21 +903,23 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "serde",
+ "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "frame-metadata"
-version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "11.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -836,8 +929,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -848,6 +941,7 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "serde",
+ "smallvec 1.4.0",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -855,13 +949,13 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
- "tracing",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.18",
@@ -871,8 +965,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -883,8 +977,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -893,8 +987,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1222,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1525,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1662,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log 0.4.8",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1725,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
+name = "libp2p"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057eba5432d3e740e313c6e13c9153d0cb76b4f71bfc2e5242ae5bdb7d41af67"
+dependencies = [
+ "bytes 0.5.5",
+ "futures 0.3.5",
+ "lazy_static",
+ "libp2p-core",
+ "libp2p-core-derive",
+ "libp2p-swarm",
+ "multihash 0.11.2",
+ "parity-multiaddr",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "smallvec 1.4.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0387b930c3d4c2533dc4893c1e0394185ddcc019846121b1b27491e45a2c08"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.5",
+ "futures-timer 3.0.2",
+ "lazy_static",
+ "libsecp256k1",
+ "log 0.4.8",
+ "multihash 0.11.2",
+ "multistream-select",
+ "parity-multiaddr",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2",
+ "smallvec 1.4.0",
+ "thiserror",
+ "unsigned-varint 0.4.0",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-core-derive"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09548626b737ed64080fde595e06ce1117795b8b9fc4d2629fa36561c583171"
+dependencies = [
+ "quote 1.0.7",
+ "syn 1.0.31",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce53ff4d127cf8b39adf84dbd381ca32d49bd85788cee08e6669da2495993930"
+dependencies = [
+ "futures 0.3.5",
+ "libp2p-core",
+ "log 0.4.8",
+ "rand 0.7.3",
+ "smallvec 1.4.0",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
 name = "librad"
 version = "0.1.0"
 source = "git+https://github.com/radicle-dev/radicle-link.git?rev=f97ed83b9d1d4303407de038206c7da852cfe22e#f97ed83b9d1d4303407de038206c7da852cfe22e"
@@ -1616,7 +1825,7 @@ dependencies = [
  "log 0.4.8",
  "minicbor",
  "multibase",
- "multihash",
+ "multihash 0.10.1",
  "nonempty 0.2.0",
  "olpc-cjson",
  "percent-encoding 2.1.0",
@@ -1750,6 +1959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be512cb2ccb4ecbdca937fdd4a62ea5f09f8e7195466a85e4632b3d5bcce82e6"
+checksum = "fb2999ff7a65d5a1d72172f6d51fa2ea03024b51aee709ba5ff81c3c629a2410"
 dependencies = [
  "ahash 0.2.18",
  "hash-db",
@@ -1965,7 +2183,42 @@ dependencies = [
  "sha-1",
  "sha2",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.3.3",
+]
+
+[[package]]
+name = "multihash"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75db05d738947aa5389863aadafbcf2e509d7ba099dc2ddcdf4fc66bf7a9e03"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "digest",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "unsigned-varint 0.3.3",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+
+[[package]]
+name = "multistream-select"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9157e87afbc2ef0d84cc0345423d715f445edde00141c93721c162de35a05e5"
+dependencies = [
+ "bytes 0.5.5",
+ "futures 0.3.5",
+ "log 0.4.8",
+ "pin-project",
+ "smallvec 1.4.0",
+ "unsigned-varint 0.4.0",
 ]
 
 [[package]]
@@ -2220,23 +2473,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-io",
  "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2248,8 +2500,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2262,8 +2514,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2278,10 +2530,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-scale-codec"
-version = "1.3.0"
+name = "parity-multiaddr"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c8f7f4244ddb5c37c103641027a76c530e65e8e4b8240b29f81ea40508b17"
+checksum = "cc20af3143a62c16e7c9e92ea5c6ae49f7d271d97d4d8fe73afc28f0514a3d0f"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash 0.11.2",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.4.0",
+ "url 2.1.1",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74f02beb35d47e0706155c9eac554b50c671e0d868fe8296bcdf44a9a4847bf"
 dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
@@ -2435,6 +2705,16 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pico-args"
@@ -2615,6 +2895,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+dependencies = [
+ "bytes 0.5.5",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+dependencies = [
+ "bytes 0.5.5",
+ "heck",
+ "itertools 0.8.2",
+ "log 0.4.8",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+dependencies = [
+ "anyhow",
+ "itertools 0.8.2",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+dependencies = [
+ "bytes 0.5.5",
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,6 +2966,7 @@ dependencies = [
  "librad",
  "log 0.4.8",
  "nonempty 0.2.0",
+ "parity-scale-codec",
  "pico-args",
  "pretty_assertions",
  "pretty_env_logger",
@@ -2741,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=0acd1e5467f0b70dfdff5fc7df1b5121d73b9858#0acd1e5467f0b70dfdff5fc7df1b5121d73b9858"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf#2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -2775,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=0acd1e5467f0b70dfdff5fc7df1b5121d73b9858#0acd1e5467f0b70dfdff5fc7df1b5121d73b9858"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf#2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -2788,8 +3120,8 @@ dependencies = [
 
 [[package]]
 name = "radicle-registry-runtime"
-version = "0.11.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=0acd1e5467f0b70dfdff5fc7df1b5121d73b9858#0acd1e5467f0b70dfdff5fc7df1b5121d73b9858"
+version = "0.16.0"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf#2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2811,6 +3143,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-std",
+ "sp-timestamp",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder-runner",
@@ -2879,6 +3212,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -3050,6 +3384,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3428,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "rental"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
+dependencies = [
+ "rental-impl",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -3170,6 +3545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rw-stream-sink"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
+dependencies = [
+ "futures 0.3.5",
+ "pin-project",
+ "static_assertions",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,8 +3587,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more 0.99.8",
  "futures 0.3.5",
@@ -3523,8 +3909,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -3538,8 +3924,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -3550,8 +3936,8 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -3562,13 +3948,12 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
- "primitive-types",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -3576,8 +3961,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3587,18 +3972,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-blockchain"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+dependencies = [
+ "derive_more 0.99.8",
+ "log 0.4.8",
+ "lru",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sp-block-builder",
+ "sp-consensus",
+ "sp-runtime",
+ "sp-state-machine",
+]
+
+[[package]]
 name = "sp-chain-spec"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
  "serde_json",
 ]
 
 [[package]]
+name = "sp-consensus"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+dependencies = [
+ "derive_more 0.99.8",
+ "futures 0.3.5",
+ "futures-timer 3.0.2",
+ "libp2p",
+ "log 0.4.8",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "serde",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-utils",
+ "sp-version",
+ "substrate-prometheus-endpoint",
+ "wasm-timer",
+]
+
+[[package]]
 name = "sp-consensus-pow"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3609,12 +4034,13 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "base58",
  "blake2-rfc",
  "byteorder",
+ "derive_more 0.99.8",
  "ed25519-dalek",
  "futures 0.3.5",
  "hash-db",
@@ -3624,6 +4050,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log 0.4.8",
+ "merlin",
  "num-traits",
  "parity-scale-codec",
  "parity-util-mem",
@@ -3649,8 +4076,8 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -3659,18 +4086,19 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "environmental",
+ "parity-scale-codec",
  "sp-std",
  "sp-storage",
 ]
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more 0.99.8",
  "parity-scale-codec",
@@ -3681,35 +4109,39 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
+ "futures 0.3.5",
  "hash-db",
  "libsecp256k1",
  "log 0.4.8",
  "parity-scale-codec",
+ "parking_lot 0.10.2",
  "sp-core",
  "sp-externalities",
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
+ "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "sp-api",
+ "sp-core",
  "sp-runtime",
 ]
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -3717,8 +4149,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
  "sp-core",
@@ -3726,9 +4158,10 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
+ "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log 0.4.8",
@@ -3747,22 +4180,23 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
+ "sp-tracing",
  "sp-wasm-interface",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -3773,26 +4207,40 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
+ "parity-scale-codec",
  "sp-api",
  "sp-core",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-staking"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+dependencies = [
+ "parity-scale-codec",
  "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
+ "itertools 0.9.0",
  "log 0.4.8",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
+ "smallvec 1.4.0",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
@@ -3803,15 +4251,16 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-serde 0.2.3",
+ "ref-cast",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -3819,8 +4268,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3832,9 +4281,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-tracing"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+dependencies = [
+ "log 0.4.8",
+ "rental",
+ "tracing",
+]
+
+[[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more 0.99.8",
  "futures 0.3.5",
@@ -3842,14 +4301,15 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-api",
+ "sp-blockchain",
  "sp-runtime",
  "sp-utils",
 ]
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -3862,19 +4322,20 @@ dependencies = [
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
+ "futures-timer 3.0.2",
  "lazy_static",
  "prometheus",
 ]
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -3885,8 +4346,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=6dc23feece77d758656651e04de964d72e9b5d34#6dc23feece77d758656651e04de964d72e9b5d34"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3899,6 +4360,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3925,6 +4392,20 @@ dependencies = [
  "pbkdf2",
  "schnorrkel",
  "sha2",
+]
+
+[[package]]
+name = "substrate-prometheus-endpoint"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate?rev=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+dependencies = [
+ "async-std",
+ "derive_more 0.99.8",
+ "futures-util",
+ "hyper 0.13.6",
+ "log 0.4.8",
+ "prometheus",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -4420,9 +4901,9 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trie-db"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc309f34008563989045a4c4dbcc5770467f3a3785ee80a9b5cc0d83362475f"
+checksum = "cb230c24c741993b04cfccbabb45acff6f6480c5f00d3ed8794ea43db3a9d727"
 dependencies = [
  "hash-db",
  "hashbrown",
@@ -4516,6 +4997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4532,6 +5019,12 @@ name = "unsigned-varint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
 
 [[package]]
 name = "untrusted"
@@ -4594,6 +5087,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
@@ -4811,6 +5310,15 @@ dependencies = [
  "tokio-io",
  "tokio-tcp",
  "tokio-tls",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -20,6 +20,7 @@ kv = { version = "0.20", features = [ "bincode-value", "json-value" ] }
 lazy_static = "1.4"
 log = "0.4"
 nonempty = "0.2"
+parity-scale-codec = "1.3.1"
 pico-args = "0.3"
 pretty_env_logger = "0.3"
 rand = "0.7"
@@ -44,7 +45,7 @@ rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "0acd1e5467f0b70dfdff5fc7df1b5121d73b9858"
+rev = "2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
 
 [dependencies.radicle-surf]
 version = "0.3.1"

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -80,6 +80,10 @@ pub enum Error {
     #[error("the Project Name '{0}' is invalid")]
     InvalidProjectName(String),
 
+    /// The given block could not be found in the registry.
+    #[error("the given block '{0}' could not be found in the Registry")]
+    BlockNotFound(registry::BlockHash),
+
     /// Accept error from `librad`.
     #[error(transparent)]
     LibradAccept(#[from] librad::net::peer::AcceptError),

--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -243,7 +243,7 @@ mod test {
                 domain_id: org_id,
             }],
             state: registry::State::Confirmed {
-                block: Some(1),
+                block: 1,
                 confirmations: 1,
                 min_confirmations: registry::MIN_CONFIRMATIONS,
                 timestamp: now,

--- a/proxy/src/http/transaction.rs
+++ b/proxy/src/http/transaction.rs
@@ -243,7 +243,7 @@ mod test {
                 domain_id: org_id,
             }],
             state: registry::State::Confirmed {
-                block: 1,
+                block: Some(1),
                 confirmations: 1,
                 min_confirmations: registry::MIN_CONFIRMATIONS,
                 timestamp: now,

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -307,10 +307,10 @@ impl Registry {
         let nonce = self.client.account_nonce(&author.public()).await?;
         let runtime_spec_version = self.client.runtime_version().await?.spec_version;
         let extra = protocol::TransactionExtra {
-            nonce,
             genesis_hash: self.client.genesis_hash(),
+            nonce,
+            runtime_spec_version,
             fee,
-            runtime_transaction_version: runtime_spec_version,
         };
         Ok(protocol::Transaction::new_signed(author, message, extra))
     }
@@ -375,7 +375,7 @@ impl Client for Registry {
         let block = self.client.block_header(applied.block).await?;
         let tx = Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.map(|b| b.number),
+            block.number,
             Message::OrgRegistration { id: org_id.clone() },
             fee,
         );
@@ -406,7 +406,7 @@ impl Client for Registry {
 
         Ok(Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.map(|b| b.number),
+            block.number,
             Message::OrgUnregistration { id: org_id },
             fee,
         ))
@@ -432,7 +432,7 @@ impl Client for Registry {
         let block = self.client.block_header(applied.block).await?;
         let tx = Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.map(|b| b.number),
+            block.number,
             Message::MemberRegistration {
                 org_id: org_id.clone(),
                 handle: user_id,
@@ -546,7 +546,7 @@ impl Client for Registry {
 
         Ok(Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.map(|b| b.number),
+            block.number,
             Message::ProjectRegistration {
                 project_name,
                 domain_type,
@@ -589,7 +589,7 @@ impl Client for Registry {
 
         Ok(Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.map(|b| b.number),
+            block.number,
             Message::UserRegistration { handle, id },
             fee,
         ))

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -307,10 +307,10 @@ impl Registry {
         let nonce = self.client.account_nonce(&author.public()).await?;
         let runtime_spec_version = self.client.runtime_version().await?.spec_version;
         let extra = protocol::TransactionExtra {
-            genesis_hash: self.client.genesis_hash(),
             nonce,
-            runtime_spec_version,
+            genesis_hash: self.client.genesis_hash(),
             fee,
+            runtime_transaction_version: runtime_spec_version,
         };
         Ok(protocol::Transaction::new_signed(author, message, extra))
     }
@@ -375,7 +375,7 @@ impl Client for Registry {
         let block = self.client.block_header(applied.block).await?;
         let tx = Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.number,
+            block.map(|b| b.number),
             Message::OrgRegistration { id: org_id.clone() },
             fee,
         );
@@ -406,7 +406,7 @@ impl Client for Registry {
 
         Ok(Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.number,
+            block.map(|b| b.number),
             Message::OrgUnregistration { id: org_id },
             fee,
         ))
@@ -432,7 +432,7 @@ impl Client for Registry {
         let block = self.client.block_header(applied.block).await?;
         let tx = Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.number,
+            block.map(|b| b.number),
             Message::MemberRegistration {
                 org_id: org_id.clone(),
                 handle: user_id,
@@ -546,7 +546,7 @@ impl Client for Registry {
 
         Ok(Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.number,
+            block.map(|b| b.number),
             Message::ProjectRegistration {
                 project_name,
                 domain_type,
@@ -589,7 +589,7 @@ impl Client for Registry {
 
         Ok(Transaction::confirmed(
             Hash(applied.tx_hash),
-            block.number,
+            block.map(|b| b.number),
             Message::UserRegistration { handle, id },
             fee,
         ))

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -376,6 +376,13 @@ where
         self.client.best_height().await
     }
 
+    async fn get_block_header(
+        &self,
+        block: registry::BlockHash,
+    ) -> Result<protocol::BlockHeader, error::Error> {
+        self.client.get_block_header(block).await
+    }
+
     async fn get_org(&self, id: registry::Id) -> Result<Option<registry::Org>, error::Error> {
         self.client.get_org(id).await
     }

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -96,7 +96,7 @@ impl Transaction {
     #[must_use]
     pub fn confirmed(
         id: registry::Hash,
-        block: Option<protocol::BlockNumber>,
+        block: protocol::BlockNumber,
         message: Message,
         fee: protocol::Balance,
     ) -> Self {
@@ -174,7 +174,7 @@ pub enum State {
     #[serde(rename_all = "camelCase")]
     Confirmed {
         /// The height of the block the transaction has been applied to.
-        block: Option<protocol::BlockNumber>,
+        block: protocol::BlockNumber,
         /// Amount of progress made towards settlement. We assume height+5 to
         /// be mathematically impossible to be reverted.
         confirmations: u32,
@@ -293,9 +293,7 @@ where
                 State::Confirmed {
                     block, timestamp, ..
                 } => {
-                    let target = block.map_or(0, |b| {
-                        b.checked_add(BLOCK_BOUND).unwrap_or(MIN_CONFIRMATIONS)
-                    });
+                    let target = block.checked_add(BLOCK_BOUND).unwrap_or(MIN_CONFIRMATIONS);
 
                     if best_height >= target {
                         tx.state = State::Settled {
@@ -521,7 +519,7 @@ mod test {
                 id: registry::Hash(protocol::TxHash::random()),
                 messages: vec![],
                 state: State::Confirmed {
-                    block: Some(1),
+                    block: 1,
                     confirmations: 3,
                     min_confirmations: MIN_CONFIRMATIONS,
                     timestamp: now,
@@ -537,7 +535,7 @@ mod test {
                     id: registry::Hash(protocol::TxHash::random()),
                     messages: vec![],
                     state: State::Confirmed {
-                        block: Some(height),
+                        block: height,
                         confirmations: 2,
                         min_confirmations: MIN_CONFIRMATIONS,
                         timestamp: now,


### PR DESCRIPTION
To go ahead with https://github.com/radicle-dev/radicle-upstream/issues/641, we need to adjust to the latest breaking changes presented by the radicle registry client.

@xla the biggest chunk here is moving to `Optional<BlockNumber>`. Could you have a detailed look at how I've done it? I didn't introduce those changes in the Registry and it's not 100% clear to me if I am doing the right thing in all affected lines of code.