### PR TITLE
chore(proxy): bump librad

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -727,6 +727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1813,56 @@ dependencies = [
  "bs58",
  "bytes 0.5.6",
  "directories",
+ "futures 0.3.5",
+ "futures-timer 3.0.2",
+ "futures_codec",
+ "git2",
+ "governor",
+ "hex",
+ "lazy_static",
+ "libc",
+ "libgit2-sys",
+ "log 0.4.8",
+ "minicbor",
+ "multibase",
+ "multihash 0.10.1",
+ "nonempty 0.2.0",
+ "olpc-cjson",
+ "percent-encoding 2.1.0",
+ "quinn",
+ "radicle-keystore",
+ "rand 0.7.3",
+ "rand_pcg 0.2.1",
+ "rcgen",
+ "regex",
+ "rustls",
+ "secstr",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sodiumoxide",
+ "tempfile",
+ "thiserror",
+ "tokio 0.2.21",
+ "tokio-util",
+ "tracing",
+ "url 2.1.1",
+ "urltemplate",
+ "webpki",
+ "yasna",
+]
+
+[[package]]
+name = "librad"
+version = "0.1.0"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=7f10f3acfa1b68b38f3c7d4ea326cdf08849405c#7f10f3acfa1b68b38f3c7d4ea326cdf08849405c"
+dependencies = [
+ "async-trait",
+ "bit-vec",
+ "bs58",
+ "bytes 0.5.6",
+ "directories",
+ "dyn-clone",
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "futures_codec",
@@ -2938,7 +2994,7 @@ dependencies = [
  "http",
  "kv",
  "lazy_static",
- "librad",
+ "librad 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=7f10f3acfa1b68b38f3c7d4ea326cdf08849405c)",
  "log 0.4.8",
  "nonempty 0.5.0",
  "parity-scale-codec",
@@ -3040,7 +3096,7 @@ dependencies = [
  "anyhow",
  "git2",
  "libgit2-sys",
- "librad",
+ "librad 0.1.0 (git+https://github.com/radicle-dev/radicle-link.git?rev=55cd394b0eede746ccf4120956f0c3eaf459b073)",
  "radicle-keystore",
 ]
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -40,7 +40,7 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "55cd394b0eede746ccf4120956f0c3eaf459b073"
+rev = "7f10f3acfa1b68b38f3c7d4ea326cdf08849405c"
 
 [dependencies.radicle-git-helpers]
 git = "https://github.com/radicle-dev/radicle-link.git"

--- a/proxy/src/coco/config.rs
+++ b/proxy/src/coco/config.rs
@@ -52,14 +52,17 @@ pub type Disco = discovery::Static<std::vec::IntoIter<(peer::PeerId, SocketAddr)
 pub fn default(
     key: keys::SecretKey,
     path: impl AsRef<std::path::Path>,
-) -> Result<net::peer::PeerConfig<Disco>, error::Error> {
+) -> Result<net::peer::PeerConfig<Disco, keys::SecretKey>, error::Error> {
     let paths = paths::Paths::from_root(path)?;
     Ok(configure(paths, key))
 }
 
 /// Configure a [`net::peer::PeerConfig`].
 #[must_use]
-pub fn configure(paths: paths::Paths, key: keys::SecretKey) -> net::peer::PeerConfig<Disco> {
+pub fn configure(
+    paths: paths::Paths,
+    key: keys::SecretKey,
+) -> net::peer::PeerConfig<Disco, keys::SecretKey> {
     // TODO(finto): There should be a coco::config module that knows how to parse the
     // configs/parameters to give us back a `PeerConfig`
 
@@ -72,7 +75,7 @@ pub fn configure(paths: paths::Paths, key: keys::SecretKey) -> net::peer::PeerCo
     let disco = discovery::Static::new(seeds);
     // TODO(finto): read in from config or passed as param
     net::peer::PeerConfig {
-        key,
+        signer: key,
         paths,
         listen_addr,
         gossip_params,

--- a/proxy/src/coco/peer.rs
+++ b/proxy/src/coco/peer.rs
@@ -35,7 +35,7 @@ impl Api {
     /// If turning the config into a `Peer` fails
     /// If trying to accept on the socket fails
     pub async fn new<I>(
-        config: PeerConfig<discovery::Static<I, SocketAddr>>,
+        config: PeerConfig<discovery::Static<I, SocketAddr>, keys::SecretKey>,
     ) -> Result<Self, error::Error>
     where
         I: Iterator<Item = (PeerId, SocketAddr)> + Send + 'static,
@@ -384,7 +384,7 @@ pub fn verify_user(user: user::User<entity::Draft>) -> Result<User, error::Error
 /// Equips a repository with a rad remote for the given id. If the directory at the given path
 /// is not managed by git yet we initialise it first.
 fn setup_remote(
-    peer: &PeerApi,
+    peer: &PeerApi<keys::SecretKey>,
     path: impl AsRef<std::path::Path>,
     id: &librad::hash::Hash,
     default_branch: &str,

--- a/proxy/src/coco/peer.rs
+++ b/proxy/src/coco/peer.rs
@@ -24,7 +24,7 @@ pub type User = user::User<entity::Verified>;
 /// High-level interface to the coco monorepo and gossip layer.
 pub struct Api {
     /// Thread-safe wrapper around [`PeerApi`].
-    peer_api: Arc<Mutex<PeerApi>>,
+    peer_api: Arc<Mutex<PeerApi<keys::SecretKey>>>,
 }
 
 impl Api {


### PR DESCRIPTION
Quoting @FintanH 
> In the latest changes of librad, the method of signing was
parameterised. For now, we will fill in this parameter using the
SecretKey. In reality, it should be a parameter itself so we can choose
SecretKey for tests or a client for the main application.