### PR TITLE
fix(proxy): signed refs retrieval for projects

### DIFF
--- a/proxy/coco/src/announcement.rs
+++ b/proxy/coco/src/announcement.rs
@@ -52,7 +52,7 @@ pub fn build(api: &peer::Api) -> Result<HashSet<Announcement>, Error> {
         Err(err) => Err(err),
         Ok(projects) => {
             for project in &projects {
-                let refs = api.list_project_refs(&project.urn())?;
+                let refs = api.list_owner_project_refs(&project.urn())?;
 
                 for (head, hash) in &refs.heads {
                     list.insert((

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -285,16 +285,35 @@ impl Api {
         api.providers(urn, timeout)
     }
 
-    /// Retrieves the [`librad::git::refs::Refs`] for the given project urn.
+    /// Retrieves the [`librad::git::refs::Refs`] for the state owner.
     ///
     /// # Errors
     ///
-    /// * if opening the storage fails
-    pub fn list_project_refs(&self, urn: &RadUrn) -> Result<Refs, Error> {
+    /// * if the call to get the signed refs fails
+    ///
+    /// # Panics
+    ///
+    /// * if we can't acquire the lock for the [`PeerApi`]`
+    pub fn list_owner_project_refs(&self, urn: &RadUrn) -> Result<Refs, Error> {
         let api = self.peer_api.lock().expect("unable to acquire lock");
-        let storage = api.storage().reopen()?;
+        let storage = api.storage();
+        storage.rad_signed_refs(urn).map_err(Error::from)
+    }
+
+    /// Retrieves the [`librad::git::refs::Refs`] for the given `PeerId`.
+    ///
+    /// # Errors
+    ///
+    /// * if the call to get the signed refs fails
+    ///
+    /// # Panics
+    ///
+    /// * if we can't acquire the lock for the [`PeerApi`]`
+    pub fn list_peer_project_refs(&self, urn: &RadUrn, peer_id: PeerId) -> Result<Refs, Error> {
+        let api = self.peer_api.lock().expect("unable to acquire lock");
+        let storage = api.storage();
         storage
-            .rad_signed_refs_of(urn, storage.peer_id().clone())
+            .rad_signed_refs_of(urn, peer_id)
             .map_err(Error::from)
     }
 


### PR DESCRIPTION
Splits up the functionality of getting signed refs for a project, to
make mis-use hard we have two methods now. One to obtain the `Refs` for
the owner of the monorepo and one to get the them for a peer.

***
Backport from #881 and sparked by https://github.com/radicle-dev/radicle-upstream/pull/881#discussion_r487044797.