### PR TITLE
refactor(proxy): extract context

### DIFF
--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -28,6 +28,12 @@ pub struct Context {
 }
 
 impl Context {
+    /// Initialises a new [`Ctx`] the given temporary directory.
+    ///
+    /// # Errors
+    ///
+    /// * coco key creation fails
+    /// * creation of the [`kv::Store`] fails
     #[cfg(test)]
     pub async fn tmp(tmp_dir: &tempfile::TempDir) -> Result<Ctx, crate::error::Error> {
         let paths = librad::paths::Paths::from_root(tmp_dir.path())?;

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -1,0 +1,86 @@
+//! Datastructure and machinery to safely share the common dependencies across components.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use librad::paths;
+
+use crate::keystore;
+
+/// Wrapper around the thread-safe handle on [`Context`].
+pub type Ctx = Arc<RwLock<Context>>;
+
+/// Container to pass down dependencies into HTTP filter chains.
+pub struct Context {
+    /// [`coco::Api`] to operate on the local monorepo.
+    pub peer_api: coco::Api,
+    /// Storage to manage keys.
+    pub keystore: keystore::Keystorage,
+    /// [`kv::Store`] used for session state and cache.
+    pub store: kv::Store,
+}
+
+impl Context {
+    #[cfg(test)]
+    pub async fn tmp(tmp_dir: &tempfile::TempDir) -> Result<Ctx, crate::error::Error> {
+        let paths = librad::paths::Paths::from_root(tmp_dir.path())?;
+
+        let pw = keystore::SecUtf8::from("radicle-upstream");
+        let mut keystore = keystore::Keystorage::new(&paths, pw);
+        let key = keystore.init_librad_key()?;
+
+        let peer_api = {
+            let config = coco::config::default(key, tmp_dir.path())?;
+            coco::Api::new(config).await?
+        };
+
+        let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store")))?;
+
+        Ok(Arc::new(RwLock::new(Self {
+            keystore,
+            peer_api,
+            store,
+        })))
+    }
+}
+
+/// Resets the peer and keystore within the `Ctx`.
+///
+/// # Errors
+///
+///   * If we could not get the librad path.
+///   * If we could not initialise the librad key.
+///   * If we could not construct the peer API.
+///
+/// # Panics
+///
+///   * If we could not get the temporary directory.
+pub async fn reset_ctx_peer(ctx: Ctx) -> Result<(), crate::error::Error> {
+    // TmpDir deletes the temporary directory once it DROPS.
+    // This means our new directory goes missing, and future calls will fail.
+    // The Peer creates the directory again.
+    //
+    // N.B. this may gather lot's of tmp files on your system. We're sorry.
+    let tmp_path = {
+        let temp_dir = tempfile::tempdir().expect("test dir creation failed");
+        log::debug!("New temporary path is: {:?}", temp_dir.path());
+        std::env::set_var("RAD_HOME", temp_dir.path());
+        temp_dir.path().to_path_buf()
+    };
+
+    let paths = paths::Paths::from_root(tmp_path)?;
+
+    let pw = keystore::SecUtf8::from("radicle-upstream");
+    let mut new_keystore = keystore::Keystorage::new(&paths, pw);
+    let key = new_keystore.init_librad_key()?;
+
+    let config = coco::config::configure(paths, key.clone(), *coco::config::LOCALHOST_ANY, vec![]);
+    let new_peer_api = coco::Api::new(config).await?;
+
+    let mut ctx = ctx.write().await;
+    ctx.peer_api = new_peer_api;
+    ctx.keystore = new_keystore;
+
+    Ok(())
+}

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -11,6 +11,12 @@ use crate::keystore;
 /// Wrapper around the thread-safe handle on [`Context`].
 pub type Ctx = Arc<RwLock<Context>>;
 
+impl From<Context> for Ctx {
+    fn from(ctx: Context) -> Self {
+        Arc::new(RwLock::new(ctx))
+    }
+}
+
 /// Container to pass down dependencies into HTTP filter chains.
 pub struct Context {
     /// [`coco::Api`] to operate on the local monorepo.

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -1,14 +1,10 @@
 //! HTTP API delivering JSON over `RESTish` endpoints.
 
-use std::sync::Arc;
-
 use serde::Deserialize;
-use tokio::sync::RwLock;
 use warp::filters::BoxedFilter;
 use warp::{path, reject, Filter, Rejection, Reply};
 
 use crate::context;
-use crate::keystore;
 
 mod avatar;
 mod control;
@@ -38,18 +34,9 @@ macro_rules! combine {
 
 /// Main entry point for HTTP API.
 pub fn api(
-    peer_api: coco::Api,
-    keystore: keystore::Keystorage,
-    store: kv::Store,
+    ctx: context::Ctx,
     enable_control: bool,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    let ctx = context::Context {
-        peer_api,
-        keystore,
-        store,
-    };
-    let ctx = Arc::new(RwLock::new(ctx));
-
     let avatar_filter = path("avatars").and(avatar::get_filter());
     let control_filter = path("control")
         .map(move || enable_control)

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -8,11 +8,12 @@ use warp::filters::BoxedFilter;
 use warp::{path, Filter, Rejection, Reply};
 
 use crate::avatar;
+use crate::context;
 use crate::http;
 use crate::identity;
 
 /// Combination of all identity routes.
-pub fn filters(ctx: http::Ctx) -> BoxedFilter<(impl Reply,)> {
+pub fn filters(ctx: context::Ctx) -> BoxedFilter<(impl Reply,)> {
     get_filter(Arc::clone(&ctx))
         .or(create_filter(Arc::clone(&ctx)))
         .or(list_filter(ctx))
@@ -20,7 +21,9 @@ pub fn filters(ctx: http::Ctx) -> BoxedFilter<(impl Reply,)> {
 }
 
 /// `POST /`
-fn create_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+fn create_filter(
+    ctx: context::Ctx,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     http::with_context(ctx)
         .and(warp::post())
         .and(warp::body::json())
@@ -42,7 +45,7 @@ fn create_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Re
 }
 
 /// `GET /<id>`
-fn get_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+fn get_filter(ctx: context::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     http::with_context(ctx)
         .and(document::param::<coco::Urn>(
             "id",
@@ -71,7 +74,7 @@ fn get_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejec
 }
 
 /// `GET /`
-fn list_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+fn list_filter(ctx: context::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     http::with_context(ctx)
         .and(warp::get())
         .and(path::end())
@@ -95,14 +98,14 @@ mod handler {
     use warp::http::StatusCode;
     use warp::{reply, Rejection, Reply};
 
+    use crate::context;
     use crate::error;
-    use crate::http;
     use crate::identity;
     use crate::session;
 
     /// Create a new [`identity::Identity`].
     pub async fn create(
-        ctx: http::Ctx,
+        ctx: context::Ctx,
         input: super::CreateInput,
     ) -> Result<impl Reply, Rejection> {
         let ctx = ctx.read().await;
@@ -122,14 +125,14 @@ mod handler {
     }
 
     /// Get the [`identity::Identity`] for the given `id`.
-    pub async fn get(ctx: http::Ctx, id: coco::Urn) -> Result<impl Reply, Rejection> {
+    pub async fn get(ctx: context::Ctx, id: coco::Urn) -> Result<impl Reply, Rejection> {
         let ctx = ctx.read().await;
         let id = identity::get(&ctx.peer_api, &id)?;
         Ok(reply::json(&id))
     }
 
     /// Retrieve the list of identities known to the session user.
-    pub async fn list(ctx: http::Ctx) -> Result<impl Reply, Rejection> {
+    pub async fn list(ctx: context::Ctx) -> Result<impl Reply, Rejection> {
         let ctx = ctx.read().await;
         let users = identity::list(&ctx.peer_api)?;
         Ok(reply::json(&users))
@@ -257,6 +260,7 @@ mod test {
     use warp::test::request;
 
     use crate::avatar;
+    use crate::context;
     use crate::error;
     use crate::http;
     use crate::identity;
@@ -265,7 +269,7 @@ mod test {
     #[tokio::test]
     async fn create() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let ctx = http::Context::tmp(&tmp_dir).await?;
+        let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
         let res = request()
@@ -313,7 +317,7 @@ mod test {
     #[tokio::test]
     async fn get() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let ctx = http::Context::tmp(&tmp_dir).await?;
+        let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
         let ctx = ctx.read().await;
@@ -349,7 +353,7 @@ mod test {
     #[tokio::test]
     async fn list() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let ctx = http::Context::tmp(&tmp_dir).await?;
+        let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
         let ctx = ctx.read().await;

--- a/proxy/api/src/http/session.rs
+++ b/proxy/api/src/http/session.rs
@@ -5,12 +5,13 @@ use warp::document::{self, ToDocumentedType};
 use warp::filters::BoxedFilter;
 use warp::{path, Filter, Rejection, Reply};
 
+use crate::context;
 use crate::http;
 use crate::identity;
 use crate::session;
 
 /// Combination of all session filters.
-pub fn filters(ctx: http::Ctx) -> BoxedFilter<(impl Reply,)> {
+pub fn filters(ctx: context::Ctx) -> BoxedFilter<(impl Reply,)> {
     delete_filter(ctx.clone())
         .or(get_filter(ctx.clone()))
         .or(update_settings_filter(ctx))
@@ -18,7 +19,9 @@ pub fn filters(ctx: http::Ctx) -> BoxedFilter<(impl Reply,)> {
 }
 
 /// `DELETE /`
-fn delete_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+fn delete_filter(
+    ctx: context::Ctx,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::delete()
         .and(path::end())
         .and(http::with_context(ctx))
@@ -33,7 +36,7 @@ fn delete_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Re
 }
 
 /// `GET /`
-fn get_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+fn get_filter(ctx: context::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::get()
         .and(path::end())
         .and(http::with_context(ctx))
@@ -53,7 +56,7 @@ fn get_filter(ctx: http::Ctx) -> impl Filter<Extract = impl Reply, Error = Rejec
 
 /// `Post /settings`
 fn update_settings_filter(
-    ctx: http::Ctx,
+    ctx: context::Ctx,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path("settings")
         .and(warp::post())
@@ -73,11 +76,11 @@ mod handler {
     use warp::http::StatusCode;
     use warp::{reply, Rejection, Reply};
 
-    use crate::http;
+    use crate::context;
     use crate::session;
 
     /// Clear the current [`session::Session`].
-    pub async fn delete(ctx: http::Ctx) -> Result<impl Reply, Rejection> {
+    pub async fn delete(ctx: context::Ctx) -> Result<impl Reply, Rejection> {
         let ctx = ctx.read().await;
         session::clear_current(&ctx.store)?;
 
@@ -85,7 +88,7 @@ mod handler {
     }
 
     /// Fetch the [`session::Session`].
-    pub async fn get(ctx: http::Ctx) -> Result<impl Reply, Rejection> {
+    pub async fn get(ctx: context::Ctx) -> Result<impl Reply, Rejection> {
         let ctx = ctx.read().await;
 
         let sess = session::current(&ctx.peer_api, &ctx.store).await?;
@@ -95,7 +98,7 @@ mod handler {
 
     /// Set the [`session::settings::Settings`] to the passed value.
     pub async fn update_settings(
-        ctx: http::Ctx,
+        ctx: context::Ctx,
         settings: session::settings::Settings,
     ) -> Result<impl Reply, Rejection> {
         let ctx = ctx.read().await;
@@ -155,14 +158,14 @@ mod test {
     use warp::http::StatusCode;
     use warp::test::request;
 
+    use crate::context;
     use crate::error;
-    use crate::http;
     use crate::session;
 
     #[tokio::test]
     async fn delete() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let ctx = http::Context::tmp(&tmp_dir).await?;
+        let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
         let ctx = ctx.read().await;
@@ -188,7 +191,7 @@ mod test {
     #[tokio::test]
     async fn get() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let ctx = http::Context::tmp(&tmp_dir).await?;
+        let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
         let res = request().method("GET").path("/").reply(&api).await;
@@ -220,7 +223,7 @@ mod test {
     #[tokio::test]
     async fn update_settings() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let ctx = http::Context::tmp(&tmp_dir).await?;
+        let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
         let mut settings = session::settings::Settings::default();

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -147,7 +147,7 @@ mod handler {
         let default_branch = match peer_id {
             Some(peer_id) if peer_id != ctx.peer_api.peer_id() => {
                 git::Branch::remote(project.default_branch(), &peer_id.to_string())
-            }
+            },
             Some(_) | None => git::Branch::local(project.default_branch()),
         };
 
@@ -283,7 +283,7 @@ mod handler {
         let default_branch = match peer_id {
             Some(peer_id) if peer_id != ctx.peer_api.peer_id() => {
                 git::Branch::remote(project.default_branch(), &peer_id.to_string())
-            }
+            },
             Some(_) | None => git::Branch::local(project.default_branch()),
         };
 

--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -27,6 +27,7 @@
 
 pub mod avatar;
 pub mod config;
+pub mod context;
 pub mod env;
 pub mod error;
 pub mod http;


### PR DESCRIPTION
As more components will rely on access to common dependencies we need a safe way to share them, beyond just the http subs-system. By extracting the context machinery into a top-level module it is not part of the http domain anymore, which not just depends on an already constructed `Ctx` instead of constructing one on the spot.

Part of #602 