### PR TITLE
fix(ci): fix flaky builds

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -6,7 +6,16 @@ TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'
 source .buildkite/env.sh
 
 echo "--- Installing yarn dependencies"
-time yarn install
+# FIXME(rudolfs): yarn install sometimes fails on the first run with the
+# following error message: "Error: ENOSPC: no space left on device, write".
+#
+# However looking at the disk image when this happens shows that there's plenty
+# of space. It might have something to do with yarn trying to run post-install
+# scripts that try to extract stuff to /tmp which is limited on CI.
+#
+# Until we figure out how to fix this proper, just retry running yarn install.
+
+time yarn install || time yarn install
 
 echo "--- Loading proxy/target cache"
 declare -r target_cache="$CACHE_FOLDER/proxy-target"


### PR DESCRIPTION
This attempts to fix failing builds due to `Error: ENOSPC: no space left on device, write` during `yarn install`.

Initially I thought it might be some limit on CI that we're hitting, but after investigating a running image where this error happens I could rule out disk space issues. However, I noticed that re-running `yarn install` a second time, it worked just fine.

So as a workaround I added a re-try to `yarn install` in the CI build script.

Here's what a [successful retry](https://buildkite.com/monadic/radicle-upstream/builds/3573#bca39fdb-061d-4e2d-84b9-9533ab07aeb7) looks like:
```
> Installing yarn dependencies
yarn install v1.22.4
--
  | [1/4] Resolving packages...
  | [2/4] Fetching packages...
  | info fsevents@2.1.3: The platform "linux" is incompatible with this module.
  | info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
  | [3/4] Linking dependencies...
  | warning " > rollup-plugin-node-externals@2.2.0" has unmet peer dependency "builtin-modules@^3.1.0".
  | [4/4] Building fresh packages...
  | error /build/node_modules/electron: Command failed.
  | Exit code: 1
  | Command: node install.js
  | Arguments:
  | Directory: /build/node_modules/electron
  | Output:
  | Error: ENOSPC: no space left on device, write
  | info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
  | elapsed time: 72.412 (user: 69.138, system: 52.491)


  | yarn install v1.22.4
  | [1/4] Resolving packages...
  | [2/4] Fetching packages...
  | info fsevents@2.1.3: The platform "linux" is incompatible with this module.
  | info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
  | [3/4] Linking dependencies...
  | warning " > rollup-plugin-node-externals@2.2.0" has unmet peer dependency "builtin-modules@^3.1.0".
  | [4/4] Building fresh packages...
  | Done in 14.84s.
  | elapsed time: 15.000 (user: 12.141, system: 6.024)
```