### PR TITLE
feat(proxy): filter projects by user URN

### DIFF
--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -1,7 +1,6 @@
 //! HTTP API delivering JSON over `RESTish` endpoints.
 
 use std::collections::HashMap;
-use std::convert::Infallible;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -1,6 +1,7 @@
 //! HTTP API delivering JSON over `RESTish` endpoints.
 
 use std::collections::HashMap;
+use std::convert::Infallible;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -701,6 +701,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[allow(clippy::indexing_slicing)]
     async fn list_for_user() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = http::Context::tmp(&tmp_dir).await?;
@@ -711,7 +712,6 @@ mod test {
         let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
 
         coco::control::setup_fixtures(&ctx.peer_api, &key, &owner)?;
-        #[allow(clippy::indexing_slicing)]
         let project = &project::list_projects(&ctx.peer_api)?[0];
         let librad_project = ctx.peer_api.get_project(&project.id, None)?;
 

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -125,7 +125,7 @@ where
     http::with_context(ctx)
         .and(warp::get())
         .and(path::end())
-        .and(http::query_default::<ListQuery>())
+        .and(http::with_qs_opt::<ListQuery>())
         .and(document::document(
             document::query("user", document::string())
                 .required(false)
@@ -245,11 +245,12 @@ mod handler {
     /// If [`super::ListUser::user`] is given we only return projects that this user tracks.
     pub async fn list<R>(
         ctx: http::Ctx<R>,
-        query: super::ListQuery,
+        opt_query: Option<super::ListQuery>,
     ) -> Result<impl Reply, Rejection>
     where
         R: Send + Sync,
     {
+        let query = opt_query.unwrap_or_default();
         let ctx = ctx.read().await;
 
         let projects = if let Some(user) = query.user {

--- a/proxy/src/http/project.rs
+++ b/proxy/src/http/project.rs
@@ -125,6 +125,12 @@ where
     http::with_context(ctx)
         .and(warp::get())
         .and(path::end())
+        .and(http::query_default::<ListQuery>())
+        .and(document::document(
+            document::query("user", document::string())
+                .required(false)
+                .description("Only list projects tracked by the user with this URN"),
+        ))
         .and(document::document(document::description("List projects")))
         .and(document::document(document::tag("Project")))
         .and(document::document(
@@ -235,12 +241,22 @@ mod handler {
     }
 
     /// List all known projects.
-    pub async fn list<R>(ctx: http::Ctx<R>) -> Result<impl Reply, Rejection>
+    ///
+    /// If [`super::ListUser::user`] is given we only return projects that this user tracks.
+    pub async fn list<R>(
+        ctx: http::Ctx<R>,
+        query: super::ListQuery,
+    ) -> Result<impl Reply, Rejection>
     where
         R: Send + Sync,
     {
         let ctx = ctx.read().await;
-        let projects = project::list_projects(&ctx.peer_api)?;
+
+        let projects = if let Some(user) = query.user {
+            project::list_projects_for_user(&ctx.peer_api, &user)?
+        } else {
+            project::list_projects(&ctx.peer_api)?
+        };
 
         Ok(reply::json(&projects))
     }
@@ -488,6 +504,13 @@ impl ToDocumentedType for MetadataInput {
     }
 }
 
+/// Query options for listing projects.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ListQuery {
+    /// Only include projects tracked by this user
+    user: Option<coco::Urn>,
+}
+
 #[allow(clippy::panic, clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
@@ -671,6 +694,38 @@ mod test {
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
             assert_eq!(have, json!(projects));
+        });
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_for_user() -> Result<(), error::Error> {
+        let tmp_dir = tempfile::tempdir()?;
+        let ctx = http::Context::tmp(&tmp_dir).await?;
+        let api = super::filters(ctx.clone());
+
+        let ctx = ctx.read().await;
+        let key = ctx.keystore.get_librad_key()?;
+        let owner = ctx.peer_api.init_owner(&key, "cloudhead")?;
+
+        coco::control::setup_fixtures(&ctx.peer_api, &key, &owner)?;
+        #[allow(clippy::indexing_slicing)]
+        let project = &project::list_projects(&ctx.peer_api)?[0];
+        let librad_project = ctx.peer_api.get_project(&project.id, None)?;
+
+        let fintohaps: identity::Identity =
+            coco::control::track_fake_peer(&ctx.peer_api, &key, &librad_project, "fintohaps")
+                .into();
+
+        let res = request()
+            .method("GET")
+            .path(&format!("/?user={}", fintohaps.urn))
+            .reply(&api)
+            .await;
+
+        http::test::assert_response(&res, StatusCode::OK, |have| {
+            assert_eq!(have, json!(vec![project]));
         });
 
         Ok(())


### PR DESCRIPTION
We add the `user` query parameter to the `GET /projects` endpoint. If provided only projects that are tracked by the given user are returned.

Closes #741