### PR TITLE
feat(ui): add keyboard shortcuts

### DIFF
--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -16,7 +16,7 @@
   import IdentityCreation from "./Screen/IdentityCreation.svelte";
   import DesignSystemGuide from "./Screen/DesignSystemGuide.svelte";
   import Discovery from "./Screen/Discovery.svelte";
-  import Help from "./Screen/Help.svelte";
+  import Shortcuts from "./Screen/Shortcuts.svelte";
   import NotFound from "./Screen/NotFound.svelte";
   import Org from "./Screen/Org.svelte";
   import OrgRegistration from "./Screen/OrgRegistration.svelte";
@@ -47,7 +47,7 @@
     "/projects/:projectId/register/:domainId": ProjectRegistration,
     "/projects/:id/*": Project,
     "/design-system-guide": DesignSystemGuide,
-    "/help": Help,
+    "/shortcuts": Shortcuts,
     "/user-registration": UserRegistration,
     "/transactions/:id": TransactionDetails,
     "/send-funds": SendFunds,

--- a/ui/DesignSystem/Primitive/Button.svelte
+++ b/ui/DesignSystem/Primitive/Button.svelte
@@ -25,7 +25,7 @@
     cursor: pointer;
     display: flex;
     align-items: center;
-    height: 40px;
+    min-height: 40px;
     outline-style: none;
     padding: 0 12px;
     user-select: none;

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -29,7 +29,7 @@
     }
 
     // To open search => OS modifier key + p
-    if (OSKey && event.code === "Comma") {
+    if (OSKey && event.code === "KeyP") {
       toggle(path.search());
     }
 

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -21,7 +21,7 @@
 
     // To open help => OS modifier key + /
     if (modifierKey && event.code === "Slash") {
-      toggle(path.help());
+      toggle(path.shortcuts());
     }
 
     // To open settings => OS modifier key + ,

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -2,6 +2,7 @@
   import { location, pop, push } from "svelte-spa-router";
 
   import * as path from "./src/path.ts";
+  import { isMac } from "./src/settings.ts";
 
   const toggle = destination => {
     if (path.active(destination, $location)) {
@@ -11,9 +12,7 @@
   };
 
   const onKeydown = event => {
-    const modifierKey = navigator.platform.includes("Mac")
-      ? event.metaKey
-      : event.ctrlKey;
+    const modifierKey = isMac ? event.metaKey : event.ctrlKey;
 
     if (event.target !== document.body) {
       return false;

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -1,6 +1,5 @@
 <script>
   import { location, pop, push } from "svelte-spa-router";
-
   import * as path from "./src/path.ts";
 
   const toggle = destination => {
@@ -11,16 +10,37 @@
   };
 
   const onKeydown = event => {
+    const OSKey = navigator.platform.includes("Mac")
+      ? event.metaKey
+      : event.ctrlKey;
+
     if (event.target !== document.body) {
       return false;
     }
 
-    if (event.shiftKey && event.code === "KeyD") {
+    // To open help => OS modifier key + /
+    if (OSKey && event.code === "Slash") {
+      toggle(path.help());
+    }
+
+    // To open settings => OS modifier key + ,
+    if (OSKey && event.code === "Comma") {
+      toggle(path.settings());
+    }
+
+    // To open search => OS modifier key + p
+    if (OSKey && event.code === "Comma") {
+      toggle(path.search());
+    }
+
+    // To open design system => OS modifier key + d
+    if (OSKey && event.code === "KeyD") {
       toggle(path.designSystemGuide());
     }
 
-    if (event.shiftKey && event.code === "Slash") {
-      toggle(path.help());
+    // To create a new project => OS modifier key + n
+    if (OSKey && event.code === "KeyN") {
+      toggle(path.createProject());
     }
   };
 </script>

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -1,5 +1,6 @@
 <script>
   import { location, pop, push } from "svelte-spa-router";
+
   import * as path from "./src/path.ts";
 
   const toggle = destination => {
@@ -10,7 +11,7 @@
   };
 
   const onKeydown = event => {
-    const OSKey = navigator.platform.includes("Mac")
+    const modifierKey = navigator.platform.includes("Mac")
       ? event.metaKey
       : event.ctrlKey;
 
@@ -19,27 +20,27 @@
     }
 
     // To open help => OS modifier key + /
-    if (OSKey && event.code === "Slash") {
+    if (modifierKey && event.code === "Slash") {
       toggle(path.help());
     }
 
     // To open settings => OS modifier key + ,
-    if (OSKey && event.code === "Comma") {
+    if (modifierKey && event.code === "Comma") {
       toggle(path.settings());
     }
 
     // To open search => OS modifier key + p
-    if (OSKey && event.code === "KeyP") {
+    if (modifierKey && event.code === "KeyP") {
       toggle(path.search());
     }
 
     // To open design system => OS modifier key + d
-    if (OSKey && event.code === "KeyD") {
+    if (modifierKey && event.code === "KeyD") {
       toggle(path.designSystemGuide());
     }
 
     // To create a new project => OS modifier key + n
-    if (OSKey && event.code === "KeyN") {
+    if (modifierKey && event.code === "KeyN") {
       toggle(path.createProject());
     }
   };

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -19,7 +19,7 @@
     }
 
     // To open help => OS modifier key + /
-    if (modifierKey && event.code === "Slash") {
+    if (event.shiftKey && event.code === "Slash") {
       toggle(path.shortcuts());
     }
 

--- a/ui/Screen/Help.svelte
+++ b/ui/Screen/Help.svelte
@@ -1,5 +1,7 @@
 <script>
   import ModalLayout from "../DesignSystem/Component/ModalLayout.svelte";
+
+  const OSKey = navigator.platform.includes("Mac") ? "cmd" : "ctrl";
 </script>
 
 <style>
@@ -7,34 +9,50 @@
     margin-bottom: 16px;
   }
 
+  .shortcut:first-child {
+    margin-top: 6rem;
+  }
+
   kbd {
-    border: 1px solid var(--color-foreground-level-6);
+    border: 1px solid var(--color-foreground-level-3);
     padding: 4px 8px 4px 8px;
-    border-radius: 2px;
+    border-radius: 4px;
   }
 </style>
 
 <ModalLayout>
   <div class="shortcut">
-    <kbd>SHIFT</kbd>
+    <kbd>{OSKey}</kbd>
     +
-    <kbd>?</kbd>
+    <kbd>/</kbd>
     - help
   </div>
   <div class="shortcut">
-    <kbd>SHIFT</kbd>
+    <kbd>{OSKey}</kbd>
     +
-    <kbd>D</kbd>
+    <kbd>,</kbd>
+    - settings
+  </div>
+  <div class="shortcut">
+    <kbd>{OSKey}</kbd>
+    +
+    <kbd>d</kbd>
     - design system
   </div>
   <div class="shortcut">
-    <kbd>SHIFT</kbd>
+    <kbd>{OSKey}</kbd>
     +
-    <kbd>C</kbd>
-    - change color theme
+    <kbd>p</kbd>
+    - search
   </div>
   <div class="shortcut">
-    <kbd>ESC</kbd>
+    <kbd>{OSKey}</kbd>
+    +
+    <kbd>n</kbd>
+    - create new project
+  </div>
+  <div class="shortcut">
+    <kbd>esc</kbd>
     - close modal
   </div>
 </ModalLayout>

--- a/ui/Screen/Help.svelte
+++ b/ui/Screen/Help.svelte
@@ -1,7 +1,7 @@
 <script>
   import ModalLayout from "../DesignSystem/Component/ModalLayout.svelte";
 
-  const OSKey = navigator.platform.includes("Mac") ? "⌘" : "ctrl";
+  const modifierKeys = navigator.platform.includes("Mac") ? "⌘" : "ctrl";
 </script>
 
 <style>
@@ -22,31 +22,31 @@
 
 <ModalLayout>
   <div class="shortcut">
-    <kbd>{OSKey}</kbd>
+    <kbd>{modifierKeys}</kbd>
     +
     <kbd>/</kbd>
     - help
   </div>
   <div class="shortcut">
-    <kbd>{OSKey}</kbd>
+    <kbd>{modifierKeys}</kbd>
     +
     <kbd>,</kbd>
     - settings
   </div>
   <div class="shortcut">
-    <kbd>{OSKey}</kbd>
+    <kbd>{modifierKeys}</kbd>
     +
     <kbd>d</kbd>
     - design system
   </div>
   <div class="shortcut">
-    <kbd>{OSKey}</kbd>
+    <kbd>{modifierKeys}</kbd>
     +
     <kbd>p</kbd>
     - search
   </div>
   <div class="shortcut">
-    <kbd>{OSKey}</kbd>
+    <kbd>{modifierKeys}</kbd>
     +
     <kbd>n</kbd>
     - create new project

--- a/ui/Screen/Help.svelte
+++ b/ui/Screen/Help.svelte
@@ -1,7 +1,7 @@
 <script>
   import ModalLayout from "../DesignSystem/Component/ModalLayout.svelte";
 
-  const OSKey = navigator.platform.includes("Mac") ? "cmd" : "ctrl";
+  const OSKey = navigator.platform.includes("Mac") ? "⌘" : "ctrl";
 </script>
 
 <style>

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { link } from "svelte-spa-router";
+
   import {
     clear,
     clearCache,
@@ -9,6 +11,7 @@
     updateRegistry,
   } from "../src/session.ts";
   import { networkOptions, themeOptions } from "../src/settings.ts";
+  import * as path from "../src/path.ts";
 
   import { Button, Input } from "../DesignSystem/Primitive";
   import { SidebarLayout, SegmentedControl } from "../DesignSystem/Component";
@@ -44,15 +47,6 @@
     justify-content: space-between;
   }
 
-  section header a {
-    color: var(--color-secondary);
-    text-decoration: underline;
-  }
-
-  section header a:hover {
-    color: var(--color-secondary-level-6);
-  }
-
   .section-item {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -72,11 +66,24 @@
     align-items: center;
     margin-left: 16px;
   }
+
+  .title {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 32px;
+    align-items: flex-end;
+    padding: 0 0.75rem;
+  }
 </style>
 
 <SidebarLayout dataCy="page">
   <div class="container">
-    <h1 style="margin-bottom: 32px;">Settings</h1>
+    <div class="title">
+      <h1>Settings</h1>
+      <a class="typo-link" href={path.shortcuts()} use:link>
+        Keyboard shortcuts
+      </a>
+    </div>
 
     <section>
       <header>
@@ -118,7 +125,7 @@
       <header>
         <h3>Seeds</h3>
         <!-- TODO(sos): link to actual docs abt seeds -->
-        <a href="link/to/docs">Learn about seeds</a>
+        <a class="typo-link" href="link/to/docs">Learn about seeds</a>
       </header>
       <div class="section-item" style="align-items: flex-start;">
         <div class="info">

--- a/ui/Screen/Shortcuts.svelte
+++ b/ui/Screen/Shortcuts.svelte
@@ -25,7 +25,7 @@
     <kbd>{modifierKeys}</kbd>
     +
     <kbd>/</kbd>
-    - help
+    - shortcuts
   </div>
   <div class="shortcut">
     <kbd>{modifierKeys}</kbd>

--- a/ui/Screen/Shortcuts.svelte
+++ b/ui/Screen/Shortcuts.svelte
@@ -1,7 +1,9 @@
 <script>
+  import { isMac } from "../src/settings.ts";
+
   import ModalLayout from "../DesignSystem/Component/ModalLayout.svelte";
 
-  const modifierKeys = navigator.platform.includes("Mac") ? "⌘" : "ctrl";
+  const modifierKeys = isMac ? "⌘" : "ctrl";
 </script>
 
 <style>

--- a/ui/Screen/Shortcuts.svelte
+++ b/ui/Screen/Shortcuts.svelte
@@ -24,7 +24,7 @@
 
 <ModalLayout>
   <div class="shortcut">
-    <kbd>{modifierKeys}</kbd>
+    <kbd>shift</kbd>
     +
     <kbd>/</kbd>
     - shortcuts

--- a/ui/src/path.ts
+++ b/ui/src/path.ts
@@ -64,7 +64,7 @@ export const transactions = (id: string, viewerAccountId: string): string =>
   `/transactions/${id}?${stringify({ viewerAccountId })}`;
 
 export const designSystemGuide = (): string => "/design-system-guide";
-export const help = (): string => "/help";
+export const shortcuts = (): string => "/shortcuts";
 
 export const active = (
   path: string,

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -60,5 +60,4 @@ export const themeOptions: Option[] = [
 ];
 
 // gives back the OS you're using in hotkeys.svelte & shortcuts.svelte
-
 export const isMac: boolean = navigator.platform.includes("Mac");

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -58,3 +58,7 @@ export const themeOptions: Option[] = [
     value: Theme.Dark,
   },
 ];
+
+// gives back the OS you're using in hotkeys.svelte & shortcuts.svelte
+
+export const isMac: boolean = navigator.platform.includes("Mac");


### PR DESCRIPTION
Adds keyboard shortcuts:
// To open help => OS modifier key + /
// To open settings => OS modifier key + ,
// To open search => OS modifier key + p
// To open design system => OS modifier key + d
// To create a new project => OS modifier key + n

Also uses `cmd` key on mac and `ctrl` on other OS's for all shortcuts.

closes #756 