### PR TITLE
refactor(proxy): move De/Serialize

### DIFF
--- a/proxy/coco/src/request/existential.rs
+++ b/proxy/coco/src/request/existential.rs
@@ -5,7 +5,7 @@
 // much.
 #![allow(clippy::wildcard_enum_match_arm)]
 
-use std::{ops::Sub, time::Instant};
+use std::ops::Sub;
 
 use serde::{Deserialize, Serialize};
 
@@ -24,8 +24,8 @@ use super::{
 ///
 /// When we pattern match we get back the request parameterised over the specific state and can
 /// work in a type safe manner with this request.
-/// TODO(sos): reintroduce camelCase?
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound = "T: serde_millis::Milliseconds")]
 pub enum SomeRequest<T> {
     /// The `Request` has been created.
     Created(Request<Created, T>),
@@ -47,68 +47,6 @@ pub enum SomeRequest<T> {
 
     /// The `Request` has timed out on querying or cloning.
     TimedOut(Request<TimedOut, T>),
-}
-
-impl Serialize for SomeRequest<Instant> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match *self {
-            SomeRequest::Created(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 0, "Created", r)
-            },
-            SomeRequest::Requested(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 1, "Requested", r)
-            },
-            SomeRequest::Found(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 2, "Found", r)
-            },
-            SomeRequest::Cloning(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 3, "Cloning", r)
-            },
-            SomeRequest::Cloned(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 4, "Cloned", r)
-            },
-            SomeRequest::Cancelled(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 5, "Cancelled", r)
-            },
-            SomeRequest::TimedOut(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 6, "TimedOut", r)
-            },
-        }
-    }
-}
-
-impl Serialize for SomeRequest<usize> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match *self {
-            SomeRequest::Created(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 0, "Created", r)
-            },
-            SomeRequest::Requested(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 1, "Requested", r)
-            },
-            SomeRequest::Found(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 2, "Found", r)
-            },
-            SomeRequest::Cloning(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 3, "Cloning", r)
-            },
-            SomeRequest::Cloned(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 4, "Cloned", r)
-            },
-            SomeRequest::Cancelled(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 5, "Cancelled", r)
-            },
-            SomeRequest::TimedOut(ref r) => {
-                serializer.serialize_newtype_variant("SomeRequest", 6, "TimedOut", r)
-            },
-        }
-    }
 }
 
 impl<T> From<&SomeRequest<T>> for RequestState {

--- a/proxy/coco/src/request/waiting_room.rs
+++ b/proxy/coco/src/request/waiting_room.rs
@@ -4,10 +4,10 @@
 // much.
 #![allow(clippy::wildcard_enum_match_arm)]
 
-use std::{collections::HashMap, ops::Sub, time::Instant};
+use std::{collections::HashMap, ops::Sub};
 
 use either::Either;
-use serde::{ser::SerializeStruct, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use librad::{
     hash::Hash,
@@ -72,30 +72,15 @@ impl<T> From<Request<TimedOut, T>> for Error {
 ///
 /// It keeps track of these states as the user tells the waiting room what is happening to the
 /// request on the outside.
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WaitingRoom<T, D> {
     /// The set of requests keyed by their `RadUrn`. This helps us keep only unique requests in the
     /// waiting room.
+    #[serde(bound = "T: serde_millis::Milliseconds")]
     requests: HashMap<Hash, SomeRequest<T>>,
 
     /// The configuration of the waiting room.
     config: Config<D>,
-}
-
-impl<D> Serialize for WaitingRoom<Instant, D>
-where
-    D: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("WaitingRoom", 2)?;
-        state.serialize_field("requests", &self.requests)?;
-        state.serialize_field("config", &self.config)?;
-        state.end()
-    }
 }
 
 /// The `Config` for the waiting room tells it what are the maximum number of query and clone


### PR DESCRIPTION
We can utilise serde's macro magic using the `with` and `bound` macros
to tell serde that we'll use the Milliseconds trait for serialisation.

Note that this enforces to use the time types defined in serde_millis
when we want serialise any of these types. Otherwise, we will have to
hand-roll implementations.