### PR TITLE
feat(proxy): Add unsealed guard

### DIFF
--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -10,7 +10,7 @@ pub struct Context {
     /// [`coco::State`] to operate on the local monorepo.
     pub state: coco::State,
     /// [`coco::signer::BoxedSigner`] for write operations on the monorepo.
-    pub signer: signer::BoxedSigner,
+    pub signer: Option<signer::BoxedSigner>,
     /// [`kv::Store`] used for session state and cache.
     pub store: kv::Store,
     /// The [`WaitingRoom`] for making requests for identities.
@@ -49,7 +49,7 @@ impl Context {
 
         Ok(Self {
             state,
-            signer,
+            signer: Some(signer),
             store,
             waiting_room,
         })

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -132,7 +132,7 @@ fn with_unsealed_guard(ctx: context::Context) -> BoxedFilter<((),)> {
     warp::any()
         .and(with_context(ctx))
         .and_then(|ctx: context::Context| async move {
-            if let Some(_) = ctx.signer {
+            if ctx.signer.is_some() {
                 Ok(())
             } else {
                 Err(Rejection::from(error::Routing::SealedKeystore))

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -40,27 +40,24 @@ pub fn api(
     enable_fixture_creation: bool,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let avatar_filter = path("avatars").and(avatar::get_filter());
-    let control_filter = path("control")
-        .and(with_unsealed_guard(ctx.clone()))
-        .untuple_one()
-        .and(control::filters(
-            ctx.clone(),
-            selfdestruct,
-            enable_fixture_creation,
-        ));
+    let control_filter =
+        path("control")
+            .and(with_unsealed_guard(ctx.clone()))
+            .and(control::filters(
+                ctx.clone(),
+                selfdestruct,
+                enable_fixture_creation,
+            ));
     let identity_filter = path("identities").and(identity::filters(ctx.clone()));
     let notification_filter = path("notifications")
         .and(with_unsealed_guard(ctx.clone()))
-        .untuple_one()
         .and(notification::filters(subscriptions));
     let project_filter = path("projects")
         .and(with_unsealed_guard(ctx.clone()))
-        .untuple_one()
         .and(project::filters(ctx.clone()));
     let session_filter = path("session").and(session::filters(ctx.clone()));
     let source_filter = path("source")
         .and(with_unsealed_guard(ctx.clone()))
-        .untuple_one()
         .and(source::filters(ctx));
 
     let api = path("v1").and(combine!(
@@ -128,7 +125,7 @@ fn with_owner_guard(ctx: context::Context) -> BoxedFilter<(coco::user::User,)> {
 
 /// Asserts presence of the signer and rejects the request early if missing.
 #[must_use]
-fn with_unsealed_guard(ctx: context::Context) -> BoxedFilter<((),)> {
+fn with_unsealed_guard(ctx: context::Context) -> BoxedFilter<()> {
     warp::any()
         .and(with_context(ctx))
         .and_then(|ctx: context::Context| async move {
@@ -138,6 +135,7 @@ fn with_unsealed_guard(ctx: context::Context) -> BoxedFilter<((),)> {
                 Err(Rejection::from(error::Routing::SealedKeystore))
             }
         })
+        .untuple_one()
         .boxed()
 }
 

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -54,7 +54,7 @@ mod handler {
 
     use coco::user;
 
-    use crate::{context, error, project};
+    use crate::{context, error, http, project};
 
     /// Create a project from the fixture repo.
     #[allow(clippy::let_underscore_must_use)]
@@ -63,9 +63,12 @@ mod handler {
         owner: user::User,
         input: super::CreateInput,
     ) -> Result<impl Reply, Rejection> {
+        let signer = ctx
+            .signer
+            .ok_or_else(|| http::error::Routing::SealedKeystore)?;
         let meta = coco::control::replicate_platinum(
             &ctx.state,
-            &ctx.signer,
+            &signer,
             &owner,
             &input.name,
             &input.description,
@@ -76,8 +79,7 @@ mod handler {
 
         if let Some(user_handle_list) = input.fake_peers {
             for user_handle in user_handle_list {
-                let _ =
-                    coco::control::track_fake_peer(&ctx.state, &ctx.signer, &meta, &user_handle);
+                let _ = coco::control::track_fake_peer(&ctx.state, &signer, &meta, &user_handle);
             }
         }
         let stats = ctx

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -84,12 +84,10 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
             )
         } else if let Some(err) = err.find::<Routing>() {
             match err {
-                Routing::MissingOwner  => {
+                Routing::MissingOwner => {
                     (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", err.to_string())
                 },
-                Routing::SealedKeystore => {
-                    (StatusCode::FORBIDDEN, "FORBIDDEN", err.to_string())
-                },
+                Routing::SealedKeystore => (StatusCode::FORBIDDEN, "FORBIDDEN", err.to_string()),
                 Routing::InvalidQuery { .. } => {
                     (StatusCode::BAD_REQUEST, "INVALID_QUERY", err.to_string())
                 },

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -84,10 +84,7 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
             )
         } else if let Some(err) = err.find::<Routing>() {
             match err {
-                Routing::MissingOwner => {
-                    (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", err.to_string())
-                },
-                Routing::SealedKeystore => {
+                Routing::MissingOwner | Routing::SealedKeystore => {
                     (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", err.to_string())
                 },
                 Routing::InvalidQuery { .. } => {

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -681,8 +681,11 @@ mod test {
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
-        let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
-        coco::control::setup_fixtures(&ctx.state, &ctx.signer, &owner).await?;
+        let owner = ctx
+            .state
+            .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+            .await?;
+        coco::control::setup_fixtures(&ctx.state, &ctx.signer.unwrap(), &owner).await?;
         let projects = project::Projects::list(&ctx.state).await?;
         let project = projects.contributed.first().expect("no projects setup");
 

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -118,7 +118,7 @@ mod handler {
 
     use warp::{http::StatusCode, reply, Rejection, Reply};
 
-    use crate::{context, error::Error, project};
+    use crate::{context, error::Error, http, project};
 
     /// Create a new [`project::Project`].
     pub async fn create(
@@ -126,9 +126,12 @@ mod handler {
         owner: coco::user::User,
         input: coco::project::Create<PathBuf>,
     ) -> Result<impl Reply, Rejection> {
+        let signer = ctx
+            .signer
+            .ok_or_else(|| http::error::Routing::SealedKeystore)?;
         let meta = ctx
             .state
-            .init_project(&ctx.signer, &owner, input)
+            .init_project(&signer, &owner, input)
             .await
             .map_err(Error::from)?;
         let urn = meta.urn();
@@ -266,12 +269,15 @@ mod test {
 
         let urn = {
             let handle = "cloudhead";
-            let owner = ctx.state.init_owner(&ctx.signer, handle).await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), handle)
+                .await?;
             session::set_identity(&ctx.store, (ctx.state.peer_id(), owner.clone()).into())?;
 
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -348,7 +354,7 @@ mod test {
 
         {
             let handle = "cloudhead";
-            let id = identity::create(&ctx.state, &ctx.signer, handle).await?;
+            let id = identity::create(&ctx.state, &ctx.signer.unwrap(), handle).await?;
 
             session::set_identity(&ctx.store, id)?;
         };
@@ -409,7 +415,7 @@ mod test {
 
         {
             let handle = "cloudhead";
-            let id = identity::create(&ctx.state, &ctx.signer, handle).await?;
+            let id = identity::create(&ctx.state, &ctx.signer.unwrap(), handle).await?;
             session::set_identity(&ctx.store, id)?;
         };
 
@@ -467,10 +473,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let urn = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -527,17 +536,24 @@ mod test {
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
-        let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
-        coco::control::setup_fixtures(&ctx.state, &ctx.signer, &owner).await?;
+        let owner = ctx
+            .state
+            .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+            .await?;
+        coco::control::setup_fixtures(&ctx.state, &ctx.signer.clone().unwrap(), &owner).await?;
 
         let projects = project::Projects::list(&ctx.state).await?;
         let project = projects.into_iter().next().unwrap();
         let coco_project = ctx.state.get_project(project.id.clone(), None).await?;
 
-        let user: identity::Identity =
-            coco::control::track_fake_peer(&ctx.state, &ctx.signer, &coco_project, "rafalca")
-                .await
-                .into();
+        let user: identity::Identity = coco::control::track_fake_peer(
+            &ctx.state,
+            &ctx.signer.unwrap(),
+            &coco_project,
+            "rafalca",
+        )
+        .await
+        .into();
 
         let res = request()
             .method("GET")
@@ -557,9 +573,12 @@ mod test {
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
-        let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+        let owner = ctx
+            .state
+            .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+            .await?;
 
-        coco::control::setup_fixtures(&ctx.state, &ctx.signer, &owner).await?;
+        coco::control::setup_fixtures(&ctx.state, &ctx.signer.unwrap(), &owner).await?;
 
         let res = request()
             .method("GET")
@@ -582,8 +601,11 @@ mod test {
         let ctx = context::Context::tmp(&tmp_dir).await?;
         let api = super::filters(ctx.clone());
 
-        let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
-        coco::control::setup_fixtures(&ctx.state, &ctx.signer, &owner).await?;
+        let owner = ctx
+            .state
+            .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+            .await?;
+        coco::control::setup_fixtures(&ctx.state, &ctx.signer.unwrap(), &owner).await?;
 
         let res = request().method("GET").path("/discover").reply(&api).await;
         let want = json!([

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -396,10 +396,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let (default_branch, urn) = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -542,10 +545,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let (default_branch, urn) = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -610,10 +616,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let urn = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -650,10 +659,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let urn = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -707,10 +719,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let urn = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -781,7 +796,7 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let peer_id = ctx.state.peer_id();
-        let id = identity::create(&ctx.state, &ctx.signer, "cloudhead").await?;
+        let id = identity::create(&ctx.state, &ctx.signer.clone().unwrap(), "cloudhead").await?;
 
         let owner = ctx.state.get_user(id.urn.clone()).await?;
         let owner = coco::user::verify(owner)?;
@@ -790,7 +805,7 @@ mod test {
 
         let platinum_project = coco::control::replicate_platinum(
             &ctx.state,
-            &ctx.signer,
+            &ctx.signer.clone().unwrap(),
             &owner,
             "git-platinum",
             "fixture data",
@@ -799,9 +814,13 @@ mod test {
         .await?;
         let urn = platinum_project.urn();
 
-        let (remote, fintohaps) =
-            coco::control::track_fake_peer(&ctx.state, &ctx.signer, &platinum_project, "fintohaps")
-                .await;
+        let (remote, fintohaps) = coco::control::track_fake_peer(
+            &ctx.state,
+            &ctx.signer.unwrap(),
+            &platinum_project,
+            "fintohaps",
+        )
+        .await;
 
         let res = request()
             .method("GET")
@@ -857,10 +876,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let urn = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -898,10 +920,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let (default_branch, urn) = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",
@@ -989,10 +1014,13 @@ mod test {
         let api = super::filters(ctx.clone());
 
         let (default_branch, urn) = {
-            let owner = ctx.state.init_owner(&ctx.signer, "cloudhead").await?;
+            let owner = ctx
+                .state
+                .init_owner(&ctx.signer.clone().unwrap(), "cloudhead")
+                .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.state,
-                &ctx.signer,
+                &ctx.signer.unwrap(),
                 &owner,
                 "git-platinum",
                 "fixture data",

--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -190,7 +190,7 @@ async fn rig(args: Args) -> Result<Rigging, Box<dyn std::error::Error>> {
     let subscriptions = notification::Subscriptions::default();
     let ctx = context::Context {
         state,
-        signer,
+        signer: Some(signer),
         store,
         waiting_room,
     };


### PR DESCRIPTION
Closes #997 

Can currently only be tested when setting the signer to `None` in `rig()` of `main.rs`

**Open tasks/questions**
- [x] add testing (on http.rs level)
- [x] ~Should any requests of session/avatar/identity be sealed?~ I would not guard any of them for now. We need the session or at least the identity for the passphrase re-enter screen. The guards can also be set at a later state when we know how the ui will distinguish/use the different requests