### PR TITLE
refactor(proxy): Simplify with_protocol

### DIFF
--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -127,14 +127,8 @@ async fn announce(ctx: context::Ctx) -> Result<(), Box<dyn std::error::Error>> {
     let updates = announcement::diff(&old, &new);
     let count = updates.len();
 
-    {
-        let updates = updates.clone();
-        ctx.peer_api
-            .with_protocol(|protocol| {
-                Box::pin(async move { announcement::announce(protocol, updates.iter()).await })
-            })
-            .await?;
-    }
+    let updates = updates.clone();
+    announcement::announce(ctx.peer_api.protocol(), updates.iter()).await?;
 
     session::announcements::save(&ctx.store, updates)?;
     log::debug!("announced {} updates", count);

--- a/proxy/coco/src/announcement.rs
+++ b/proxy/coco/src/announcement.rs
@@ -112,11 +112,7 @@ mod test {
 
         // TODO(xla): Build up proper testnet to assert that haves are announced.
         let updates = super::build(&api)?;
-        let res = api
-            .with_protocol(|protocol| {
-                Box::pin(async move { super::announce(protocol, updates.iter()).await })
-            })
-            .await;
+        let res = super::announce(api.protocol(), updates.iter()).await;
 
         assert!(res.is_ok());
 

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -5,7 +5,6 @@ use std::net::SocketAddr;
 use std::path::{self, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use futures::future::BoxFuture;
 use futures::stream::StreamExt;
 
 use librad::git::local::{transport, url::LocalUrl};
@@ -376,21 +375,10 @@ impl Api {
     }
 
     /// Get the underlying [`librad::net::protocol::Protocol`].
-    ///
-    /// # Errors
-    ///
-    /// * if they `callback` errors
-    pub fn with_protocol<F, T>(&self, callback: F) -> BoxFuture<'static, Result<T, Error>>
-    where
-        T: 'static,
-        F: Send
-            + FnOnce(
-                Protocol<PeerStorage<keys::SecretKey>, Gossip>,
-            ) -> BoxFuture<'static, Result<T, Error>>,
-    {
+    #[must_use]
+    pub fn protocol(&self) -> Protocol<PeerStorage<keys::SecretKey>, Gossip> {
         let api = self.peer_api.lock().expect("unable to acquire lock");
-
-        Box::pin(callback(api.protocol().clone()))
+        api.protocol().clone()
     }
 
     /// Initialize a [`librad_project::Project`] that is owned by the `owner`.


### PR DESCRIPTION
The function `with_protocol` in `coco` can just be a simple delegated
getter to the underlying coco peer api. No need to receive a function as an
argument and operate on BoxFuture.

Triggering context: https://github.com/radicle-dev/radicle-upstream/pull/875#discussion_r484342112