### PR TITLE
fix(proxy): drain peer channels

### DIFF
--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -384,7 +384,8 @@ impl Future for Subroutines {
     type Output = Result<(), SpawnAbortableError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        // Drain the task queue
+        // Ensure the `JoinHandle`s of the tasks are consumed, droped to release associated
+        // resources.
         loop {
             match self.pending_tasks.poll_next_unpin(cx) {
                 Poll::Ready(Some(Err(e))) => {

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -209,7 +209,7 @@ impl Future for Running {
                     Ok(Ok(())) => Ok(()),
                 };
                 Poll::Ready(val)
-            }
+            },
             Poll::Pending => Poll::Pending,
         }
     }
@@ -282,7 +282,7 @@ impl<T> Future for SpawnAbortable<T> {
                     Ok(Ok(t)) => Ok(t),
                 };
                 Poll::Ready(val)
-            }
+            },
         }
     }
 }
@@ -390,7 +390,7 @@ impl Future for Subroutines {
                 Poll::Ready(Some(Err(e))) => {
                     log::warn!("error in spawned subroutine task: {:?}", e);
                     return Poll::Ready(Err(e));
-                }
+                },
                 Poll::Ready(Some(Ok(()))) => continue,
                 // Either pending, or FuturesUnordered thinks it's done, but
                 // we'll enqueue new tasks below
@@ -466,7 +466,7 @@ impl Future for Subroutines {
                     )),
                     Command::Request(RequestCommand::Found(url)) => {
                         SpawnAbortable::new(found(url, self.waiting_room.clone()))
-                    }
+                    },
                     Command::Request(RequestCommand::Clone(url)) => SpawnAbortable::new(clone(
                         url,
                         self.state.clone(),
@@ -489,11 +489,11 @@ async fn announce(state: State, store: kv::Store, mut sender: mpsc::Sender<Annou
     match announcement::run(&state, &store).await {
         Ok(updates) => {
             sender.send(AnnounceEvent::Succeeded(updates)).await.ok();
-        }
+        },
         Err(err) => {
             log::error!("announce error: {:?}", err);
             sender.send(AnnounceEvent::Failed).await.ok();
-        }
+        },
     }
 }
 
@@ -507,11 +507,11 @@ async fn sync(state: State, peer_id: PeerId, mut sender: mpsc::Sender<SyncEvent>
                 .send(SyncEvent::Succeeded(peer_id.clone()))
                 .await
                 .ok();
-        }
+        },
         Err(err) => {
             log::error!("sync error for {}: {:?}", peer_id, err);
             sender.send(SyncEvent::Failed(peer_id.clone())).await.ok();
-        }
+        },
     }
 }
 
@@ -557,7 +557,7 @@ async fn clone(
     match request::clone(url.clone(), state, waiting_room).await {
         Ok(()) => {
             sender.send(RequestEvent::Cloned(url)).await.ok();
-        }
+        },
         Err(err) => {
             log::warn!(
                 "an error occurred for the command 'Clone' for the URL '{}':\n{}",
@@ -571,6 +571,6 @@ async fn clone(
                 })
                 .await
                 .ok();
-        }
+        },
     }
 }

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -209,7 +209,7 @@ impl Future for Running {
                     Ok(Ok(())) => Ok(()),
                 };
                 Poll::Ready(val)
-            },
+            }
             Poll::Pending => Poll::Pending,
         }
     }
@@ -282,7 +282,7 @@ impl<T> Future for SpawnAbortable<T> {
                     Ok(Ok(t)) => Ok(t),
                 };
                 Poll::Ready(val)
-            },
+            }
         }
     }
 }
@@ -390,7 +390,7 @@ impl Future for Subroutines {
                 Poll::Ready(Some(Err(e))) => {
                     log::warn!("error in spawned subroutine task: {:?}", e);
                     return Poll::Ready(Err(e));
-                },
+                }
                 Poll::Ready(Some(Ok(()))) => continue,
                 // Either pending, or FuturesUnordered thinks it's done, but
                 // we'll enqueue new tasks below
@@ -401,39 +401,39 @@ impl Future for Subroutines {
         // Collect any task results, and enqueue new tasks if applicable
         let mut events = Vec::with_capacity(9);
         {
-            if let Poll::Ready(Some(protocol_event)) = self.protocol_events.poll_next_unpin(cx) {
+            while let Poll::Ready(Some(protocol_event)) = self.protocol_events.poll_next_unpin(cx) {
                 events.push(Event::Protocol(protocol_event));
             }
 
-            if let Poll::Ready(Some(_)) = self.announce_timer.poll_next_unpin(cx) {
+            while let Poll::Ready(Some(_)) = self.announce_timer.poll_next_unpin(cx) {
                 events.push(Event::Announce(AnnounceEvent::Tick));
             }
 
-            if let Poll::Ready(Some(_)) = self.ping_timer.poll_next_unpin(cx) {
+            while let Poll::Ready(Some(_)) = self.ping_timer.poll_next_unpin(cx) {
                 events.push(Event::Ping);
             }
 
-            if let Poll::Ready(Some(announce_event)) = self.announcements.poll_recv(cx) {
+            while let Poll::Ready(Some(announce_event)) = self.announcements.poll_recv(cx) {
                 events.push(Event::Announce(announce_event));
             }
 
-            if let Poll::Ready(Some(sync_event)) = self.peer_syncs.poll_recv(cx) {
+            while let Poll::Ready(Some(sync_event)) = self.peer_syncs.poll_recv(cx) {
                 events.push(Event::PeerSync(sync_event));
             }
 
-            if let Poll::Ready(Some(timeout_event)) = self.timeouts.poll_recv(cx) {
+            while let Poll::Ready(Some(timeout_event)) = self.timeouts.poll_recv(cx) {
                 events.push(Event::Timeout(timeout_event));
             }
 
-            if let Poll::Ready(Some(urn)) = self.request_queries.poll_next_unpin(cx) {
+            while let Poll::Ready(Some(urn)) = self.request_queries.poll_next_unpin(cx) {
                 events.push(Event::Request(RequestEvent::Query(urn)));
             }
 
-            if let Poll::Ready(Some(url)) = self.request_clones.poll_next_unpin(cx) {
+            while let Poll::Ready(Some(url)) = self.request_clones.poll_next_unpin(cx) {
                 events.push(Event::Request(RequestEvent::Clone(url)));
             }
 
-            if let Poll::Ready(Some(request_event)) = self.requests.poll_next_unpin(cx) {
+            while let Poll::Ready(Some(request_event)) = self.requests.poll_next_unpin(cx) {
                 events.push(Event::Request(request_event));
             }
         }
@@ -466,7 +466,7 @@ impl Future for Subroutines {
                     )),
                     Command::Request(RequestCommand::Found(url)) => {
                         SpawnAbortable::new(found(url, self.waiting_room.clone()))
-                    },
+                    }
                     Command::Request(RequestCommand::Clone(url)) => SpawnAbortable::new(clone(
                         url,
                         self.state.clone(),
@@ -489,11 +489,11 @@ async fn announce(state: State, store: kv::Store, mut sender: mpsc::Sender<Annou
     match announcement::run(&state, &store).await {
         Ok(updates) => {
             sender.send(AnnounceEvent::Succeeded(updates)).await.ok();
-        },
+        }
         Err(err) => {
             log::error!("announce error: {:?}", err);
             sender.send(AnnounceEvent::Failed).await.ok();
-        },
+        }
     }
 }
 
@@ -507,11 +507,11 @@ async fn sync(state: State, peer_id: PeerId, mut sender: mpsc::Sender<SyncEvent>
                 .send(SyncEvent::Succeeded(peer_id.clone()))
                 .await
                 .ok();
-        },
+        }
         Err(err) => {
             log::error!("sync error for {}: {:?}", peer_id, err);
             sender.send(SyncEvent::Failed(peer_id.clone())).await.ok();
-        },
+        }
     }
 }
 
@@ -557,7 +557,7 @@ async fn clone(
     match request::clone(url.clone(), state, waiting_room).await {
         Ok(()) => {
             sender.send(RequestEvent::Cloned(url)).await.ok();
-        },
+        }
         Err(err) => {
             log::warn!(
                 "an error occurred for the command 'Clone' for the URL '{}':\n{}",
@@ -571,6 +571,6 @@ async fn clone(
                 })
                 .await
                 .ok();
-        },
+        }
     }
 }

--- a/proxy/coco/tests/common.rs
+++ b/proxy/coco/tests/common.rs
@@ -56,6 +56,7 @@ macro_rules! assert_event {
 /// # Errors
 ///
 /// * if the timeout waiting for the [`ProtocolEvent::Connected`] has been reached.
+#[allow(dead_code)] // NOTE(finto): this is used in integrations tests.
 pub async fn connected(
     receiver: broadcast::Receiver<PeerEvent>,
     expected_id: &PeerId,
@@ -105,6 +106,7 @@ pub async fn build_peer(
     Ok((peer, state, signer))
 }
 
+#[allow(dead_code)] // NOTE(finto): this is used in integrations tests.
 pub async fn build_peer_with_seeds(
     tmp_dir: &tempfile::TempDir,
     seeds: Vec<Seed>,
@@ -146,6 +148,7 @@ pub fn radicle_project(path: PathBuf) -> project::Create<PathBuf> {
     }
 }
 
+#[allow(dead_code)] // NOTE(finto): this is used in integrations tests.
 pub fn shia_le_pathbuf(path: PathBuf) -> project::Create<PathBuf> {
     project::Create {
         repo: project::Repo::New {

--- a/proxy/coco/tests/internal.rs
+++ b/proxy/coco/tests/internal.rs
@@ -1,0 +1,45 @@
+use std::time::{Duration, Instant};
+
+use futures::{future, stream::StreamExt as _};
+use tokio::time::timeout;
+
+use coco::{
+    request::waiting_room::{self, WaitingRoom},
+    shared::Shared,
+    PeerEvent, RunConfig,
+};
+
+#[macro_use]
+mod common;
+use common::*;
+
+#[tokio::test]
+async fn can_observe_timers() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
+    let alice_tmp_dir = tempfile::tempdir()?;
+    let waiting_room: Shared<WaitingRoom<Instant, Duration>> =
+        Shared::from(WaitingRoom::new(waiting_room::Config::default()));
+    let (alice_peer, _alice_state, _alice_signer) =
+        build_peer(&alice_tmp_dir, waiting_room, RunConfig::default()).await?;
+
+    let alice_events = alice_peer.subscribe();
+
+    tokio::spawn(alice_peer.into_running());
+
+    let pinged = alice_events
+        .into_stream()
+        .scan(0, |pinged, event| {
+            let event = event.unwrap();
+            if let PeerEvent::Ping = event {
+                *pinged += 1;
+            }
+
+            future::ready(if *pinged >= 10 { None } else { Some(event) })
+        })
+        .collect::<Vec<_>>();
+    tokio::pin!(pinged);
+    timeout(Duration::from_secs(5), pinged).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
The polling of subroutines can starve if the channels are not completely
drained. async/await while being young already is a form of witchcraft
only the elder gods can control. Who knows what else lurks in the depth
of its abyss. Only the brave willl risk the decent into madness.