### PR TITLE
chore(proxy): remove needless_pass_by_value check

### DIFF
--- a/proxy/src/coco/control.rs
+++ b/proxy/src/coco/control.rs
@@ -32,8 +32,7 @@ pub fn nuke_monorepo() -> Result<(), std::io::Error> {
 ///
 /// Will error if filesystem access is not granted or broken for the configured
 /// [`librad::paths::Paths`].
-#[allow(clippy::needless_pass_by_value)] // We don't want to keep `SecretKey` in memory.
-pub fn setup_fixtures(api: &Api, key: keys::SecretKey, owner: &User) -> Result<(), error::Error> {
+pub fn setup_fixtures(api: &Api, key: &keys::SecretKey, owner: &User) -> Result<(), error::Error> {
     let infos = vec![
         ("monokel", "A looking glass into the future", "master"),
         (
@@ -56,7 +55,7 @@ pub fn setup_fixtures(api: &Api, key: keys::SecretKey, owner: &User) -> Result<(
     for info in infos {
         // let path = format!("{}/{}/{}", root, "repos", info.0);
         // std::fs::create_dir_all(path.clone())?;
-        replicate_platinum(api, &key, owner, info.0, info.1, info.2)?;
+        replicate_platinum(api, key, owner, info.0, info.1, info.2)?;
     }
 
     Ok(())
@@ -92,7 +91,7 @@ pub fn replicate_platinum(
         },
     };
 
-    let meta = api.init_project(key, owner, project_creation)?;
+    let meta = api.init_project(key, owner, &project_creation)?;
 
     // Push branches and tags.
     {
@@ -138,7 +137,7 @@ pub fn platinum_directory() -> io::Result<path::PathBuf> {
 #[must_use]
 pub fn track_fake_peer(
     api: &Api,
-    key: keys::SecretKey,
+    key: &keys::SecretKey,
     project: &project::Project<entity::Draft>,
     fake_user_handle: &str,
 ) -> (

--- a/proxy/src/coco/source.rs
+++ b/proxy/src/coco/source.rs
@@ -682,7 +682,7 @@ mod tests {
         let key = SecretKey::new();
         let config = coco::config::default(key.clone(), tmp_dir)?;
         let api = coco::Api::new(config).await?;
-        let owner = api.init_owner(key.clone(), "cloudhead")?;
+        let owner = api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &api,
             &key,

--- a/proxy/src/http/control.rs
+++ b/proxy/src/http/control.rs
@@ -109,8 +109,7 @@ mod handler {
 
         if let Some(user_handle_list) = input.fake_peers {
             for user_handle in user_handle_list {
-                let _ =
-                    coco::control::track_fake_peer(&ctx.peer_api, key.clone(), &meta, &user_handle);
+                let _ = coco::control::track_fake_peer(&ctx.peer_api, &key, &meta, &user_handle);
             }
         }
         let stats = ctx

--- a/proxy/src/http/identity.rs
+++ b/proxy/src/http/identity.rs
@@ -135,7 +135,7 @@ mod handler {
         }
 
         let key = ctx.keystore.get_librad_key().map_err(error::Error::from)?;
-        let id = identity::create(&ctx.peer_api, key, &input.handle)?;
+        let id = identity::create(&ctx.peer_api, &key, &input.handle)?;
 
         session::set_identity(&ctx.store, id.clone())?;
 
@@ -349,7 +349,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let user = ctx.peer_api.init_user(key, "cloudhead")?;
+        let user = ctx.peer_api.init_user(&key, "cloudhead")?;
         let urn = user.urn();
         let handle = user.name().to_string();
         let peer_id = ctx.peer_api.peer_id();
@@ -387,7 +387,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let id = identity::create(&ctx.peer_api, key.clone(), "cloudhead")?;
+        let id = identity::create(&ctx.peer_api, &key, "cloudhead")?;
 
         let owner = ctx.peer_api.get_user(&id.clone().urn)?;
         let owner = coco::verify_user(owner)?;
@@ -404,7 +404,7 @@ mod test {
         )?;
 
         let fintohaps: identity::Identity =
-            coco::control::track_fake_peer(&ctx.peer_api, key, &platinum_project, "fintohaps")
+            coco::control::track_fake_peer(&ctx.peer_api, &key, &platinum_project, "fintohaps")
                 .into();
 
         let res = request().method("GET").path("/").reply(&api).await;

--- a/proxy/src/http/org.rs
+++ b/proxy/src/http/org.rs
@@ -683,7 +683,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key, "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let author = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
         let handle = registry::Id::try_from("alice")?;
         let org_id = registry::Id::try_from("radicle")?;
@@ -809,7 +809,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let project_name = "upstream";
         let project_description = "desktop client for radicle";
         let default_branch = "master";

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -192,7 +192,7 @@ mod handler {
 
         let key = ctx.keystore.get_librad_key().map_err(Error::from)?;
 
-        let meta = ctx.peer_api.init_project(&key, &owner, input)?;
+        let meta = ctx.peer_api.init_project(&key, &owner, &input)?;
         let urn = meta.urn();
 
         let stats = ctx
@@ -514,7 +514,7 @@ mod test {
         let ctx = ctx.read().await;
         let handle = "cloudhead";
         let key = ctx.keystore.get_librad_key()?;
-        let id = identity::create(&ctx.peer_api, key, handle)?;
+        let id = identity::create(&ctx.peer_api, &key, handle)?;
 
         session::set_identity(&ctx.store, id.clone())?;
 
@@ -572,7 +572,7 @@ mod test {
         let ctx = ctx.read().await;
         let handle = "cloudhead";
         let key = ctx.keystore.get_librad_key()?;
-        let id = identity::create(&ctx.peer_api, key, handle)?;
+        let id = identity::create(&ctx.peer_api, &key, handle)?;
 
         session::set_identity(&ctx.store, id.clone())?;
 
@@ -628,7 +628,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -662,9 +662,9 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
 
-        coco::control::setup_fixtures(&ctx.peer_api, key, &owner)?;
+        coco::control::setup_fixtures(&ctx.peer_api, &key, &owner)?;
 
         let projects = project::list_projects(&ctx.peer_api)?;
         let res = request().method("GET").path("/").reply(&api).await;
@@ -684,9 +684,9 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
 
-        coco::control::setup_fixtures(&ctx.peer_api, key, &owner)?;
+        coco::control::setup_fixtures(&ctx.peer_api, &key, &owner)?;
 
         let res = request().method("GET").path("/discover").reply(&api).await;
         let want = json!([

--- a/proxy/src/http/source.rs
+++ b/proxy/src/http/source.rs
@@ -853,7 +853,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -988,7 +988,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -1042,7 +1042,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -1080,7 +1080,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -1134,7 +1134,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -1214,7 +1214,7 @@ mod test {
         let key = ctx.keystore.get_librad_key()?;
         let peer_id = ctx.peer_api.peer_id();
 
-        let id = identity::create(&ctx.peer_api, key.clone(), "cloudhead")?;
+        let id = identity::create(&ctx.peer_api, &key, "cloudhead")?;
 
         let owner = ctx.peer_api.get_user(&id.clone().urn)?;
         let owner = coco::verify_user(owner)?;
@@ -1232,7 +1232,7 @@ mod test {
         let urn = platinum_project.urn();
 
         let (remote, fintohaps) =
-            coco::control::track_fake_peer(&ctx.peer_api, key, &platinum_project, "fintohaps");
+            coco::control::track_fake_peer(&ctx.peer_api, &key, &platinum_project, "fintohaps");
 
         let res = request()
             .method("GET")
@@ -1289,7 +1289,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -1329,7 +1329,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,
@@ -1416,7 +1416,7 @@ mod test {
 
         let ctx = ctx.read().await;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key.clone(), "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer_api,
             &key,

--- a/proxy/src/http/user.rs
+++ b/proxy/src/http/user.rs
@@ -539,7 +539,7 @@ mod test {
         let author = radicle_registry_client::ed25519::Pair::from_legacy_string("//Alice", None);
         let handle = registry::Id::try_from("alice")?;
         let key = ctx.keystore.get_librad_key()?;
-        let owner = ctx.peer_api.init_owner(key, "cloudhead")?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
         let urn = coco::Urn::new(
             owner.root_hash().clone(),
             librad::uri::Protocol::Git,

--- a/proxy/src/identity.rs
+++ b/proxy/src/identity.rs
@@ -68,7 +68,7 @@ pub struct Metadata {
 /// # Errors
 pub fn create(
     api: &coco::Api,
-    key: keys::SecretKey,
+    key: &keys::SecretKey,
     handle: &str,
 ) -> Result<Identity, error::Error> {
     let user = api.init_owner(key, handle)?;

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -80,8 +80,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.test {
         // TODO(xla): Given that we have proper ownership and user handling in coco, we should
         // evaluate how meaningful these fixtures are.
-        let owner = coco_api.init_owner(key.clone(), "cloudhead")?;
-        coco::control::setup_fixtures(&coco_api, key, &owner).expect("fixture creation failed");
+        let owner = coco_api.init_owner(&key, "cloudhead")?;
+        coco::control::setup_fixtures(&coco_api, &key, &owner).expect("fixture creation failed");
     }
 
     let store = {

--- a/proxy/tests/checkout.rs
+++ b/proxy/tests/checkout.rs
@@ -21,7 +21,7 @@ async fn can_checkout() -> Result<(), error::Error> {
     let api = coco::Api::new(config).await?;
 
     let handle = "cloudhead";
-    let owner = api.init_owner(key.clone(), handle)?;
+    let owner = api.init_owner(&key, handle)?;
 
     let platinum_project = coco::control::replicate_platinum(
         &api,


### PR DESCRIPTION
We had a clippy warning to allow passing by value even though the
function was not consuming. This removes that pragma and fixes the
clippy and compiler errors.