### PR TITLE
fix: show commit count on project page

### DIFF
--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -22,6 +22,8 @@ context("repository stats", () => {
 context("commit browsing", () => {
   context("commit history", () => {
     it("shows the commit history for the default branch", () => {
+      // Wait for the commit tab to be updated
+      cy.pick("horizontal-menu", "Commits", "counter").contains("14");
       cy.pick("horizontal-menu", "Commits").click();
       cy.pick("commits-page").should("exist");
       cy.pick("commit-teaser")

--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -9,15 +9,15 @@ before(() => {
 beforeEach(() => {
   cy.visit("./public/index.html#/profile/projects");
   cy.contains("platinum").click();
-  // cy.contains("Source").click();
+  // Make sure there is enough time to load the commits which refreshes the horizontal menu
+  cy.wait(500);
+  cy.contains("Source").click();
 });
 
 context("repository stats", () => {
   it("shows the correct numbers", () => {
     cy.pick("header", "project-stats").contains("2 Branches");
     cy.pick("header", "project-stats").contains("4 Contributors");
-    // Make sure there is enough time to load the commits
-    cy.wait(500);
     cy.pick("horizontal-menu", "Commits").contains("Commits 14");
   });
 });

--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -9,16 +9,13 @@ before(() => {
 beforeEach(() => {
   cy.visit("./public/index.html#/profile/projects");
   cy.contains("platinum").click();
-  // Make sure there is enough time to load the commits which refreshes the horizontal menu
-  cy.wait(500);
-  cy.contains("Source").click();
 });
 
 context("repository stats", () => {
   it("shows the correct numbers", () => {
     cy.pick("header", "project-stats").contains("2 Branches");
     cy.pick("header", "project-stats").contains("4 Contributors");
-    cy.pick("horizontal-menu", "Commits").contains("Commits 14");
+    cy.pick("horizontal-menu", "Commits", "counter").contains("14");
   });
 });
 
@@ -42,8 +39,8 @@ context("commit browsing", () => {
     it("shows the commit history for another branch", () => {
       cy.pick("revision-selector").click();
       cy.get('[data-branch="dev"]').click();
-      // Make sure there is enough time to load the commits
-      cy.wait(500);
+      // Wait for the commit tab to be updated
+      cy.pick("horizontal-menu", "Commits", "counter").contains("8");
       cy.pick("horizontal-menu", "Commits").click();
 
       cy.pick("commits-page").should("exist");

--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -9,14 +9,16 @@ before(() => {
 beforeEach(() => {
   cy.visit("./public/index.html#/profile/projects");
   cy.contains("platinum").click();
-  cy.contains("Source").click();
+  // cy.contains("Source").click();
 });
 
 context("repository stats", () => {
   it("shows the correct numbers", () => {
-    cy.pick("horizontal-menu", "Commits").contains("Commits 14");
     cy.pick("header", "project-stats").contains("2 Branches");
     cy.pick("header", "project-stats").contains("4 Contributors");
+    // Make sure there is enough time to load the commits
+    cy.wait(500);
+    cy.pick("horizontal-menu", "Commits").contains("Commits 14");
   });
 });
 
@@ -40,6 +42,8 @@ context("commit browsing", () => {
     it("shows the commit history for another branch", () => {
       cy.pick("revision-selector").click();
       cy.get('[data-branch="dev"]').click();
+      // Make sure there is enough time to load the commits
+      cy.wait(500);
       cy.pick("horizontal-menu", "Commits").click();
 
       cy.pick("commits-page").should("exist");

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -691,6 +691,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[allow(clippy::indexing_slicing)]
     async fn commits() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -729,10 +729,11 @@ mod test {
         })?;
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
-            assert_eq!(have, json!(want));
-            assert_eq!(have.as_array().unwrap().len(), 14);
+            assert_eq!(have["headers"], json!(want.headers));
+            assert_eq!(have["headers"].as_array().unwrap().len(), 14);
+            assert_eq!(have["stats"]["commits"], json!(14));
             assert_eq!(
-                have.as_array().unwrap().first().unwrap(),
+                have["headers"].as_array().unwrap().first().unwrap(),
                 &serde_json::to_value(&head_commit).unwrap(),
                 "the first commit is the head of the branch"
             );

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -691,7 +691,6 @@ mod test {
     }
 
     #[tokio::test]
-    #[allow(clippy::indexing_slicing)]
     async fn commits() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;

--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -186,23 +186,12 @@ impl Serialize for CommitHeader {
 }
 
 /// A selection of commit headers and their statistics.
+#[derive(Serialize)]
 pub struct Commits {
     /// The commit headers
     pub headers: Vec<CommitHeader>,
     /// The statistics for the commit headers
     pub stats: Stats,
-}
-
-impl Serialize for Commits {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Commits", 2)?;
-        state.serialize_field("headers", &self.headers)?;
-        state.serialize_field("stats", &self.stats)?;
-        state.end()
-    }
 }
 
 /// Git object types.

--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -10,7 +10,7 @@ use syntect::{
 
 use radicle_surf::{
     diff, file_system,
-    vcs::git::{self, git2, BranchType, Browser, Rev},
+    vcs::git::{self, git2, BranchType, Browser, Rev, Stats},
 };
 
 use crate::{error::Error, oid::Oid};
@@ -181,6 +181,26 @@ impl Serialize for CommitHeader {
         state.serialize_field("description", &self.description())?;
         state.serialize_field("committer", &self.committer)?;
         state.serialize_field("committerTime", &self.committer_time.seconds())?;
+        state.end()
+    }
+}
+
+/// A selection of commit headers and their statistics.
+pub struct Commits {
+    /// The commit headers
+    pub headers: Vec<CommitHeader>,
+    /// The statistics for the commit headers
+    pub stats: Stats,
+}
+
+impl Serialize for Commits {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Commits", 2)?;
+        state.serialize_field("headers", &self.headers)?;
+        state.serialize_field("stats", &self.stats)?;
         state.end()
     }
 }
@@ -627,15 +647,13 @@ pub fn commit<'repo>(browser: &mut Browser<'repo>, sha1: Oid) -> Result<Commit, 
 /// # Errors
 ///
 /// Will return [`Error`] if the project doesn't exist or the surf interaction fails.
-pub fn commits<'repo>(
-    browser: &mut Browser<'repo>,
-    branch: git::Branch,
-) -> Result<Vec<CommitHeader>, Error> {
+pub fn commits<'repo>(browser: &mut Browser<'repo>, branch: git::Branch) -> Result<Commits, Error> {
     browser.branch(branch)?;
 
     let headers = browser.get().iter().map(CommitHeader::from).collect();
+    let stats = browser.get_stats()?;
 
-    Ok(headers)
+    Ok(Commits { headers, stats })
 }
 
 /// Retrieves the list of [`Tag`] for the given project `id`.

--- a/ui/DesignSystem/Component/HorizontalMenu.svelte
+++ b/ui/DesignSystem/Component/HorizontalMenu.svelte
@@ -6,6 +6,7 @@
 
   import MenuItem from "./HorizontalMenu/MenuItem.svelte";
 
+  export let style = "";
   export let items: {
     icon: typeof SvelteComponent;
     title: string;
@@ -42,7 +43,7 @@
   }
 </style>
 
-<nav data-cy="horizontal-menu">
+<nav data-cy="horizontal-menu" {style}>
   <ul class="menu-list">
     {#each items as item}
       <li class="menu-list-item">

--- a/ui/DesignSystem/Component/HorizontalMenu/MenuItem.svelte
+++ b/ui/DesignSystem/Component/HorizontalMenu/MenuItem.svelte
@@ -53,7 +53,9 @@
   {/if}
 
   <p class="item typo-text-bold" class:active>{title}</p>
-  {#if counter}<span class="counter typo-mono-bold">{counter}</span>{/if}
+  {#if counter}
+    <span class="counter typo-mono-bold" data-cy="counter">{counter}</span>
+  {/if}
 </a>
 
 {#if active}

--- a/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
@@ -9,11 +9,11 @@
   export let currentRevision = null;
   export let currentPeerId = null;
   export let expanded = false;
+  export let revisions = null;
 
   let currentSelectedPeer;
 
   const { metadata } = getContext("project");
-  const revisions = getContext("revisions");
 
   $: if (currentPeerId) {
     currentSelectedPeer = revisions.find(rev => {

--- a/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
@@ -52,7 +52,7 @@
     }
   };
 
-  const selectRevision = (peerId, revision) => {
+  const selectRevision = revision => {
     currentRevision = revision;
     hideDropdown();
   };
@@ -166,14 +166,11 @@
           class="branch typo-overflow-ellipsis"
           class:selected={currentRevision.name === branch && currentSelectedPeer.identity.peerId === currentSelectedPeer.identity.peerId}
           data-branch={branch}
-          on:click|stopPropagation={() => selectRevision(
-              currentSelectedPeer.identity.peerId,
-              {
-                type: RevisionType.Branch,
-                peerId: currentSelectedPeer.identity.peerId,
-                name: branch,
-              }
-            )}>
+          on:click|stopPropagation={() => selectRevision({
+              type: RevisionType.Branch,
+              peerId: currentSelectedPeer.identity.peerId,
+              name: branch,
+            })}>
           <Icon.Branch
             dataCy="branch-icon"
             style="vertical-align: bottom; fill:
@@ -187,13 +184,10 @@
             class="tag typo-overflow-ellipsis"
             class:selected={currentRevision.name === tag && currentSelectedPeer.identity.peerId === currentSelectedPeer.identity.peerId}
             data-tag={tag}
-            on:click|stopPropagation={() => selectRevision(
-                currentSelectedPeer.identity.peerId,
-                {
-                  type: RevisionType.Tag,
-                  name: tag,
-                }
-              )}>
+            on:click|stopPropagation={() => selectRevision({
+                type: RevisionType.Tag,
+                name: tag,
+              })}>
             <Icon.Label
               dataCy="tag-icon"
               style="vertical-align: bottom; fill:

--- a/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/RevisionSelector.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { createEventDispatcher } from "svelte";
+  import { getContext } from "svelte";
 
   import { isExperimental } from "../../../../native/ipc.js";
   import { RevisionType } from "../../../src/source.ts";
@@ -9,9 +9,11 @@
   export let currentRevision = null;
   export let currentPeerId = null;
   export let expanded = false;
-  export let revisions = null;
 
   let currentSelectedPeer;
+
+  const { metadata } = getContext("project");
+  const revisions = getContext("revisions");
 
   $: if (currentPeerId) {
     currentSelectedPeer = revisions.find(rev => {
@@ -21,6 +23,15 @@
     // The API returns a revision list where the first entry is the default
     // peer.
     currentSelectedPeer = revisions[0];
+  }
+
+  // initialize currentRevision
+  $: if (!currentRevision) {
+    currentRevision = {
+      type: RevisionType.Branch,
+      name: metadata.defaultBranch,
+      peerId: currentSelectedPeer ? currentSelectedPeer.identity.peerId : "",
+    };
   }
 
   // Dropdown element. Set by the view.
@@ -41,9 +52,8 @@
     }
   };
 
-  const dispatch = createEventDispatcher();
   const selectRevision = (peerId, revision) => {
-    dispatch("select", { revision, peerId });
+    currentRevision = revision;
     hideDropdown();
   };
 </script>

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -7,6 +7,7 @@
   import { checkout, fetch, project as store } from "../src/project.ts";
   import * as screen from "../src/screen.ts";
   import {
+    commits as commitsStore,
     currentRevision,
     currentPeerId,
     fetchCommits,
@@ -14,7 +15,6 @@
     resetCurrentRevision,
     resetCurrentPeerId,
     revisions as revisionsStore,
-    RevisionType,
   } from "../src/source.ts";
 
   import {
@@ -53,17 +53,7 @@
   resetCurrentRevision();
   resetCurrentPeerId();
 
-  const defaultRevision = (project, peerId) => {
-    return {
-      type: RevisionType.Branch,
-      name: project.metadata.defaultBranch,
-      peerId: peerId || "",
-    };
-  };
-
-  $: topbarMenuItems = (project, peerId, revision) => {
-    revision = revision || defaultRevision(project, peerId);
-    fetchCommits({ projectId: project.id, revision });
+  $: topbarMenuItems = (project, commitCounter) => {
     const items = [
       {
         icon: Icon.House,
@@ -74,7 +64,7 @@
       {
         icon: Icon.Commit,
         title: "Commits",
-        counter: project.stats.commits,
+        counter: commitCounter,
         href: path.projectCommits(project.id),
         looseActiveStateMatching: true,
       },
@@ -124,6 +114,8 @@
 
   fetch({ id: projectId });
   fetchRevisions({ projectId });
+  $: if ($currentRevision)
+    fetchCommits({ projectId, revision: $currentRevision });
 </script>
 
 <style>
@@ -136,7 +128,7 @@
 
 <SidebarLayout dataCy="project-screen">
   <Remote {store} let:data={project} context="project">
-    <Remote store={revisionsStore} let:data={revisions}>
+    <Remote store={revisionsStore} let:data={revisions} context="revisions">
       <Header.Large
         name={project.metadata.name}
         urn={project.shareableEntityIdentifier}
@@ -146,16 +138,16 @@
           <div style="display: flex">
             <div class="revision-selector-wrapper">
               <RevisionSelector
-                currentPeerId={$currentPeerId}
-                currentRevision={$currentRevision || defaultRevision(project, $currentPeerId)}
-                maintainers={project.metadata.maintainers}
-                {revisions}
-                on:select={event => {
-                  currentRevision.set(event.detail.revision);
-                }} />
+                bind:currentPeerId={$currentPeerId}
+                bind:currentRevision={$currentRevision} />
             </div>
-            <HorizontalMenu
-              items={topbarMenuItems(project, $currentPeerId, $currentRevision)} />
+            <Remote store={commitsStore} let:data={commits}>
+              <HorizontalMenu
+                items={topbarMenuItems(project, commits.stats.commits)} />
+              <div slot="loading">
+                <HorizontalMenu items={topbarMenuItems(project, null)} />
+              </div>
+            </Remote>
           </div>
         </div>
         <div slot="right">
@@ -166,12 +158,9 @@
         <div slot="top">
           <div style="display: flex">
             <PeerSelector
-              currentPeerId={$currentPeerId}
-              maintainers={project.maintainers}
-              {revisions}
-              on:select={event => {
-                currentPeerId.set(event.detail.peerId);
-                currentRevision.set(defaultRevision(project, event.detail.peerId));
+              bind:currentPeerId={$currentPeerId}
+              on:select={() => {
+                resetCurrentRevision();
               }} />
             <TrackToggle />
           </div>

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -128,7 +128,7 @@
 
 <SidebarLayout dataCy="project-screen">
   <Remote {store} let:data={project} context="project">
-    <Remote store={revisionsStore} let:data={revisions} context="revisions">
+    <Remote store={revisionsStore} context="revisions">
       <Header.Large
         name={project.metadata.name}
         urn={project.shareableEntityIdentifier}
@@ -145,7 +145,9 @@
               <HorizontalMenu
                 items={topbarMenuItems(project, commits.stats.commits)} />
               <div slot="loading">
-                <HorizontalMenu items={topbarMenuItems(project, null)} />
+                <HorizontalMenu
+                  items={topbarMenuItems(project, null)}
+                  style="display: inline" />
               </div>
             </Remote>
           </div>

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -128,7 +128,7 @@
 
 <SidebarLayout dataCy="project-screen">
   <Remote {store} let:data={project} context="project">
-    <Remote store={revisionsStore} context="revisions">
+    <Remote store={revisionsStore} let:data={revisions} context="revisions">
       <Header.Large
         name={project.metadata.name}
         urn={project.shareableEntityIdentifier}
@@ -139,7 +139,8 @@
             <div class="revision-selector-wrapper">
               <RevisionSelector
                 bind:currentPeerId={$currentPeerId}
-                bind:currentRevision={$currentRevision} />
+                bind:currentRevision={$currentRevision}
+                {revisions} />
             </div>
             <Remote store={commitsStore} let:data={commits}>
               <HorizontalMenu
@@ -161,6 +162,7 @@
           <div style="display: flex">
             <PeerSelector
               bind:currentPeerId={$currentPeerId}
+              {revisions}
               on:select={() => {
                 resetCurrentRevision();
               }} />

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -137,10 +137,12 @@
         <div slot="left">
           <div style="display: flex">
             <div class="revision-selector-wrapper">
-              <RevisionSelector
-                bind:currentPeerId={$currentPeerId}
-                bind:currentRevision={$currentRevision}
-                {revisions} />
+              {#if $currentPeerId}
+                <RevisionSelector
+                  currentPeerId={$currentPeerId}
+                  bind:currentRevision={$currentRevision}
+                  {revisions} />
+              {/if}
             </div>
             <Remote store={commitsStore} let:data={commits}>
               <HorizontalMenu

--- a/ui/Screen/Project/Commits.svelte
+++ b/ui/Screen/Project/Commits.svelte
@@ -51,8 +51,8 @@
 </style>
 
 <div class="commits-page" data-cy="commits-page">
-  <Remote {store} let:data={histories}>
-    {#each histories as history}
+  <Remote {store} let:data={commits}>
+    {#each commits.history as history}
       <div class="commit-group">
         <header>
           <p>{formatTime(history.time * 1000)}</p>

--- a/ui/Screen/Project/PeerSelector.svelte
+++ b/ui/Screen/Project/PeerSelector.svelte
@@ -10,12 +10,12 @@
 
   export let currentPeerId = null;
   export let expanded = false;
-  export let revisions = null;
-  export let maintainers = [];
 
   let currentSelectedPeer;
 
   const session = getContext("session");
+  const { metadata } = getContext("project");
+  const revisions = getContext("revisions");
 
   $: if (currentPeerId) {
     currentSelectedPeer = revisions.find(rev => {
@@ -140,7 +140,7 @@
       {currentSelectedPeer.identity.metadata.handle || currentSelectedPeer.identity.shareableEntityIdentifier}
     </p>
     <p>
-      {#if maintainers.includes(currentSelectedPeer.identity.urn)}
+      {#if metadata.maintainers.includes(currentSelectedPeer.identity.urn)}
         <Badge style="margin-left: 0.5rem" variant={BadgeType.Maintainer} />
       {/if}
     </p>
@@ -170,7 +170,7 @@
             {repo.identity.metadata.handle || repo.identity.shareableEntityIdentifier}
           </p>
           <p>
-            {#if maintainers.includes(repo.identity.urn)}
+            {#if metadata.maintainers.includes(repo.identity.urn)}
               <Badge
                 style="margin-left: 0.5rem"
                 variant={BadgeType.Maintainer} />

--- a/ui/Screen/Project/PeerSelector.svelte
+++ b/ui/Screen/Project/PeerSelector.svelte
@@ -25,6 +25,7 @@
     // The API returns a revision list where the first entry is the default
     // peer.
     currentSelectedPeer = revisions[0];
+    currentPeerId = currentSelectedPeer.identity.peerId;
   }
 
   // Dropdown element. Set by the view.
@@ -56,6 +57,7 @@
   const dispatch = createEventDispatcher();
   const selectPeer = peerId => {
     hideDropdown();
+    currentPeerId = peerId;
     dispatch("select", { peerId });
   };
 </script>

--- a/ui/Screen/Project/PeerSelector.svelte
+++ b/ui/Screen/Project/PeerSelector.svelte
@@ -10,12 +10,12 @@
 
   export let currentPeerId = null;
   export let expanded = false;
+  export let revisions = null;
 
   let currentSelectedPeer;
 
   const session = getContext("session");
   const { metadata } = getContext("project");
-  const revisions = getContext("revisions");
 
   $: if (currentPeerId) {
     currentSelectedPeer = revisions.find(rev => {

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -2,7 +2,6 @@
   import { getContext } from "svelte";
   import { format } from "timeago.js";
 
-  import { project as projectStore } from "../../src/project.ts";
   import { Variant as IllustrationVariant } from "../../src/illustration.ts";
   import {
     currentPeerId,
@@ -24,7 +23,7 @@
   import Readme from "../../DesignSystem/Component/SourceBrowser/Readme.svelte";
   import Folder from "../../DesignSystem/Component/SourceBrowser/Folder.svelte";
 
-  const { id } = getContext("project");
+  const project = getContext("project");
 
   // Reset some stores on first load
   resetObjectPath();
@@ -33,7 +32,7 @@
   $: fetchObject({
     path: $objectPath,
     peerId: $currentPeerId,
-    projectId: id,
+    projectId: project.id,
     revision: $currentRevision,
     type: $objectType,
   });
@@ -78,58 +77,56 @@
   }
 </style>
 
-<Remote store={projectStore} let:data={project}>
-  <div class="wrapper">
-    <div class="container center-content">
-      <div class="column-left">
-        <!-- Tree -->
-        <div class="source-tree" data-cy="source-tree">
-          <Folder
-            currentRevision={$currentRevision}
-            currentPeerId={$currentPeerId}
-            projectId={project.id}
-            toplevel
-            name={project.metadata.name} />
-        </div>
-      </div>
-
-      <div class="column-right">
-        <!-- Object -->
-        <Remote store={objectStore} let:data={object}>
-          {#if object.info.objectType === ObjectType.Blob}
-            <FileSource
-              blob={object}
-              path={$objectPath}
-              projectName={project.metadata.name}
-              projectId={project.id} />
-          {:else if object.path === ''}
-            <!-- Repository root -->
-            <div class="commit-header">
-              <CommitTeaser
-                projectId={project.id}
-                user={{ username: object.info.lastCommit.author.name, avatar: object.info.lastCommit.author.avatar }}
-                commitMessage={object.info.lastCommit.summary}
-                commitSha={object.info.lastCommit.sha1}
-                timestamp={format(object.info.lastCommit.committerTime * 1000)}
-                style="height: 100%" />
-            </div>
-
-            <!-- Readme -->
-            <Remote
-              store={readme(id, $currentPeerId, $currentRevision)}
-              let:data={readme}>
-              {#if readme}
-                <Readme content={readme.content} path={readme.path} />
-              {:else}
-                <EmptyState
-                  text="This project doesn't have a README yet."
-                  illustration={IllustrationVariant.Eyes}
-                  style="height: 320px;" />
-              {/if}
-            </Remote>
-          {/if}
-        </Remote>
+<div class="wrapper">
+  <div class="container center-content">
+    <div class="column-left">
+      <!-- Tree -->
+      <div class="source-tree" data-cy="source-tree">
+        <Folder
+          currentRevision={$currentRevision}
+          currentPeerId={$currentPeerId}
+          projectId={project.id}
+          toplevel
+          name={project.metadata.name} />
       </div>
     </div>
+
+    <div class="column-right">
+      <!-- Object -->
+      <Remote store={objectStore} let:data={object}>
+        {#if object.info.objectType === ObjectType.Blob}
+          <FileSource
+            blob={object}
+            path={$objectPath}
+            projectName={project.metadata.name}
+            projectId={project.id} />
+        {:else if object.path === ''}
+          <!-- Repository root -->
+          <div class="commit-header">
+            <CommitTeaser
+              projectId={project.id}
+              user={{ username: object.info.lastCommit.author.name, avatar: object.info.lastCommit.author.avatar }}
+              commitMessage={object.info.lastCommit.summary}
+              commitSha={object.info.lastCommit.sha1}
+              timestamp={format(object.info.lastCommit.committerTime * 1000)}
+              style="height: 100%" />
+          </div>
+
+          <!-- Readme -->
+          <Remote
+            store={readme(project.id, $currentPeerId, $currentRevision)}
+            let:data={readme}>
+            {#if readme}
+              <Readme content={readme.content} path={readme.path} />
+            {:else}
+              <EmptyState
+                text="This project doesn't have a README yet."
+                illustration={IllustrationVariant.Eyes}
+                style="height: 320px;" />
+            {/if}
+          </Remote>
+        {/if}
+      </Remote>
+    </div>
   </div>
-</Remote>
+</div>

--- a/ui/src/source.ts
+++ b/ui/src/source.ts
@@ -23,6 +23,22 @@ interface Commit {
   changeset: Record<string, unknown>;
 }
 
+interface Stats {
+  branches: number;
+  commits: number;
+  contributors: number;
+}
+
+interface Commits {
+  headers: CommitSummary[];
+  stats: Stats;
+}
+
+interface CommitsStore {
+  history: CommitHistory;
+  stats: Stats;
+}
+
 interface CommitSummary {
   sha1: string;
   author: Person;
@@ -118,7 +134,7 @@ export type RevisionQuery = Branch | Tag | Sha;
 const commitStore = remote.createStore<Commit>();
 export const commit = commitStore.readable;
 
-const commitsStore = remote.createStore<CommitHistory>();
+const commitsStore = remote.createStore<CommitsStore>();
 export const commits = commitsStore.readable;
 
 const objectStore = remote.createStore<SourceObject>();
@@ -214,14 +230,17 @@ const update = (msg: Msg): void => {
       commitsStore.loading();
 
       api
-        .get<CommitSummary[]>(`source/commits/${msg.projectId}/`, {
+        .get<Commits>(`source/commits/${msg.projectId}/`, {
           query: {
             peerId: msg.revision.peerId,
             branch: msg.revision.name,
           },
         })
-        .then(history => {
-          commitsStore.success(groupCommits(history));
+        .then(response => {
+          commitsStore.success({
+            stats: response.stats,
+            history: groupCommits(response.headers),
+          });
         })
         .catch(commitsStore.error);
       break;


### PR DESCRIPTION
* extends the commit endpoint with stats
* shows the correct commit count of the selected peer and branch
* cleans up the variables project page components

Note: Changing the selected peer can't be tested right now.

Closes #924 

**TODO**
- [x] fix source browsing test
- [x] fix jumpy horizontal header (jump between no-count & count)