### PR TITLE
chore(proxy): attempt 3 at proper async task management

### DIFF
--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -110,7 +110,7 @@ async fn run(
     };
     let peer = async move {
         log::info!("... peer");
-        peer.into_running().await.await
+        peer.into_running().await
     };
 
     log::info!("Starting...");

--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokio::select! {
             r = runner => match r {
                 // We've been shut down, ignore
-                Err(RunError::Peer(coco::peer::Error::Aborted(_))) | Ok(()) => {
+                Err(RunError::Peer(coco::peer::Error::Spawn(_))) | Ok(()) => {
                     log::debug!("aborted")
                 },
                 // Actual error, abort the process
@@ -110,7 +110,7 @@ async fn run(
     };
     let peer = async move {
         log::info!("... peer");
-        peer.into_running().await
+        peer.into_running().await.await
     };
 
     log::info!("Starting...");

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -460,16 +460,12 @@ impl Future for Subroutines {
             }
         }
 
-        match self.tasks.poll_next_unpin(cx) {
-            Poll::Pending => log::trace!("subroutine tasks pending"),
-            Poll::Ready(None) => {
-                log::trace!("no more subroutine tasks");
-            },
-            Poll::Ready(Some(r)) => {
-                log::trace!("got a subroutine task result: {:?}", r);
-            },
-        }
-
+        // We must poll the tasks, but ignore the result and always return
+        // `Pending`, because:
+        //
+        // 1. We're not interested in task results
+        // 2. The task queue could be empty
+        self.tasks.poll_next_unpin(cx).is_ready();
         Poll::Pending
     }
 }

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -388,7 +388,7 @@ impl Future for Subroutines {
             match self.pending_tasks.poll_next_unpin(cx) {
                 Poll::Ready(Some(Err(e))) => {
                     log::warn!("error in spawned subroutine task: {:?}", e);
-                    return Poll::Ready(Err(e))
+                    return Poll::Ready(Err(e));
                 },
                 Poll::Ready(Some(Ok(()))) => continue,
                 // FuturesUnordered thinks it's done, but we'll enqueue new

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -5,23 +5,25 @@ use std::{
     convert::From,
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
     time::{Duration, Instant},
 };
 
 use futures::{
     future::{self, FutureExt as _},
-    stream::StreamExt as _,
+    stream::{BoxStream, FuturesUnordered, StreamExt as _},
 };
 use tokio::{
     sync::{broadcast, mpsc},
     task::{JoinError, JoinHandle},
-    time::interval,
+    time::{interval, Interval},
 };
 
 use librad::{
-    net::peer::RunLoop,
+    net::{
+        peer::{Gossip, RunLoop},
+        protocol::ProtocolEvent,
+    },
     peer::PeerId,
     uri::{RadUrl, RadUrn},
 };
@@ -59,13 +61,9 @@ pub enum Error {
     #[error(transparent)]
     Announcement(#[from] announcement::Error),
 
-    /// The future was aborted.
-    #[error("the running peer was aborted")]
-    Aborted(#[source] future::Aborted),
-
     /// There was an error in a spawned task.
     #[error("the running peer was either cancelled, or one of its tasks panicked")]
-    Join(#[source] JoinError),
+    Spawn(#[source] SpawnAbortableError),
 
     /// Stop-gap until we get rid of crate level errors.
     // TODO(xla): Remove once we transitioned to per module errors.
@@ -123,88 +121,52 @@ impl Peer {
     /// Start up the internal machinery to advance the underlying protocol, react to significant
     /// events and keep auxiliary tasks running.
     ///
-    /// Calling this method spawns tasks onto the async executor, so the returned future has
-    /// similar semantics to [`JoinHandle`]. Unlike [`JoinHandle`], however, dropping the
-    /// [`Running`] future will cancel all its tasks. It is advisable to poll the [`Running`] future
-    /// in order to be able to get notified of errors -- in which case, however, not much can be
-    /// done except for creating a new [`Peer`] and put it into running state.
-    pub fn into_running(self) -> Running {
-        self.into()
-    }
-}
-
-/// [`JoinHandle`] for the protocol run loop task.
-type JoinProtocol = JoinHandle<Result<(), future::Aborted>>;
-
-/// [`JoinHandle`] for the subroutines task.
-type JoinSubroutines = JoinHandle<Result<(), Error>>;
-
-/// Future returned by [`Peer::into_running`].
-#[must_use = "to the sig hup, don't stup, don't drop"]
-pub struct Running {
-    /// Join and abort handles for the protocol run loop.
-    protocol: (JoinProtocol, future::AbortHandle),
-    /// Join and abort handles for the subroutines task.
-    subroutines: (JoinSubroutines, Arc<tokio::sync::Notify>),
-}
-
-impl Running {
-    /// Abort the tasks of this future.
-    ///
-    /// The next call to [`Future::poll`] will return an [`Error::Aborted`].
-    pub fn abort(&mut self) {
-        self.protocol.1.abort();
-        self.subroutines.1.notify();
-    }
-}
-
-impl From<Peer> for Running {
-    fn from(peer: Peer) -> Self {
-        let Peer {
+    /// Note that the returned [`Running`] future spawns tasks internally. In order to cancel all
+    /// outstanding tasks, and release all resources, the [`Running`] must be dropped.
+    #[must_use = "this method is async, but it also returns a Future. you may need to .await.await"]
+    pub async fn into_running(self) -> Running {
+        let Self {
             run_loop,
             state,
             store,
             waiting_room,
             subscriber,
             run_config,
-        } = peer;
+        } = self;
 
-        // Note: this must be spawned first to not lose the race for the first
-        // protocol event
-        let subroutines = {
-            let stop = Arc::new(tokio::sync::Notify::new());
-            let fut = subroutines(
-                state,
-                store,
-                waiting_room,
-                run_config,
-                subscriber,
-                stop.clone(),
-            );
-            let join = tokio::spawn(fut);
+        // Note: this must be acquired before spawning the protocol, so we don't
+        // miss any event
+        let protocol_events = state.api.protocol().subscribe().await.boxed();
+        let subroutines = Subroutines::new(
+            state,
+            store,
+            waiting_room,
+            run_config,
+            protocol_events,
+            subscriber,
+        );
+        let protocol = SpawnAbortable::new(run_loop);
 
-            (join, stop)
-        };
-
-        let protocol = {
-            let (handle, registration) = future::AbortHandle::new_pair();
-            let fut = future::Abortable::new(run_loop, registration);
-            let join = tokio::spawn(fut);
-
-            (join, handle)
-        };
-
-        Self {
+        Running {
             protocol,
             subroutines,
         }
     }
 }
 
+/// Future returned by [`Peer::into_running`].
+#[must_use = "to the sig hup, don't stop, just drop"]
+pub struct Running {
+    /// Join and abort handles for the protocol run loop.
+    protocol: SpawnAbortable<()>,
+    /// The [`Subroutines`] associated with this [`Peer`] instance.
+    subroutines: Subroutines,
+}
+
 impl Drop for Running {
     fn drop(&mut self) {
-        log::debug!("dropping `Peer`");
-        self.abort()
+        log::trace!("`peer::Running` is being dropped");
+        self.protocol.abort()
     }
 }
 
@@ -212,296 +174,372 @@ impl Future for Running {
     type Output = Result<(), Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        let err = match self.protocol.0.poll_unpin(cx) {
+        let err = match self.protocol.poll_unpin(cx) {
             Poll::Ready(val) => match val {
-                Err(e) => Some(Error::Join(e)),
-                Ok(Err(e)) => Some(Error::Aborted(e)),
-                Ok(Ok(())) => None,
+                Err(e) => Some(Error::Spawn(e)),
+                Ok(()) => None,
             },
             Poll::Pending => None,
         };
 
         if let Some(err) = err {
+            log::trace!("run loop error: {:?}", err);
             return Poll::Ready(Err(err));
         }
 
-        match self.subroutines.0.poll_unpin(cx) {
-            Poll::Ready(val) => match val {
-                Err(e) => Poll::Ready(Err(Error::Join(e))),
-                Ok(Err(e)) => Poll::Ready(Err(e)),
-                Ok(Ok(())) => Poll::Ready(Ok(())),
-            },
+        match self.subroutines.poll_unpin(cx) {
+            Poll::Ready(()) => Poll::Ready(Ok(())),
             Poll::Pending => Poll::Pending,
         }
     }
 }
 
-/// Schedule subroutines.
-async fn subroutines(
-    state: State,
-    store: kv::Store,
-    waiting_room: Shared<WaitingRoom<Instant, Duration>>,
-    run_config: RunConfig,
-    subscriber: broadcast::Sender<Event>,
-    stop: Arc<tokio::sync::Notify>,
-) -> Result<(), Error> {
-    let mut protocol_events = state.api.protocol().subscribe().await;
-    let mut announce_timer = interval(run_config.announce.interval);
-    let mut ping = interval(PING_PERIOD);
+/// [`SpawnAbortable`] errors.
+#[derive(Debug, thiserror::Error)]
+pub enum SpawnAbortableError {
+    /// The spawned task either panicked, or was cancelled by the runtime.
+    #[error(transparent)]
+    Join(#[from] JoinError),
 
-    let (announce_sender, mut announcements) = mpsc::channel::<AnnounceEvent>(RECEIVER_CAPACITY);
-    let (peer_sync_sender, mut peer_syncs) = mpsc::channel::<SyncEvent>(RECEIVER_CAPACITY);
-    let (timeout_sender, mut timeouts) = mpsc::channel::<TimeoutEvent>(RECEIVER_CAPACITY);
-    let (request_sender, mut requests) = mpsc::channel::<RequestEvent>(RECEIVER_CAPACITY);
+    /// The spawned task was aborted by calling [`SpawnAbortable::abort`].
+    #[error(transparent)]
+    Abort(#[from] future::Aborted),
+}
 
-    let request_queries = waiting_room::stream::Queries::new(waiting_room.clone().value);
-    tokio::pin!(request_queries);
-    let request_clones = waiting_room::stream::Clones::new(waiting_room.clone().value);
-    tokio::pin!(request_clones);
+/// A spawned task which can also be aborted by the user.
+///
+/// Stop-gap until we can abort [`JoinHandle`]s directly:
+/// tokio-rs@cbb14a7bb9a13363e1abee8caff2bad1f996c263
+pub struct SpawnAbortable<T> {
+    join_handle: JoinHandle<Result<T, future::Aborted>>,
+    abort_handle: future::AbortHandle,
+}
 
-    let mut run_state = RunState::from(run_config);
-    loop {
-        let event = tokio::select! {
-            _ = ping.tick() => Event::Ping,
-            _ = announce_timer.tick() => Event::Announce(AnnounceEvent::Tick),
-            Some(announce_event) = announcements.recv() => Event::Announce(announce_event),
-            Some(protocol_event) = protocol_events.next() => Event::Protocol(protocol_event),
-            Some(sync_event) = peer_syncs.recv() => Event::PeerSync(sync_event),
-            Some(timeout_event) = timeouts.recv() => Event::Timeout(timeout_event),
-            Some(urn) = request_queries.next() => Event::Request(RequestEvent::Query(urn)),
-            Some(url) = request_clones.next() => Event::Request(RequestEvent::Clone(url)),
-            Some(request_event) = requests.next() => Event::Request(request_event),
-            else => {
-                break
-            },
-        };
+impl<T> SpawnAbortable<T> {
+    /// Create a new [`SpawnAbortable`] from a [`Future`].
+    ///
+    /// The supplied [`Future`] will be spawned onto the async executor **immediately**!
+    pub fn new<Fut>(fut: Fut) -> Self
+    where
+        Fut: Future<Output = T> + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
+        let (abort_handle, abort_reg) = future::AbortHandle::new_pair();
+        let join_handle = tokio::spawn(future::Abortable::new(fut, abort_reg));
 
-        // Send will error if there are no active receivers. This
-        // case is expected and should not terminate the run loop.
-        subscriber.send(event.clone()).ok();
-        log::debug!("{:?}", event);
-
-        for cmd in run_state.transition(&event) {
-            match cmd {
-                Command::Request(RequestCommand::Query(urn)) => {
-                    let stop = stop.clone();
-                    query(
-                        urn,
-                        state.clone(),
-                        waiting_room.clone(),
-                        async move { stop.notified().await }.boxed(),
-                    );
-                },
-                Command::Request(RequestCommand::Found(url)) => {
-                    let stop = stop.clone();
-                    found(
-                        url,
-                        waiting_room.clone(),
-                        async move { stop.notified().await }.boxed(),
-                    );
-                },
-                Command::Request(RequestCommand::Clone(url)) => {
-                    let stop = stop.clone();
-                    clone(
-                        url,
-                        state.clone(),
-                        waiting_room.clone(),
-                        request_sender.clone(),
-                        async move { stop.notified().await }.boxed(),
-                    );
-                },
-                Command::Announce => {
-                    let stop = stop.clone();
-                    announce(
-                        state.clone(),
-                        store.clone(),
-                        announce_sender.clone(),
-                        async move { stop.notified().await }.boxed(),
-                    )
-                },
-                Command::SyncPeer(peer_id) => {
-                    // Cancel when either the parent shuts down, or the timeout
-                    // task fired
-                    let stopper = {
-                        let on_stop = {
-                            let stop = stop.clone();
-                            async move { stop.notified().await }
-                        };
-                        let on_timeout = {
-                            let events = subscriber.subscribe();
-                            async move {
-                                tokio::stream::StreamExt::skip_while(events, |e| match e {
-                                    Ok(Event::Timeout(TimeoutEvent::SyncPeriod)) | Err(_) => false,
-                                    _ => true,
-                                })
-                                .map(|_| ())
-                                .next()
-                                .await
-                            }
-                        };
-
-                        future::select(on_stop.boxed(), on_timeout.boxed()).map(|_| ())
-                    };
-
-                    sync(
-                        state.clone(),
-                        peer_id.clone(),
-                        peer_sync_sender.clone(),
-                        stopper,
-                    );
-                },
-                Command::StartSyncTimeout(sync_period) => {
-                    start_sync_timeout(sync_period, timeout_sender.clone());
-                },
-            };
+        Self {
+            join_handle,
+            abort_handle,
         }
     }
 
-    Ok(())
+    /// Abort this future.
+    ///
+    /// Subsequent polls will return `SpawnAbortableError::Abort`.
+    pub fn abort(&mut self) {
+        self.abort_handle.abort()
+    }
+}
+
+impl<T> Drop for SpawnAbortable<T> {
+    fn drop(&mut self) {
+        self.abort()
+    }
+}
+
+impl<T> Future for SpawnAbortable<T> {
+    type Output = Result<T, SpawnAbortableError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.join_handle.poll_unpin(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(val) => {
+                let val = match val {
+                    Err(join) => Err(join.into()),
+                    Ok(Err(abort)) => Err(abort.into()),
+                    Ok(Ok(t)) => Ok(t),
+                };
+                Poll::Ready(val)
+            },
+        }
+    }
+}
+
+/// Management of "subroutine" tasks.
+struct Subroutines {
+    tasks: FuturesUnordered<SpawnAbortable<()>>,
+
+    state: State,
+    store: kv::Store,
+    waiting_room: Shared<WaitingRoom<Instant, Duration>>,
+    run_state: RunState,
+
+    protocol_events: BoxStream<'static, ProtocolEvent<Gossip>>,
+
+    announce_timer: Interval,
+    ping_timer: Interval,
+
+    subscriber: broadcast::Sender<Event>,
+
+    request_queries: waiting_room::stream::Queries,
+    request_clones: waiting_room::stream::Clones,
+
+    announce_sender: mpsc::Sender<AnnounceEvent>,
+    peer_sync_sender: mpsc::Sender<SyncEvent>,
+    timeout_sender: mpsc::Sender<TimeoutEvent>,
+    request_sender: mpsc::Sender<RequestEvent>,
+
+    announcements: mpsc::Receiver<AnnounceEvent>,
+    peer_syncs: mpsc::Receiver<SyncEvent>,
+    timeouts: mpsc::Receiver<TimeoutEvent>,
+    requests: mpsc::Receiver<RequestEvent>,
+}
+
+impl Subroutines {
+    pub fn new(
+        state: State,
+        store: kv::Store,
+        waiting_room: Shared<WaitingRoom<Instant, Duration>>,
+        run_config: RunConfig,
+        protocol_events: BoxStream<'static, ProtocolEvent<Gossip>>,
+        subscriber: broadcast::Sender<Event>,
+    ) -> Self {
+        let announce_timer = interval(run_config.announce.interval);
+        let ping_timer = interval(PING_PERIOD);
+
+        let (announce_sender, announcements) = mpsc::channel::<AnnounceEvent>(RECEIVER_CAPACITY);
+        let (peer_sync_sender, peer_syncs) = mpsc::channel::<SyncEvent>(RECEIVER_CAPACITY);
+        let (timeout_sender, timeouts) = mpsc::channel::<TimeoutEvent>(RECEIVER_CAPACITY);
+        let (request_sender, requests) = mpsc::channel::<RequestEvent>(RECEIVER_CAPACITY);
+
+        let run_state = RunState::from(run_config);
+
+        let request_queries = waiting_room::stream::Queries::new(waiting_room.clone().value);
+        let request_clones = waiting_room::stream::Clones::new(waiting_room.clone().value);
+
+        Self {
+            tasks: FuturesUnordered::new(),
+
+            state,
+            store,
+            waiting_room,
+            run_state,
+
+            protocol_events: protocol_events.boxed(),
+
+            announce_timer,
+            ping_timer,
+
+            subscriber,
+
+            request_queries,
+            request_clones,
+
+            announce_sender,
+            peer_sync_sender,
+            timeout_sender,
+            request_sender,
+
+            announcements,
+            peer_syncs,
+            timeouts,
+            requests,
+        }
+    }
+}
+
+impl Drop for Subroutines {
+    fn drop(&mut self) {
+        for task in self.tasks.iter_mut() {
+            task.abort()
+        }
+    }
+}
+
+impl Future for Subroutines {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let mut events = Vec::with_capacity(9);
+
+        // FIXME(kim): can we not somehow coalesce all of these into a stream?
+        {
+            if let Poll::Ready(Some(protocol_event)) = self.protocol_events.poll_next_unpin(cx) {
+                events.push(Event::Protocol(protocol_event));
+            }
+
+            if let Poll::Ready(Some(_)) = self.announce_timer.poll_next_unpin(cx) {
+                events.push(Event::Announce(AnnounceEvent::Tick));
+            }
+
+            if let Poll::Ready(Some(_)) = self.ping_timer.poll_next_unpin(cx) {
+                events.push(Event::Ping);
+            }
+
+            if let Poll::Ready(Some(announce_event)) = self.announcements.poll_recv(cx) {
+                events.push(Event::Announce(announce_event));
+            }
+
+            if let Poll::Ready(Some(sync_event)) = self.peer_syncs.poll_recv(cx) {
+                events.push(Event::PeerSync(sync_event));
+            }
+
+            if let Poll::Ready(Some(timeout_event)) = self.timeouts.poll_recv(cx) {
+                events.push(Event::Timeout(timeout_event));
+            }
+
+            if let Poll::Ready(Some(urn)) = self.request_queries.poll_next_unpin(cx) {
+                events.push(Event::Request(RequestEvent::Query(urn)));
+            }
+
+            if let Poll::Ready(Some(url)) = self.request_clones.poll_next_unpin(cx) {
+                events.push(Event::Request(RequestEvent::Clone(url)));
+            }
+
+            if let Poll::Ready(Some(request_event)) = self.requests.poll_next_unpin(cx) {
+                events.push(Event::Request(request_event));
+            }
+        }
+
+        for event in events {
+            log::debug!("handling subroutine event: {:?}", event);
+            self.subscriber.send(event.clone()).ok();
+            for cmd in self.run_state.transition(&event) {
+                let task = match cmd {
+                    Command::Announce => SpawnAbortable::new(announce(
+                        self.state.clone(),
+                        self.store.clone(),
+                        self.announce_sender.clone(),
+                    )),
+                    Command::SyncPeer(peer_id) => SpawnAbortable::new(sync(
+                        self.state.clone(),
+                        peer_id.clone(),
+                        self.peer_sync_sender.clone(),
+                    )),
+                    Command::StartSyncTimeout(sync_period) => SpawnAbortable::new(
+                        start_sync_timeout(sync_period, self.timeout_sender.clone()),
+                    ),
+                    Command::Request(RequestCommand::Query(urn)) => SpawnAbortable::new(query(
+                        urn,
+                        self.state.clone(),
+                        self.waiting_room.clone(),
+                    )),
+                    Command::Request(RequestCommand::Found(url)) => {
+                        SpawnAbortable::new(found(url, self.waiting_room.clone()))
+                    },
+                    Command::Request(RequestCommand::Clone(url)) => SpawnAbortable::new(clone(
+                        url,
+                        self.state.clone(),
+                        self.waiting_room.clone(),
+                        self.request_sender.clone(),
+                    )),
+                };
+
+                self.tasks.push(task);
+            }
+        }
+
+        match self.tasks.poll_next_unpin(cx) {
+            Poll::Pending => log::trace!("subroutine tasks pending"),
+            Poll::Ready(None) => {
+                log::trace!("no more subroutine tasks");
+            },
+            Poll::Ready(Some(r)) => {
+                log::trace!("got a subroutine task result: {:?}", r);
+            },
+        }
+
+        Poll::Pending
+    }
 }
 
 /// Announcement subroutine.
-fn announce(
-    state: State,
-    store: kv::Store,
-    mut sender: mpsc::Sender<AnnounceEvent>,
-    stop: impl Future<Output = ()> + Send + Unpin + 'static,
-) {
-    tokio::spawn(async move {
-        let go = async {
-            match announcement::run(&state, &store).await {
-                Ok(updates) => {
-                    sender.send(AnnounceEvent::Succeeded(updates)).await.ok();
-                },
-                Err(err) => {
-                    log::error!("announce error: {:?}", err);
-                    sender.send(AnnounceEvent::Failed).await.ok();
-                },
-            }
-        };
-        tokio::pin!(go);
-
-        future::select(stop, go).map(|_| ()).await;
-    });
+async fn announce(state: State, store: kv::Store, mut sender: mpsc::Sender<AnnounceEvent>) {
+    match announcement::run(&state, &store).await {
+        Ok(updates) => {
+            sender.send(AnnounceEvent::Succeeded(updates)).await.ok();
+        },
+        Err(err) => {
+            log::error!("announce error: {:?}", err);
+            sender.send(AnnounceEvent::Failed).await.ok();
+        },
+    }
 }
 
 /// Peer syncing subroutine.
-fn sync(
-    state: State,
-    peer_id: PeerId,
-    mut sender: mpsc::Sender<SyncEvent>,
-    stop: impl Future<Output = ()> + Send + Unpin + 'static,
-) {
-    tokio::spawn(async move {
-        sender.send(SyncEvent::Started(peer_id.clone())).await.ok();
+async fn sync(state: State, peer_id: PeerId, mut sender: mpsc::Sender<SyncEvent>) {
+    sender.send(SyncEvent::Started(peer_id.clone())).await.ok();
 
-        let go = async {
-            match sync::sync(&state, peer_id.clone()).await {
-                Ok(_) => {
-                    sender
-                        .send(SyncEvent::Succeeded(peer_id.clone()))
-                        .await
-                        .ok();
-                },
-                Err(err) => {
-                    log::error!("sync error for {}: {:?}", peer_id, err);
-                    sender.send(SyncEvent::Failed(peer_id.clone())).await.ok();
-                },
-            }
-        };
-        tokio::pin!(go);
-
-        future::select(stop, go).map(|_| ()).await;
-    });
+    match sync::sync(&state, peer_id.clone()).await {
+        Ok(_) => {
+            sender
+                .send(SyncEvent::Succeeded(peer_id.clone()))
+                .await
+                .ok();
+        },
+        Err(err) => {
+            log::error!("sync error for {}: {:?}", peer_id, err);
+            sender.send(SyncEvent::Failed(peer_id.clone())).await.ok();
+        },
+    }
 }
 
 /// Sync timeout subroutine.
-fn start_sync_timeout(sync_period: Duration, mut sender: mpsc::Sender<TimeoutEvent>) {
-    tokio::spawn(async move {
-        tokio::time::delay_for(sync_period).await;
-        sender.send(TimeoutEvent::SyncPeriod).await.ok();
-    });
+async fn start_sync_timeout(sync_period: Duration, mut sender: mpsc::Sender<TimeoutEvent>) {
+    tokio::time::delay_for(sync_period).await;
+    sender.send(TimeoutEvent::SyncPeriod).await.ok();
 }
 
 /// Query subroutine.
-fn query(
-    urn: RadUrn,
-    state: State,
-    waiting_room: Shared<WaitingRoom<Instant, Duration>>,
-    stop: impl Future<Output = ()> + Send + Unpin + 'static,
-) {
-    tokio::spawn(async move {
-        let go = async {
-            request::query(urn.clone(), state.clone(), waiting_room.clone())
-                .await
-                .unwrap_or_else(|err| {
-                    log::warn!(
-                        "an error occurred for the command 'Query' for the URN '{}':\n{}",
-                        urn,
-                        err
-                    );
-                });
-        };
-        tokio::pin!(go);
-
-        future::select(stop, go).map(|_| ()).await;
-    });
+async fn query(urn: RadUrn, state: State, waiting_room: Shared<WaitingRoom<Instant, Duration>>) {
+    request::query(urn.clone(), state, waiting_room)
+        .await
+        .unwrap_or_else(|err| {
+            log::warn!(
+                "an error occurred for the command 'Query' for the URN '{}':\n{}",
+                urn,
+                err
+            );
+        });
 }
 
 /// Found subroutine.
-fn found(
-    url: RadUrl,
-    waiting_room: Shared<WaitingRoom<Instant, Duration>>,
-    stop: impl Future<Output = ()> + Send + Unpin + 'static,
-) {
-    tokio::spawn(async move {
-        let go = async {
-            request::found(url.clone(), waiting_room.clone())
-                .await
-                .unwrap_or_else(|err| {
-                    log::warn!(
-                        "an error occurred for the command 'Found' for the URL '{}':\n{}",
-                        url,
-                        err
-                    );
-                });
-        };
-        tokio::pin!(go);
-
-        future::select(stop, go).map(|_| ()).await;
-    });
+async fn found(url: RadUrl, waiting_room: Shared<WaitingRoom<Instant, Duration>>) {
+    request::found(url.clone(), waiting_room)
+        .await
+        .unwrap_or_else(|err| {
+            log::warn!(
+                "an error occurred for the command 'Found' for the URL '{}':\n{}",
+                url,
+                err
+            );
+        });
 }
 
 /// Clone subroutine.
-fn clone(
+async fn clone(
     url: RadUrl,
     state: State,
     waiting_room: Shared<WaitingRoom<Instant, Duration>>,
     mut sender: mpsc::Sender<RequestEvent>,
-    stop: impl Future<Output = ()> + Send + Unpin + 'static,
 ) {
-    tokio::spawn(async move {
-        let go = async {
-            match request::clone(url.clone(), state.clone(), waiting_room.clone()).await {
-                Ok(()) => sender.send(RequestEvent::Cloned(url)).await.ok(),
-                Err(err) => {
-                    log::warn!(
-                        "an error occurred for the command 'Clone' for the URL '{}':\n{}",
-                        url,
-                        err
-                    );
-                    sender
-                        .send(RequestEvent::Failed {
-                            url,
-                            reason: err.to_string(),
-                        })
-                        .await
-                        .ok()
-                },
-            }
-        };
-        tokio::pin!(go);
-
-        future::select(stop, go).map(|_| ()).await;
-    });
+    match request::clone(url.clone(), state, waiting_room).await {
+        Ok(()) => {
+            sender.send(RequestEvent::Cloned(url)).await.ok();
+        },
+        Err(err) => {
+            log::warn!(
+                "an error occurred for the command 'Clone' for the URL '{}':\n{}",
+                url,
+                err
+            );
+            sender
+                .send(RequestEvent::Failed {
+                    url,
+                    reason: err.to_string(),
+                })
+                .await
+                .ok();
+        },
+    }
 }

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -210,6 +210,7 @@ pub enum SpawnAbortableError {
 ///
 /// Stop-gap until we can abort [`JoinHandle`]s directly:
 /// tokio-rs@cbb14a7bb9a13363e1abee8caff2bad1f996c263
+#[allow(clippy::missing_docs_in_private_items)]
 pub struct SpawnAbortable<T> {
     join_handle: JoinHandle<Result<T, future::Aborted>>,
     abort_handle: future::AbortHandle,
@@ -266,6 +267,7 @@ impl<T> Future for SpawnAbortable<T> {
 }
 
 /// Management of "subroutine" tasks.
+#[allow(clippy::missing_docs_in_private_items)]
 struct Subroutines {
     tasks: FuturesUnordered<SpawnAbortable<()>>,
 
@@ -296,6 +298,7 @@ struct Subroutines {
 }
 
 impl Subroutines {
+    /// Constructor.
     pub fn new(
         state: State,
         store: kv::Store,

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -181,7 +181,8 @@ pub struct Running {
 impl Drop for Running {
     fn drop(&mut self) {
         log::trace!("`peer::Running` is being dropped");
-        self.protocol.abort()
+        self.protocol.abort();
+        self.subroutines.abort();
     }
 }
 

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -40,7 +40,7 @@ async fn can_announce_new_project() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
     let alice_events = alice_peer.subscribe();
 
-    tokio::spawn(alice_peer.into_running().await);
+    tokio::spawn(alice_peer.into_running());
 
     let alice = alice_state.init_owner(&alice_signer, "alice").await?;
     alice_state
@@ -103,8 +103,8 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
     let bob_connected = bob_peer.subscribe();
     let bob_events = bob_peer.subscribe();
 
-    tokio::spawn(alice_peer.into_running().await);
-    tokio::spawn(bob_peer.into_running().await);
+    tokio::spawn(alice_peer.into_running());
+    tokio::spawn(bob_peer.into_running());
 
     connected(bob_connected, &alice_peer_id).await?;
 
@@ -143,7 +143,7 @@ async fn providers_is_none() -> Result<(), Box<dyn std::error::Error>> {
         Shared::from(WaitingRoom::new(waiting_room::Config::default()));
     let (peer, state, _signer) = build_peer(&tmp_dir, waiting_room, RunConfig::default()).await?;
 
-    tokio::spawn(peer.into_running().await);
+    tokio::spawn(peer.into_running());
 
     let unkown_urn = Urn {
         id: Hash::hash(b"project0"),
@@ -191,8 +191,8 @@ async fn providers() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
     let bob_events = bob_peer.subscribe();
 
-    tokio::spawn(alice_peer.into_running().await);
-    tokio::spawn(bob_peer.into_running().await);
+    tokio::spawn(alice_peer.into_running());
+    tokio::spawn(bob_peer.into_running());
 
     connected(bob_events, &alice_peer_id).await?;
 
@@ -250,8 +250,8 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     let clone_listener = bob_peer.subscribe();
     let query_listener = bob_peer.subscribe();
 
-    tokio::task::spawn(alice_peer.into_running().await);
-    tokio::task::spawn(bob_peer.into_running().await);
+    tokio::task::spawn(alice_peer.into_running());
+    tokio::task::spawn(bob_peer.into_running());
 
     connected(bob_events, &alice_peer_id).await?;
 

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -40,16 +40,13 @@ async fn can_announce_new_project() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
     let alice_events = alice_peer.subscribe();
 
-    let _alice_runs = alice_peer.into_running();
+    tokio::spawn(alice_peer.into_running().await);
 
     let alice = alice_state.init_owner(&alice_signer, "alice").await?;
-
-    {
-        alice_state
-            .init_project(&alice_signer, &alice, shia_le_pathbuf(alice_repo_path))
-            .await
-            .expect("unable to init project");
-    }
+    alice_state
+        .init_project(&alice_signer, &alice, shia_le_pathbuf(alice_repo_path))
+        .await
+        .expect("unable to init project");
 
     let announced = alice_events
         .into_stream()
@@ -106,8 +103,8 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
     let bob_connected = bob_peer.subscribe();
     let bob_events = bob_peer.subscribe();
 
-    tokio::task::spawn(alice_peer.into_running());
-    tokio::task::spawn(bob_peer.into_running());
+    tokio::spawn(alice_peer.into_running().await);
+    tokio::spawn(bob_peer.into_running().await);
 
     connected(bob_connected, &alice_peer_id).await?;
 
@@ -146,7 +143,7 @@ async fn providers_is_none() -> Result<(), Box<dyn std::error::Error>> {
         Shared::from(WaitingRoom::new(waiting_room::Config::default()));
     let (peer, state, _signer) = build_peer(&tmp_dir, waiting_room, RunConfig::default()).await?;
 
-    tokio::task::spawn(peer.into_running());
+    tokio::spawn(peer.into_running().await);
 
     let unkown_urn = Urn {
         id: Hash::hash(b"project0"),
@@ -194,8 +191,8 @@ async fn providers() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
     let bob_events = bob_peer.subscribe();
 
-    tokio::task::spawn(alice_peer.into_running());
-    tokio::task::spawn(bob_peer.into_running());
+    tokio::spawn(alice_peer.into_running().await);
+    tokio::spawn(bob_peer.into_running().await);
 
     connected(bob_events, &alice_peer_id).await?;
 

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -250,8 +250,8 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     let clone_listener = bob_peer.subscribe();
     let query_listener = bob_peer.subscribe();
 
-    tokio::task::spawn(alice_peer.into_running());
-    tokio::task::spawn(bob_peer.into_running());
+    tokio::task::spawn(alice_peer.into_running().await);
+    tokio::task::spawn(bob_peer.into_running().await);
 
     connected(bob_events, &alice_peer_id).await?;
 

--- a/proxy/coco/tests/replication.rs
+++ b/proxy/coco/tests/replication.rs
@@ -37,8 +37,8 @@ async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
         build_peer(&bob_tmp_dir, waiting_room, RunConfig::default()).await?;
     let _bob = bob_state.init_owner(&bob_signer, "bob").await?;
 
-    tokio::task::spawn(alice_peer.into_running());
-    tokio::task::spawn(bob_peer.into_running());
+    tokio::task::spawn(alice_peer.into_running().await);
+    tokio::task::spawn(bob_peer.into_running().await);
 
     let project = alice_state
         .init_project(&alice_signer, &alice, shia_le_pathbuf(alice_repo_path))
@@ -86,8 +86,8 @@ async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
     let (bob_peer, bob_state, _bob_signer) =
         build_peer(&bob_tmp_dir, waiting_room, RunConfig::default()).await?;
 
-    tokio::task::spawn(alice_peer.into_running());
-    tokio::task::spawn(bob_peer.into_running());
+    tokio::task::spawn(alice_peer.into_running().await);
+    tokio::task::spawn(bob_peer.into_running().await);
 
     let cloned_urn = {
         let alice_peer_id = alice_state.peer_id();
@@ -132,8 +132,8 @@ async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
         build_peer(&bob_tmp_dir, waiting_room, RunConfig::default()).await?;
     let _bob = bob_state.init_owner(&bob_signer, "bob").await?;
 
-    tokio::task::spawn(alice_peer.into_running());
-    tokio::task::spawn(bob_peer.into_running());
+    tokio::task::spawn(alice_peer.into_running().await);
+    tokio::task::spawn(bob_peer.into_running().await);
 
     let project = alice_state
         .init_project(
@@ -276,8 +276,8 @@ async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let bob_events = bob_peer.subscribe();
-    let _alice_runs = alice_peer.into_running();
-    let _bob_runs = bob_peer.into_running();
+    tokio::task::spawn(alice_peer.into_running().await);
+    tokio::task::spawn(bob_peer.into_running().await);
     connected(bob_events, &alice_peer_id).await?;
 
     assert_event!(

--- a/proxy/coco/tests/replication.rs
+++ b/proxy/coco/tests/replication.rs
@@ -37,8 +37,8 @@ async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
         build_peer(&bob_tmp_dir, waiting_room, RunConfig::default()).await?;
     let _bob = bob_state.init_owner(&bob_signer, "bob").await?;
 
-    tokio::task::spawn(alice_peer.into_running().await);
-    tokio::task::spawn(bob_peer.into_running().await);
+    tokio::task::spawn(alice_peer.into_running());
+    tokio::task::spawn(bob_peer.into_running());
 
     let project = alice_state
         .init_project(&alice_signer, &alice, shia_le_pathbuf(alice_repo_path))
@@ -86,8 +86,8 @@ async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
     let (bob_peer, bob_state, _bob_signer) =
         build_peer(&bob_tmp_dir, waiting_room, RunConfig::default()).await?;
 
-    tokio::task::spawn(alice_peer.into_running().await);
-    tokio::task::spawn(bob_peer.into_running().await);
+    tokio::task::spawn(alice_peer.into_running());
+    tokio::task::spawn(bob_peer.into_running());
 
     let cloned_urn = {
         let alice_peer_id = alice_state.peer_id();
@@ -132,8 +132,8 @@ async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
         build_peer(&bob_tmp_dir, waiting_room, RunConfig::default()).await?;
     let _bob = bob_state.init_owner(&bob_signer, "bob").await?;
 
-    tokio::task::spawn(alice_peer.into_running().await);
-    tokio::task::spawn(bob_peer.into_running().await);
+    tokio::task::spawn(alice_peer.into_running());
+    tokio::task::spawn(bob_peer.into_running());
 
     let project = alice_state
         .init_project(
@@ -276,8 +276,8 @@ async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let bob_events = bob_peer.subscribe();
-    tokio::task::spawn(alice_peer.into_running().await);
-    tokio::task::spawn(bob_peer.into_running().await);
+    tokio::task::spawn(alice_peer.into_running());
+    tokio::task::spawn(bob_peer.into_running());
     connected(bob_events, &alice_peer_id).await?;
 
     assert_event!(


### PR DESCRIPTION
As a follow-up to #944, this implements the `Peer` task orchestration using hand-rolled futures, in order to ensure proper lifecycle management of spawned tasks.