### PR TITLE
feat(proxy): keep CoCo alive

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=3eb9d1fb671d8123cb40b2365e2fbde7f3ea8973#3eb9d1fb671d8123cb40b2365e2fbde7f3ea8973"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=01f95786b1c05bf167b27dcf54e4cbe0e9b38a43#01f95786b1c05bf167b27dcf54e4cbe0e9b38a43"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -1870,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "radicle-git-helpers"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=3eb9d1fb671d8123cb40b2365e2fbde7f3ea8973#3eb9d1fb671d8123cb40b2365e2fbde7f3ea8973"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=01f95786b1c05bf167b27dcf54e4cbe0e9b38a43#01f95786b1c05bf167b27dcf54e4cbe0e9b38a43"
 dependencies = [
  "anyhow",
  "git2",

--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -155,7 +155,7 @@ async fn rig(args: Args) -> Result<Rigging, Box<dyn std::error::Error>> {
             log::error!("Error parsing seed list {:?}: {}", seeds, err);
             vec![]
         });
-        let config = coco::config::configure(paths, key, *coco::config::LOCALHOST_ANY, seeds);
+        let config = coco::config::configure(paths, key, *coco::config::INADDR_ANY, seeds);
 
         coco::into_peer_state(config, signer.clone(), store.clone(), RunConfig::default()).await?
     };

--- a/proxy/coco/Cargo.toml
+++ b/proxy/coco/Cargo.toml
@@ -29,11 +29,11 @@ features = [ "json-value" ]
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "3eb9d1fb671d8123cb40b2365e2fbde7f3ea8973"
+rev = "01f95786b1c05bf167b27dcf54e4cbe0e9b38a43"
 
 [dependencies.radicle-git-helpers]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "3eb9d1fb671d8123cb40b2365e2fbde7f3ea8973"
+rev = "01f95786b1c05bf167b27dcf54e4cbe0e9b38a43"
 
 [dependencies.radicle-surf]
 version = "0.4.1"

--- a/proxy/coco/src/config.rs
+++ b/proxy/coco/src/config.rs
@@ -14,7 +14,7 @@ lazy_static::lazy_static! {
     pub static ref LOCALHOST_ANY: SocketAddr =
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
 
-    /// Binds to all local addresses and any available port.
+    /// Binds to all local interfaces and any available port.
     pub static ref INADDR_ANY: SocketAddr =
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0));
 }

--- a/proxy/coco/src/config.rs
+++ b/proxy/coco/src/config.rs
@@ -13,6 +13,10 @@ lazy_static::lazy_static! {
     /// Localhost binding to any available port, i.e. `127.0.0.1:0`.
     pub static ref LOCALHOST_ANY: SocketAddr =
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
+
+    /// Binds to all local addresses and any available port.
+    pub static ref INADDR_ANY: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0));
 }
 
 /// The environment variable that points to where librad data lives.


### PR DESCRIPTION
Bumps to the link version that keeps connections alive sending keep
alive messages. Additionally introduces the ability to listen on all
network addresses to enable communication with remote hosts.