### PR TITLE
refactor(proxy): clean up init_* functions

### DIFF
--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -106,9 +106,11 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
                             include_error.to_string(),
                         ),
                     },
-                    coco::Error::Storage(storage::Error::AlreadyExists(_)) => {
-                        (StatusCode::CONFLICT, "ENTITY_EXISTS", err.to_string())
-                    },
+                    coco::Error::Storage(storage::Error::AlreadyExists(urn)) => (
+                        StatusCode::CONFLICT,
+                        "ENTITY_EXISTS",
+                        format!("the identity '{}' already exists", urn),
+                    ),
                     coco::Error::Git(git_error) => (
                         StatusCode::BAD_REQUEST,
                         "GIT_ERROR",

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -5,6 +5,8 @@ use serde::Serialize;
 use std::{convert::Infallible, fmt};
 use warp::{http::StatusCode, reject, reply, Rejection, Reply};
 
+use coco::error::storage;
+
 use crate::error;
 
 /// HTTP layer specific rejections.
@@ -104,7 +106,7 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
                             include_error.to_string(),
                         ),
                     },
-                    coco::Error::EntityExists(_) => {
+                    coco::Error::Storage(storage::Error::AlreadyExists(_)) => {
                         (StatusCode::CONFLICT, "ENTITY_EXISTS", err.to_string())
                     },
                     coco::Error::Git(git_error) => (

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -59,7 +59,7 @@ mod handler {
             .identity
         {
             return Err(Rejection::from(error::Error::from(
-                coco::Error::EntityExists(identity.urn),
+                coco::error::storage::already_exists(identity.urn),
             )));
         }
 

--- a/proxy/coco/src/error.rs
+++ b/proxy/coco/src/error.rs
@@ -2,15 +2,23 @@
 
 use std::{io, path};
 
-use librad::{
-    git::{repo, storage},
-    meta::entity,
-    net, uri,
-};
+use librad::{git::repo, meta::entity, net, uri};
 use radicle_surf::{
     file_system,
     vcs::{git, git::git2},
 };
+
+/// Re-export [`librad::git::storage::Error`] under the `coco::error` namespace.
+pub mod storage {
+    pub use librad::git::storage::Error;
+    use librad::uri::RadUrn;
+
+    /// Easily create an [`storage::Error::AlreadyExists`] exists error.
+    #[must_use = "you made it, you use it"]
+    pub const fn already_exists(urn: RadUrn) -> super::Error {
+        super::Error::Storage(Error::AlreadyExists(urn))
+    }
+}
 
 /// Error emitted by one of the modules.
 #[derive(Debug, thiserror::Error)]
@@ -44,10 +52,6 @@ pub enum Error {
         "while trying to get user revisions we could not find any, there should be at least one"
     )]
     EmptyRevisions,
-
-    /// Returned when an attempt to create an identity was made and there is one present.
-    #[error("the identity '{0}' already exists")]
-    EntityExists(uri::RadUrn),
 
     /// An error occurred when performing git operations.
     #[error(transparent)]

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -50,7 +50,7 @@ pub use radicle_surf::{
 
 pub mod config;
 pub mod control;
-mod error;
+pub mod error;
 pub use error::Error;
 pub mod git_helper;
 mod identifier;


### PR DESCRIPTION
librad takes care of checking the existence before creation + setting
the rad/self references.
We remove the EntityExists variant from Error and expose the storage
Error upstream so that the consumer can handle cases for special
http rejection.