### PR TITLE
feat(ui): introduce experimental flag

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -101,6 +101,7 @@ Here is a list of the most commonly used ones:
 
 ```sh
 yarn start                  # Start Upstream in development mode
+yarn start:public           # Start Upstream in the public mode, hidding experimental features.
 
 yarn test                   # Run all ui tests
 yarn test:integration       # Run only integration tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,6 +68,20 @@ On Linux:
 3. Start Upstream in development mode: `yarn start`.
 
 
+### Feature flagging
+
+UI features that are experimental or under construction that find their way into the main
+branch must be placed behind the feature flag, to make them inaccessible for the general public.
+
+We do that by using `native > ipc.js > isExperimental` as a feature flag to enable or
+disable said features accordingly to the mode in which we are running the app.
+
+See the [scripts](#scripts) section below to learn which commands to use to toggle this flag
+accordingly to your current workflow.
+
+The feature flag is only available in development mode. It is always disabled in production.
+
+
 ### Running tests
 
 Before running UI end-to-end tests locally you'll need to check out the latest
@@ -101,7 +115,7 @@ Here is a list of the most commonly used ones:
 
 ```sh
 yarn start                  # Start Upstream in development mode
-yarn start:experimental           # Start Upstream in experimental mode, showing unfinished features
+yarn start:experimental     # Start Upstream in experimental mode, showing unfinished features
 
 yarn test                   # Run all ui tests
 yarn test:integration       # Run only integration tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -101,7 +101,7 @@ Here is a list of the most commonly used ones:
 
 ```sh
 yarn start                  # Start Upstream in development mode
-yarn start:public           # Start Upstream in the public mode, hidding experimental features.
+yarn start:experimental           # Start Upstream in experimental mode, showing unfinished features
 
 yarn test                   # Run all ui tests
 yarn test:integration       # Run only integration tests

--- a/cypress/integration/project_creation.spec.js
+++ b/cypress/integration/project_creation.spec.js
@@ -19,6 +19,7 @@ const withEmptyRepositoryStub = callback => {
           },
         },
         isDev: true,
+        isExperimental: true,
       };
     });
 
@@ -50,6 +51,7 @@ const withPlatinumStub = callback => {
           },
         },
         isDev: true,
+        isExperimental: true,
       };
     });
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,9 +1,10 @@
 import "./commands";
 import "./assertions";
 
-// Stub electron preloader to always set isDev to true during tests.
+// Stub electron preloader to always enable `isDev` and `isExperimental` before executing tests.
 Cypress.on("window:before:load", appWindow => {
   appWindow.electron = {
     isDev: true,
+    isExperimental: true,
   };
 });

--- a/native/ipc.js
+++ b/native/ipc.js
@@ -28,7 +28,7 @@ export const isDev = () => {
 
 // Informs whether it's running in experimental mode, where
 // features under construction are enabled and can thus be used.
-// This option can only be enaled iff `isDev()` as we should only
+// This option can only be enabled iff `isDev()` as we should only
 // want to toggle it while in development mode.
 export const isExperimental = () => {
   return isDev() && window.electron.isExperimental;

--- a/native/ipc.js
+++ b/native/ipc.js
@@ -21,6 +21,15 @@ export const copyToClipboard = text =>
 export const openPath = path =>
   window.electron.ipcRenderer.invoke(OPEN_PATH, path);
 
+// Informs whether it's running in a development environment.
 export const isDev = () => {
   return window.electron.isDev;
+};
+
+// Informs whether it's running in experimental mode, where
+// features under construction are enabled and can thus be used.
+// This option can only be enaled iff `isDev()` as we should only
+// want to toggle it while in development mode.
+export const isExperimental = () => {
+  return isDev() && window.electron.isExperimental;
 };

--- a/native/preload.js
+++ b/native/preload.js
@@ -1,4 +1,5 @@
 window.electron = {
   ipcRenderer: { invoke: require("electron").ipcRenderer.invoke },
   isDev: process.env.NODE_ENV === "development",
+  isExperimental: process.env.RADICLE_UPSTREAM_EXPERIMENTAL === "true",
 };

--- a/package.json
+++ b/package.json
@@ -106,7 +106,9 @@
     "wait-on": "^5.1.0"
   },
   "scripts": {
-    "start": "run-p --race svelte:watch proxy:start electron:start",
+    "start": "RADICLE_UPSTREAM_EXPERIMENTAL=true start:app",
+    "start:public": "RADICLE_UPSTREAM_EXPERIMENTAL=false start:app",
+    "start:app": "run-p --race svelte:watch proxy:start electron:start",
     "start:test": "run-p --race svelte:watch proxy:start:test electron:start",
     "test": "TZ='UTC' yarn test:unit && TZ='UTC' yarn test:integration",
     "test:integration": "TZ='UTC' run-p --race proxy:start:test wait:test",
@@ -115,7 +117,7 @@
     "test:unit:watch": "jest --watchAll",
     "wait:test": "wait-on tcp:8080 && yarn svelte:build && yarn cypress:run",
     "wait:debug": "wait-on tcp:8080 && yarn cypress:open",
-    "dist": "rm -rf ./dist && mkdir ./dist && yarn proxy:clean && yarn svelte:clean && yarn svelte:build && yarn proxy:build:release && cp proxy/target/release/api dist/proxy && cp proxy/target/release/git-remote-rad dist && electron-builder --publish never",
+    "dist": "rm -rf ./dist && mkdir ./dist && yarn proxy:clean && yarn svelte:clean && RADICLE_UPSTREAM_EXPERIMENTAL=false NODE_ENV=production yarn svelte:build && yarn proxy:build:release && cp proxy/target/release/api dist/proxy && cp proxy/target/release/git-remote-rad dist && electron-builder --publish never",
     "electron:start": "wait-on ./public/bundle.js && wait-on ./native/main.comp.js && wait-on tcp:8080 && NODE_ENV=development electron .",
     "svelte:check": "svelte-check",
     "svelte:clean": "rm -rf public/bundle.*",

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "wait-on": "^5.1.0"
   },
   "scripts": {
-    "start": "RADICLE_UPSTREAM_EXPERIMENTAL=true start:app",
-    "start:public": "RADICLE_UPSTREAM_EXPERIMENTAL=false start:app",
+    "start": "RADICLE_UPSTREAM_EXPERIMENTAL=false start:app",
+    "start:experimental": "RADICLE_UPSTREAM_EXPERIMENTAL=true start:app",
     "start:app": "run-p --race svelte:watch proxy:start electron:start",
     "start:test": "run-p --race svelte:watch proxy:start:test electron:start",
     "test": "TZ='UTC' yarn test:unit && TZ='UTC' yarn test:integration",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "test:unit:watch": "jest --watchAll",
     "wait:test": "wait-on tcp:8080 && yarn svelte:build && yarn cypress:run",
     "wait:debug": "wait-on tcp:8080 && yarn cypress:open",
-    "dist": "rm -rf ./dist && mkdir ./dist && yarn proxy:clean && yarn svelte:clean && RADICLE_UPSTREAM_EXPERIMENTAL=false NODE_ENV=production yarn svelte:build && yarn proxy:build:release && cp proxy/target/release/api dist/proxy && cp proxy/target/release/git-remote-rad dist && electron-builder --publish never",
+    "dist": "rm -rf ./dist && mkdir ./dist && yarn proxy:clean && yarn svelte:clean && yarn svelte:build && yarn proxy:build:release && cp proxy/target/release/api dist/proxy && cp proxy/target/release/git-remote-rad dist && electron-builder --publish never",
     "electron:start": "wait-on ./public/bundle.js && wait-on ./native/main.comp.js && wait-on tcp:8080 && NODE_ENV=development electron .",
     "svelte:check": "svelte-check",
     "svelte:clean": "rm -rf public/bundle.*",

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "wait-on": "^5.1.0"
   },
   "scripts": {
-    "start": "RADICLE_UPSTREAM_EXPERIMENTAL=false start:app",
-    "start:experimental": "RADICLE_UPSTREAM_EXPERIMENTAL=true start:app",
+    "start": "RADICLE_UPSTREAM_EXPERIMENTAL=false yarn start:app",
+    "start:experimental": "RADICLE_UPSTREAM_EXPERIMENTAL=true yarn start:app",
     "start:app": "run-p --race svelte:watch proxy:start electron:start",
     "start:test": "run-p --race svelte:watch proxy:start:test electron:start",
     "test": "TZ='UTC' yarn test:unit && TZ='UTC' yarn test:integration",

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -6,6 +6,7 @@
   import * as screen from "./src/screen.ts";
   import { isMac } from "./src/settings.ts";
   import * as hotkeys from "./src/hotkeys.ts";
+  import { isDev } from "../native/ipc.js";
 
   const toggle = destination => {
     if (path.active(destination, $location)) {
@@ -46,7 +47,7 @@
     }
 
     // To open design system => OS modifier key + d
-    if (modifierKey && event.key === "d") {
+    if (isDev() && modifierKey && event.key === "d") {
       toggle(path.designSystemGuide());
     }
 

--- a/ui/Modal/Shortcuts.svelte
+++ b/ui/Modal/Shortcuts.svelte
@@ -2,6 +2,7 @@
   import { Illustration } from "../DesignSystem/Component";
   import { isMac } from "../src/settings.ts";
   import { Variant as IllustrationVariant } from "../src/illustration";
+  import { isDev } from "../../native/ipc.js";
 
   export let content;
 
@@ -67,12 +68,14 @@
       <kbd class="typo-text-bold">,</kbd>
       <p class="description">Settings</p>
     </div>
-    <div class="shortcut">
-      <kbd class="typo-text-bold">{modifierKey}</kbd>
-      <p class="plus">+</p>
-      <kbd class="typo-text-bold">d</kbd>
-      <p class="description">Design system</p>
-    </div>
+    {#if isDev()}
+      <div class="shortcut">
+        <kbd class="typo-text-bold">{modifierKey}</kbd>
+        <p class="plus">+</p>
+        <kbd class="typo-text-bold">d</kbd>
+        <p class="description">Design system</p>
+      </div>
+    {/if}
     <div class="shortcut">
       <kbd class="typo-text-bold">{modifierKey}</kbd>
       <p class="plus">+</p>

--- a/ui/Screen/Org.svelte
+++ b/ui/Screen/Org.svelte
@@ -2,7 +2,7 @@
   import { getContext } from "svelte";
   import Router, { push } from "svelte-spa-router";
 
-  import { isDev } from "../../native/ipc.js";
+  import { isExperimental } from "../../native/ipc.js";
   import { fetch, org as store } from "../src/org.ts";
   import * as path from "../src/path.ts";
 
@@ -47,7 +47,7 @@
         looseActiveStateMatching: true,
       },
     ];
-    isDev() &&
+    isExperimental() &&
       items.push({
         icon: Icon.Wallet,
         title: "Wallet",
@@ -93,7 +93,7 @@
     };
   }
 
-  if (isDev()) {
+  if (isExperimental()) {
     sendFundsMenuItem = {
       title: "Send funds",
       icon: Icon.ArrowUp,

--- a/ui/Screen/Org/Members.svelte
+++ b/ui/Screen/Org/Members.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { isDev } from "../../../native/ipc.js";
+  import { isExperimental } from "../../../native/ipc.js";
   import { org as store } from "../../src/org.ts";
 
   import { Icon } from "../../DesignSystem/Primitive";
@@ -79,7 +79,7 @@
             <p class="typo-text-small">Pending</p>
           </div>
         {/if}
-        {#if isDev()}
+        {#if isExperimental()}
           <AdditionalActionsDropdown menuItems={menuItems(member)} />
         {/if}
       </div>

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { isDev } from "../../native/ipc.js";
+  import { isExperimental } from "../../native/ipc.js";
   import Router, { link } from "svelte-spa-router";
 
   import * as path from "../src/path.ts";
@@ -57,7 +57,7 @@
         looseActiveStateMatching: true,
       },
     ];
-    isDev() &&
+    isExperimental() &&
       items.push(
         {
           icon: Icon.ExclamationCircle,
@@ -75,7 +75,7 @@
     return items;
   };
 
-  if (isDev()) {
+  if (isExperimental()) {
     codeCollabMenuItems = [
       {
         title: "New issue",

--- a/ui/Screen/Project/SourceMenu.svelte
+++ b/ui/Screen/Project/SourceMenu.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { isDev } from "../../../native/ipc.js";
+  import { isExperimental } from "../../../native/ipc.js";
 
   import { SupportButton } from "../../DesignSystem/Component";
 </script>
 
-{#if isDev()}
+{#if isExperimental()}
   <SupportButton on:click={() => console.log('event(support-project)')} />
 {/if}


### PR DESCRIPTION
Closes #888 

This is a feature flag that is consumed by the app as `isExperimental`,
signalling whether we are running the app with the experimental mode on,
which toggles experimental/under construction features. This flag is
only allowed in development mode.
A new yarn command is added, `yarn start:public`, which starts the app
in public mode, i.e, hiding all the experimental features. Such run
simulates a production preview while running in development mode.
