### PR TITLE
fix(ui): Accessible hotkeys for other layouts

### DIFF
--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -20,8 +20,8 @@
       return false;
     }
 
-    // To open help => OS modifier key + h
-    if (modifierKey && event.key === "h") {
+    // To open help => ?
+    if (event.key === "?") {
       toggle(path.shortcuts());
     }
 

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -11,35 +11,37 @@
     push(destination);
   };
 
+  // Don’t forget to update `ui/Secreen/Shortcuts.svelte` if you update the key
+  // bindings.
   const onKeydown = event => {
     const modifierKey = isMac ? event.metaKey : event.ctrlKey;
 
-    if (event.target !== document.body) {
+    if (event.target !== document.body || event.repeat) {
       return false;
     }
 
-    // To open help => OS modifier key + /
-    if (event.shiftKey && event.code === "Slash") {
+    // To open help => OS modifier key + h
+    if (modifierKey && event.key === "h") {
       toggle(path.shortcuts());
     }
 
     // To open settings => OS modifier key + ,
-    if (modifierKey && event.code === "Comma") {
+    if (modifierKey && event.key === ",") {
       toggle(path.settings());
     }
 
     // To open search => OS modifier key + p
-    if (modifierKey && event.code === "KeyP") {
+    if (modifierKey && event.key === "p") {
       toggle(path.search());
     }
 
     // To open design system => OS modifier key + d
-    if (modifierKey && event.code === "KeyD") {
+    if (modifierKey && event.key === "d") {
       toggle(path.designSystemGuide());
     }
 
     // To create a new project => OS modifier key + n
-    if (modifierKey && event.code === "KeyN") {
+    if (modifierKey && event.key === "n") {
       toggle(path.createProject());
     }
   };

--- a/ui/Screen/Shortcuts.svelte
+++ b/ui/Screen/Shortcuts.svelte
@@ -24,9 +24,9 @@
 
 <ModalLayout>
   <div class="shortcut">
-    <kbd>shift</kbd>
+    <kbd>{modifierKeys}</kbd>
     +
-    <kbd>/</kbd>
+    <kbd>h</kbd>
     - shortcuts
   </div>
   <div class="shortcut">

--- a/ui/Screen/Shortcuts.svelte
+++ b/ui/Screen/Shortcuts.svelte
@@ -24,9 +24,7 @@
 
 <ModalLayout>
   <div class="shortcut">
-    <kbd>{modifierKeys}</kbd>
-    +
-    <kbd>h</kbd>
+    <kbd>?</kbd>
     - shortcuts
   </div>
   <div class="shortcut">

--- a/ui/Screen/Shortcuts.svelte
+++ b/ui/Screen/Shortcuts.svelte
@@ -3,7 +3,7 @@
 
   import ModalLayout from "../DesignSystem/Component/ModalLayout.svelte";
 
-  const modifierKeys = isMac ? "⌘" : "ctrl";
+  const modifierKey = isMac ? "⌘" : "ctrl";
 </script>
 
 <style>
@@ -28,25 +28,25 @@
     - shortcuts
   </div>
   <div class="shortcut">
-    <kbd>{modifierKeys}</kbd>
+    <kbd>{modifierKey}</kbd>
     +
     <kbd>,</kbd>
     - settings
   </div>
   <div class="shortcut">
-    <kbd>{modifierKeys}</kbd>
+    <kbd>{modifierKey}</kbd>
     +
     <kbd>d</kbd>
     - design system
   </div>
   <div class="shortcut">
-    <kbd>{modifierKeys}</kbd>
+    <kbd>{modifierKey}</kbd>
     +
     <kbd>p</kbd>
     - search
   </div>
   <div class="shortcut">
-    <kbd>{modifierKeys}</kbd>
+    <kbd>{modifierKey}</kbd>
     +
     <kbd>n</kbd>
     - create new project


### PR DESCRIPTION
* Hotkeys dispatch uses `KeyboardEvent.key` instead of `KeyboardEvent.code` which does not respect the keyboard layout.
* Use Cmd/Ctrl+h for hotkey list instead of shift+/ which is hard to type on non-US layouts.
* Prevent fast toggling on repeat presses