### PR TITLE
refactor(proxy): module errors

### DIFF
--- a/proxy/api/src/error.rs
+++ b/proxy/api/src/error.rs
@@ -1,84 +1,23 @@
 //! Proxy library errors usable for caller control flow and additional context for API responses.
 
-use std::time::SystemTimeError;
-
-/// Project problems.
-#[derive(Debug, thiserror::Error)]
-pub enum ProjectValidation {
-    /// Project names (String32) can only be at most 32 bytes.
-    #[error("the Org Name exceeded 32 bytes")]
-    NameTooLong,
-    /// Org ids (String32) can only be at most 32 bytes.
-    #[error("the Org Name exceeded 32 bytes")]
-    OrgTooLong,
-}
-
-/// Validation errors for inputs of user registrations.
-#[derive(Debug, thiserror::Error)]
-pub enum UserValidation {
-    /// Given handle is too long.
-    #[error("the User Handle provided is too long")]
-    HandleTooLong,
-    /// Given id is too long.
-    #[error("the User Id provided is too long")]
-    IdTooLong,
-}
+use std::io;
 
 /// All error variants the API will return.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Coco errors.
-    #[error(transparent)]
-    Coco(#[from] coco::Error),
-
-    /// Integer conversion failed.
-    #[error(transparent)]
-    IntConversion(#[from] std::num::TryFromIntError),
-
-    /// Length limitation on String32 has been exceeded.
-    #[error("the provided string's length exceeds 32")]
-    InordinateString32(),
-
-    /// Id input is invalid, variant carries the reason.
-    #[error("the ID '{0}' is invalid")]
-    InvalidId(String),
-
-    /// Project name input is invalid, variant carries the reason.
-    #[error("the Project Name '{0}' is invalid")]
-    InvalidProjectName(String),
-
     /// Keystore error.
     #[error(transparent)]
     Keystore(#[from] coco::keystore::Error),
 
-    /// Common I/O errors.
+    /// Error interacting with [`state::State`].
     #[error(transparent)]
-    Io(#[from] std::io::Error),
+    State(#[from] coco::state::Error),
 
-    /// Project name validation.
+    /// An I/O error occurred.
     #[error(transparent)]
-    ProjectValidation(#[from] ProjectValidation),
-
-    /// User registration validation errors.
-    #[error(transparent)]
-    UserValidation(#[from] UserValidation),
+    Io(#[from] io::Error),
 
     /// Issues when access persistent storage.
     #[error(transparent)]
     Store(#[from] kv::Error),
-
-    /// Errors from handling time.
-    #[error(transparent)]
-    Time(#[from] SystemTimeError),
-
-    /// Overflow while incrementing confirmed transaction.
-    #[error("while calculating the number of confirmed transactions, we encountered an overflow")]
-    TransactionConfirmationOverflow,
-
-    /// We expect at least one [`coco::Revisions`] when looking at a project, however the
-    /// computation found none.
-    #[error(
-        "while trying to get user revisions we could not find any, there should be at least one"
-    )]
-    EmptyRevisions,
 }

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -82,7 +82,7 @@ mod handler {
         }
         let stats = ctx
             .state
-            .with_browser(meta.urn(), |browser| Ok(browser.get_stats()?))
+            .with_browser(meta.urn(), |browser| Ok(browser.get_stats().map_err(coco::source::Error::from)?))
             .await
             .map_err(error::Error::from)?;
         let project: project::Project = (meta, stats).into();

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -82,7 +82,7 @@ mod handler {
         }
         let stats = ctx
             .state
-            .with_browser(meta.urn(), |browser| Ok(browser.get_stats().map_err(coco::source::Error::from)?))
+            .with_browser(meta.urn(), |browser| Ok(browser.get_stats()?))
             .await
             .map_err(error::Error::from)?;
         let project: project::Project = (meta, stats).into();

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -116,15 +116,15 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
                         "GIT_ERROR",
                         format!("Internal Git error: {:?}", git_error),
                     ),
-                    coco::Error::SurfGit(git_error) => (
+                    coco::Error::Source(coco::source::Error::Git(git_error)) => (
                         StatusCode::BAD_REQUEST,
                         "GIT_ERROR",
-                        format!("Internal Git error: {:?}", git_error),
+                        format!("Internal Git error: {}", git_error),
                     ),
-                    coco::Error::NoBranches => (
+                    coco::Error::Source(coco::source::Error::NoBranches) => (
                         StatusCode::BAD_REQUEST,
                         "GIT_ERROR",
-                        coco::Error::NoBranches.to_string(),
+                        coco::source::Error::NoBranches.to_string(),
                     ),
                     _ => {
                         // TODO(xla): Match all variants and properly transform similar to

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -59,7 +59,7 @@ mod handler {
             .identity
         {
             return Err(Rejection::from(error::Error::from(
-                coco::error::storage::already_exists(identity.urn),
+                coco::state::Error::already_exists(identity.urn),
             )));
         }
 

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -135,7 +135,7 @@ mod handler {
 
         let stats = ctx
             .state
-            .with_browser(urn, |browser| Ok(browser.get_stats()?))
+            .with_browser(urn, |browser| Ok(browser.get_stats().map_err(coco::source::Error::from)?))
             .await
             .map_err(Error::from)?;
         let project: project::Project = (meta, stats).into();

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -159,7 +159,7 @@ mod handler {
         let blob = ctx
             .state
             .with_browser(project_urn, |mut browser| {
-                Ok(coco::blob(&mut browser, default_branch, revision, &path, theme)?)
+                coco::blob(&mut browser, default_branch, revision, &path, theme)
             })
             .await
             .map_err(error::Error::from)?;
@@ -176,7 +176,7 @@ mod handler {
         let branches = ctx
             .state
             .with_browser(project_urn, |browser| {
-                Ok(coco::branches(browser, Some(coco::into_branch_type(peer_id)))?)
+                coco::branches(browser, Some(coco::into_branch_type(peer_id)))
             })
             .await
             .map_err(error::Error::from)?;
@@ -192,7 +192,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let commit = ctx
             .state
-            .with_browser(project_urn, |mut browser| Ok(coco::commit(&mut browser, sha1)?))
+            .with_browser(project_urn, |mut browser| coco::commit(&mut browser, sha1))
             .await
             .map_err(error::Error::from)?;
 
@@ -208,7 +208,7 @@ mod handler {
         let commits = ctx
             .state
             .with_browser(project_urn, |mut browser| {
-                Ok(coco::commits(&mut browser, query.into())?)
+                coco::commits(&mut browser, query.into())
             })
             .await
             .map_err(error::Error::from)?;
@@ -237,11 +237,11 @@ mod handler {
             .await
             .map_err(error::Error::from)?;
         let peer_id = ctx.state.peer_id();
+        let owner = owner.to_data().build().map_err(coco::error::Error::from).map_err(error::Error::from)?;
         let revisions: Vec<super::Revisions> = ctx
             .state
             .with_browser(project_urn, |browser| {
                 // TODO(finto): downgraded verified user, which should not be needed.
-                let owner = owner.to_data().build()?;
                 Ok(coco::revisions(browser, peer_id, owner, peers)?
                     .into_iter()
                     .map(|revision| revision.into())
@@ -260,7 +260,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let tags = ctx
             .state
-            .with_browser(project_urn, |browser| Ok(coco::tags(browser)?))
+            .with_browser(project_urn, |browser| coco::tags(browser))
             .await
             .map_err(error::Error::from)?;
 
@@ -292,7 +292,7 @@ mod handler {
         let tree = ctx
             .state
             .with_browser(project_urn, |mut browser| {
-                Ok(coco::tree(&mut browser, default_branch, revision, prefix)?)
+                coco::tree(&mut browser, default_branch, revision, prefix)
             })
             .await
             .map_err(error::Error::from)?;
@@ -727,7 +727,7 @@ mod test {
         let want = ctx
             .state
             .with_browser(urn, |mut browser| {
-                Ok(coco::commits(&mut browser, branch.clone())?)
+                coco::commits(&mut browser, branch.clone())
             })
             .await?;
 
@@ -1023,7 +1023,6 @@ mod test {
             .state
             .with_browser(urn, |mut browser| {
                 coco::tree(&mut browser, default_branch, Some(revision), None)
-                    .map_err(coco::Error::from)
             })
             .await?;
 

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -219,7 +219,7 @@ mod handler {
     /// Fetch the list [`coco::Branch`] for a local repository.
     pub async fn local_state(path: Tail) -> Result<impl Reply, Rejection> {
         let state = coco::local_state(path.as_str())
-            .map_err(coco::Error::from)
+            .map_err(coco::state::Error::from)
             .map_err(error::Error::from)?;
 
         Ok(reply::json(&state))
@@ -237,7 +237,11 @@ mod handler {
             .await
             .map_err(error::Error::from)?;
         let peer_id = ctx.state.peer_id();
-        let owner = owner.to_data().build().map_err(coco::error::Error::from).map_err(error::Error::from)?;
+        let owner = owner
+            .to_data()
+            .build()
+            .map_err(coco::state::Error::from)
+            .map_err(error::Error::from)?;
         let revisions: Vec<super::Revisions> = ctx
             .state
             .with_browser(project_urn, |browser| {
@@ -383,10 +387,10 @@ mod test {
 
     use radicle_surf::vcs::git;
 
-    use crate::{context, error, http, identity, session};
+    use crate::{context, http, identity, session};
 
     #[tokio::test]
-    async fn blob() -> Result<(), error::Error> {
+    async fn blob() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -532,7 +536,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn blob_dev_branch() -> Result<(), error::Error> {
+    async fn blob_dev_branch() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -600,7 +604,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn branches() -> Result<(), error::Error> {
+    async fn branches() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -640,7 +644,7 @@ mod test {
 
     #[tokio::test]
     #[allow(clippy::indexing_slicing)]
-    async fn commit() -> Result<(), error::Error> {
+    async fn commit() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -659,8 +663,7 @@ mod test {
             platinum_project.urn()
         };
 
-        let sha1 = coco::oid::Oid::try_from("3873745c8f6ffb45c990eb23b491d4b4b6182f95")
-            .map_err(coco::Error::from)?;
+        let sha1 = coco::oid::Oid::try_from("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
 
         let res = request()
             .method("GET")
@@ -698,7 +701,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn commits() -> Result<(), error::Error> {
+    async fn commits() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -739,7 +742,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn local_state() -> Result<(), error::Error> {
+    async fn local_state() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -772,7 +775,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn revisions() -> Result<(), error::Error> {
+    async fn revisions() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -806,7 +809,7 @@ mod test {
             .reply(&api)
             .await;
 
-        let owner = owner.to_data().build().map_err(coco::Error::from)?; // TODO(finto): Unverify owner, unfortunately
+        let owner = owner.to_data().build()?; // TODO(finto): Unverify owner, unfortunately
         http::test::assert_response(&res, StatusCode::OK, |have| {
             assert_eq!(
                 have,
@@ -848,7 +851,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn tags() -> Result<(), error::Error> {
+    async fn tags() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -889,7 +892,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn tree() -> Result<(), error::Error> {
+    async fn tree() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
@@ -972,7 +975,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn tree_dev_branch() -> Result<(), error::Error> {
+    async fn tree_dev_branch() -> Result<(), Box<dyn std::error::Error>> {
         // Testing that the endpoint works with URL encoding
         const FRAGMENT: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
             .add(b' ')

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -159,7 +159,7 @@ mod handler {
         let blob = ctx
             .state
             .with_browser(project_urn, |mut browser| {
-                coco::blob(&mut browser, default_branch, revision, &path, theme)
+                Ok(coco::blob(&mut browser, default_branch, revision, &path, theme)?)
             })
             .await
             .map_err(error::Error::from)?;
@@ -176,7 +176,7 @@ mod handler {
         let branches = ctx
             .state
             .with_browser(project_urn, |browser| {
-                coco::branches(browser, Some(coco::into_branch_type(peer_id)))
+                Ok(coco::branches(browser, Some(coco::into_branch_type(peer_id)))?)
             })
             .await
             .map_err(error::Error::from)?;
@@ -192,7 +192,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let commit = ctx
             .state
-            .with_browser(project_urn, |mut browser| coco::commit(&mut browser, sha1))
+            .with_browser(project_urn, |mut browser| Ok(coco::commit(&mut browser, sha1)?))
             .await
             .map_err(error::Error::from)?;
 
@@ -208,7 +208,7 @@ mod handler {
         let commits = ctx
             .state
             .with_browser(project_urn, |mut browser| {
-                coco::commits(&mut browser, query.into())
+                Ok(coco::commits(&mut browser, query.into())?)
             })
             .await
             .map_err(error::Error::from)?;
@@ -218,7 +218,9 @@ mod handler {
 
     /// Fetch the list [`coco::Branch`] for a local repository.
     pub async fn local_state(path: Tail) -> Result<impl Reply, Rejection> {
-        let state = coco::local_state(path.as_str()).map_err(error::Error::from)?;
+        let state = coco::local_state(path.as_str())
+            .map_err(coco::Error::from)
+            .map_err(error::Error::from)?;
 
         Ok(reply::json(&state))
     }
@@ -258,7 +260,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let tags = ctx
             .state
-            .with_browser(project_urn, |browser| coco::tags(browser))
+            .with_browser(project_urn, |browser| Ok(coco::tags(browser)?))
             .await
             .map_err(error::Error::from)?;
 
@@ -290,7 +292,7 @@ mod handler {
         let tree = ctx
             .state
             .with_browser(project_urn, |mut browser| {
-                coco::tree(&mut browser, default_branch, revision, prefix)
+                Ok(coco::tree(&mut browser, default_branch, revision, prefix)?)
             })
             .await
             .map_err(error::Error::from)?;

--- a/proxy/api/src/project.rs
+++ b/proxy/api/src/project.rs
@@ -126,7 +126,7 @@ impl Projects {
             let refs = state.list_owner_project_refs(project.urn()).await?;
             let project = state
                 .with_browser(project.urn(), |browser| {
-                    let project_stats = browser.get_stats().map_err(coco::Error::from)?;
+                    let project_stats = browser.get_stats().map_err(coco::source::Error::from)?;
                     Ok((project, project_stats).into())
                 })
                 .await?;
@@ -218,7 +218,7 @@ impl Iterator for IntoIter {
 pub async fn get(state: &coco::State, project_urn: coco::Urn) -> Result<Project, error::Error> {
     let project = state.get_project(project_urn.clone(), None).await?;
     let project_stats = state
-        .with_browser(project_urn, |browser| Ok(browser.get_stats()?))
+        .with_browser(project_urn, |browser| Ok(browser.get_stats().map_err(coco::source::Error::from)?))
         .await?;
 
     Ok((project, project_stats).into())
@@ -254,7 +254,7 @@ pub async fn list_for_user(
         {
             let proj = state
                 .with_browser(project.urn(), |browser| {
-                    let project_stats = browser.get_stats().map_err(coco::Error::from)?;
+                    let project_stats = browser.get_stats().map_err(coco::source::Error::from)?;
                     Ok((project, project_stats).into())
                 })
                 .await?;

--- a/proxy/api/src/project.rs
+++ b/proxy/api/src/project.rs
@@ -274,13 +274,13 @@ pub fn discover() -> Result<Vec<Project>, error::Error> {
     let urn = coco::Urn::new(
         coco::Hash::hash(b"hash"),
         coco::uri::Protocol::Git,
-        coco::uri::Path::parse("").map_err(coco::Error::from)?,
+        coco::uri::Path::empty(),
     );
 
     let other_urn = coco::Urn::new(
         coco::Hash::hash(b"something_else"),
         coco::uri::Protocol::Git,
-        coco::uri::Path::parse("").map_err(coco::Error::from)?,
+        coco::uri::Path::empty(),
     );
 
     let projects = vec![

--- a/proxy/api/src/project.rs
+++ b/proxy/api/src/project.rs
@@ -126,7 +126,7 @@ impl Projects {
             let refs = state.list_owner_project_refs(project.urn()).await?;
             let project = state
                 .with_browser(project.urn(), |browser| {
-                    let project_stats = browser.get_stats().map_err(coco::source::Error::from)?;
+                    let project_stats = browser.get_stats()?;
                     Ok((project, project_stats).into())
                 })
                 .await?;
@@ -218,7 +218,7 @@ impl Iterator for IntoIter {
 pub async fn get(state: &coco::State, project_urn: coco::Urn) -> Result<Project, error::Error> {
     let project = state.get_project(project_urn.clone(), None).await?;
     let project_stats = state
-        .with_browser(project_urn, |browser| Ok(browser.get_stats().map_err(coco::source::Error::from)?))
+        .with_browser(project_urn, |browser| Ok(browser.get_stats()?))
         .await?;
 
     Ok((project, project_stats).into())
@@ -254,7 +254,7 @@ pub async fn list_for_user(
         {
             let proj = state
                 .with_browser(project.urn(), |browser| {
-                    let project_stats = browser.get_stats().map_err(coco::source::Error::from)?;
+                    let project_stats = browser.get_stats()?;
                     Ok((project, project_stats).into())
                 })
                 .await?;

--- a/proxy/coco/src/config.rs
+++ b/proxy/coco/src/config.rs
@@ -2,12 +2,13 @@
 
 use std::{
     convert::TryFrom,
+    io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
 };
 
 use librad::{keys, net, net::discovery, paths, peer};
 
-use crate::{error::Error, seed};
+use crate::seed;
 
 lazy_static::lazy_static! {
     /// Localhost binding to any available port, i.e. `127.0.0.1:0`.
@@ -40,7 +41,7 @@ impl Default for Paths {
 }
 
 impl TryFrom<Paths> for paths::Paths {
-    type Error = Error;
+    type Error = io::Error;
 
     fn try_from(config: Paths) -> Result<Self, Self::Error> {
         match config {
@@ -69,7 +70,7 @@ pub type Disco = discovery::Static<
 pub fn default(
     key: keys::SecretKey,
     path: impl AsRef<std::path::Path>,
-) -> Result<net::peer::PeerConfig<Disco, keys::SecretKey>, Error> {
+) -> Result<net::peer::PeerConfig<Disco, keys::SecretKey>, io::Error> {
     let paths = paths::Paths::from_root(path)?;
     Ok(configure(paths, key, *LOCALHOST_ANY, vec![]))
 }

--- a/proxy/coco/src/control.rs
+++ b/proxy/coco/src/control.rs
@@ -8,7 +8,11 @@ use librad::{
 };
 use radicle_surf::vcs::git::git2;
 
-use crate::{config, error::Error, project, signer, state::State, user::User};
+use crate::{
+    config, project, signer,
+    state::{Error, State},
+    user::User,
+};
 
 /// Deletes the local git repsoitory coco uses for its state.
 ///
@@ -235,7 +239,7 @@ pub async fn track_fake_peer(
 ///   * The platinum directory path was malformed
 ///   * Getting the branches fails
 pub fn clone_platinum(platinum_into: impl AsRef<path::Path>) -> Result<(), Error> {
-    let platinum_from = platinum_directory()?;
+    let platinum_from = platinum_directory().expect("failed to get platinum directory");
     let platinum_from = platinum_from
         .to_str()
         .expect("failed to get platinum directory");

--- a/proxy/coco/src/error.rs
+++ b/proxy/coco/src/error.rs
@@ -36,10 +36,6 @@ pub enum Error {
     #[error(transparent)]
     Checkout(#[from] crate::project::checkout::Error),
 
-    /// Seed DNS failed to resolve to an address.
-    #[error("the seed '{0}' failed to resolve to an address")]
-    DnsLookupFailed(String),
-
     /// An error occurred when performing git operations.
     #[error(transparent)]
     Git(#[from] git2::Error),
@@ -47,10 +43,6 @@ pub enum Error {
     /// An error occured building include files.
     #[error(transparent)]
     Include(#[from] librad::git::include::Error),
-
-    /// Seed input is invalid.
-    #[error("the seed '{0}' is invalid: {:1}")]
-    InvalidSeed(String, Option<librad::peer::conversion::Error>),
 
     /// I/O error.
     #[error(transparent)]

--- a/proxy/coco/src/error.rs
+++ b/proxy/coco/src/error.rs
@@ -1,6 +1,6 @@
 //! Collection of all crate errors.
 
-use std::{io, path};
+use std::io;
 
 use librad::{git::repo, meta::entity, net, uri};
 use radicle_surf::{
@@ -31,6 +31,10 @@ pub enum Error {
     #[error(transparent)]
     Bootstrap(#[from] net::peer::BootstrapError),
 
+    /// An error occurred while trying to create a working copy of a project.
+    #[error(transparent)]
+    Create(#[from] crate::project::create::Error),
+
     /// An error occurred while performing the checkout of a project.
     #[error(transparent)]
     Checkout(#[from] crate::project::checkout::Error),
@@ -38,13 +42,6 @@ pub enum Error {
     /// Seed DNS failed to resolve to an address.
     #[error("the seed '{0}' failed to resolve to an address")]
     DnsLookupFailed(String),
-
-    /// An existing project is being created, but we couldn't get the `name` of the project, i.e.
-    /// the final suffix of the file path.
-    #[error(
-        "the existing path provided '{0}' was empty, and we could not get the project name from it"
-    )]
-    EmptyExistingPath(path::PathBuf),
 
     /// We expect at least one [`crate::source::Revisions`] when looking at a project, however the
     /// computation found none.
@@ -72,17 +69,6 @@ pub enum Error {
     /// Entity meta error.
     #[error(transparent)]
     Meta(#[from] entity::Error),
-
-    /// Configured default branch for the project is missing.
-    #[error(
-        "the default branch '{branch}' supplied was not found for the repository at '{repo_path}'"
-    )]
-    MissingDefaultBranch {
-        /// The repository path we're setting up.
-        repo_path: path::PathBuf,
-        /// The default branch that was expected to be found.
-        branch: String,
-    },
 
     /// Peer API error
     #[error(transparent)]

--- a/proxy/coco/src/error.rs
+++ b/proxy/coco/src/error.rs
@@ -3,10 +3,7 @@
 use std::io;
 
 use librad::{git::repo, meta::entity, net, uri};
-use radicle_surf::{
-    file_system,
-    vcs::{git, git::git2},
-};
+use radicle_surf::vcs::git::git2;
 
 /// Re-export [`librad::git::storage::Error`] under the `coco::error` namespace.
 pub mod storage {
@@ -43,13 +40,6 @@ pub enum Error {
     #[error("the seed '{0}' failed to resolve to an address")]
     DnsLookupFailed(String),
 
-    /// We expect at least one [`crate::source::Revisions`] when looking at a project, however the
-    /// computation found none.
-    #[error(
-        "while trying to get user revisions we could not find any, there should be at least one"
-    )]
-    EmptyRevisions,
-
     /// An error occurred when performing git operations.
     #[error(transparent)]
     Git(#[from] git2::Error),
@@ -74,25 +64,17 @@ pub enum Error {
     #[error(transparent)]
     PeerApi(#[from] net::peer::ApiError),
 
-    /// Trying to find a file path which could not be found.
-    #[error("the path '{0}' was not found")]
-    PathNotFound(file_system::Path),
-
     /// Repo error.
     #[error(transparent)]
     Repo(#[from] repo::Error),
 
+    /// An error occurred when interacting with the source code of a project.
+    #[error(transparent)]
+    Source(#[from] crate::source::Error),
+
     /// Storage error.
     #[error(transparent)]
     Storage(#[from] storage::Error),
-
-    /// Originated from `radicle-surf`.
-    #[error(transparent)]
-    SurfFFS(#[from] file_system::Error),
-
-    /// Originated from `radicle_surf`.
-    #[error(transparent)]
-    SurfGit(#[from] git::error::Error),
 
     /// Emitted when the parsing of a [`librad::uri::Path`] failed.
     #[error(transparent)]
@@ -101,8 +83,4 @@ pub enum Error {
     /// Verifcation error.
     #[error(transparent)]
     Verification(#[from] entity::HistoryVerificationError),
-
-    /// When trying to query a repositories branches, but there are none.
-    #[error("The repository has no branches")]
-    NoBranches,
 }

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -50,8 +50,6 @@ pub use radicle_surf::{
 
 pub mod config;
 pub mod control;
-pub mod error;
-pub use error::Error;
 pub mod git_helper;
 mod identifier;
 pub use identifier::Identifier;
@@ -63,7 +61,7 @@ pub use peer::{
     SyncEvent,
 };
 pub mod shared;
-mod state;
+pub mod state;
 pub use state::State;
 pub mod project;
 pub mod request;
@@ -92,7 +90,7 @@ pub async fn into_peer_state<I>(
     store: kv::Store,
     waiting_room: shared::Shared<request::waiting_room::WaitingRoom<Instant, Duration>>,
     run_config: RunConfig,
-) -> Result<(Peer, State), Error>
+) -> Result<(Peer, State), state::Error>
 where
     I: Iterator<Item = (PeerId, SocketAddr)> + Send + 'static,
 {

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -71,7 +71,7 @@ pub mod request;
 pub mod seed;
 pub mod signer;
 
-mod source;
+pub mod source;
 pub use source::{
     blob, branches, commit, commit_header, commits, into_branch_type, local_state, revisions, tags,
     tree, Blob, BlobContent, Branch, Commit, CommitHeader, Info, ObjectType, Person, Revision,

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -29,7 +29,7 @@ use librad::{
 use crate::{
     request::waiting_room::{self, WaitingRoom},
     shared::Shared,
-    state::State,
+    state::{self, State},
 };
 
 mod announcement;
@@ -67,10 +67,9 @@ pub enum Error {
     #[error("the running peer was either cancelled, or one of its tasks panicked")]
     Join(#[source] JoinError),
 
-    /// Stop-gap until we get rid of crate level errors.
-    // TODO(xla): Remove once we transitioned to per module errors.
+    /// There was an error when interacting with [`State`].
     #[error(transparent)]
-    Crate(#[from] crate::error::Error),
+    State(#[from] state::Error),
 }
 
 /// Local peer to participate in the radicle code-collaboration network.

--- a/proxy/coco/src/peer/request.rs
+++ b/proxy/coco/src/peer/request.rs
@@ -8,10 +8,9 @@ use librad::{
 };
 
 use crate::{
-    error,
     request::waiting_room::{self, WaitingRoom},
     shared::Shared,
-    State,
+    state, State,
 };
 
 /// An error that can occur when attempting to work with the waiting room or cloning a project.
@@ -22,7 +21,7 @@ pub enum Error {
     WaitingRoom(#[from] waiting_room::Error),
     /// An error occurred when attempting to clone a project.
     #[error(transparent)]
-    Crate(#[from] error::Error),
+    State(#[from] state::Error),
 }
 
 /// Emit a [`Gossip`] request for the given `urn` and mark the `urn` as [`WaitingRoom`::queried`].

--- a/proxy/coco/src/project/create.rs
+++ b/proxy/coco/src/project/create.rs
@@ -15,7 +15,37 @@ use librad::{
 };
 use radicle_surf::vcs::git::git2;
 
-use crate::{config, error::Error, user::User};
+use crate::{config, user::User};
+
+/// Errors that occur when attempting to create a working copy of a project.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An existing project is being created, but we couldn't get the `name` of the project, i.e.
+    /// the final suffix of the file path.
+    #[error(
+        "the existing path provided '{0}' was empty, and we could not get the project name from it"
+    )]
+    EmptyExistingPath(PathBuf),
+
+    /// Internal git error while trying to create the project.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// Entity meta error.
+    #[error(transparent)]
+    Meta(#[from] entity::Error),
+
+    /// Configured default branch for the project is missing.
+    #[error(
+        "the default branch '{branch}' supplied was not found for the repository at '{repo_path}'"
+    )]
+    MissingDefaultBranch {
+        /// The repository path we're setting up.
+        repo_path: PathBuf,
+        /// The default branch that was expected to be found.
+        branch: String,
+    },
+}
 
 /// The data required to either open an existing repository or create a new one.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/proxy/coco/src/seed.rs
+++ b/proxy/coco/src/seed.rs
@@ -1,9 +1,23 @@
 //! Seed nodes.
-use std::net::SocketAddr;
+use std::{io, net::SocketAddr};
 
 use librad::peer;
 
-use crate::error::Error;
+/// Errors that occur when resolving seed addresses.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Seed DNS failed to resolve to an address.
+    #[error("the seed '{0}' failed to resolve to an address")]
+    DnsLookupFailed(String),
+
+    /// Seed input is invalid.
+    #[error("the seed '{0}' is invalid: {:1}")]
+    InvalidSeed(String, Option<librad::peer::conversion::Error>),
+
+    /// I/O error.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
 
 /// A peer used to seed our client.
 #[derive(Debug, Clone)]

--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -13,7 +13,34 @@ use radicle_surf::{
     vcs::git::{self, git2, BranchType, Browser, Rev, Stats},
 };
 
-use crate::{error::Error, oid::Oid};
+use crate::oid::Oid;
+
+/// An error occurred when interacting with [`radicle_surf`] for browsing source code.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// We expect at least one [`crate::source::Revisions`] when looking at a project, however the
+    /// computation found none.
+    #[error(
+        "while trying to get user revisions we could not find any, there should be at least one"
+    )]
+    EmptyRevisions,
+
+    /// An error occurred during a [`radicle_surf::file_system`] operation.
+    #[error(transparent)]
+    FileSystem(#[from] file_system::Error),
+
+    /// An error occurred during a [`radicle_surf::git`] operation.
+    #[error(transparent)]
+    Git(#[from] git::error::Error),
+
+    /// When trying to query a repositories branches, but there are none.
+    #[error("The repository has no branches")]
+    NoBranches,
+
+    /// Trying to find a file path which could not be found.
+    #[error("the path '{0}' was not found")]
+    PathNotFound(file_system::Path),
+}
 
 lazy_static::lazy_static! {
     // The syntax set is slow to load (~30ms), so we make sure to only load it once.
@@ -519,9 +546,10 @@ pub struct LocalState {
 ///
 /// Will return [`Error`] if the repository doesn't exist.
 pub fn local_state(repo_path: &str) -> Result<LocalState, Error> {
-    let repo = git2::Repository::open(repo_path)?;
+    let repo = git2::Repository::open(repo_path).map_err(git::error::Error::from)?;
     let first_branch = repo
-        .branches(Some(git2::BranchType::Local))?
+        .branches(Some(git2::BranchType::Local))
+        .map_err(git::error::Error::from)?
         .filter_map(|branch_result| {
             let (branch, _) = branch_result.ok()?;
             let name = branch.name().ok()?;

--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -857,11 +857,9 @@ mod tests {
 
     use crate::{config, control, oid, signer, state::State};
 
-    use super::Error;
-
     // TODO(xla): A wise man once said: This probably should be an integration test.
     #[tokio::test]
-    async fn browse_commit() -> Result<(), Error> {
+    async fn browse_commit() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir().expect("failed to get tempdir");
         let key = SecretKey::new();
         let signer = signer::BoxedSigner::new(signer::SomeSigner { signer: key });

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -350,7 +350,7 @@ impl State {
     /// * If the passed `callback` errors.
     pub async fn with_browser<F, T>(&self, urn: RadUrn, callback: F) -> Result<T, Error>
     where
-        F: Send + FnOnce(&mut git::Browser) -> Result<T, Error>,
+        F: Send + FnOnce(&mut git::Browser) -> Result<T, source::Error>,
     {
         let monorepo = self.monorepo();
         let project = self.get_project(urn, None).await?;
@@ -360,7 +360,7 @@ impl State {
         let namespace = git::Namespace::try_from(project.urn().id.to_string().as_str()).map_err(source::Error::from)?;
         let mut browser = git::Browser::new_with_namespace(&repo, &namespace, default_branch).map_err(source::Error::from)?;
 
-        callback(&mut browser)
+        callback(&mut browser).map_err(Error::from)
     }
 
     /// Initialize a [`librad_project::Project`] that is owned by the `owner`.

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -31,6 +31,7 @@ use crate::{
     seed::Seed,
     signer,
     user::{verify as verify_user, User},
+    source,
 };
 
 /// High-level interface to the coco monorepo and gossip layer.
@@ -354,9 +355,10 @@ impl State {
         let monorepo = self.monorepo();
         let project = self.get_project(urn, None).await?;
         let default_branch = git::Branch::local(project.default_branch());
-        let repo = git::Repository::new(monorepo)?;
-        let namespace = git::Namespace::try_from(project.urn().id.to_string().as_str())?;
-        let mut browser = git::Browser::new_with_namespace(&repo, &namespace, default_branch)?;
+
+        let repo = git::Repository::new(monorepo).map_err(source::Error::from)?;
+        let namespace = git::Namespace::try_from(project.urn().id.to_string().as_str()).map_err(source::Error::from)?;
+        let mut browser = git::Browser::new_with_namespace(&repo, &namespace, default_branch).map_err(source::Error::from)?;
 
         callback(&mut browser)
     }

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -742,6 +742,8 @@ mod test {
 
     #[tokio::test]
     async fn create_with_existing_remote_with_reset() -> Result<(), Error> {
+        use radicle_surf::vcs::git::Branch;
+
         let tmp_dir = tempfile::tempdir().expect("failed to create tempdir");
         let repo_path = tmp_dir.path().join("radicle");
         let key = SecretKey::new();
@@ -773,9 +775,11 @@ mod test {
             .await?;
 
         // Attempt to initialise a browser to ensure we can look at branches in the project
-        let _stats = state
-            .with_browser(fakie.urn(), |browser| Ok(browser.get_stats()?))
+        let branches = state
+            .with_browser(fakie.urn(), |browser| Ok(browser.list_branches(None).map_err(crate::source::Error::from)?))
             .await?;
+
+        assert_eq!(branches, vec![Branch::local("dope")]);
 
         Ok(())
     }

--- a/proxy/coco/src/user.rs
+++ b/proxy/coco/src/user.rs
@@ -5,7 +5,7 @@ use librad::{
     uri::RadUrn,
 };
 
-use crate::error::Error;
+use crate::state;
 
 /// Export a verified [`user::User`] type.
 pub type User = user::User<entity::Verified>;
@@ -17,7 +17,7 @@ pub type User = user::User<entity::Verified>;
 /// # Errors
 ///
 /// If any of the verification steps fail
-pub fn verify(user: user::User<entity::Draft>) -> Result<User, Error> {
+pub fn verify(user: user::User<entity::Draft>) -> Result<User, state::Error> {
     let fake_resolver = FakeUserResolver(user.clone());
     let verified_user = user.check_history_status(&fake_resolver, &fake_resolver)?;
     Ok(verified_user)


### PR DESCRIPTION
Fixes #850 

The aim of the game is to have `Error` enums located next to their module, splitting up the mega enum. Some advantages to this approach:
* This minimises the chance of cross-module interactions since we can't conflate errors of the same domain
* Where the error comes from is more specific, since we would get something like `State(Source(Git(...)))` vs `State(Git(...))`. We know the former is a git related error located in source browsing vs a git related error during state interactions.