### PR TITLE
chore(proxy): bump librad and keystore

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=18e629a8c9e8bd6d0bbd95c50c9a605b316ce04c#18e629a8c9e8bd6d0bbd95c50c9a605b316ce04c"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=e471952ec83579e313d77e5f428fa272da20fa4c#e471952ec83579e313d77e5f428fa272da20fa4c"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -3083,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "radicle-git-helpers"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=18e629a8c9e8bd6d0bbd95c50c9a605b316ce04c#18e629a8c9e8bd6d0bbd95c50c9a605b316ce04c"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=e471952ec83579e313d77e5f428fa272da20fa4c#e471952ec83579e313d77e5f428fa272da20fa4c"
 dependencies = [
  "anyhow",
  "git2",
@@ -3095,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "radicle-keystore"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-keystore.git?rev=27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6#27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
+source = "git+https://github.com/radicle-dev/radicle-keystore.git?rev=3377e666bde3130a06dd19343e7df2eaa774176a#3377e666bde3130a06dd19343e7df2eaa774176a"
 dependencies = [
  "async-trait",
  "futures 0.3.5",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -40,15 +40,15 @@ warp = { git = "https://github.com/radicle-dev/warp", branch = "openapi", featur
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "18e629a8c9e8bd6d0bbd95c50c9a605b316ce04c"
+rev = "e471952ec83579e313d77e5f428fa272da20fa4c"
 
 [dependencies.radicle-git-helpers]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "18e629a8c9e8bd6d0bbd95c50c9a605b316ce04c"
+rev = "e471952ec83579e313d77e5f428fa272da20fa4c"
 
 [dependencies.radicle-keystore]
 git = "https://github.com/radicle-dev/radicle-keystore.git"
-rev = "27c9a7b8ce5b87d2be3703f7a3290fa7a0552fc6"
+rev = "3377e666bde3130a06dd19343e7df2eaa774176a"
 
 [dependencies.radicle-registry-client]
 git = "https://github.com/radicle-dev/radicle-registry.git"


### PR DESCRIPTION
Catch up with radicle-dev/radicle-keystore#6 and
radicle-dev/radicle-link#281