### PR TITLE
refactor(proxy): move http mount points

### DIFF
--- a/proxy/src/http/avatar.rs
+++ b/proxy/src/http/avatar.rs
@@ -2,13 +2,14 @@
 
 use serde::Deserialize;
 use warp::document::{self, ToDocumentedType};
-use warp::{path, Filter, Rejection, Reply};
+use warp::filters::BoxedFilter;
+use warp::{Filter, Reply};
 
 use crate::avatar;
 
-/// `GET /avatars/<id>?usage=<usage>`
-pub fn get_filter() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    path("avatars")
+/// `GET /<id>?usage=<usage>`
+pub fn get_filter() -> BoxedFilter<(impl Reply,)> {
+    warp::any()
         .and(document::param::<String>(
             "id",
             "ID for the Avatar creation",
@@ -38,6 +39,7 @@ pub fn get_filter() -> impl Filter<Extract = (impl Reply,), Error = Rejection> +
             .description("Wrong usage for Avatar"),
         ))
         .and_then(handler::get)
+        .boxed()
 }
 
 /// Avatar handlers for conversion between core domain and http request fullfilment.
@@ -96,7 +98,7 @@ mod test {
         let api = super::get_filter();
         let res = request()
             .method("GET")
-            .path(&format!("/avatars/{}?usage={}", "monadic", "org"))
+            .path(&format!("/{}?usage={}", "monadic", "org"))
             .reply(&api)
             .await;
 

--- a/proxy/src/http/id.rs
+++ b/proxy/src/http/id.rs
@@ -2,20 +2,18 @@
 
 use serde::{Deserialize, Serialize};
 use warp::document::{self, ToDocumentedType};
-use warp::{path, Filter, Rejection, Reply};
+use warp::filters::BoxedFilter;
+use warp::{path, Filter, Reply};
 
 use crate::http;
 use crate::registry;
 
-/// `GET ids/<id>/status`
-pub fn get_status_filter<R>(
-    ctx: http::Ctx<R>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+/// `GET /<id>/status`
+pub fn get_status_filter<R>(ctx: http::Ctx<R>) -> BoxedFilter<(impl Reply,)>
 where
     R: registry::Client + 'static,
 {
-    path("ids")
-        .and(http::with_context(ctx))
+    http::with_context(ctx)
         .and(warp::get())
         .and(document::param::<String>(
             "id",
@@ -35,6 +33,7 @@ where
             .description("Successful retrieval"),
         ))
         .and_then(handler::get_status)
+        .boxed()
 }
 
 /// The status of an org or user id in the Registry.
@@ -99,7 +98,7 @@ mod test {
         let id = registry::Id::try_from("monadic")?;
         let res = request()
             .method("GET")
-            .path(&format!("/ids/{}/status", id.to_string()))
+            .path(&format!("/{}/status", id.to_string()))
             .reply(&api)
             .await;
 
@@ -127,7 +126,7 @@ mod test {
 
         let res = request()
             .method("GET")
-            .path(&format!("/ids/{}/status", handle.to_string()))
+            .path(&format!("/{}/status", handle.to_string()))
             .reply(&api)
             .await;
 
@@ -160,7 +159,7 @@ mod test {
 
         let res = request()
             .method("GET")
-            .path(&format!("/ids/{}/status", org_id.to_string()))
+            .path(&format!("/{}/status", org_id.to_string()))
             .reply(&api)
             .await;
 
@@ -192,7 +191,7 @@ mod test {
 
         let res = request()
             .method("GET")
-            .path(&format!("/ids/{}/status", handle.to_string()))
+            .path(&format!("/{}/status", handle.to_string()))
             .reply(&api)
             .await;
 
@@ -230,7 +229,7 @@ mod test {
 
         let res = request()
             .method("GET")
-            .path(&format!("/ids/{}/status", org_id.to_string()))
+            .path(&format!("/{}/status", org_id.to_string()))
             .reply(&api)
             .await;
 

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -3,6 +3,7 @@
 use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize, Serializer};
 use warp::document::{self, ToDocumentedType};
+use warp::filters::BoxedFilter;
 use warp::{path, Filter, Rejection, Reply};
 
 use crate::avatar;
@@ -10,25 +11,8 @@ use crate::http;
 use crate::project;
 use crate::registry;
 
-/// Prefixed filters.
-pub fn routes<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
-where
-    R: registry::Client + 'static,
-{
-    path("orgs").and(
-        get_filter(ctx.clone())
-            .or(register_project_filter(ctx.clone()))
-            .or(get_project_filter(ctx.clone()))
-            .or(get_projects_filter(ctx.clone()))
-            .or(register_filter(ctx.clone()))
-            .or(register_member_filter(ctx.clone()))
-            .or(transfer_filter(ctx)),
-    )
-}
-
 /// Combination of all org routes.
-#[cfg(test)]
-fn filters<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+pub fn filters<R>(ctx: http::Ctx<R>) -> BoxedFilter<(impl Reply,)>
 where
     R: registry::Client + 'static,
 {
@@ -39,6 +23,7 @@ where
         .or(register_filter(ctx.clone()))
         .or(register_member_filter(ctx.clone()))
         .or(transfer_filter(ctx))
+        .boxed()
 }
 
 /// `GET /<id>`

--- a/proxy/src/http/session.rs
+++ b/proxy/src/http/session.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use warp::document::{self, ToDocumentedType};
+use warp::filters::BoxedFilter;
 use warp::{path, Filter, Rejection, Reply};
 
 use crate::http;
@@ -9,22 +10,8 @@ use crate::identity;
 use crate::registry;
 use crate::session;
 
-/// Prefixed fitlers.
-pub fn routes<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
-where
-    R: registry::Cache + registry::Client + 'static,
-{
-    path("session").and(
-        clear_cache_filter(ctx.clone())
-            .or(delete_filter(ctx.clone()))
-            .or(get_filter(ctx.clone()))
-            .or(update_settings_filter(ctx)),
-    )
-}
-
 /// Combination of all session filters.
-#[cfg(test)]
-pub fn filters<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+pub fn filters<R>(ctx: http::Ctx<R>) -> BoxedFilter<(impl Reply,)>
 where
     R: registry::Cache + registry::Client + 'static,
 {
@@ -32,6 +19,7 @@ where
         .or(delete_filter(ctx.clone()))
         .or(get_filter(ctx.clone()))
         .or(update_settings_filter(ctx))
+        .boxed()
 }
 
 /// `DELETE /cache`

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -3,8 +3,8 @@
 use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize, Serializer};
 use warp::document::{self, ToDocumentedType};
-use warp::{path, Filter, Rejection, Reply};
 use warp::filters::BoxedFilter;
+use warp::{path, Filter, Rejection, Reply};
 
 use librad::meta::user;
 use librad::peer;

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -4,6 +4,7 @@ use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize, Serializer};
 use warp::document::{self, ToDocumentedType};
 use warp::{path, Filter, Rejection, Reply};
+use warp::filters::BoxedFilter;
 
 use librad::meta::user;
 use librad::peer;
@@ -14,26 +15,8 @@ use crate::http;
 use crate::identity;
 use crate::registry;
 
-/// Prefixed filters.
-pub fn routes<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
-where
-    R: registry::Client + 'static,
-{
-    path("source").and(
-        blob_filter(ctx.clone())
-            .or(branches_filter(ctx.clone()))
-            .or(commit_filter(ctx.clone()))
-            .or(commits_filter(ctx.clone()))
-            .or(local_state_filter())
-            .or(revisions_filter(ctx.clone()))
-            .or(tags_filter(ctx.clone()))
-            .or(tree_filter(ctx)),
-    )
-}
-
 /// Combination of all source filters.
-#[cfg(test)]
-fn filters<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+pub fn filters<R>(ctx: http::Ctx<R>) -> BoxedFilter<(impl Reply,)>
 where
     R: registry::Client + 'static,
 {
@@ -45,6 +28,7 @@ where
         .or(revisions_filter(ctx.clone()))
         .or(tags_filter(ctx.clone()))
         .or(tree_filter(ctx))
+        .boxed()
 }
 
 /// `GET /blob/<project_id>?revision=<revision>&path=<path>`

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -3,28 +3,14 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use warp::document::{self, ToDocumentedType};
+use warp::filters::BoxedFilter;
 use warp::{path, Filter, Rejection, Reply};
 
 use crate::http;
 use crate::registry;
 
-/// Prefixed filter
-pub fn routes<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
-where
-    R: registry::Client + 'static,
-{
-    path("users").and(
-        list_orgs_filter(ctx.clone())
-            .or(register_project_filter(ctx.clone()))
-            .or(get_filter(ctx.clone()))
-            .or(register_filter(ctx.clone()))
-            .or(transfer_filter(ctx)),
-    )
-}
-
 /// Combination of all user filters.
-#[cfg(test)]
-fn filters<R>(ctx: http::Ctx<R>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone
+pub fn filters<R>(ctx: http::Ctx<R>) -> BoxedFilter<(impl Reply,)>
 where
     R: registry::Client + 'static,
 {
@@ -33,6 +19,7 @@ where
         .or(get_filter(ctx.clone()))
         .or(register_filter(ctx.clone()))
         .or(transfer_filter(ctx))
+        .boxed()
 }
 
 /// GET /<handle>


### PR DESCRIPTION
In order to have the endpoint modules not be concerned/in the know of
where they are mounted in the public API we centralis these in the main
http module. This in turn reduces unnecessary compilation guards and the
overhead to think about when boostrapping another namespace.