### PR TITLE
fix(ui): fix remote helper export

### DIFF
--- a/ui/DesignSystem/Component/RemoteHelperHint.svelte
+++ b/ui/DesignSystem/Component/RemoteHelperHint.svelte
@@ -46,6 +46,6 @@
     .
   </p>
   <Copyable>
-    <p class="typo-text-small-mono">export PATH="~/.radicle/bin:$PATH"</p>
+    <p class="typo-text-small-mono">export PATH="$HOME/.radicle/bin:$PATH"</p>
   </Copyable>
 </div>

--- a/ui/Screen/Project/CheckoutButton.svelte
+++ b/ui/Screen/Project/CheckoutButton.svelte
@@ -38,7 +38,7 @@
     border: 1px solid var(--color-foreground-level-3);
     box-shadow: var(--elevation-medium);
     padding: 1rem;
-    width: 22.8rem;
+    width: 25rem;
   }
 
   p {


### PR DESCRIPTION
`~` never gets expanded in exports.