### PR TITLE
fix(ui): extend password text

### DIFF
--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -126,7 +126,7 @@
       computer’s password. <span class="typo-text-bold">
         You can’t recover your account with it,
       </span> but it prevents someone from accessing your account if this computer
-      is stolen or hacked.
+      is stolen or hacked. Be sure to put this in a safe place!
     </p>
 
     <Input.Password


### PR DESCRIPTION
Contributes to resolving #836 

Adds `Be sure to put this in a safe place!` to the description on the onboarding password screen