### PR TITLE
feat(proxy): local peer status event stream

### DIFF
--- a/proxy/api/src/http/notification.rs
+++ b/proxy/api/src/http/notification.rs
@@ -42,8 +42,8 @@ mod handler {
         subscriber: mpsc::UnboundedReceiver<Notification>,
     ) -> impl Stream<Item = Result<impl sse::ServerSentEvent, Infallible>> {
         subscriber.map(|notification| match notification {
-            Notification::LocalPeerListening(addr) => {
-                Ok((sse::event("LOCAL_PEER_LISTENING"), sse::json(addr)))
+            Notification::LocalPeerStatus(status) => {
+                Ok((sse::event("LOCAL_PEER_STATUS"), sse::json(status)))
             },
         })
     }

--- a/proxy/api/src/notification.rs
+++ b/proxy/api/src/notification.rs
@@ -25,6 +25,8 @@ pub struct Subscriptions {
     next_id: Arc<AtomicUsize>,
     /// Active subscribers.
     subs: Arc<RwLock<HashMap<usize, mpsc::UnboundedSender<Notification>>>>,
+    /// Cache for last event sent through this stream. This allows us to replay the last event
+    /// whenever a new consumer starts listening on this stream.
     last_state: Arc<RwLock<Option<Notification>>>,
 }
 

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -57,8 +57,8 @@ pub mod keystore;
 pub mod oid;
 pub mod peer;
 pub use peer::{
-    AnnounceConfig, AnnounceEvent, Event as PeerEvent, Peer, RequestEvent, RunConfig, SyncConfig,
-    SyncEvent,
+    AnnounceConfig, AnnounceEvent, Event as PeerEvent, Peer, RequestEvent, RunConfig, Status,
+    SyncConfig, SyncEvent,
 };
 pub mod shared;
 pub mod state;

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -83,6 +83,7 @@ pub struct Peer {
     waiting_room: Shared<WaitingRoom<Instant, Duration>>,
     /// Handle used to broadcast [`Event`].
     subscriber: broadcast::Sender<Event>,
+    /// Handle used to broadcast peer status changes.
     status_subscriber: broadcast::Sender<Status>,
     /// Subroutine config.
     run_config: RunConfig,

--- a/proxy/coco/src/peer/run_state.rs
+++ b/proxy/coco/src/peer/run_state.rs
@@ -200,6 +200,7 @@ pub struct RunState {
     connected_peers: HashSet<PeerId>,
     /// Current internal status.
     pub status: Status,
+    /// Timestamp of last status change.
     status_since: Instant,
 }
 

--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -8,6 +8,14 @@
   import { Avatar, Icon } from "../Primitive";
 
   export let identity = null;
+
+  const sse = new EventSource("http://localhost:8080/v1/notifications");
+
+  let peerState;
+
+  sse.addEventListener("LOCAL_PEER_STATUS", event => {
+    peerState = JSON.parse(event.data);
+  });
 </script>
 
 <style>
@@ -121,6 +129,14 @@
     </li>
   </ul>
   <ul class="bottom">
+    <li class="item indicator" data-cy="network">
+      <Tooltip value={JSON.stringify(peerState)}>
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a>
+          <Icon.Network />
+        </a>
+      </Tooltip>
+    </li>
     <li
       class="item indicator"
       data-cy="search"


### PR DESCRIPTION
This PR only addresses the proxy part, the UI is there only for debugging and will be implemented in #1000.

![progress](https://user-images.githubusercontent.com/158411/95602419-33a6cf00-0a55-11eb-97f2-0578be2f2a91.gif)


Refs: https://github.com/radicle-dev/radicle-upstream/issues/1001.