### PR TITLE
fix(proxy): ignore fetch errors in when syncing

### DIFF
--- a/proxy/coco/src/peer/sync.rs
+++ b/proxy/coco/src/peer/sync.rs
@@ -22,8 +22,10 @@ pub async fn sync(state: &State, peer_id: PeerId) -> Result<(), Error> {
 
     for url in urls {
         log::debug!("Starting fetch of {} from {}", url.clone(), peer_id);
-        state.fetch(url.clone(), vec![]).await?;
-        log::debug!("Finished fetch of {} from {}", url, peer_id);
+        match state.fetch(url.clone(), vec![]).await {
+            Ok(()) => log::debug!("Finished fetch of {} from {}", url, peer_id),
+            Err(e) => log::debug!("Fetch of {} from {} errored: {}", url, peer_id, e),
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Fixes a regression introduced in #944: while syncing, the other end may
not have the URLs we're interested in, or may go away in the middle of
us fetching. We should thus just ignore any errors.