### PR TITLE
feat(proxy): build and package rad-remote-helper with Upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
       {
         "from": "dist/proxy",
         "to": "proxy"
+      },
+      {
+        "from": "dist/git-remote-rad",
+        "to": "git-remote-rad"
       }
     ],
     "linux": {
@@ -107,7 +111,7 @@
     "test:unit:watch": "jest --watchAll",
     "wait:test": "wait-on tcp:8080 && yarn svelte:build && yarn cypress:run",
     "wait:debug": "wait-on tcp:8080 && yarn cypress:open",
-    "dist": "rm -rf ./dist && mkdir ./dist && yarn svelte:clean && yarn svelte:build && yarn proxy:build:release && cp proxy/target/release/proxy dist && electron-builder --publish never",
+    "dist": "rm -rf ./dist && mkdir ./dist && yarn svelte:clean && yarn svelte:build && yarn proxy:build:release && cp proxy/target/release/proxy dist && cp proxy/target/release/git-remote-rad dist && electron-builder --publish never",
     "electron:start": "wait-on ./public/bundle.js && wait-on ./native/main.comp.js && wait-on tcp:8080 && NODE_ENV=development electron .",
     "svelte:check": "svelte-check",
     "svelte:clean": "rm -rf public/bundle.*",

--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -2929,6 +2929,7 @@ checksum = "d883f78645c21b7281d21305181aa1f4dd9e9363e7cf2566c93121552cff003e"
 name = "proxy"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes 0.5.6",
  "directories",
@@ -2945,6 +2946,7 @@ dependencies = [
  "pico-args",
  "pretty_assertions",
  "pretty_env_logger",
+ "radicle-git-helpers",
  "radicle-keystore",
  "radicle-registry-client",
  "radicle-surf",
@@ -3028,6 +3030,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2 1.0.18",
+]
+
+[[package]]
+name = "radicle-git-helpers"
+version = "0.1.0"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=55cd394b0eede746ccf4120956f0c3eaf459b073#55cd394b0eede746ccf4120956f0c3eaf459b073"
+dependencies = [
+ "anyhow",
+ "git2",
+ "libgit2-sys",
+ "librad",
+ "radicle-keystore",
 ]
 
 [[package]]
@@ -4917,7 +4931,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.5.6",
 ]
 
 [[package]]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -13,6 +13,7 @@ default-run = "proxy"
 
 [dependencies]
 async-trait = "0.1"
+anyhow = "1.0"
 directories = "2.0"
 futures = { version = "0.3", features = [ "compat" ] }
 hex = "0.4"
@@ -38,6 +39,10 @@ url = "2.1"
 warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", features = [ "openapi" ], default-features = false }
 
 [dependencies.librad]
+git = "https://github.com/radicle-dev/radicle-link.git"
+rev = "55cd394b0eede746ccf4120956f0c3eaf459b073"
+
+[dependencies.radicle-git-helpers]
 git = "https://github.com/radicle-dev/radicle-link.git"
 rev = "55cd394b0eede746ccf4120956f0c3eaf459b073"
 

--- a/proxy/src/bin/git-remote-rad.rs
+++ b/proxy/src/bin/git-remote-rad.rs
@@ -1,0 +1,5 @@
+use radicle_git_helpers::remote_helper;
+
+fn main() -> anyhow::Result<()> {
+    remote_helper::run()
+}


### PR DESCRIPTION
Pre-requisite for: https://github.com/radicle-dev/radicle-upstream/issues/601.