### PR TITLE
feat(ui): lock screen during long backend activity

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -30,3 +30,11 @@ a {
   --content-padding: 2rem;
   --content-max-width: 90rem;
 }
+
+.lock-screen > * {
+  pointer-events: none;
+}
+
+.lock-screen {
+  cursor: wait;
+}

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -8,6 +8,7 @@
   import { checkout } from "../../src/project.ts";
   import * as notification from "../../src/notification.ts";
   import * as path from "../../src/path.ts";
+  import * as screen from "../../src/screen.ts";
   import { project as projectStore } from "../../src/project.ts";
   import * as remote from "../../src/remote.ts";
   import { Variant as IllustrationVariant } from "../../src/illustration.ts";
@@ -81,6 +82,7 @@
 
   const handleCheckout = async event => {
     try {
+      screen.lock();
       const path = await checkout(
         id,
         event.detail.checkoutDirectoryPath,
@@ -98,6 +100,8 @@
       );
     } catch (error) {
       notification.error(`Checkout failed: ${error.message}`, true);
+    } finally {
+      screen.unLock();
     }
   };
 

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -101,7 +101,7 @@
     } catch (error) {
       notification.error(`Checkout failed: ${error.message}`, true);
     } finally {
-      screen.unLock();
+      screen.unlock();
     }
   };
 

--- a/ui/Screen/ProjectCreation.svelte
+++ b/ui/Screen/ProjectCreation.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onDestroy } from "svelte";
   import { pop, push } from "svelte-spa-router";
   import validatejs from "validate.js";
 
@@ -8,6 +9,7 @@
   import { create, RepoType } from "../src/project.ts";
   import { getLocalState } from "../src/source.ts";
   import { getValidationState } from "../src/validation.ts";
+  import * as screen from "../src/screen.ts";
   import {
     dismissRemoteHelperHint,
     fetch as fetchSession,
@@ -37,6 +39,8 @@
 
   let validations = false;
   let beginValidation = false;
+
+  let loading = false;
 
   validatejs.options = {
     fullMessages: false,
@@ -147,6 +151,9 @@
     let response;
 
     try {
+      loading = true;
+      screen.lock();
+
       response = await create({
         description,
         defaultBranch,
@@ -168,8 +175,18 @@
       notification.error(
         `Could not create project: ${shortenUrn(error.message)}`
       );
+    } finally {
+      loading = false;
+      screen.unLock();
     }
   };
+
+  // We unlock the screen already after the request, this is just a fail-safe
+  // to make sure the screen gets unlocked in any case when the component gets
+  // destroyed.
+  onDestroy(() => {
+    screen.unLock();
+  });
 
   const shortenUrn = string => {
     return string.replace(/(rad:git:[\w]{3})[\w]{53}([\w]{3})/, "$1…$2");
@@ -368,7 +385,7 @@
             </Button>
             <Button
               dataCy="create-project-button"
-              disabled={!(name && currentSelection)}
+              disabled={!(name && currentSelection) || loading}
               variant="primary"
               on:click={createProject}>
               Create project

--- a/ui/Screen/ProjectCreation.svelte
+++ b/ui/Screen/ProjectCreation.svelte
@@ -177,7 +177,7 @@
       );
     } finally {
       loading = false;
-      screen.unLock();
+      screen.unlock();
     }
   };
 
@@ -185,7 +185,7 @@
   // to make sure the screen gets unlocked in any case when the component gets
   // destroyed.
   onDestroy(() => {
-    screen.unLock();
+    screen.unlock();
   });
 
   const shortenUrn = string => {

--- a/ui/src/screen.ts
+++ b/ui/src/screen.ts
@@ -2,6 +2,6 @@ export const lock = (): void => {
   document.documentElement.classList.add("lock-screen");
 };
 
-export const unLock = (): void => {
+export const unlock = (): void => {
   document.documentElement.classList.remove("lock-screen");
 };

--- a/ui/src/screen.ts
+++ b/ui/src/screen.ts
@@ -1,0 +1,7 @@
+export const lock = (): void => {
+  document.documentElement.classList.add("lock-screen");
+};
+
+export const unLock = (): void => {
+  document.documentElement.classList.remove("lock-screen");
+};


### PR DESCRIPTION
This locks the project creation modal and the project checkout flow while waiting for proxy to finish the request.

It's a stop-gap solution for: https://github.com/radicle-dev/radicle-upstream/issues/650 and https://github.com/radicle-dev/radicle-upstream/issues/512.

![lock2](https://user-images.githubusercontent.com/158411/91190821-4c049980-e6f4-11ea-862a-8c1ed2ce3d7b.gif)

![lock](https://user-images.githubusercontent.com/158411/91189565-dfd56600-e6f2-11ea-9d72-e4b5c588ac32.gif)

NB: the cursor looks broken only in the screengrab. It looks like this in reality:

<img width="46" alt="Screenshot 2020-08-25 at 16 50 19" src="https://user-images.githubusercontent.com/158411/91189796-2925b580-e6f3-11ea-873a-866a6fa342cc.png">




Inspired by: https://github.com/radicle-dev/radicle-upstream/pull/566.