### PR TITLE
chore(ui): Adjust id validation

### DIFF
--- a/cypress/integration/org_registration.spec.js
+++ b/cypress/integration/org_registration.spec.js
@@ -111,7 +111,7 @@ context("org registration", () => {
 
       cy.pick("org-registration-modal", "input").type("coolname");
       cy.pick("org-registration-modal").contains(
-        "Sorry, this one is already taken"
+        "Sorry, this one is no longer available"
       );
       cy.pick("submit-button").should("be.disabled");
     });
@@ -121,7 +121,7 @@ context("org registration", () => {
 
       cy.pick("org-registration-modal", "input").type("userxyz");
       cy.pick("org-registration-modal").contains(
-        "Sorry, this one is already taken"
+        "Sorry, this one is no longer available"
       );
       cy.pick("submit-button").should("be.disabled");
     });

--- a/cypress/integration/user_registration.spec.js
+++ b/cypress/integration/user_registration.spec.js
@@ -83,7 +83,7 @@ context("user registration", () => {
     it("prevents the user from registering an unavailable handle", () => {
       cy.pick("handle").clear();
       cy.pick("handle").type("nope");
-      cy.pick("page").contains("Sorry, this one is already taken");
+      cy.pick("page").contains("Sorry, this one is no longer available");
     });
 
     it("prevents the user from registering an id already taken by an org", () => {
@@ -92,7 +92,9 @@ context("user registration", () => {
 
       cy.pick("register-user", "handle").clear();
       cy.pick("register-user", "handle").type("neoxyz");
-      cy.pick("register-user").contains("Sorry, this one is already taken");
+      cy.pick("register-user").contains(
+        "Sorry, this one is no longer available"
+      );
       cy.pick("next-button").should("be.disabled");
     });
   });

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=dff300142510e11153b943cb668991dd45860286#dff300142510e11153b943cb668991dd45860286"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d1e653d180e700733bac940c22ee00881e108edf#d1e653d180e700733bac940c22ee00881e108edf"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -3083,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=dff300142510e11153b943cb668991dd45860286#dff300142510e11153b943cb668991dd45860286"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d1e653d180e700733bac940c22ee00881e108edf#d1e653d180e700733bac940c22ee00881e108edf"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.16.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=dff300142510e11153b943cb668991dd45860286#dff300142510e11153b943cb668991dd45860286"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d1e653d180e700733bac940c22ee00881e108edf#d1e653d180e700733bac940c22ee00881e108edf"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d1e653d180e700733bac940c22ee00881e108edf#d1e653d180e700733bac940c22ee00881e108edf"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=e98f433712646bf29815f287d228154282c7e819#e98f433712646bf29815f287d228154282c7e819"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -3083,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d1e653d180e700733bac940c22ee00881e108edf#d1e653d180e700733bac940c22ee00881e108edf"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=e98f433712646bf29815f287d228154282c7e819#e98f433712646bf29815f287d228154282c7e819"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.16.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=d1e653d180e700733bac940c22ee00881e108edf#d1e653d180e700733bac940c22ee00881e108edf"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=e98f433712646bf29815f287d228154282c7e819#e98f433712646bf29815f287d228154282c7e819"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-client"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf#2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=dff300142510e11153b943cb668991dd45860286#dff300142510e11153b943cb668991dd45860286"
 dependencies = [
  "async-trait",
  "derive_more 0.15.0",
@@ -3083,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-core"
 version = "0.0.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf#2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=dff300142510e11153b943cb668991dd45860286#dff300142510e11153b943cb668991dd45860286"
 dependencies = [
  "derive-try-from-primitive",
  "parity-scale-codec",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "radicle-registry-runtime"
 version = "0.16.0"
-source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf#2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
+source = "git+https://github.com/radicle-dev/radicle-registry.git?rev=dff300142510e11153b943cb668991dd45860286#dff300142510e11153b943cb668991dd45860286"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -47,7 +47,7 @@ rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "dff300142510e11153b943cb668991dd45860286"
+rev = "d1e653d180e700733bac940c22ee00881e108edf"
 
 [dependencies.radicle-surf]
 version = "0.4.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -47,7 +47,7 @@ rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "2cb4f5da3b28dc5239dd0a301d67ee88277a7dcf"
+rev = "dff300142510e11153b943cb668991dd45860286"
 
 [dependencies.radicle-surf]
 version = "0.4.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -47,7 +47,7 @@ rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"
-rev = "d1e653d180e700733bac940c22ee00881e108edf"
+rev = "e98f433712646bf29815f287d228154282c7e819"
 
 [dependencies.radicle-surf]
 version = "0.4.0"

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -22,6 +22,7 @@ mod avatar;
 mod control;
 mod doc;
 mod error;
+mod id;
 mod identity;
 mod notification;
 mod org;
@@ -73,6 +74,7 @@ where
         Arc::clone(&registry),
         Arc::clone(&store),
     );
+    let id_filter = id::routes(&Arc::clone(&registry));
     let identity_filter = identity::filters(
         Arc::clone(&peer),
         Arc::clone(&keystore),
@@ -100,6 +102,7 @@ where
     let api = path("v1").and(combine!(
         avatar_filter,
         control_filter,
+        id_filter,
         identity_filter,
         notification_filter,
         org_filter,

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -74,7 +74,7 @@ where
         Arc::clone(&registry),
         Arc::clone(&store),
     );
-    let id_filter = id::routes(&Arc::clone(&registry));
+    let id_filter = id::get_status_filter(Arc::clone(&registry));
     let identity_filter = identity::filters(
         Arc::clone(&peer),
         Arc::clone(&keystore),

--- a/proxy/src/http/id.rs
+++ b/proxy/src/http/id.rs
@@ -61,7 +61,6 @@ mod handler {
     use crate::http;
     use crate::registry;
 
-    #[allow(clippy::all)]
     /// Get the status for the given `id`.
     pub async fn get_status<R: registry::Client>(
         registry: http::Shared<R>,

--- a/proxy/src/http/id.rs
+++ b/proxy/src/http/id.rs
@@ -173,7 +173,7 @@ mod test {
 
         let author = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
         let handle = registry::Id::try_from("alice")?;
-        // Register the user to that it can register orgs
+        // Register the user so that it can register orgs
         registry
             .write()
             .await
@@ -248,7 +248,7 @@ mod test {
 
         let author = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
         let handle = registry::Id::try_from("alice")?;
-        // Register the user to that it can register orgs
+        // Register the user so that it can register orgs
         registry
             .write()
             .await

--- a/proxy/src/http/id.rs
+++ b/proxy/src/http/id.rs
@@ -1,0 +1,134 @@
+//! Endpoints for Id.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use warp::document::{self, ToDocumentedType};
+use warp::{path, Filter, Rejection, Reply};
+
+use crate::http;
+use crate::registry;
+
+/// Prefixed filters.
+pub fn routes<R>(
+    registry: &http::Shared<R>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+where
+    R: registry::Client,
+{
+    get_status_filter(Arc::clone(registry))
+}
+
+/// Combination of all ids routes.
+#[cfg(test)]
+fn filters<R>(
+    registry: &http::Shared<R>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+where
+    R: registry::Client,
+{
+    get_status_filter(Arc::clone(registry))
+}
+
+/// `GET /<id>/status`
+fn get_status_filter<R: registry::Client>(
+    registry: http::Shared<R>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+where
+    R: registry::Client,
+{
+    http::with_shared(registry)
+        .and(warp::get())
+        .and(document::param::<String>(
+            "id",
+            "The id whose status will be obtained",
+        ))
+        .and(path("status"))
+        .and(path::end())
+        .and(document::document(document::description(
+            "Get the status for the given id",
+        )))
+        .and(document::document(
+            document::response(
+                200,
+                document::body(Status::document()).mime("application/json"),
+            )
+            .description("Successful retrieval"),
+        ))
+        .and_then(handler::get_status)
+}
+
+/// The type of domain under which a project is registered.
+/// Only used for implementing `ToDocumentedType`.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub struct Status;
+
+impl ToDocumentedType for Status {
+    fn document() -> document::DocumentedType {
+        document::enum_string(vec!["available".into(), "taken".into(), "retired".into()])
+            .description("Variants for possible id statuses.")
+            .example("available")
+    }
+}
+
+/// Org handlers for conversion between core domain and http request fullfilment.
+mod handler {
+    use std::convert::TryFrom;
+    use warp::{reply, Rejection, Reply};
+
+    use crate::error::Error;
+    use crate::http;
+    use crate::registry;
+
+    /// Get the status for the given `id`.
+    pub async fn get_status<R: registry::Client>(
+        registry: http::Shared<R>,
+        id_string: String,
+    ) -> Result<impl Reply, Rejection> {
+        let reg = registry.read().await;
+        let id = registry::Id::try_from(id_string).map_err(Error::from)?;
+        let id_status = reg.get_id_status(&id).await;
+
+        Ok(reply::json(&id_status))
+    }
+}
+
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, clippy::panic)]
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+    use std::convert::TryFrom;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use warp::http::StatusCode;
+    use warp::test::request;
+
+    use crate::error;
+    use crate::http;
+    use crate::registry;
+
+    #[tokio::test]
+    async fn get_status() -> Result<(), error::Error> {
+        let registry = {
+            let (client, _) = radicle_registry_client::Client::new_emulator();
+            Arc::new(RwLock::new(registry::Registry::new(client)))
+        };
+        let api = super::filters(&Arc::clone(&registry));
+
+        let id = registry::Id::try_from("monadic")?;
+        let res = request()
+            .method("GET")
+            .path(&format!("/{}/status", id.to_string()))
+            .reply(&api)
+            .await;
+
+        http::test::assert_response(&res, StatusCode::OK, |have| {
+            assert_eq!(have, json!(registry::IdStatus::Available));
+        });
+
+        Ok(())
+    }
+
+    //TODO(nuno): test taken and retired
+}

--- a/proxy/src/http/id.rs
+++ b/proxy/src/http/id.rs
@@ -17,7 +17,7 @@ where
     path("ids")
         .and(http::with_shared(registry))
         .and(warp::get())
-        .and(document::param::<String>(
+        .and(document::param::<registry::Id>(
             "id",
             "The id whose status will be obtained",
         ))
@@ -64,10 +64,9 @@ mod handler {
     /// Get the status for the given `id`.
     pub async fn get_status<R: registry::Client>(
         registry: http::Shared<R>,
-        id_string: String,
+        id: registry::Id,
     ) -> Result<impl Reply, Rejection> {
         let reg = registry.read().await;
-        let id = registry::Id::try_from(id_string).map_err(Error::from)?;
         let id_status = reg.get_id_status(&id).await?;
 
         Ok(reply::json(&id_status))

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -733,6 +733,27 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_unregister_user() -> Result<(), error::Error> {
+        // Test that org unregistration submits valid transactions and they succeed.
+        let (client, _) = protocol::Client::new_emulator();
+        let registry = Registry::new(client.clone());
+        let author = protocol::ed25519::Pair::from_legacy_string("//Alice", None);
+        let handle = Id::try_from("alice")?;
+
+        // Register the user
+        let user_registration = registry
+            .register_user(&author, handle.clone(), Some("123abcd.git".into()), 100)
+            .await;
+        assert!(user_registration.is_ok());
+
+        // Unregister the org
+        let unregistration = registry.unregister_user(&author, handle, 10).await;
+        assert!(unregistration.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_unregister_org() -> Result<(), error::Error> {
         // Test that org unregistration submits valid transactions and they succeed.
         let (client, _) = protocol::Client::new_emulator();

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 use radicle_registry_client::{self as protocol, ClientT, CryptoPair};
 pub use radicle_registry_client::{
-    Balance, BlockHash, Id, ProjectDomain, ProjectName, MINIMUM_FEE,
+    Balance, BlockHash, Id, IdStatus, ProjectDomain, ProjectName, MINIMUM_FEE,
 };
 
 use crate::avatar;
@@ -157,6 +157,13 @@ pub trait Client: Clone + Send + Sync {
         &self,
         block: BlockHash,
     ) -> Result<protocol::BlockHeader, error::Error>;
+
+    /// Fetch the status of a given id.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if a protocol error occurs.
+    async fn get_id_status(&self, id: &Id) -> IdStatus;
 
     /// Try to retrieve org from the Registry by id.
     ///
@@ -366,6 +373,10 @@ impl Client for Registry {
             .block_header(block)
             .await?
             .ok_or(error::Error::BlockNotFound(block))
+    }
+
+    async fn get_id_status(&self, id: &Id) -> IdStatus {
+        self.client.get_id_status(id).await
     }
 
     async fn list_orgs(&self, handle: Id) -> Result<Vec<Org>, error::Error> {

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -383,6 +383,10 @@ where
         self.client.get_block_header(block).await
     }
 
+    async fn get_id_status(&self, id: &registry::Id) -> registry::IdStatus {
+        self.client.get_id_status(id).await
+    }
+
     async fn get_org(&self, id: registry::Id) -> Result<Option<registry::Org>, error::Error> {
         self.client.get_org(id).await
     }

--- a/proxy/src/registry/transaction.rs
+++ b/proxy/src/registry/transaction.rs
@@ -155,6 +155,13 @@ pub enum Message {
         id: Option<String>,
     },
 
+    /// Issue an org unregistration with a given id.
+    #[serde(rename_all = "camelCase")]
+    UserUnregistration {
+        /// The [`registry::User`] id.
+        id: registry::Id,
+    },
+
     /// Issue a member registration for a given handle under a given org.
     #[serde(rename_all = "camelCase")]
     MemberRegistration {
@@ -383,7 +390,7 @@ where
         self.client.get_block_header(block).await
     }
 
-    async fn get_id_status(&self, id: &registry::Id) -> registry::IdStatus {
+    async fn get_id_status(&self, id: &registry::Id) -> Result<registry::IdStatus, error::Error> {
         self.client.get_id_status(id).await
     }
 
@@ -490,6 +497,17 @@ where
 
         self.cache_transaction(tx.clone())?;
 
+        Ok(tx)
+    }
+
+    async fn unregister_user(
+        &self,
+        author: &protocol::ed25519::Pair,
+        handle: registry::Id,
+        fee: protocol::Balance,
+    ) -> Result<Transaction, error::Error> {
+        let tx = self.unregister_user(author, handle, fee).await?;
+        self.cache_transaction(tx.clone())?;
         Ok(tx)
     }
 

--- a/ui/src/id.ts
+++ b/ui/src/id.ts
@@ -1,10 +1,22 @@
-import * as org from "./org";
-import * as user from "./user";
+import * as api from "./api";
 import * as validation from "./validation";
+
+// The possible availability statuses of an Id
+enum Status {
+  // Available
+  Available = "available",
+  // Currently taken by an Org or a User
+  Taken = "taken",
+  // The id was unregistered by an Org or a User and is no longer claimable
+  Retired = "retired",
+}
+
+const getStatus = (id: string): Promise<Status> =>
+  api.get<Status>(`ids/${id}/status`);
 
 // Check if the given id is available
 const isAvailable = (id: string): Promise<boolean> =>
-  org.getOrg(id).then(org => !org && user.get(id).then(user => !user));
+  getStatus(id).then(status => status == Status.Available);
 
 // ID validation
 const VALID_ID_MATCH_STR = "^[a-z0-9][a-z0-9]+$";

--- a/ui/src/id.ts
+++ b/ui/src/id.ts
@@ -17,7 +17,7 @@ enum Status {
 
 // Check if the given id is available
 const isAvailable = (id: string): Promise<boolean> =>
-  api.get<string>(`ids/${id}/status`).then(status => status == "available");
+  api.get<string>(`ids/${id}/status`).then(status => status === "available");
 
 // ID validation
 const VALID_ID_MATCH_STR = "^[a-z0-9][a-z0-9]+$";

--- a/ui/src/id.ts
+++ b/ui/src/id.ts
@@ -1,4 +1,5 @@
 import * as api from "./api";
+import * as org from "./org";
 import * as validation from "./validation";
 
 // The possible availability statuses of an Id
@@ -11,12 +12,12 @@ enum Status {
   Retired = "retired",
 }
 
-const getStatus = (id: string): Promise<Status> =>
-  api.get<Status>(`ids/${id}/status`);
+// const getStatus = (id: string): Promise<Status> =>
+//   api.get<Status>(`ids/${id}/status`);
 
 // Check if the given id is available
 const isAvailable = (id: string): Promise<boolean> =>
-  getStatus(id).then(status => status == Status.Available);
+  api.get<string>(`ids/${id}/status`).then(status => status == "available");
 
 // ID validation
 const VALID_ID_MATCH_STR = "^[a-z0-9][a-z0-9]+$";
@@ -37,6 +38,6 @@ export const idValidationStore = (): validation.ValidationStore =>
   validation.createValidationStore(idConstraints, [
     {
       promise: isAvailable,
-      validationMessage: "Sorry, this one is already taken",
+      validationMessage: "Sorry, this one is no longer available",
     },
   ]);

--- a/ui/src/org.test.ts
+++ b/ui/src/org.test.ts
@@ -34,7 +34,7 @@ describe("validation", () => {
     process.nextTick(() => {
       expect(get(validation)).toEqual({
         status: ValidationStatus.Error,
-        message: "Sorry, this one is already taken",
+        message: "Sorry, this one is no longer available",
       });
     });
   });
@@ -85,7 +85,7 @@ describe("validation", () => {
     process.nextTick(() => {
       expect(get(validation)).toEqual({
         status: ValidationStatus.Error,
-        message: "Sorry, this one is already taken",
+        message: "Sorry, this one is no longer available",
       });
     });
   });

--- a/ui/src/org.test.ts
+++ b/ui/src/org.test.ts
@@ -32,7 +32,10 @@ describe("validation", () => {
     });
 
     process.nextTick(() => {
-      expect(get(validation)).toEqual({ status: ValidationStatus.Success });
+      expect(get(validation)).toEqual({
+        status: ValidationStatus.Error,
+        message: "Sorry, this one is already taken",
+      });
     });
   });
 


### PR DESCRIPTION
Closes #641 

It introduces a new endpoint `ids/<id>/status` that fetches the availability status of a given id in the registry, that is either `available | retired | taken`. In the UI, we now call this endpoint and validate the availability of an id based on its status being `available`. The error message is changed from "Sorry, this one is already taken" to "Sorry, this one is no longer available", which better represents the semantics behind an id not being available.

To make testing possible, I added support to unregister a user from the registry in the proxy only.

**Note**: In a follow up issue I would move the `avatars/<id>` endpoint under `ids`, as `ids/<id>/avatar`.