### PR TITLE
fix(ui): always tracked toggle for projects

### DIFF
--- a/ui/DesignSystem/Component/TrackToggle.svelte
+++ b/ui/DesignSystem/Component/TrackToggle.svelte
@@ -42,12 +42,10 @@
   .toggle.hover {
     border: 1px solid var(--color-secondary-level-2);
     background-color: var(--color-secondary-level-2);
-    box-shadow: 0 0 0 1px var(--color-secondary-level-2);
   }
   .toggle.active {
     border: 1px solid var(--color-secondary-level-1);
     background-color: var(--color-secondary-level-1);
-    box-shadow: 0 0 0 1px var(--color-secondary-level-1);
   }
   .toggle.tracking {
     border: 1px solid var(--color-foreground-level-3);
@@ -57,18 +55,15 @@
   .toggle.tracking.hover {
     border: 1px solid var(--color-foreground-level-2);
     background-color: var(--color-foreground-level-2);
-    box-shadow: 0 0 0 1px var(--color-foreground-level-2);
     color: var(--color-foreground-level-6);
   }
   .toggle.tracking.hover.warning {
     color: var(--color-background);
     border: none;
-    box-shadow: none;
   }
   .toggle.tracking.active {
     border: 1px solid var(--color-foreground-level-2);
     background-color: var(--color-foreground-level-2);
-    box-shadow: 0 0 0 1px var(--color-foreground-level-2);
     color: var(--color-foreground-level-4);
   }
   .left {

--- a/ui/DesignSystem/Component/TrackToggle.svelte
+++ b/ui/DesignSystem/Component/TrackToggle.svelte
@@ -120,13 +120,17 @@
 <Hoverable let:hovering={hover}>
   <div
     class:active
-    class:hover
+    class:hover={hover && !disabled}
     class:tracking
     class:warning
     class="toggle"
     {style}
-    on:mousedown={down}
-    on:mouseup={up}>
+    on:mousedown={() => {
+      !disabled && down();
+    }}
+    on:mouseup={() => {
+      !disabled && up();
+    }}>
     <div
       class="left"
       class:active

--- a/ui/DesignSystem/Component/TrackToggle.svelte
+++ b/ui/DesignSystem/Component/TrackToggle.svelte
@@ -6,12 +6,14 @@
   import { Icon } from "../Primitive";
   import Hoverable from "./Hoverable.svelte";
 
-  export let style = "";
-  export let tracking: boolean = false;
+  export let disabled: boolean = false;
   export let expanded: boolean = false;
+  export let tracking: boolean = false;
+  export let style = "";
 
   export let warning: boolean = false;
 
+  const dispatch = createEventDispatcher();
   let active: boolean = false;
 
   const down = () => {
@@ -23,8 +25,6 @@
     tracking = !tracking;
     dispatch(tracking ? track.Event.Track : track.Event.Untrack);
   };
-
-  const dispatch = createEventDispatcher();
 </script>
 
 <style>
@@ -112,23 +112,32 @@
   .left.tracking.warning.hover :global(svg) {
     fill: var(--color-background);
   }
+  .disabled {
+    cursor: auto;
+  }
 </style>
 
 <Hoverable let:hovering={hover}>
   <div
-    class:hover
     class:active
+    class:hover
     class:tracking
     class:warning
     class="toggle"
     {style}
     on:mousedown={down}
     on:mouseup={up}>
-    <div class="left" class:hover class:active class:tracking class:warning>
+    <div
+      class="left"
+      class:active
+      class:disabled
+      class:hover={hover && !disabled}
+      class:tracking
+      class:warning>
       {#if !tracking}
         <Icon.Network style="margin: 0 8px 0 12px" />
         <p class="typo-text-bold" style="margin-right: 12px">Follow</p>
-      {:else if hover}
+      {:else if hover && !disabled}
         <Icon.Network style="margin: 0 8px 0 12px" />
         <p class="typo-text-bold" style="margin-right: 12px">Unfollow</p>
       {:else if expanded}

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -167,7 +167,7 @@
               on:select={() => {
                 resetCurrentRevision();
               }} />
-            <TrackToggle disabled tracking />
+            <TrackToggle disabled expanded tracking />
           </div>
         </div>
       </Header.Large>

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -168,7 +168,7 @@
               on:select={() => {
                 resetCurrentRevision();
               }} />
-            <TrackToggle />
+            <TrackToggle disabled tracking />
           </div>
         </div>
       </Header.Large>

--- a/ui/Screen/Project/PeerSelector.svelte
+++ b/ui/Screen/Project/PeerSelector.svelte
@@ -57,7 +57,6 @@
     border: 1px solid var(--color-foreground-level-3);
     border-radius: 4px;
     padding: 0.5rem;
-    margin-right: 1rem;
     display: flex;
     cursor: pointer;
     justify-content: space-between;
@@ -86,6 +85,7 @@
   .peer-dropdown-container {
     display: flex;
     position: absolute;
+    right: 0;
     top: 0;
   }
 
@@ -115,7 +115,10 @@
   }
 </style>
 
-<Overlay {expanded} on:hide={hideDropdown} style="position: relative;">
+<Overlay
+  {expanded}
+  on:hide={hideDropdown}
+  style="margin-right: 1rem; position: relative; user-select: none;">
   <div
     class="peer-selector"
     data-cy="peer-selector"


### PR DESCRIPTION
Until we introduce explicit untracking of projects, whenever we show
a project page it is inherently tracked. Therefore the track toggle
should be in tracked state and the unfollow action disabled.

Closes #1045

***
![2020-10-16-094442_1738x1408_scrot](https://user-images.githubusercontent.com/1585/96227711-c636f900-0f94-11eb-82b5-eb91526ab860.png)
