### PR TITLE
chore(proxy): avoid building non-release targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "svelte:build": "yarn svelte:clean && rollup -c",
     "svelte:watch": "yarn svelte:clean && rollup -c -w",
     "proxy:build": "cd proxy && cargo build --all-features --all-targets",
-    "proxy:build:release": "cd proxy && cargo build --release --all-features --all-targets",
+    "proxy:build:release": "cd proxy && cargo build --release",
     "proxy:clean": "cd proxy && cargo clean",
     "proxy:start": "cd proxy && cargo build --bin git-remote-rad && cargo run",
     "proxy:start:test": "cd proxy && cargo build --bin git-remote-rad && cargo run -- --test",


### PR DESCRIPTION
With the flags so far we used to build integration test suites during
release, this is unnecessary and takes time.