### PR TITLE
chore(ui): fix ui consistency

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -30,8 +30,14 @@
 ### Packaging and distribution
 
 - [ ] Check that unreleased features are not visible in the UI
-  - [ ] Issues, Revisions, Wallets, Design Sytem Guide, and anything else
-        that's in the UI but clearly not wired up
+  - [ ] Experimental features and developer helpers are not accessible
+    - Issues and Revisions tabs on the Project screen
+    - Wallets on the User Profile screen
+    - Design Sytem Guide is not listed in the shortcuts modal <kbd>?</kbd> and
+      the respective global hotkey is disabled <kbd>⌘</kbd>+<kbd>d</kbd>
+    - Tags are not visible in the revision selector on the Project Source screen
+    - There is no "Session management" section and no "Clear session" button on
+      the Settings screen
 - [ ] App icon is shown correctly
   - [ ] macOS: dock, <kbd>⌘</kbd> + <kbd>tab</kbd> task switcher, mounted dmg,
         app icon, "About radicle-upstream" window

--- a/cypress/integration/onboarding.spec.js
+++ b/cypress/integration/onboarding.spec.js
@@ -127,7 +127,8 @@ context("identity creation", () => {
 
     context("handle", () => {
       it("prevents the user from submitting an invalid handle", () => {
-        const validationError = "Handle should match ^[a-z0-9][a-z0-9_-]+$";
+        const validationError =
+          "Display name should match ^[a-z0-9][a-z0-9_-]+$";
 
         cy.pick("handle-input").type("_rafalca");
         cy.pick("next-button").click();

--- a/cypress/integration/onboarding.spec.js
+++ b/cypress/integration/onboarding.spec.js
@@ -134,7 +134,9 @@ context("identity creation", () => {
 
         // Handle is required.
         cy.pick("handle-input").clear();
-        cy.pick("enter-name-screen").contains("You must provide a handle");
+        cy.pick("enter-name-screen").contains(
+          "You must provide a display name"
+        );
 
         // No spaces.
         cy.pick("handle-input").type("no spaces");

--- a/ui/DesignSystem/Component/Header/Large.svelte
+++ b/ui/DesignSystem/Component/Header/Large.svelte
@@ -146,13 +146,15 @@
           <div class="project-stats" data-cy="project-stats">
             <div class="project-stat-item">
               <Icon.Branch />
-              <p style="margin-left: 0.5rem;">{stats.branches} Branches</p>
+              <p style="margin-left: 0.5rem;">
+                {stats.branches === 1 ? `1 Branch` : `${stats.branches} Branches`}
+              </p>
             </div>
             <span class="typo-mono-bold project-stat-separator">•</span>
             <div class="project-stat-item">
               <Icon.User />
               <p style="margin-left: 0.5rem;">
-                {stats.contributors} Contributors
+                {stats.contributors === 1 ? `1 Contributor` : `${stats.contributors} Contributors`}
               </p>
             </div>
           </div>

--- a/ui/Modal/ProjectCreation.svelte
+++ b/ui/Modal/ProjectCreation.svelte
@@ -233,7 +233,7 @@
     </div>
 
     <Tooltip
-      value={isExisting && 'The project name is taken from the the repository you selected'}
+      value={isExisting && 'The project name is taken from the repository you selected'}
       position="top">
       <Input.Text
         placeholder="Project name*"

--- a/ui/Screen/Onboarding/EnterName.svelte
+++ b/ui/Screen/Onboarding/EnterName.svelte
@@ -73,7 +73,7 @@
     </p>
     <Input.Text
       autofocus={true}
-      placeholder="Enter a display name (i.e. coolprogrammer3000)"
+      placeholder="Enter a display name (e.g. coolprogrammer3000)"
       bind:value={handle}
       on:enter={next}
       dataCy="handle-input"

--- a/ui/Screen/Onboarding/EnterName.svelte
+++ b/ui/Screen/Onboarding/EnterName.svelte
@@ -73,7 +73,7 @@
     </p>
     <Input.Text
       autofocus={true}
-      placeholder="Enter a name"
+      placeholder="Enter a display name (i.e. coolprogrammer3000)"
       bind:value={handle}
       on:enter={next}
       dataCy="handle-input"

--- a/ui/Screen/Onboarding/Success.svelte
+++ b/ui/Screen/Onboarding/Success.svelte
@@ -48,8 +48,8 @@
     <p
       style="text-align: center; width: 23.13rem; margin: 1.75rem 0 1.75rem 0;
       color: var(--color-foreground-level-6);">
-      This is your <span class="typo-text-bold">Radicle ID</span>. Click to copy
-      it and share it with others so that they can find you.
+      This is your Radicle ID — it's unique to you!<br /> Click to copy it and share
+      it with others so that they can find you.
     </p>
 
     <Button dataCy="go-to-profile-button" on:click={next}>

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -11,7 +11,7 @@
   import { themeOptions } from "../src/settings.ts";
   import * as path from "../src/path.ts";
   import * as modal from "../src/modal.ts";
-  import { getVersion } from "../../native/ipc.js";
+  import { getVersion, isDev } from "../../native/ipc.js";
 
   import { Button, Input } from "../DesignSystem/Primitive";
   import { SidebarLayout, SegmentedControl } from "../DesignSystem/Component";
@@ -161,28 +161,30 @@
       </div>
     </section>
 
-    <section>
-      <header>
-        <h3>Session management</h3>
-      </header>
-      <div class="section-item">
-        <div class="info">
-          <p class="typo-text-bold">Clears all authentication data</p>
-          <p style="color: var(--color-foreground-level-6);">
-            This is similar to how logout works. You will have to create a new
-            identity or restore your existing identity.
-          </p>
+    {#if isDev()}
+      <section>
+        <header>
+          <h3>Session management</h3>
+        </header>
+        <div class="section-item">
+          <div class="info">
+            <p class="typo-text-bold">Clears all authentication data</p>
+            <p style="color: var(--color-foreground-level-6);">
+              This is similar to how logout works. You will have to create a new
+              identity or restore your existing identity.
+            </p>
+          </div>
+          <div class="action">
+            <Button
+              dataCy="clear-session-button"
+              variant="outline"
+              on:click={clear}>
+              Clear session
+            </Button>
+          </div>
         </div>
-        <div class="action">
-          <Button
-            dataCy="clear-session-button"
-            variant="outline"
-            on:click={clear}>
-            Clear session
-          </Button>
-        </div>
-      </div>
-    </section>
+      </section>
+    {/if}
 
     <section>
       <header>

--- a/ui/src/onboarding.ts
+++ b/ui/src/onboarding.ts
@@ -11,12 +11,12 @@ const HANDLE_MATCH = "^[a-z0-9][a-z0-9_-]+$";
 
 const handleConstraints = {
   presence: {
-    message: "You must provide a handle",
+    message: "You must provide a display name",
     allowEmpty: false,
   },
   format: {
     pattern: new RegExp(HANDLE_MATCH, "i"),
-    message: `Handle should match ${HANDLE_MATCH}`,
+    message: `Display name should match ${HANDLE_MATCH}`,
   },
 };
 


### PR DESCRIPTION
- use `display name` instead of `handle` in validations, closes: https://github.com/radicle-dev/radicle-upstream/issues/919
- hide "Session management" section in settings behind `isDev` (based on discussion in Figma)
- update onboarding success screen copy
- fix wording in project creation tooltip ("the the" -> "the")
- respect singular/plural noun forms in project stats