### PR TITLE
fix(ci): make clippy work on CI again

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -43,7 +43,7 @@ echo "--- Run proxy fmt"
 (cd proxy && time cargo fmt --all -- --check)
 
 echo "--- Run proxy lints"
-(cd proxy && time cargo clippy --all --all-features --all-targets)
+(cd proxy && time cargo clippy --all --all-features --all-targets -Z unstable-options)
 
 echo "--- Run app eslint checks"
 time yarn lint

--- a/proxy/src/registry.rs
+++ b/proxy/src/registry.rs
@@ -337,6 +337,7 @@ pub struct Registry {
     client: protocol::Client,
 }
 
+/// A fake credit balance which we use in integration tests.
 const PREPAID_AMOUNT_MICRO_RAD: Balance = 321 * 1_000_000;
 
 /// Registry client wrapper methods


### PR DESCRIPTION
This was first fixed in:
https://github.com/radicle-dev/radicle-upstream/pull/430.

But then later broken in:
https://github.com/radicle-dev/radicle-upstream/pull/721.