### PR TITLE
fix(ui): improve checkout error message

### DIFF
--- a/cypress/integration/project_checkout.spec.js
+++ b/cypress/integration/project_checkout.spec.js
@@ -112,6 +112,24 @@ context("project checkout", () => {
         cy.exec(`git -C ${checkoutPath}/platinum remote show`).then(result => {
           expect(result.stdout).to.equal(`rad`);
         });
+
+        // Make sure we can't check out a project to the same directory twice.
+        cy.pick("checkout-modal-toggle").click();
+
+        cy.pick("choose-path-button").click();
+        // Make sure UI has time to update path value from stub,
+        // prevents this spec from failing on CI.
+        cy.wait(500);
+
+        // Perform the checkout.
+        cy.pick("checkout-button").click();
+
+        // Notification should contain the full path to the working directory.
+        cy.pick("notification")
+          .contains(
+            /Checkout failed: '.*checkout\/platinum' exists and is not an empty directory/
+          )
+          .should("exist");
       });
     });
   });

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -137,6 +137,13 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
                         )
                     },
                 },
+                error::Error::Checkout(checkout_error) => match checkout_error {
+                    coco::project::checkout::Error::Git(git_error) => (
+                        StatusCode::CONFLICT,
+                        "WORKING_DIRECTORY_EXISTS",
+                        git_error.message().to_string(),
+                    ),
+                },
                 _ => {
                     // TODO(xla): Match all variants and properly transform similar to
                     // gaphql::error.


### PR DESCRIPTION
We disallow checking out a project to the same directory more than once.
This improves the error message.

Before:
<img width="427" alt="Screenshot 2020-08-26 at 14 13 01" src="https://user-images.githubusercontent.com/158411/91303094-cb9f7080-e7a7-11ea-8d78-13ca84ad9b81.png">

After:
<img width="970" alt="Screenshot 2020-08-26 at 14 12 01" src="https://user-images.githubusercontent.com/158411/91303089-c9d5ad00-e7a7-11ea-8e46-ce159b087ea9.png">
