### PR TITLE
refactor: move request urn endpoint to PUT

### DIFF
--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -32,6 +32,17 @@ fn checkout_filter(
         .and_then(handler::checkout)
 }
 
+/// `GET /contributed`
+fn contributed_filter(
+    ctx: context::Context,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path("contributed")
+        .and(warp::get())
+        .and(http::with_context(ctx))
+        .and(path::end())
+        .and_then(handler::list_contributed)
+}
+
 /// `POST /`
 fn create_filter(
     ctx: context::Context,
@@ -42,6 +53,17 @@ fn create_filter(
         .and(http::with_owner_guard(ctx))
         .and(warp::body::json())
         .and_then(handler::create)
+}
+
+/// `GET /discover`
+fn discover_filter(
+    ctx: context::Context,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path("discover")
+        .and(warp::get())
+        .and(http::with_context(ctx))
+        .and(path::end())
+        .and_then(handler::discover)
 }
 
 /// `GET /<id>`
@@ -67,6 +89,19 @@ fn request_filter(
         .and_then(handler::request)
 }
 
+/// `PUT /<urn>/track/<peer_id>`
+fn track_filter(
+    ctx: context::Context,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    http::with_context(ctx)
+        .and(warp::put())
+        .and(path::param::<coco::Urn>())
+        .and(path("track"))
+        .and(path::param::<coco::PeerId>())
+        .and(path::end())
+        .and_then(handler::track)
+}
+
 /// `GET /tracked`
 fn tracked_filter(
     ctx: context::Context,
@@ -76,17 +111,6 @@ fn tracked_filter(
         .and(http::with_context(ctx))
         .and(path::end())
         .and_then(handler::list_tracked)
-}
-
-/// `GET /contributed`
-fn contributed_filter(
-    ctx: context::Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    path("contributed")
-        .and(warp::get())
-        .and(http::with_context(ctx))
-        .and(path::end())
-        .and_then(handler::list_contributed)
 }
 
 /// `GET /user/<id>`
@@ -99,30 +123,6 @@ fn user_filter(
         .and(path::param::<coco::Urn>())
         .and(path::end())
         .and_then(handler::list_for_user)
-}
-
-/// `GET /discover`
-fn discover_filter(
-    ctx: context::Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    path("discover")
-        .and(warp::get())
-        .and(http::with_context(ctx))
-        .and(path::end())
-        .and_then(handler::discover)
-}
-
-/// `PUT /<urn>/track/<peer_id>`
-fn track_filter(
-    ctx: context::Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    http::with_context(ctx)
-        .and(warp::put())
-        .and(path::param::<coco::Urn>())
-        .and(path("track"))
-        .and(path::param::<coco::PeerId>())
-        .and(path::end())
-        .and_then(handler::track)
 }
 
 /// Project handlers to implement conversion and translation between core domain and http request
@@ -179,26 +179,16 @@ mod handler {
         Ok(reply::with_status(reply::json(&path), StatusCode::CREATED))
     }
 
+    /// Get a feed of untracked projects.
+    pub async fn discover(_ctx: context::Context) -> Result<impl Reply, Rejection> {
+        let feed = project::discover()?;
+
+        Ok(reply::json(&feed))
+    }
+
     /// Get the [`project::Project`] for the given `id`.
     pub async fn get(ctx: context::Context, urn: coco::Urn) -> Result<impl Reply, Rejection> {
         Ok(reply::json(&project::get(&ctx.state, urn).await?))
-    }
-
-    /// Kick off a network request for the [`project::Project`] of the given `id`.
-    pub async fn request(ctx: context::Context, urn: coco::Urn) -> Result<impl Reply, Rejection> {
-        let mut peer_control = ctx.peer_control;
-        // TODO(finto): Check the request exists in the monorepo
-        let _request = peer_control.request_urn(&urn, Instant::now()).await;
-
-        // TODO(finto): Serialise request and respond with that.
-        Ok(reply::json(&true))
-    }
-
-    /// List all projects tracked by the current user.
-    pub async fn list_tracked(ctx: context::Context) -> Result<impl Reply, Rejection> {
-        let projects = project::Projects::list(&ctx.state).await?.tracked;
-
-        Ok(reply::json(&projects))
     }
 
     /// List all projects the current user has contributed to.
@@ -221,11 +211,21 @@ mod handler {
         Ok(reply::json(&projects))
     }
 
-    /// Get a feed of untracked projects.
-    pub async fn discover(_ctx: context::Context) -> Result<impl Reply, Rejection> {
-        let feed = project::discover()?;
+    /// List all projects tracked by the current user.
+    pub async fn list_tracked(ctx: context::Context) -> Result<impl Reply, Rejection> {
+        let projects = project::Projects::list(&ctx.state).await?.tracked;
 
-        Ok(reply::json(&feed))
+        Ok(reply::json(&projects))
+    }
+
+    /// Kick off a network request for the [`project::Project`] of the given `id`.
+    pub async fn request(ctx: context::Context, urn: coco::Urn) -> Result<impl Reply, Rejection> {
+        let mut peer_control = ctx.peer_control;
+        // TODO(finto): Check the request exists in the monorepo
+        let _request = peer_control.request_urn(&urn, Instant::now()).await;
+
+        // TODO(finto): Serialise request and respond with that.
+        Ok(reply::json(&true))
     }
 
     /// Track the peer for the provided project.

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -77,12 +77,12 @@ fn get_filter(
         .and_then(handler::get)
 }
 
-/// `GET /request/<id>`
+/// `PUT /request/<id>`
 fn request_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path("request")
-        .and(warp::get())
+        .and(warp::put())
         .and(http::with_context(ctx))
         .and(path::param::<coco::Urn>())
         .and(path::end())
@@ -541,7 +541,7 @@ mod test {
         );
 
         let res = request()
-            .method("GET")
+            .method("PUT")
             .path(&format!("/request/{}", urn))
             .reply(&api)
             .await;

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -69,6 +69,19 @@ export const post = async <I, D>(
     })
   );
 
+export const put = async <I, D>(
+  endpoint: string,
+  body: I,
+  options?: Options
+): Promise<D> =>
+  http<D>(
+    request(endpoint, {
+      method: "PUT",
+      body: body !== null ? JSON.stringify(body) : undefined,
+      ...options,
+    })
+  );
+
 export const set = async <T>(
   endpoint: string,
   body: T,

--- a/ui/src/search.ts
+++ b/ui/src/search.ts
@@ -26,7 +26,7 @@ const update = (msg: Msg): void => {
     case Kind.Update:
       requestStore.loading();
       api
-        .get<boolean>(`projects/request/${formatUrn(msg.urn)}`)
+        .put<null, boolean>(`projects/request/${formatUrn(msg.urn)}`, null)
         .then(res => {
           console.log(res);
           requestStore.success(res);


### PR DESCRIPTION
Part of #984 

Instead of using POST this change converts the endpoint to PUT to
convey that the operation is idempotent. A new request for an already
requested URN should not lead to an error, instead just a noop and a
friendly message.
