### PR TITLE
chore(proxy): tests and binaries can be run with lint warnings

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -43,7 +43,7 @@ echo "--- Run proxy fmt"
 (cd proxy && time cargo fmt --all -- --check)
 
 echo "--- Run proxy lints"
-(cd proxy && time cargo clippy --all --all-features --all-targets -Z unstable-options --deny warnings)
+(cd proxy && time cargo clippy --all --all-features --all-targets -Z unstable-options -- --deny warnings)
 
 echo "--- Run app eslint checks"
 time yarn lint

--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -43,7 +43,7 @@ echo "--- Run proxy fmt"
 (cd proxy && time cargo fmt --all -- --check)
 
 echo "--- Run proxy lints"
-(cd proxy && time cargo clippy --all --all-features --all-targets -Z unstable-options)
+(cd proxy && time cargo clippy --all --all-features --all-targets -Z unstable-options --deny warnings)
 
 echo "--- Run app eslint checks"
 time yarn lint

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -1,7 +1,9 @@
 //! Proxy serving a specialized API to the Upstream UI.
 
-#![deny(missing_docs, unused_import_braces, unused_qualifications, warnings)]
-#![deny(
+#![warn(
+    missing_docs,
+    unused_import_braces,
+    unused_qualifications,
     clippy::all,
     // clippy::cargo,
     clippy::nursery,


### PR DESCRIPTION
We remove `#[deny(warnings)]` since this is [considered an anti-pattern][1]. Instead we deny warnings during CI to ensure that we only commit warning-free code.

[1]: https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md