### PR TITLE
fix(proxy): project creation from repo without master

### DIFF
--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -512,10 +512,8 @@ pub struct LocalState {
 ///
 /// Will return [`Error`] if the repository doesn't exist.
 pub fn local_state(repo_path: &str) -> Result<LocalState, Error> {
-    let repo = git::Repository::new(repo_path)?;
-
-    let repoo = git2::Repository::open(repo_path)?;
-    let first_branch = repoo
+    let repo = git2::Repository::open(repo_path)?;
+    let first_branch = repo
         .branches(Some(git2::BranchType::Local))?
         .filter_map(|branch_result| {
             let branch = match branch_result {
@@ -531,7 +529,12 @@ pub fn local_state(repo_path: &str) -> Result<LocalState, Error> {
         .min()
         .expect("Could not find any branches.");
 
-    println!("first_branch: {:?}", first_branch);
+    log::debug!(
+        "The fallback branch for this repository is: {:?}",
+        first_branch
+    );
+
+    let repo = git::Repository::new(repo_path)?;
 
     let browser = match Browser::new(&repo, git::Branch::local("master")) {
         Ok(browser) => browser,

--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -516,15 +516,9 @@ pub fn local_state(repo_path: &str) -> Result<LocalState, Error> {
     let first_branch = repo
         .branches(Some(git2::BranchType::Local))?
         .filter_map(|branch_result| {
-            let branch = match branch_result {
-                Ok(s) => s,
-                Err(_) => return None,
-            };
-
-            match branch.0.name() {
-                Ok(Some(n)) => Some(n.to_owned()),
-                Ok(None) | Err(_) => None,
-            }
+            let (branch, _) = branch_result.ok()?;
+            let name = branch.name().ok()?;
+            name.map(String::from)
         })
         .min()
         .expect("Could not find any branches.");

--- a/ui/Screen/ProjectCreation.svelte
+++ b/ui/Screen/ProjectCreation.svelte
@@ -214,6 +214,9 @@
 
     try {
       localState = await getLocalState(path);
+      if (!localState.branches.includes(defaultBranch)) {
+        defaultBranch = localState.branches[0];
+      }
     } catch (error) {
       localStateError = error.message;
     }


### PR DESCRIPTION
It failed because the surf `Browser` has to be initialised with a revision. This revision was set to "master" by default.
The workaround for now is to fall back to the first branch of the repository, if it doesn't have a "master" branch.

Closes: https://github.com/radicle-dev/radicle-upstream/issues/821.