### PR TITLE
fix(ui): close all other modals when opening a modal

### DIFF
--- a/ui/DesignSystem/Component/AdditionalActionsDropdown.svelte
+++ b/ui/DesignSystem/Component/AdditionalActionsDropdown.svelte
@@ -1,23 +1,29 @@
 <script>
   import { fade } from "svelte/transition";
 
+  import {
+    openDropdown,
+    closeCurrentDropdown,
+    currentlyOpen,
+  } from "../../src/dropdown.ts";
+
   import { Icon } from "../Primitive";
   import Urn from "./Urn.svelte";
   import Tooltip from "./Tooltip.svelte";
 
+  let dropdown;
   let triggerEl;
   let expanded = false;
 
   const toggleModal = () => {
     expanded = !expanded;
-  };
-
-  const hideModal = () => {
-    expanded = false;
+    if (expanded) {
+      openDropdown(dropdown);
+    }
   };
 
   const handleItemSelection = item => {
-    hideModal();
+    closeCurrentDropdown();
     item.event();
   };
 
@@ -25,6 +31,8 @@
   export let style = null;
   export let menuItems = null;
   export let headerTitle = null;
+
+  $: expanded = $currentlyOpen === dropdown;
 </script>
 
 <style>
@@ -109,7 +117,6 @@
   }
 </style>
 
-<svelte:window on:click={hideModal} />
 <div data-cy={dataCy} class="container" {style}>
   <button
     class="additional-actions-dropdown-button"
@@ -117,34 +124,34 @@
     on:click|stopPropagation={toggleModal}>
     <svelte:component this={Icon.Ellipsis} />
   </button>
-  {#if expanded}
-    <div out:fade={{ duration: 100 }} class="modal" hidden={!expanded}>
-      {#if headerTitle}
-        <div class="header">
-          <Urn urn={headerTitle} truncate />
-        </div>
-      {/if}
+  <div
+    out:fade={{ duration: 100 }}
+    class="modal"
+    hidden={!expanded}
+    bind:this={dropdown}>
+    {#if headerTitle}
+      <div class="header">
+        <Urn urn={headerTitle} truncate />
+      </div>
+    {/if}
 
-      {#if menuItems}
-        <div class="menu" data-cy="dropdown-menu">
-          {#each menuItems as item}
-            {#if item !== undefined}
-              <Tooltip value={item.tooltip} position="bottom">
-                <div
-                  data-cy={item.dataCy}
-                  class="menu-item"
-                  class:disabled={item.disabled}
-                  on:click|stopPropagation={!item.disabled && handleItemSelection(item)}>
-                  <svelte:component
-                    this={item.icon}
-                    style="margin-right: 12px" />
-                  <p>{item.title}</p>
-                </div>
-              </Tooltip>
-            {/if}
-          {/each}
-        </div>
-      {/if}
-    </div>
-  {/if}
+    {#if menuItems}
+      <div class="menu" data-cy="dropdown-menu">
+        {#each menuItems as item}
+          {#if item !== undefined}
+            <Tooltip value={item.tooltip} position="bottom">
+              <div
+                data-cy={item.dataCy}
+                class="menu-item"
+                class:disabled={item.disabled}
+                on:click|stopPropagation={!item.disabled && handleItemSelection(item)}>
+                <svelte:component this={item.icon} style="margin-right: 12px" />
+                <p>{item.title}</p>
+              </div>
+            </Tooltip>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+  </div>
 </div>

--- a/ui/Screen/Project/CheckoutButton.svelte
+++ b/ui/Screen/Project/CheckoutButton.svelte
@@ -4,6 +4,7 @@
   import { Button, Input, Icon } from "../../DesignSystem/Primitive";
   import { RemoteHelperHint, Tooltip } from "../../DesignSystem/Component";
   import { dismissRemoteHelperHint, settings } from "../../src/session.ts";
+  import { openDropdown, currentlyOpen } from "../../src/dropdown.ts";
 
   const dispatch = createEventDispatcher();
 
@@ -14,17 +15,15 @@
 
   const toggleDropdown = ev => {
     expanded = !expanded;
+    if (expanded) {
+      openDropdown(dropdown);
+    }
     ev && ev.stopPropagation();
   };
 
-  const clickOutside = ev => {
-    // Any click *outside* the dropdown should hide the dropdown.
-    if (expanded && dropdown !== ev.target && !dropdown.contains(ev.target)) {
-      expanded = false;
-    }
-  };
-
   let checkoutDirectoryPath;
+
+  $: expanded = $currentlyOpen === dropdown;
 </script>
 
 <style>
@@ -45,8 +44,6 @@
     user-select: none;
   }
 </style>
-
-<svelte:window on:click={clickOutside} />
 
 <div class="clone-dropdown" hidden={!expanded} bind:this={dropdown}>
   <p style="margin-bottom: 0.5rem;">


### PR DESCRIPTION
While checking out @sarahscott's proof-of-concept, I wanted to see if it covers other edge cases.
Adding my findings here, since they might be useful to continue work on #963.

**This PR fixes:**

<details>
<summary>
checkout modal
</summary>

![checkout](https://user-images.githubusercontent.com/158411/94253636-e0e1f900-ff25-11ea-9844-22f28e5cb84b.gif)
</details>

<details>
<summary>
the additional actions dropdown.
</summary>

![add](https://user-images.githubusercontent.com/158411/94253655-e6d7da00-ff25-11ea-9b03-b8bc0b9715b6.gif)
![add2](https://user-images.githubusercontent.com/158411/94253660-e8a19d80-ff25-11ea-83da-61add6c4fe56.gif)
</details>



**Discovered regression:**
<details>
<summary>
When adding the new click handling to `AdditionalActionsDropdown` to the project list,  there's flickering.
</summary>

![flicker](https://user-images.githubusercontent.com/158411/94253726-02db7b80-ff26-11ea-96a1-31878f3f9354.gif)

```diff
diff --git a/ui/DesignSystem/Component/ProjectList.svelte b/ui/DesignSystem/Component/ProjectList.svelte
index c9b96880..29242a39 100644
--- a/ui/DesignSystem/Component/ProjectList.svelte
+++ b/ui/DesignSystem/Component/ProjectList.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import AdditionalActionsDropdown from "./AdditionalActionsDropdown.svelte";
+  import { Icon } from "../Primitive";
   import type { Project } from "../../src/project";

   import { Flex } from "../Primitive";
@@ -9,6 +11,14 @@
   export let projects: Project[];
   export let urn: string;

+  const contextMenuItems = [
+    {
+      title: "Register project",
+      icon: Icon.Ledger,
+      event: () => {},
+    },
+  ];
+
   const projectCardProps = (project: Project) => ({
     title: project.metadata.name,
     description: project.metadata.description,
@@ -36,6 +46,9 @@
           commits={project.stats.commits}
           contributors={project.stats.contributors} />
       {/if}
+      <AdditionalActionsDropdown
+        headerTitle={project.id}
+        menuItems={contextMenuItems} />
     </div>
   </Flex>
 </List>
```
</details>

<details>
<summary>
Without the fix in #963, there is no flickering.
</summary>

![no-flicker](https://user-images.githubusercontent.com/158411/94255210-2f909280-ff28-11ea-827d-f43d07ac4a58.gif)
</details>


