### PR TITLE
style(ui): cleanup

### DIFF
--- a/ui/DesignSystem/Component/RadioOption.svelte
+++ b/ui/DesignSystem/Component/RadioOption.svelte
@@ -15,13 +15,16 @@
   }
 
   .option.active {
-    border: 1px solid var(--color-primary);
+    border: 1px solid var(--color-foreground-level-3);
+  }
+
+  .option.active:hover {
+    background-color: var(--color-background);
   }
 
   .option:hover {
     outline: none;
-    border: 1px solid var(--color-primary);
-    color: var(--color-primary);
+    background-color: var(--color-foreground-level-1);
   }
 
   .header {

--- a/ui/Screen/Discovery/Project.svelte
+++ b/ui/Screen/Discovery/Project.svelte
@@ -32,8 +32,6 @@
   }
 
   .container:hover {
-    box-shadow: 0 0 0 1px
-      var(--color-foreground-level-3, var(--color-foreground-level-3));
     background: var(--color-foreground-level-1);
     border-color: var(--color-foreground-level-3);
   }


### PR DESCRIPTION
- Fixing hoverstates on `new project creation`
<img width="736" alt="Screenshot 2020-07-16 at 17 39 13" src="https://user-images.githubusercontent.com/2326909/87691893-6b221a00-c78b-11ea-87a4-2139362af76b.png">

- fixes hoverstates on discovery
<img width="596" alt="Screenshot 2020-07-16 at 17 40 28" src="https://user-images.githubusercontent.com/2326909/87691916-71b09180-c78b-11ea-8f51-ad3bf3ae6c97.png">

closes #674 