### PR TITLE
chore(proxy): rustfmt merge_imports

### DIFF
--- a/proxy/.rustfmt.toml
+++ b/proxy/.rustfmt.toml
@@ -5,6 +5,7 @@ comment_width = 100
 wrap_comments = true
 
 # imports
+merge_imports = true
 reorder_imports = true
 
 # strings

--- a/proxy/api/src/bin/nuke.rs
+++ b/proxy/api/src/bin/nuke.rs
@@ -1,13 +1,10 @@
-use std::fs::remove_dir_all;
-use std::io::ErrorKind;
-use std::process::exit;
+use std::{fs::remove_dir_all, io::ErrorKind, process::exit};
 
 use log::{info, trace};
 
 use coco::control;
 
-use api::config;
-use api::env;
+use api::{config, env};
 
 fn main() {
     env::set_if_unset("RUST_BACKTRACE", "full");

--- a/proxy/api/src/config.rs
+++ b/proxy/api/src/config.rs
@@ -1,9 +1,6 @@
 //! Configuration vital to the setup and alteration of the application.
 
-use std::env;
-use std::ffi;
-use std::io;
-use std::path;
+use std::{env, ffi, io, path};
 
 use directories::ProjectDirs;
 

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
-use coco::keystore;
-use coco::signer;
+use coco::{keystore, signer};
 
 /// Wrapper around the thread-safe handle on [`Context`].
 pub type Ctx = Arc<RwLock<Context>>;

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -1,11 +1,9 @@
 //! HTTP API delivering JSON over `RESTish` endpoints.
 
 use serde::Deserialize;
-use warp::filters::BoxedFilter;
-use warp::{path, reject, Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, path, reject, Filter, Rejection, Reply};
 
-use crate::context;
-use crate::notification::Subscriptions;
+use crate::{context, notification::Subscriptions};
 
 mod avatar;
 mod control;

--- a/proxy/api/src/http/avatar.rs
+++ b/proxy/api/src/http/avatar.rs
@@ -1,8 +1,7 @@
 //! Endpoints for Avatar.
 
 use serde::Deserialize;
-use warp::filters::BoxedFilter;
-use warp::{path, Filter, Reply};
+use warp::{filters::BoxedFilter, path, Filter, Reply};
 
 /// `GET /<id>?usage=<usage>`
 pub fn get_filter() -> BoxedFilter<(impl Reply,)> {
@@ -16,11 +15,9 @@ pub fn get_filter() -> BoxedFilter<(impl Reply,)> {
 
 /// Avatar handlers for conversion between core domain and http request fullfilment.
 mod handler {
-    use warp::http::StatusCode;
-    use warp::{reply, Rejection, Reply};
+    use warp::{http::StatusCode, reply, Rejection, Reply};
 
-    use crate::avatar;
-    use crate::http::error;
+    use crate::{avatar, http::error};
 
     /// Get the avatar for the given `id`.
     #[allow(clippy::wildcard_enum_match_arm)]
@@ -61,8 +58,7 @@ pub struct GetAvatarQuery {
 mod test {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
-    use warp::http::StatusCode;
-    use warp::test::request;
+    use warp::{http::StatusCode, test::request};
 
     #[tokio::test]
     async fn get() {

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -1,8 +1,7 @@
 //! Endpoints to manipulate app state in test mode.
 
 use serde::{Deserialize, Serialize};
-use warp::filters::BoxedFilter;
-use warp::{path, Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
 use crate::context;
 
@@ -35,15 +34,11 @@ fn nuke_coco_filter(
 
 /// Control handlers for conversion between core domain and http request fulfilment.
 mod handler {
-    use warp::http::StatusCode;
-    use warp::{reply, Rejection, Reply};
+    use warp::{http::StatusCode, reply, Rejection, Reply};
 
-    use coco::keystore;
-    use coco::signer;
+    use coco::{keystore, signer};
 
-    use crate::context;
-    use crate::error;
-    use crate::project;
+    use crate::{context, error, project};
 
     /// Create a project from the fixture repo.
     #[allow(clippy::let_underscore_must_use)]
@@ -120,8 +115,7 @@ mod handler {
     mod test {
         use pretty_assertions::assert_ne;
 
-        use crate::context;
-        use crate::error;
+        use crate::{context, error};
 
         #[tokio::test]
         async fn nuke_coco() -> Result<(), error::Error> {
@@ -173,12 +167,9 @@ pub struct CreateInput {
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
-    use warp::http::StatusCode;
-    use warp::test::request;
+    use warp::{http::StatusCode, test::request};
 
-    use crate::context;
-    use crate::error;
-    use crate::http;
+    use crate::{context, error, http};
 
     // TODO(xla): This can't hold true anymore, given that we nuke the owner. Which is required in
     // order to register a project. Should we rework the test? How do we make sure an owner is

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -2,10 +2,8 @@
 //! for API consumers to act on.
 
 use serde::Serialize;
-use std::convert::Infallible;
-use std::fmt;
-use warp::http::StatusCode;
-use warp::{reject, reply, Rejection, Reply};
+use std::{convert::Infallible, fmt};
+use warp::{http::StatusCode, reject, reply, Rejection, Reply};
 
 use crate::error;
 
@@ -160,8 +158,7 @@ mod tests {
     use futures::stream::TryStreamExt;
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
-    use warp::reply::Reply as _;
-    use warp::Rejection;
+    use warp::{reply::Reply as _, Rejection};
 
     #[tokio::test]
     async fn recover_custom() {

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -3,11 +3,9 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
-use warp::filters::BoxedFilter;
-use warp::{path, Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
-use crate::context;
-use crate::http;
+use crate::{context, http};
 
 /// Combination of all identity routes.
 pub fn filters(ctx: context::Ctx) -> BoxedFilter<(impl Reply,)> {
@@ -45,13 +43,9 @@ fn list_filter(ctx: context::Ctx) -> impl Filter<Extract = impl Reply, Error = R
 
 /// Identity handlers for conversion between core domain and http request fullfilment.
 mod handler {
-    use warp::http::StatusCode;
-    use warp::{reply, Rejection, Reply};
+    use warp::{http::StatusCode, reply, Rejection, Reply};
 
-    use crate::context;
-    use crate::error;
-    use crate::identity;
-    use crate::session;
+    use crate::{context, error, identity, session};
 
     /// Create a new [`identity::Identity`].
     pub async fn create(
@@ -103,15 +97,9 @@ pub struct CreateInput {
 mod test {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
-    use warp::http::StatusCode;
-    use warp::test::request;
+    use warp::{http::StatusCode, test::request};
 
-    use crate::avatar;
-    use crate::context;
-    use crate::error;
-    use crate::http;
-    use crate::identity;
-    use crate::session;
+    use crate::{avatar, context, error, http, identity, session};
 
     #[tokio::test]
     async fn create() -> Result<(), error::Error> {

--- a/proxy/api/src/http/notification.rs
+++ b/proxy/api/src/http/notification.rs
@@ -1,8 +1,7 @@
 //! Unidirectional stream of events happening in the proxy. This enables exposing tailing logs to
 //! users, or widgets which show topology information like how many and what peers are connected.
 
-use warp::filters::BoxedFilter;
-use warp::{Filter, Reply};
+use warp::{filters::BoxedFilter, Filter, Reply};
 
 use crate::notification::Subscriptions;
 
@@ -55,8 +54,7 @@ mod test {
     use pretty_assertions::assert_eq;
     use warp::test::request;
 
-    use crate::error;
-    use crate::notification;
+    use crate::{error, notification};
 
     /// This test blocks as we don't have a termination condition for the stream. We need to find
     /// a way to test this properly. Warp does have test utility for websockets but not for SSE

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -2,14 +2,10 @@
 
 use std::path::PathBuf;
 
-use serde::ser::SerializeStruct as _;
-use serde::{Deserialize, Serialize, Serializer};
-use warp::filters::BoxedFilter;
-use warp::{path, Filter, Rejection, Reply};
+use serde::{ser::SerializeStruct as _, Deserialize, Serialize, Serializer};
+use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
-use crate::context;
-use crate::http;
-use crate::project;
+use crate::{context, http, project};
 
 /// Combination of all routes.
 pub fn filters(ctx: context::Ctx) -> BoxedFilter<(impl Reply,)> {
@@ -78,12 +74,9 @@ fn discover_filter(
 mod handler {
     use std::path::PathBuf;
 
-    use warp::http::StatusCode;
-    use warp::{reply, Rejection, Reply};
+    use warp::{http::StatusCode, reply, Rejection, Reply};
 
-    use crate::context;
-    use crate::error::Error;
-    use crate::project;
+    use crate::{context, error::Error, project};
 
     /// Create a new [`project::Project`].
     pub async fn create(
@@ -226,17 +219,11 @@ pub struct ListQuery {
 mod test {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
-    use warp::http::StatusCode;
-    use warp::test::request;
+    use warp::{http::StatusCode, test::request};
 
     use radicle_surf::vcs::git::git2;
 
-    use crate::context;
-    use crate::error;
-    use crate::http;
-    use crate::identity;
-    use crate::project;
-    use crate::session;
+    use crate::{context, error, http, identity, project, session};
 
     #[tokio::test]
     async fn checkout() -> Result<(), error::Error> {

--- a/proxy/api/src/http/session.rs
+++ b/proxy/api/src/http/session.rs
@@ -1,10 +1,8 @@
 //! Endpoints and serialisation for [`session::Session`] related types.
 
-use warp::filters::BoxedFilter;
-use warp::{path, Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
-use crate::context;
-use crate::http;
+use crate::{context, http};
 
 /// Combination of all session filters.
 pub fn filters(ctx: context::Ctx) -> BoxedFilter<(impl Reply,)> {
@@ -46,11 +44,9 @@ fn update_settings_filter(
 
 /// Session handlers for conversion between core domain and HTTP request fullfilment.
 mod handler {
-    use warp::http::StatusCode;
-    use warp::{reply, Rejection, Reply};
+    use warp::{http::StatusCode, reply, Rejection, Reply};
 
-    use crate::context;
-    use crate::session;
+    use crate::{context, session};
 
     /// Clear the current [`session::Session`].
     pub async fn delete(ctx: context::Ctx) -> Result<impl Reply, Rejection> {
@@ -86,12 +82,9 @@ mod handler {
 mod test {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
-    use warp::http::StatusCode;
-    use warp::test::request;
+    use warp::{http::StatusCode, test::request};
 
-    use crate::context;
-    use crate::error;
-    use crate::session;
+    use crate::{context, error, session};
 
     #[tokio::test]
     async fn delete() -> Result<(), error::Error> {

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -1,14 +1,11 @@
 //! Endpoints and serialisation for source code browsing.
 
 use serde::{Deserialize, Serialize};
-use warp::filters::BoxedFilter;
-use warp::{path, Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
 use radicle_surf::vcs::git;
 
-use crate::context;
-use crate::http;
-use crate::identity;
+use crate::{context, http, identity};
 
 /// Combination of all source filters.
 pub fn filters(ctx: context::Ctx) -> BoxedFilter<(impl Reply,)> {
@@ -110,17 +107,13 @@ fn tree_filter(ctx: context::Ctx) -> impl Filter<Extract = impl Reply, Error = R
 
 /// Source handlers for conversion between core domain and http request fullfilment.
 mod handler {
-    use warp::path::Tail;
-    use warp::{reply, Rejection, Reply};
+    use warp::{path::Tail, reply, Rejection, Reply};
 
     use radicle_surf::vcs::git;
 
     use coco::oid;
 
-    use crate::context;
-    use crate::error;
-    use crate::session;
-    use crate::session::settings;
+    use crate::{context, error, session, session::settings};
 
     /// Fetch a [`coco::Blob`].
     pub async fn blob(
@@ -370,21 +363,15 @@ impl<S> From<coco::Revisions<coco::PeerId, coco::MetaUser<S>>> for Revisions {
 #[allow(clippy::non_ascii_literal, clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
-    use std::env;
+    use std::{convert::TryFrom, env};
 
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
-    use warp::http::StatusCode;
-    use warp::test::request;
+    use warp::{http::StatusCode, test::request};
 
     use radicle_surf::vcs::git;
 
-    use crate::context;
-    use crate::error;
-    use crate::http;
-    use crate::identity;
-    use crate::session;
+    use crate::{context, error, http, identity, session};
 
     #[tokio::test]
     async fn blob() -> Result<(), error::Error> {

--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -4,8 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use coco::signer;
 
-use crate::avatar;
-use crate::error;
+use crate::{avatar, error};
 
 /// The users personal identifying metadata and keys.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -1,16 +1,8 @@
 use std::convert::TryFrom;
 
-use coco::announcement;
-use coco::keystore;
-use coco::seed;
-use coco::signer;
+use coco::{announcement, keystore, seed, signer};
 
-use api::config;
-use api::context;
-use api::env;
-use api::http;
-use api::notification;
-use api::session;
+use api::{config, context, env, http, notification, session};
 
 /// Flags accepted by the proxy binary.
 struct Args {

--- a/proxy/api/src/notification.rs
+++ b/proxy/api/src/notification.rs
@@ -1,13 +1,16 @@
 //! Machinery to signal significant events to clients.
 
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use serde::Serialize;
-use tokio::sync::mpsc;
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 
 /// Significant events happening during proxy runtime.
 #[derive(Clone, Debug, Serialize)]

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -3,8 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::error;
-use crate::identity;
+use crate::{error, identity};
 
 pub mod announcements;
 pub mod settings;

--- a/proxy/api/src/session/announcements.rs
+++ b/proxy/api/src/session/announcements.rs
@@ -51,8 +51,7 @@ pub fn save(
 mod test {
     use std::collections::HashSet;
 
-    use coco::oid;
-    use coco::uri;
+    use coco::{oid, uri};
 
     use crate::error;
 

--- a/proxy/coco/src/announcement.rs
+++ b/proxy/coco/src/announcement.rs
@@ -1,15 +1,10 @@
 //! Compute, track and announce noteworthy changes to the network.
 
-use std::collections::HashSet;
-use std::ops::Deref as _;
+use std::{collections::HashSet, ops::Deref as _};
 
-use librad::keys;
-use librad::net;
-use librad::uri;
+use librad::{keys, net, uri};
 
-use crate::error::Error;
-use crate::oid::Oid;
-use crate::peer;
+use crate::{error::Error, oid::Oid, peer};
 
 /// An update and all the required information that can be announced on the network.
 pub type Announcement = (uri::RadUrn, Oid);
@@ -88,15 +83,9 @@ mod test {
 
     use pretty_assertions::assert_eq;
 
-    use librad::hash::Hash;
-    use librad::keys::SecretKey;
-    use librad::uri;
+    use librad::{hash::Hash, keys::SecretKey, uri};
 
-    use crate::config;
-    use crate::error::Error;
-    use crate::oid;
-    use crate::peer;
-    use crate::signer;
+    use crate::{config, error::Error, oid, peer, signer};
 
     #[tokio::test]
     async fn announce() -> Result<(), Error> {

--- a/proxy/coco/src/config.rs
+++ b/proxy/coco/src/config.rs
@@ -1,16 +1,13 @@
 //! Crate configuration.
 
-use std::convert::TryFrom;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::{
+    convert::TryFrom,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+};
 
-use librad::keys;
-use librad::net;
-use librad::net::discovery;
-use librad::paths;
-use librad::peer;
+use librad::{keys, net, net::discovery, paths, peer};
 
-use crate::error::Error;
-use crate::seed;
+use crate::{error::Error, seed};
 
 lazy_static::lazy_static! {
     /// Localhost binding to any available port, i.e. `127.0.0.1:0`.

--- a/proxy/coco/src/control.rs
+++ b/proxy/coco/src/control.rs
@@ -1,20 +1,14 @@
 //! Utility for fixture data in the monorepo.
 
-use std::convert::TryFrom;
-use std::env;
-use std::io;
-use std::path;
+use std::{convert::TryFrom, env, io, path};
 
-use librad::keys;
-use librad::meta::entity;
-use librad::meta::project as librad_project;
+use librad::{
+    keys,
+    meta::{entity, project as librad_project},
+};
 use radicle_surf::vcs::git::git2;
 
-use crate::config;
-use crate::error::Error;
-use crate::peer;
-use crate::project;
-use crate::signer;
+use crate::{config, error::Error, peer, project, signer};
 
 /// Deletes the local git repsoitory coco uses to keep its state.
 ///

--- a/proxy/coco/src/error.rs
+++ b/proxy/coco/src/error.rs
@@ -1,15 +1,16 @@
 //! Collection of all crate errors.
 
-use std::io;
-use std::path;
+use std::{io, path};
 
-use librad::git::{repo, storage};
-use librad::meta::entity;
-use librad::net;
-use librad::uri;
-use radicle_surf::file_system;
-use radicle_surf::vcs::git;
-use radicle_surf::vcs::git::git2;
+use librad::{
+    git::{repo, storage},
+    meta::entity,
+    net, uri,
+};
+use radicle_surf::{
+    file_system,
+    vcs::{git, git::git2},
+};
 
 /// Error emitted by one of the modules.
 #[derive(Debug, thiserror::Error)]

--- a/proxy/coco/src/git_helper.rs
+++ b/proxy/coco/src/git_helper.rs
@@ -1,9 +1,6 @@
 //! git-remote-rad git helper related functionality.
 
-use std::fs;
-use std::io;
-use std::os::unix::fs::PermissionsExt as _;
-use std::path;
+use std::{fs, io, os::unix::fs::PermissionsExt as _, path};
 
 /// Git helper errors.
 #[derive(Debug, thiserror::Error)]
@@ -52,8 +49,7 @@ pub fn setup(src_dir: &path::PathBuf, dst_dir: &path::PathBuf) -> Result<(), Err
 
 #[cfg(test)]
 mod test {
-    use std::fs;
-    use std::os::unix::fs::PermissionsExt as _;
+    use std::{fs, os::unix::fs::PermissionsExt as _};
 
     use super::Error;
 

--- a/proxy/coco/src/identifier.rs
+++ b/proxy/coco/src/identifier.rs
@@ -5,8 +5,7 @@ use std::{fmt, str::FromStr};
 
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-use librad::meta::user;
-use librad::peer;
+use librad::{meta::user, peer};
 
 /// Errors captured when parsing a shareable identifier of the form `<handle>@<urn>`.
 #[derive(Debug, thiserror::Error)]

--- a/proxy/coco/src/keystore.rs
+++ b/proxy/coco/src/keystore.rs
@@ -2,8 +2,7 @@
 
 use std::convert::Infallible;
 
-use librad::keys;
-use librad::paths;
+use librad::{keys, paths};
 pub use radicle_keystore::pinentry::SecUtf8;
 use radicle_keystore::{
     crypto::{Pwhash, SecretBoxError},

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -19,18 +19,21 @@
     clippy::multiple_crate_versions
 )]
 
-pub use librad::git::local::url::LocalUrl;
-pub use librad::hash::Hash;
-pub use librad::meta::project::Project;
-pub use librad::meta::user::User as MetaUser;
-pub use librad::paths::Paths;
-pub use librad::peer::PeerId;
-pub use librad::uri::{self, RadUrn as Urn};
+pub use librad::{
+    git::local::url::LocalUrl,
+    hash::Hash,
+    meta::{project::Project, user::User as MetaUser},
+    paths::Paths,
+    peer::PeerId,
+    uri::{self, RadUrn as Urn},
+};
 
 pub use radicle_git_helpers::remote_helper;
 
-pub use radicle_surf::diff::{Diff, FileDiff};
-pub use radicle_surf::vcs::git::Stats;
+pub use radicle_surf::{
+    diff::{Diff, FileDiff},
+    vcs::git::Stats,
+};
 
 pub mod announcement;
 pub mod config;

--- a/proxy/coco/src/oid.rs
+++ b/proxy/coco/src/oid.rs
@@ -1,8 +1,6 @@
 //! Machinery to handle object ids conversion and serialization.
 
-use std::convert::TryFrom;
-use std::fmt;
-use std::str;
+use std::{convert::TryFrom, fmt, str};
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -1,33 +1,36 @@
 //! Utility to work with the peer api of librad.
 
-use std::convert::TryFrom;
-use std::net::SocketAddr;
-use std::path::{self, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::{
+    convert::TryFrom,
+    net::SocketAddr,
+    path::{self, PathBuf},
+    sync::{Arc, Mutex},
+};
 
 use futures::stream::StreamExt;
 
-use librad::git::local::{transport, url::LocalUrl};
-use librad::git::refs::Refs;
-use librad::git::storage;
-use librad::keys;
-use librad::meta::entity;
-use librad::meta::project as librad_project;
-use librad::meta::user;
-use librad::net::discovery;
-use librad::net::peer::{Gossip, PeerApi, PeerConfig, PeerStorage};
-use librad::net::protocol::Protocol;
-use librad::paths;
-use librad::peer::PeerId;
-use librad::signer::SomeSigner;
-use librad::uri::{RadUrl, RadUrn};
+use librad::{
+    git::{
+        local::{transport, url::LocalUrl},
+        refs::Refs,
+        storage,
+    },
+    keys,
+    meta::{entity, project as librad_project, user},
+    net::{
+        discovery,
+        peer::{Gossip, PeerApi, PeerConfig, PeerStorage},
+        protocol::Protocol,
+    },
+    paths,
+    peer::PeerId,
+    signer::SomeSigner,
+    uri::{RadUrl, RadUrn},
+};
 use radicle_keystore::sign::Signer as _;
-use radicle_surf::vcs::git;
-use radicle_surf::vcs::git::git2;
+use radicle_surf::vcs::{git, git::git2};
 
-use crate::error::Error;
-use crate::project;
-use crate::signer;
+use crate::{error::Error, project, signer};
 
 /// Export a verified [`user::User`] type.
 pub type User = user::User<entity::Verified>;
@@ -518,18 +521,12 @@ impl entity::Resolver<user::User<entity::Draft>> for FakeUserResolver {
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod test {
-    use std::env;
-    use std::path::PathBuf;
-    use std::process::Command;
+    use std::{env, path::PathBuf, process::Command};
 
-    use librad::keys::SecretKey;
-    use librad::uri;
+    use librad::{keys::SecretKey, uri};
     use radicle_surf::vcs::git::git2;
 
-    use crate::config;
-    use crate::control;
-    use crate::project;
-    use crate::signer;
+    use crate::{config, control, project, signer};
 
     use super::{Api, Error};
 

--- a/proxy/coco/src/project/checkout.rs
+++ b/proxy/coco/src/project/checkout.rs
@@ -1,10 +1,13 @@
-use std::ffi;
-use std::path::{self, PathBuf};
+use std::{
+    ffi,
+    path::{self, PathBuf},
+};
 
-use librad::git::local::url::LocalUrl;
-use librad::git::types::remote::Remote;
 pub use librad::meta::project::Project;
-use librad::peer::PeerId;
+use librad::{
+    git::{local::url::LocalUrl, types::remote::Remote},
+    peer::PeerId,
+};
 use radicle_surf::vcs::git::git2;
 
 /// When checking out a working copy, we can run into several I/O failures.

--- a/proxy/coco/src/project/create.rs
+++ b/proxy/coco/src/project/create.rs
@@ -1,18 +1,21 @@
-use std::marker::PhantomData;
-use std::path::{self, PathBuf};
+use std::{
+    marker::PhantomData,
+    path::{self, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
-use librad::git::local::url::LocalUrl;
-use librad::git::types::{remote::Remote, FlatRef};
-use librad::keys;
-use librad::meta::entity;
-use librad::meta::project;
+use librad::{
+    git::{
+        local::url::LocalUrl,
+        types::{remote::Remote, FlatRef},
+    },
+    keys,
+    meta::{entity, project},
+};
 use radicle_surf::vcs::git::git2;
 
-use crate::config;
-use crate::error::Error;
-use crate::peer;
+use crate::{config, error::Error, peer};
 
 /// The data required to either open an existing repository or create a new one.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -1,24 +1,19 @@
 //! Source code related functionality.
 
-use std::convert::TryFrom;
-use std::fmt;
-use std::path;
-use std::str::FromStr;
+use std::{convert::TryFrom, fmt, path, str::FromStr};
 
 use nonempty::NonEmpty;
-use serde::ser::SerializeStruct as _;
-use serde::{Deserialize, Serialize, Serializer};
-use syntect::easy::HighlightLines;
-use syntect::highlighting::ThemeSet;
-use syntect::parsing::SyntaxSet;
-use syntect::util::LinesWithEndings;
+use serde::{ser::SerializeStruct as _, Deserialize, Serialize, Serializer};
+use syntect::{
+    easy::HighlightLines, highlighting::ThemeSet, parsing::SyntaxSet, util::LinesWithEndings,
+};
 
-use radicle_surf::vcs::git::git2;
-use radicle_surf::vcs::git::{self, BranchType, Browser, Rev};
-use radicle_surf::{diff, file_system};
+use radicle_surf::{
+    diff, file_system,
+    vcs::git::{self, git2, BranchType, Browser, Rev},
+};
 
-use crate::error::Error;
-use crate::oid::Oid;
+use crate::{error::Error, oid::Oid};
 
 lazy_static::lazy_static! {
     // The syntax set is slow to load (~30ms), so we make sure to only load it once.
@@ -825,11 +820,7 @@ mod tests {
 
     use librad::keys::SecretKey;
 
-    use crate::config;
-    use crate::control;
-    use crate::oid;
-    use crate::peer;
-    use crate::signer;
+    use crate::{config, control, oid, peer, signer};
 
     use super::Error;
 


### PR DESCRIPTION
Enable Rust cargo fmt `merge_imports`.

**Why**:

- This is enabled on `link`, therefore enabling it here as well reduces the gap between the two projects
- I have come to appreciate this on `link`, as it reduces the amount of duplicated `import <crate>::` lines
- Neater imports  