### PR TITLE
feat(proxy): waiting room persistence

### DIFF
--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -8,13 +8,7 @@ use tokio::{
 };
 
 use api::{config, context, env, http, notification, session};
-use coco::{
-    keystore,
-    request::waiting_room::{self, WaitingRoom},
-    seed,
-    shared::Shared,
-    signer, Peer, RunConfig, SyncConfig,
-};
+use coco::{keystore, seed, shared::Shared, signer, Peer, RunConfig, SyncConfig};
 
 /// Flags accepted by the proxy binary.
 #[derive(Clone, Copy)]
@@ -155,11 +149,12 @@ async fn rig(args: Args) -> Result<Rigging, Box<dyn std::error::Error>> {
 
     let signer = signer::BoxedSigner::new(signer::SomeSigner { signer: key });
 
-    // TODO(finto): We should store and load the waiting room
+    // TODO(finto/sos): When is the optimal time to store/update the waiting room?
+    // - After a new request is created
+    // - Upon each state change of each request?
     let waiting_room = {
-        let mut config = waiting_room::Config::default();
-        config.delta = Duration::from_secs(10);
-        Shared::from(WaitingRoom::new(config))
+        let stored = session::waiting_room(&store).await?;
+        Shared::from(stored)
     };
 
     let (peer, state) = {

--- a/proxy/coco/src/request.rs
+++ b/proxy/coco/src/request.rs
@@ -66,7 +66,7 @@ pub struct Request<S, T> {
     attempts: Attempts,
     /// The timestamp of the latest action to be taken on this request.
     #[serde(with = "serde_millis", bound = "T: serde_millis::Milliseconds")]
-    timestamp: T,
+    pub timestamp: T,
     /// The state of the request, as mentioned above.
     state: S,
 }

--- a/proxy/coco/src/request/waiting_room.rs
+++ b/proxy/coco/src/request/waiting_room.rs
@@ -83,6 +83,15 @@ pub struct WaitingRoom<T, D> {
     config: Config<D>,
 }
 
+impl<T, D> Default for WaitingRoom<T, D>
+where
+    D: Default,
+{
+    fn default() -> Self {
+        Self::new(Config::default())
+    }
+}
+
 /// The `Config` for the waiting room tells it what are the maximum number of query and clone
 /// attempts that can be made for a single request.
 ///
@@ -149,7 +158,7 @@ impl<T, D> WaitingRoom<T, D> {
     /// This will return the request for the given `urn` if one exists in the `WaitingRoom`.
     ///
     /// If there is no such `urn` then it create a fresh `Request` using the `urn` and `timestamp`
-    /// and it will return `None`.
+    /// and it will return the new `Request`.
     pub fn request(&mut self, urn: RadUrn, timestamp: T) -> Option<SomeRequest<T>>
     where
         T: Clone,
@@ -157,8 +166,8 @@ impl<T, D> WaitingRoom<T, D> {
         match self.get(&urn) {
             None => {
                 let request = SomeRequest::Created(Request::new(urn.clone(), timestamp));
-                self.requests.insert(urn.id, request);
-                None
+                self.requests.insert(urn.id, request.clone());
+                Some(request)
             },
             Some(request) => Some(request.clone()),
         }


### PR DESCRIPTION
 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 

Towards #984 

- [x] Implements `Default` for `WaitingRoom`
- [x] Adds `waiting_room` to `session` store
- [x] Loads session `waiting_room` upon startup
- [x] `projects/request/<id>` is now a `POST` request
- [ ] Store the waiting room in the `session` at appropriate intervals
- [ ] Test the `request/` endpoint properly 
