### PR TITLE
TypeScript targets ES2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
   "exclude": ["native/*", "node_modules/*", "public/*"],
   "compilerOptions": {
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "target": "es6",
+    "target": "ES2018",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "module": "es6",
     /* Specify library files to be included in the compilation. */


### PR DESCRIPTION
Set ES2018 as the target for the typescript compiler. This works because
electron supports this standard and results in less compilation overhead
and smaller/better sourcemaps