### PR TITLE
fix(proxy): reintroduce sync on startup

### DIFF
--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -8,17 +8,13 @@ use tokio::{
 };
 
 use api::{config, context, env, http, notification, session};
-<<<<<<< HEAD
-use coco::{keystore, seed, signer, Peer, RunConfig, SyncConfig};
-=======
 use coco::{
     keystore,
     request::waiting_room::{self, WaitingRoom},
     seed,
     shared::Shared,
-    signer, Peer, RunConfig,
+    signer, Peer, RunConfig, SyncConfig,
 };
->>>>>>> master
 
 /// Flags accepted by the proxy binary.
 #[derive(Clone, Copy)]

--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -8,7 +8,7 @@ use tokio::{
 };
 
 use api::{config, context, env, http, notification, session};
-use coco::{keystore, seed, signer, Peer, RunConfig};
+use coco::{keystore, seed, signer, Peer, RunConfig, SyncConfig};
 
 /// Flags accepted by the proxy binary.
 #[derive(Clone, Copy)]
@@ -157,7 +157,20 @@ async fn rig(args: Args) -> Result<Rigging, Box<dyn std::error::Error>> {
         });
         let config = coco::config::configure(paths, key, *coco::config::INADDR_ANY, seeds);
 
-        coco::into_peer_state(config, signer.clone(), store.clone(), RunConfig::default()).await?
+        coco::into_peer_state(
+            config,
+            signer.clone(),
+            store.clone(),
+            RunConfig {
+                sync: SyncConfig {
+                    max_peers: 1,
+                    on_startup: true,
+                    period: Duration::from_secs(5),
+                },
+                ..RunConfig::default()
+            },
+        )
+        .await?
     };
 
     let subscriptions = notification::Subscriptions::default();

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -238,7 +238,7 @@ async fn subroutines(
         subscriber.send(event.clone()).ok();
         log::debug!("{:?}", event);
 
-        for cmd in run_state.transition(event) {
+        for cmd in run_state.transition(&event) {
             match cmd {
                 Command::Announce => {
                     let stop = stop.clone();

--- a/proxy/coco/src/peer/run_state.rs
+++ b/proxy/coco/src/peer/run_state.rs
@@ -287,12 +287,12 @@ impl RunState {
             (
                 Status::Online(_) | Status::Syncing(_, _),
                 Event::Request(RequestEvent::Query(urn)),
-            ) => vec![RequestCommand::Query(urn).into()],
+            ) => vec![RequestCommand::Query(urn.clone()).into()],
             // Clone requested URLs while online.
             (
                 Status::Online(_) | Status::Syncing(_, _),
                 Event::Request(RequestEvent::Clone(url)),
-            ) => vec![RequestCommand::Clone(url).into()],
+            ) => vec![RequestCommand::Clone(url.clone()).into()],
             // Found URN.
             (
                 _,
@@ -301,8 +301,8 @@ impl RunState {
                     val: Gossip { urn, .. },
                 }))),
             ) => vec![RequestCommand::Found(RadUrl {
-                authority: provider.peer_id,
-                urn,
+                authority: provider.peer_id.clone(),
+                urn: urn.clone(),
             })
             .into()],
             _ => vec![],
@@ -521,22 +521,22 @@ mod test {
 
         let status = Status::Stopped(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Query(urn.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Query(urn.clone())));
         assert_eq!(cmds.first(), None,);
 
         let status = Status::Started(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Query(urn.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Query(urn.clone())));
         assert_eq!(cmds.first(), None);
 
         let status = Status::Offline(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Query(urn.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Query(urn.clone())));
         assert_eq!(cmds.first(), None,);
 
         let status = Status::Syncing(Instant::now(), 1);
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Query(urn.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Query(urn.clone())));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Query(urn.clone()))
@@ -544,7 +544,7 @@ mod test {
 
         let status = Status::Online(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Query(urn.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Query(urn.clone())));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Query(urn))
@@ -584,7 +584,7 @@ mod test {
 
         let status = Status::Stopped(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Protocol(gossip.clone()));
+        let cmds = state.transition(&Event::Protocol(gossip.clone()));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Found(url.clone()))
@@ -592,7 +592,7 @@ mod test {
 
         let status = Status::Started(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Protocol(gossip.clone()));
+        let cmds = state.transition(&Event::Protocol(gossip.clone()));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Found(url.clone()))
@@ -600,7 +600,7 @@ mod test {
 
         let status = Status::Offline(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Protocol(gossip.clone()));
+        let cmds = state.transition(&Event::Protocol(gossip.clone()));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Found(url.clone()))
@@ -608,7 +608,7 @@ mod test {
 
         let status = Status::Syncing(Instant::now(), 1);
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Protocol(gossip.clone()));
+        let cmds = state.transition(&Event::Protocol(gossip.clone()));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Found(url.clone()))
@@ -616,7 +616,7 @@ mod test {
 
         let status = Status::Online(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Protocol(gossip));
+        let cmds = state.transition(&Event::Protocol(gossip));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Found(url))
@@ -637,22 +637,22 @@ mod test {
 
         let status = Status::Stopped(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Clone(url.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Clone(url.clone())));
         assert_eq!(cmds.first(), None,);
 
         let status = Status::Started(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Clone(url.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Clone(url.clone())));
         assert_eq!(cmds.first(), None);
 
         let status = Status::Offline(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Clone(url.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Clone(url.clone())));
         assert_eq!(cmds.first(), None,);
 
         let status = Status::Syncing(Instant::now(), 1);
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Clone(url.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Clone(url.clone())));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Clone(url.clone()))
@@ -660,7 +660,7 @@ mod test {
 
         let status = Status::Online(Instant::now());
         let mut state = RunState::new(Config::default(), HashSet::new(), status);
-        let cmds = state.transition(Event::Request(RequestEvent::Clone(url.clone())));
+        let cmds = state.transition(&Event::Request(RequestEvent::Clone(url.clone())));
         assert_eq!(
             *cmds.first().unwrap(),
             Command::Request(RequestCommand::Clone(url))


### PR DESCRIPTION
During the great merges of 2020 we went back to the default of
RunConfig, which does not have sync on startup enabled. This behaviour
is desired for proxies running in "production".