### PR TITLE
fix: "run all specs" from cypress UI

### DIFF
--- a/cypress/integration/onboarding.spec.js
+++ b/cypress/integration/onboarding.spec.js
@@ -1,4 +1,4 @@
-context("identity creation", () => {
+context("onboarding", () => {
   const validUser = {
     handle: "rafalca",
     passphrase: "curled",

--- a/cypress/integration/project_checkout.spec.js
+++ b/cypress/integration/project_checkout.spec.js
@@ -1,135 +1,139 @@
 import { DIALOG_SHOWOPENDIALOG, OPEN_PATH } from "../../native/ipc.js";
 
-const withWorkspaceStub = callback => {
-  cy.exec("pwd").then(result => {
-    const pwd = result.stdout;
-    const checkoutPath = `${pwd}/cypress/workspace/checkout`;
-
-    // Clean up any left-overs from previous failed tests.
-    cy.exec(`rm -rf ${checkoutPath}`);
-    cy.exec(`mkdir -p ${checkoutPath}`);
-
-    // Stub Electron native calls
-    cy.window().then(appWindow => {
-      appWindow.mockOpenPathCalled = false;
-
-      appWindow.electron = {
-        ipcRenderer: {
-          invoke: msg => {
-            if (msg === DIALOG_SHOWOPENDIALOG) {
-              return checkoutPath;
-            } else if (msg === OPEN_PATH) {
-              appWindow.mockOpenPathCalled = true;
-            }
-          },
-        },
-      };
-    });
-
-    callback(checkoutPath);
-
-    // Clean up the cypress workspace.
-    cy.exec(`rm -rf ${checkoutPath}`);
-  });
-};
-
-beforeEach(() => {
-  cy.resetAllState();
-  cy.onboardUser();
-  cy.createProjectWithFixture();
-  cy.visit("./public/index.html");
-});
-
 context("project checkout", () => {
-  context("git remote helper setup hints", () => {
-    it("shows hints on how to set up the remote helper", () => {
-      // The hint is visible in the project checkout modal.
-      cy.pick("project-list-entry-platinum").click();
-      cy.pick("checkout-modal-toggle").click();
-      cy.pick("remote-helper-hint").should("be.visible");
-      cy.pick("profile").click();
+  const withWorkspaceStub = callback => {
+    cy.exec("pwd").then(result => {
+      const pwd = result.stdout;
+      const checkoutPath = `${pwd}/cypress/workspace/checkout`;
 
-      // The hint is visible in the project creation modal.
-      cy.pick("new-project-button").click();
-      cy.pick("remote-helper-hint").should("be.visible");
+      // Clean up any left-overs from previous failed tests.
+      cy.exec(`rm -rf ${checkoutPath}`);
+      cy.exec(`mkdir -p ${checkoutPath}`);
 
-      // Dismiss the hint.
-      cy.pick("close-hint-button").click();
-      cy.pick("remote-helper-hint").should("not.be.visible");
-      cy.pick("cancel-button").click();
+      // Stub Electron native calls
+      cy.window().then(appWindow => {
+        appWindow.mockOpenPathCalled = false;
 
-      // Hint is still hidden when re-entering project creation
-      cy.pick("new-project-button").click();
-      cy.pick("remote-helper-hint").should("not.be.visible");
-      cy.pick("cancel-button").click();
+        appWindow.electron = {
+          ipcRenderer: {
+            invoke: msg => {
+              if (msg === DIALOG_SHOWOPENDIALOG) {
+                return checkoutPath;
+              } else if (msg === OPEN_PATH) {
+                appWindow.mockOpenPathCalled = true;
+              }
+            },
+          },
+        };
+      });
 
-      // The hint is also hidden in the project creation modal.
-      cy.pick("new-project-button").click();
-      cy.pick("remote-helper-hint").should("not.be.visible");
+      callback(checkoutPath);
+
+      // Clean up the cypress workspace.
+      cy.exec(`rm -rf ${checkoutPath}`);
     });
+  };
+
+  beforeEach(() => {
+    cy.resetAllState();
+    cy.onboardUser();
+    cy.createProjectWithFixture();
+    cy.visit("./public/index.html");
   });
 
-  context("happy path", () => {
-    it("checks out the project into a working directory", () => {
-      cy.pick("project-list-entry-platinum").click();
-      cy.pick("checkout-modal-toggle").click();
+  context("project checkout", () => {
+    context("git remote helper setup hints", () => {
+      it("shows hints on how to set up the remote helper", () => {
+        // The hint is visible in the project checkout modal.
+        cy.pick("project-list-entry-platinum").click();
+        cy.pick("checkout-modal-toggle").click();
+        cy.pick("remote-helper-hint").should("be.visible");
+        cy.pick("profile").click();
 
-      withWorkspaceStub(checkoutPath => {
-        cy.pick("choose-path-button").click();
-        // Make sure UI has time to update path value from stub,
-        // prevents this spec from failing on CI.
-        cy.wait(500);
+        // The hint is visible in the project creation modal.
+        cy.pick("new-project-button").click();
+        cy.pick("remote-helper-hint").should("be.visible");
 
-        // Make sure mock is set up correctly.
-        cy.window().then(appWindow => {
-          expect(appWindow.mockOpenPathCalled).to.be.false;
-        });
+        // Dismiss the hint.
+        cy.pick("close-hint-button").click();
+        cy.pick("remote-helper-hint").should("not.be.visible");
+        cy.pick("cancel-button").click();
 
-        // Perform the checkout.
-        cy.pick("checkout-button").click();
+        // Hint is still hidden when re-entering project creation
+        cy.pick("new-project-button").click();
+        cy.pick("remote-helper-hint").should("not.be.visible");
+        cy.pick("cancel-button").click();
 
-        // Notification should contain the full path to the working directory.
-        cy.pick("notification")
-          .contains("platinum checked out to")
-          .should("exist");
-        cy.pick("notification")
-          .contains("cypress/workspace/checkout/platinum")
-          .should("exist");
-        cy.pick("notification").contains("Open folder").should("exist");
-        cy.pick("notification").contains("Open folder").click();
+        // The hint is also hidden in the project creation modal.
+        cy.pick("new-project-button").click();
+        cy.pick("remote-helper-hint").should("not.be.visible");
+      });
+    });
 
-        // Make sure we do the electron call for opening the folder in the OS
-        // file browser.
-        cy.window().then(appWindow => {
-          expect(appWindow.mockOpenPathCalled).to.be.true;
-        });
-
-        // Make sure the notification gets closed after we open the folder in
-        // the OS file browser.
-        cy.contains("platinum checked out to").should("not.exist");
-
-        // Check that the working directory has the rad remote.
-        cy.exec(`git -C ${checkoutPath}/platinum remote show`).then(result => {
-          expect(result.stdout).to.equal(`rad`);
-        });
-
-        // Make sure we can't check out a project to the same directory twice.
+    context("happy path", () => {
+      it("checks out the project into a working directory", () => {
+        cy.pick("project-list-entry-platinum").click();
         cy.pick("checkout-modal-toggle").click();
 
-        cy.pick("choose-path-button").click();
-        // Make sure UI has time to update path value from stub,
-        // prevents this spec from failing on CI.
-        cy.wait(500);
+        withWorkspaceStub(checkoutPath => {
+          cy.pick("choose-path-button").click();
+          // Make sure UI has time to update path value from stub,
+          // prevents this spec from failing on CI.
+          cy.wait(500);
 
-        // Perform the checkout.
-        cy.pick("checkout-button").click();
+          // Make sure mock is set up correctly.
+          cy.window().then(appWindow => {
+            expect(appWindow.mockOpenPathCalled).to.be.false;
+          });
 
-        // Notification should contain the full path to the working directory.
-        cy.pick("notification")
-          .contains(
-            /Checkout failed: '.*checkout\/platinum' exists and is not an empty directory/
-          )
-          .should("exist");
+          // Perform the checkout.
+          cy.pick("checkout-button").click();
+
+          // Notification should contain the full path to the working directory.
+          cy.pick("notification")
+            .contains("platinum checked out to")
+            .should("exist");
+          cy.pick("notification")
+            .contains("cypress/workspace/checkout/platinum")
+            .should("exist");
+          cy.pick("notification").contains("Open folder").should("exist");
+          cy.pick("notification").contains("Open folder").click();
+
+          // Make sure we do the electron call for opening the folder in the OS
+          // file browser.
+          cy.window().then(appWindow => {
+            expect(appWindow.mockOpenPathCalled).to.be.true;
+          });
+
+          // Make sure the notification gets closed after we open the folder in
+          // the OS file browser.
+          cy.contains("platinum checked out to").should("not.exist");
+
+          // Check that the working directory has the rad remote.
+          cy.exec(`git -C ${checkoutPath}/platinum remote show`).then(
+            result => {
+              expect(result.stdout).to.equal(`rad`);
+            }
+          );
+
+          // Make sure we can't check out a project to the same directory twice.
+          cy.pick("checkout-modal-toggle").click();
+
+          cy.pick("choose-path-button").click();
+          // Make sure UI has time to update path value from stub,
+          // prevents this spec from failing on CI.
+          cy.wait(500);
+
+          // Perform the checkout.
+          cy.pick("checkout-button").click();
+
+          // Notification should contain the full path to the working directory.
+          cy.pick("notification")
+            .contains(
+              /Checkout failed: '.*checkout\/platinum' exists and is not an empty directory/
+            )
+            .should("exist");
+        });
       });
     });
   });

--- a/cypress/integration/project_creation.spec.js
+++ b/cypress/integration/project_creation.spec.js
@@ -1,301 +1,217 @@
 import { DIALOG_SHOWOPENDIALOG } from "../../native/ipc.js";
 
-const withEmptyDirectoryStub = callback => {
-  cy.exec("pwd").then(result => {
-    const pwd = result.stdout;
-    const emptyDirectoryPath = `${pwd}/cypress/workspace/empty-directory`;
-
-    cy.exec(`rm -rf ${emptyDirectoryPath}`);
-    cy.exec(`mkdir -p ${emptyDirectoryPath}`);
-
-    // stub native call and return the directory path to the UI
-    cy.window().then(appWindow => {
-      appWindow.electron = {
-        ipcRenderer: {
-          invoke: msg => {
-            if (msg === DIALOG_SHOWOPENDIALOG) {
-              return emptyDirectoryPath;
-            }
-          },
-        },
-        isDev: true,
-        isExperimental: true,
-      };
-    });
-
-    callback();
-
-    // clean up the fixture
-    cy.exec(`rm -rf ${emptyDirectoryPath}`);
-  });
-};
-
-const withNoCommitsRepositoryStub = callback => {
-  cy.exec("pwd").then(result => {
-    const pwd = result.stdout;
-    const noCommitsRepoPath = `${pwd}/cypress/workspace/no-commits-repo`;
-
-    cy.exec(`rm -rf ${noCommitsRepoPath}`);
-    cy.exec(`mkdir -p ${noCommitsRepoPath}`);
-    cy.exec(`git init ${noCommitsRepoPath}`);
-
-    // stub native call and return the directory path to the UI
-    cy.window().then(appWindow => {
-      appWindow.electron = {
-        ipcRenderer: {
-          invoke: msg => {
-            if (msg === DIALOG_SHOWOPENDIALOG) {
-              return noCommitsRepoPath;
-            }
-          },
-        },
-        isDev: true,
-        isExperimental: true,
-      };
-    });
-
-    callback();
-
-    // clean up the fixture
-    cy.exec(`rm -rf ${noCommitsRepoPath}`);
-  });
-};
-
-const withPlatinumStub = callback => {
-  cy.exec("pwd").then(result => {
-    const pwd = result.stdout;
-    const platinumPath = `${pwd}/cypress/workspace/git-platinum-copy`;
-
-    cy.exec(`rm -rf ${platinumPath}`);
-    cy.exec(
-      `git clone ${pwd}/.git/modules/fixtures/git-platinum ${platinumPath}`
-    );
-
-    // stub native call and return the directory path to the UI
-    cy.window().then(appWindow => {
-      appWindow.electron = {
-        ipcRenderer: {
-          invoke: msg => {
-            if (msg === DIALOG_SHOWOPENDIALOG) {
-              return platinumPath;
-            }
-          },
-        },
-        isDev: true,
-        isExperimental: true,
-      };
-    });
-
-    callback();
-
-    cy.exec(`rm -rf ${platinumPath}`);
-  });
-};
-
-beforeEach(() => {
-  cy.resetAllState();
-  cy.onboardUser();
-  cy.visit("./public/index.html");
-});
-
 context("project creation", () => {
-  context("project creation modal", () => {
-    // TODO(rudolfs): test empty project listing has wording and button
+  const withEmptyDirectoryStub = callback => {
+    cy.exec("pwd").then(result => {
+      const pwd = result.stdout;
+      const emptyDirectoryPath = `${pwd}/cypress/workspace/empty-directory`;
 
-    it("can be opened via the profile header action button and closed by pressing cancel", () => {
-      cy.pick("new-project-button").click();
-      cy.pick("page", "create-project").should("exist");
-      cy.pick("create-project", "cancel-button").click();
-      cy.pick("profile-screen").should("exist");
-    });
+      cy.exec(`rm -rf ${emptyDirectoryPath}`);
+      cy.exec(`mkdir -p ${emptyDirectoryPath}`);
 
-    it("can be closed by pressing escape key", () => {
-      cy.pick("new-project-button").click();
-      cy.pick("page", "create-project").should("exist");
-      cy.get("body").type("{esc}");
-      cy.pick("profile-screen").should("exist");
+      // stub native call and return the directory path to the UI
+      cy.window().then(appWindow => {
+        appWindow.electron = {
+          ipcRenderer: {
+            invoke: msg => {
+              if (msg === DIALOG_SHOWOPENDIALOG) {
+                return emptyDirectoryPath;
+              }
+            },
+          },
+          isDev: true,
+          isExperimental: true,
+        };
+      });
+
+      callback();
+
+      // clean up the fixture
+      cy.exec(`rm -rf ${emptyDirectoryPath}`);
     });
+  };
+
+  const withNoCommitsRepositoryStub = callback => {
+    cy.exec("pwd").then(result => {
+      const pwd = result.stdout;
+      const noCommitsRepoPath = `${pwd}/cypress/workspace/no-commits-repo`;
+
+      cy.exec(`rm -rf ${noCommitsRepoPath}`);
+      cy.exec(`mkdir -p ${noCommitsRepoPath}`);
+      cy.exec(`git init ${noCommitsRepoPath}`);
+
+      // stub native call and return the directory path to the UI
+      cy.window().then(appWindow => {
+        appWindow.electron = {
+          ipcRenderer: {
+            invoke: msg => {
+              if (msg === DIALOG_SHOWOPENDIALOG) {
+                return noCommitsRepoPath;
+              }
+            },
+          },
+          isDev: true,
+          isExperimental: true,
+        };
+      });
+
+      callback();
+
+      // clean up the fixture
+      cy.exec(`rm -rf ${noCommitsRepoPath}`);
+    });
+  };
+
+  const withPlatinumStub = callback => {
+    cy.exec("pwd").then(result => {
+      const pwd = result.stdout;
+      const platinumPath = `${pwd}/cypress/workspace/git-platinum-copy`;
+
+      cy.exec(`rm -rf ${platinumPath}`);
+      cy.exec(
+        `git clone ${pwd}/.git/modules/fixtures/git-platinum ${platinumPath}`
+      );
+
+      // stub native call and return the directory path to the UI
+      cy.window().then(appWindow => {
+        appWindow.electron = {
+          ipcRenderer: {
+            invoke: msg => {
+              if (msg === DIALOG_SHOWOPENDIALOG) {
+                return platinumPath;
+              }
+            },
+          },
+          isDev: true,
+          isExperimental: true,
+        };
+      });
+
+      callback();
+
+      cy.exec(`rm -rf ${platinumPath}`);
+    });
+  };
+
+  beforeEach(() => {
+    cy.resetAllState();
+    cy.onboardUser();
+    cy.visit("./public/index.html");
   });
 
-  context("validations", () => {
-    beforeEach(() => {
-      cy.pick("new-project-button").click();
+  context("project creation", () => {
+    context("project creation modal", () => {
+      // TODO(rudolfs): test empty project listing has wording and button
 
-      // Set up minimal form input to show validations
-      cy.pick("page", "name").type("this-name-is-valid");
-      cy.pick("page", "new-project").click();
-    });
+      it("can be opened via the profile header action button and closed by pressing cancel", () => {
+        cy.pick("new-project-button").click();
+        cy.pick("page", "create-project").should("exist");
+        cy.pick("create-project", "cancel-button").click();
+        cy.pick("profile-screen").should("exist");
+      });
 
-    afterEach(() => {
-      cy.get("body").type("{esc}", { force: true });
-    });
-
-    context("name", () => {
-      it("prevents the user from creating a project with an invalid name", () => {
-        const characterError =
-          "Your project name has unsupported characters in it. You can only use basic letters, numbers, and the _ , - and . characters.";
-        const firstCharacterError =
-          "Your project name should start with a letter or a number.";
-        const lengthError =
-          "Your project name should be at least 2 characters long.";
-
-        // the submit button is disabled when name is not present
-        cy.pick("page", "name").clear();
-        cy.pick("create-project-button").should("be.disabled");
-
-        // spaces should be changed into dashes
-        cy.pick("page", "name").type("no spaces");
-        cy.pick("page", "name").should("have.value", "no-spaces");
-
-        // shows a validation message when name contains invalid characters
-
-        // special characters are disallowed
-        cy.pick("page", "name").clear();
-        cy.pick("page", "name").type("bad$");
-        cy.pick("page").contains(characterError);
-
-        // can't start with an underscore
-        cy.pick("page", "name").clear();
-        cy.pick("page", "name").type("_nein");
-        cy.pick("page").contains(firstCharacterError);
-
-        // can't start with a dash
-        cy.pick("page", "name").clear();
-        cy.pick("page", "name").type("-nope");
-        cy.pick("page").contains(firstCharacterError);
-
-        // has to be at least two characters long
-        cy.pick("page", "name").clear();
-        cy.pick("page", "name").type("x");
-        cy.pick("page").contains(lengthError);
+      it("can be closed by pressing escape key", () => {
+        cy.pick("new-project-button").click();
+        cy.pick("page", "create-project").should("exist");
+        cy.get("body").type("{esc}");
+        cy.pick("profile-screen").should("exist");
       });
     });
 
-    context("new repository", () => {
-      it("prevents the user from picking an invalid directory", () => {
-        // shows a validation message when new project path is empty
-        cy.pick("page", "new-project")
-          .contains("Pick a directory for the new project")
-          .should("exist");
+    context("validations", () => {
+      beforeEach(() => {
+        cy.pick("new-project-button").click();
 
-        withPlatinumStub(() => {
-          cy.pick("new-project", "choose-path-button").click();
+        // Set up minimal form input to show validations
+        cy.pick("page", "name").type("this-name-is-valid");
+        cy.pick("page", "new-project").click();
+      });
 
+      afterEach(() => {
+        cy.get("body").type("{esc}", { force: true });
+      });
+
+      context("name", () => {
+        it("prevents the user from creating a project with an invalid name", () => {
+          const characterError =
+            "Your project name has unsupported characters in it. You can only use basic letters, numbers, and the _ , - and . characters.";
+          const firstCharacterError =
+            "Your project name should start with a letter or a number.";
+          const lengthError =
+            "Your project name should be at least 2 characters long.";
+
+          // the submit button is disabled when name is not present
+          cy.pick("page", "name").clear();
+          cy.pick("create-project-button").should("be.disabled");
+
+          // spaces should be changed into dashes
+          cy.pick("page", "name").type("no spaces");
+          cy.pick("page", "name").should("have.value", "no-spaces");
+
+          // shows a validation message when name contains invalid characters
+
+          // special characters are disallowed
+          cy.pick("page", "name").clear();
+          cy.pick("page", "name").type("bad$");
+          cy.pick("page").contains(characterError);
+
+          // can't start with an underscore
+          cy.pick("page", "name").clear();
+          cy.pick("page", "name").type("_nein");
+          cy.pick("page").contains(firstCharacterError);
+
+          // can't start with a dash
+          cy.pick("page", "name").clear();
+          cy.pick("page", "name").type("-nope");
+          cy.pick("page").contains(firstCharacterError);
+
+          // has to be at least two characters long
+          cy.pick("page", "name").clear();
+          cy.pick("page", "name").type("x");
+          cy.pick("page").contains(lengthError);
+        });
+      });
+
+      context("new repository", () => {
+        it("prevents the user from picking an invalid directory", () => {
+          // shows a validation message when new project path is empty
           cy.pick("page", "new-project")
-            .contains(
-              "Please choose a directory that's not already a git repository."
-            )
+            .contains("Pick a directory for the new project")
+            .should("exist");
+
+          withPlatinumStub(() => {
+            cy.pick("new-project", "choose-path-button").click();
+
+            cy.pick("page", "new-project")
+              .contains(
+                "Please choose a directory that's not already a git repository."
+              )
+              .should("exist");
+          });
+        });
+      });
+
+      context("form", () => {
+        it("clears name input when switching from new to existing project", () => {
+          cy.pick("name").clear();
+          cy.pick("name").type("this-will-be-a-new-project");
+          cy.pick("new-project").click();
+          cy.pick("name").should("have.value", "this-will-be-a-new-project");
+          cy.pick("existing-project").click();
+          cy.pick("name").should("have.value", "");
+        });
+
+        it("prevents the user from submitting invalid data", () => {
+          // shows a validation message when new project path is empty
+          cy.pick("page", "new-project")
+            .contains("Pick a directory for the new project")
             .should("exist");
         });
       });
     });
 
-    context("form", () => {
-      it("clears name input when switching from new to existing project", () => {
-        cy.pick("name").clear();
-        cy.pick("name").type("this-will-be-a-new-project");
-        cy.pick("new-project").click();
-        cy.pick("name").should("have.value", "this-will-be-a-new-project");
-        cy.pick("existing-project").click();
-        cy.pick("name").should("have.value", "");
-      });
-
-      it("prevents the user from submitting invalid data", () => {
-        // shows a validation message when new project path is empty
-        cy.pick("page", "new-project")
-          .contains("Pick a directory for the new project")
-          .should("exist");
-      });
-    });
-  });
-
-  it("disallows creating a project from a repository without commits", () => {
-    withNoCommitsRepositoryStub(() => {
-      cy.pick("new-project-button").click();
-
-      cy.pick("existing-project").click();
-
-      cy.pick("existing-project", "choose-path-button").click();
-      // Make sure UI has time to update path value from stub,
-      // this prevents this spec from failing on CI.
-      cy.wait(500);
-
-      cy.pick("existing-project")
-        .contains(
-          "The directory should contain a git repository with at least one branch"
-        )
-        .should("exist");
-    });
-  });
-
-  context("happy paths", () => {
-    it("creates a new project from an empty directory", () => {
-      withEmptyDirectoryStub(() => {
-        cy.pick("new-project-button").click();
-
-        cy.pick("name").type("new-fancy-project.xyz");
-        cy.pick("description").type("My new fancy project");
-
-        cy.pick("new-project").click();
-        cy.pick("new-project", "choose-path-button").click();
-        // Make sure UI has time to update path value from stub,
-        // this prevents this spec from failing on CI.
-        cy.wait(500);
-
-        cy.pick("create-project-button").click();
-
-        cy.pick("project-screen", "header").contains("new-fancy-project");
-
-        cy.pick("notification").contains(
-          "Project new-fancy-project.xyz successfully created"
-        );
-
-        cy.pick("profile").click();
-        cy.pick("profile-screen", "project-list").contains(
-          "new-fancy-project.xyz"
-        );
-        cy.pick("profile-screen", "project-list").contains(
-          "My new fancy project"
-        );
-      });
-    });
-
-    it("creates a new project from an existing repository", () => {
-      withPlatinumStub(() => {
-        cy.pick("new-project-button").click();
-
-        cy.pick("name").should("not.be.disabled");
-
-        cy.pick("existing-project").click();
-        cy.pick("name").should("be.disabled");
-
-        cy.pick("existing-project", "choose-path-button").click();
-        // Make sure UI has time to update path value from stub,
-        // this prevents this spec from failing on CI.
-        cy.wait(500);
-
-        cy.pick("name").should("have.value", "git-platinum-copy");
-        cy.pick("description").type("Best project");
-
-        cy.pick("create-project-button").click();
-        cy.pick("project-screen", "header").contains("git-platinum-copy");
-
-        cy.pick("project-screen", "header").contains("Best project");
-
-        cy.pick("notification").contains(
-          "Project git-platinum-copy successfully created"
-        );
-
-        cy.pick("profile").click();
-        cy.pick("profile-screen", "project-list").contains("git-platinum-copy");
-        cy.pick("profile-screen", "project-list").contains("Best project");
-
-        cy.pick("notification")
-          .contains("Project git-platinum-copy successfully created")
-          .should("exist");
-        cy.pick("notification").contains("Close").click();
-
-        // Make sure we can't add the same project twice.
+    it("disallows creating a project from a repository without commits", () => {
+      withNoCommitsRepositoryStub(() => {
         cy.pick("new-project-button").click();
 
         cy.pick("existing-project").click();
@@ -305,17 +221,105 @@ context("project creation", () => {
         // this prevents this spec from failing on CI.
         cy.wait(500);
 
-        cy.pick("name").should("have.value", "git-platinum-copy");
-        cy.pick("description").type("Best project");
-
-        cy.pick("create-project-button").click();
-
-        cy.pick("notification")
+        cy.pick("existing-project")
           .contains(
-            /Could not create project: the identity 'rad:git:[\w]{3}…[\w]{3}' already exists/
+            "The directory should contain a git repository with at least one branch"
           )
           .should("exist");
-        cy.pick("notification").contains("Close").click();
+      });
+    });
+
+    context("happy paths", () => {
+      it("creates a new project from an empty directory", () => {
+        withEmptyDirectoryStub(() => {
+          cy.pick("new-project-button").click();
+
+          cy.pick("name").type("new-fancy-project.xyz");
+          cy.pick("description").type("My new fancy project");
+
+          cy.pick("new-project").click();
+          cy.pick("new-project", "choose-path-button").click();
+          // Make sure UI has time to update path value from stub,
+          // this prevents this spec from failing on CI.
+          cy.wait(500);
+
+          cy.pick("create-project-button").click();
+
+          cy.pick("project-screen", "header").contains("new-fancy-project");
+
+          cy.pick("notification").contains(
+            "Project new-fancy-project.xyz successfully created"
+          );
+
+          cy.pick("profile").click();
+          cy.pick("profile-screen", "project-list").contains(
+            "new-fancy-project.xyz"
+          );
+          cy.pick("profile-screen", "project-list").contains(
+            "My new fancy project"
+          );
+        });
+      });
+
+      it("creates a new project from an existing repository", () => {
+        withPlatinumStub(() => {
+          cy.pick("new-project-button").click();
+
+          cy.pick("name").should("not.be.disabled");
+
+          cy.pick("existing-project").click();
+          cy.pick("name").should("be.disabled");
+
+          cy.pick("existing-project", "choose-path-button").click();
+          // Make sure UI has time to update path value from stub,
+          // this prevents this spec from failing on CI.
+          cy.wait(500);
+
+          cy.pick("name").should("have.value", "git-platinum-copy");
+          cy.pick("description").type("Best project");
+
+          cy.pick("create-project-button").click();
+          cy.pick("project-screen", "header").contains("git-platinum-copy");
+
+          cy.pick("project-screen", "header").contains("Best project");
+
+          cy.pick("notification").contains(
+            "Project git-platinum-copy successfully created"
+          );
+
+          cy.pick("profile").click();
+          cy.pick("profile-screen", "project-list").contains(
+            "git-platinum-copy"
+          );
+          cy.pick("profile-screen", "project-list").contains("Best project");
+
+          cy.pick("notification")
+            .contains("Project git-platinum-copy successfully created")
+            .should("exist");
+          cy.pick("notification").contains("Close").click();
+
+          // Make sure we can't add the same project twice.
+          cy.pick("new-project-button").click();
+
+          cy.pick("existing-project").click();
+
+          cy.pick("existing-project", "choose-path-button").click();
+          // Make sure UI has time to update path value from stub,
+          // this prevents this spec from failing on CI.
+          cy.wait(500);
+
+          cy.pick("name").should("have.value", "git-platinum-copy");
+          cy.pick("description").type("Best project");
+
+          cy.pick("create-project-button").click();
+
+          cy.pick("notification")
+            .contains(
+              /Could not create project: the identity 'rad:git:[\w]{3}…[\w]{3}' already exists/
+            )
+            .should("exist");
+          cy.pick("notification").contains("Close").click();
+        });
       });
     });
   });

--- a/cypress/integration/project_source_browsing.spec.js
+++ b/cypress/integration/project_source_browsing.spec.js
@@ -1,389 +1,393 @@
-before(() => {
-  cy.resetAllState();
-  cy.onboardUser("cloudhead");
+context("project source browsing", () => {
+  before(() => {
+    cy.resetAllState();
+    cy.onboardUser("cloudhead");
 
-  // TODO(sos): add fake peers again when we have a peer testnet
-  cy.createProjectWithFixture();
-});
-
-beforeEach(() => {
-  cy.visit("./public/index.html#/profile/projects");
-  cy.contains("platinum").click();
-});
-
-context("repository stats", () => {
-  it("shows the correct numbers", () => {
-    cy.pick("header", "project-stats").contains("2 Branches");
-    cy.pick("header", "project-stats").contains("4 Contributors");
-    cy.pick("horizontal-menu", "Commits", "counter").contains("14");
+    // TODO(sos): add fake peers again when we have a peer testnet
+    cy.createProjectWithFixture();
   });
-});
 
-context("commit browsing", () => {
-  context("commit history", () => {
-    it("shows the commit history for the default branch", () => {
-      // Wait for the commit tab to be updated
+  beforeEach(() => {
+    cy.visit("./public/index.html#/profile/projects");
+    cy.contains("platinum").click();
+  });
+
+  context("repository stats", () => {
+    it("shows the correct numbers", () => {
+      cy.pick("header", "project-stats").contains("2 Branches");
+      cy.pick("header", "project-stats").contains("4 Contributors");
       cy.pick("horizontal-menu", "Commits", "counter").contains("14");
-      cy.pick("horizontal-menu", "Commits").click();
-      cy.pick("commits-page").should("exist");
-      cy.pick("commit-teaser")
-        .contains("Commit on the dev branch")
-        .should("not.exist");
-      cy.pick("commit-teaser")
-        .contains("Merge pull request #4 from FintanH/fintan")
-        .click();
-      cy.pick("commit-page").should("exist");
-      cy.pick("commit-header")
-        .contains("Commit 223aaf87d6ea62eef0014857640fd7c8dd0f80b5")
-        .should("exist");
-    });
-
-    it("shows the commit history for another branch", () => {
-      cy.pick("revision-selector").click();
-      cy.get('[data-branch="dev"]').click();
-      // Wait for the commit tab to be updated
-      cy.pick("horizontal-menu", "Commits", "counter").contains("8");
-      cy.pick("horizontal-menu", "Commits").click();
-
-      cy.pick("commits-page").should("exist");
-      cy.pick("commit-teaser")
-        .contains("Merge pull request #4 from FintanH/fintan")
-        .should("not.exist");
-      cy.pick("commit-teaser").contains("Commit on the dev branch").click();
-      cy.pick("commit-header")
-        .contains("Commit 27acd68c7504755aa11023300890bb85bbd69d45")
-        .should("exist");
-    });
-  });
-});
-
-context("source code browsing", () => {
-  context("relative timestamps", () => {
-    context("when the timeframe is less than a day", () => {
-      it("shows timeframe in hours", () => {
-        cy.clock(Date.parse("5 dec 2019"));
-        cy.pick("revision-selector").click();
-        cy.get('[data-tag="v0.5.0"]').click();
-        cy.contains("9 hours ago").should("exist");
-      });
-    });
-
-    context("when the timeframe is less than 2 days", () => {
-      it("shows timeframe in days", () => {
-        cy.clock(Date.parse("6 dec 2019"));
-        cy.pick("revision-selector").click();
-        cy.get('[data-tag="v0.5.0"]').click();
-        cy.contains("1 day ago").should("exist");
-      });
-    });
-
-    context("when the timeframe is less than a week", () => {
-      it("shows timeframe in days", () => {
-        cy.clock(Date.parse("10 dec 2019"));
-        cy.pick("revision-selector").click();
-        cy.get('[data-tag="v0.5.0"]').click();
-        cy.contains("5 days ago").should("exist");
-      });
-    });
-
-    context("when the timeframe is more than a week", () => {
-      it("shows timeframe in weeks", () => {
-        cy.clock(Date.parse("15 dec 2019"));
-        cy.pick("revision-selector").click();
-        cy.get('[data-tag="v0.5.0"]').click();
-        cy.contains("1 week ago").should("exist");
-      });
-    });
-
-    context("when the timeframe is more than 2 weeks", () => {
-      it("shows timeframe in weeks", () => {
-        cy.clock(Date.parse("21 dec 2019"));
-        cy.pick("revision-selector").click();
-        cy.get('[data-tag="v0.5.0"]').click();
-        cy.contains("2 weeks ago").should("exist");
-      });
     });
   });
 
-  context("when the Source menu item is selected in project top-bar", () => {
-    it("expands a tree starting at the root of the repo", () => {
-      cy.pick("source-tree").within(() => {
-        cy.contains("src").should("exist");
-        cy.contains("README.md").should("exist");
-      });
-    });
-
-    it("shows readme file for the latest revision", () => {
-      // the default revision is selected
-      cy.get('[data-cy=revision-selector][data-revision="master"]').should(
-        "exist"
-      );
-
-      // there is a commit teaser
-      cy.pick("commit-teaser").contains("Alexander Simmerl").should("exist");
-      cy.pick("commit-teaser")
-        .contains(
-          "Merge pull request #4 from FintanH/fintan/update-readme-no-sig"
-        )
-        .should("exist");
-      cy.pick("commit-teaser").contains("223aaf8").should("exist");
-
-      // the readme is shown
-      cy.pick("file-source").within(() => {
-        cy.contains("README.md").should("exist");
-      });
-    });
-  });
-
-  context("page view", () => {
-    context("when we're looking at the project root", () => {
-      context("when there is a README file", () => {
-        it("shows the README file", () => {
-          // It contains the commit teaser for the latest commit.
-          cy.pick("project-screen", "commit-teaser").contains("223aaf8");
-          cy.pick("project-screen", "commit-teaser").contains(
-            "Merge pull request #4"
-          );
-          cy.pick("project-screen", "commit-teaser").contains(
-            "Alexander Simmerl"
-          );
-
-          cy.pick("project-screen", "file-source").contains("README.md");
-          cy.pick("project-screen", "file-source").contains(
-            "This repository is a data source for the Upstream front-end tests and the radicle-surf unit tests."
-          );
-
-          // Going to a different path and then switching back to the root path
-          // shows the README again.
-          cy.pick("source-tree").within(() => {
-            cy.contains(".i-am-well-hidden").click();
-          });
-          cy.pick("project-screen", "file-source").contains(
-            "platinum / .i-am-well-hidden"
-          );
-          cy.pick("project-screen", "file-source").contains("platinum").click();
-          cy.pick("project-screen", "file-source").contains("README.md");
-
-          cy.pick("source-tree").within(() => {
-            cy.contains(".i-too-am-hidden").click();
-          });
-          cy.pick("project-screen", "file-source").contains(
-            "platinum / .i-too-am-hidden"
-          );
-          cy.pick("project-screen", "file-source", "root-link").click();
-          cy.pick("project-screen", "file-source").contains("README.md");
-
-          // Switching between different revisions shows the correct README
-          cy.pick("revision-selector").click();
-          cy.get('.revision-dropdown [data-branch="dev"]').click();
-          cy.pick("project-screen", "file-source").contains("README.md");
-          cy.pick("project-screen", "file-source").contains(
-            "This repository is a data source for the Upstream front-end tests."
-          );
-        });
-      });
-    });
-
-    context("revision selector", () => {
-      it("allows switching to a different branch", () => {
-        cy.pick("revision-selector").click();
-        cy.get('.revision-dropdown [data-branch="dev"]').click();
-        cy.contains("here-we-are-on-a-dev-branch.lol").should("exist");
-
-        cy.pick("revision-selector").click();
-        cy.get('.revision-dropdown [data-branch="master"]').click();
-        cy.contains("here-we-are-on-a-dev-branch.lol").should("not.exist");
+  context("commit browsing", () => {
+    context("commit history", () => {
+      it("shows the commit history for the default branch", () => {
+        // Wait for the commit tab to be updated
+        cy.pick("horizontal-menu", "Commits", "counter").contains("14");
+        cy.pick("horizontal-menu", "Commits").click();
+        cy.pick("commits-page").should("exist");
+        cy.pick("commit-teaser")
+          .contains("Commit on the dev branch")
+          .should("not.exist");
+        cy.pick("commit-teaser")
+          .contains("Merge pull request #4 from FintanH/fintan")
+          .click();
+        cy.pick("commit-page").should("exist");
+        cy.pick("commit-header")
+          .contains("Commit 223aaf87d6ea62eef0014857640fd7c8dd0f80b5")
+          .should("exist");
       });
 
-      it("allows switching to a different tag", () => {
-        cy.pick("revision-selector").click();
-        cy.get('.revision-dropdown [data-tag="v0.4.0"]').click();
-        cy.contains("test-file-deletion.txt").should("exist");
-
-        cy.pick("revision-selector").click();
-        cy.get('.revision-dropdown [data-tag="v0.5.0"]').click();
-        cy.contains("test-file-deletion.txt").should("not.exist");
-      });
-
-      it("does not crash on a page reload", () => {
-        cy.pick("revision-selector").click();
-        cy.get('.revision-dropdown [data-branch="dev"]').click();
-
-        cy.reload();
-
-        // Make sure the revision selector still loads.
-        cy.contains(".i-too-am-hidden").should("exist");
-      });
-    });
-
-    context("peer selector", () => {
-      // TODO(sos): unskip when we have a proxy testnet
-      it.skip("highlights the selected peer", () => {
-        cy.pick("peer-selector").click();
-        // Default peer is highlighted.
-        cy.get('.peer-dropdown [data-peer-handle="cloudhead"]').should(
-          "have.class",
-          "selected"
-        );
-        // Switch to another peer
-        cy.get('.peer-dropdown [data-peer-handle="abbey"]').click();
-        cy.pick("peer-selector").click();
-        // Selected peer is highlighted.
-        cy.get('.peer-dropdown [data-peer-handle="abbey"]').should(
-          "have.class",
-          "selected"
-        );
-      });
-
-      // TODO(sos): unskip when we have a proxy testnet
-      it.skip("updates the revision selector", () => {
-        cy.pick("revision-selector").click();
-        // Default revision is highlighted.
-        cy.get('.revision-dropdown [data-branch="master"]').should(
-          "have.class",
-          "selected"
-        );
-        cy.get('.revision-dropdown [data-branch="dev"]').click();
-        // Switch to another peer
-        cy.pick("peer-selector").click();
-        cy.get('.peer-dropdown [data-peer-handle="abbey"]').click();
-
-        cy.pick("revision-selector").contains("master");
-        cy.pick("revision-selector", "branch-icon").should("exist");
-
-        cy.pick("peer-selector").click();
-        cy.get('.peer-dropdown [data-peer-handle="cloudhead"]').click();
-        cy.pick("revision-selector").click();
-        cy.get('.revision-dropdown [data-tag="v0.1.0"]').click();
-
-        cy.pick("revision-selector").contains("v0.1.0");
-        cy.pick("revision-selector", "tag-icon").should("exist");
-
-        cy.pick("revision-selector").click();
-        // Previous selection is highlighted.
-        cy.get('.revision-dropdown [data-tag="v0.1.0"]').should(
-          "have.class",
-          "selected"
-        );
-      });
-    });
-
-    context("when switching between projects", () => {
-      it("opens the selected project on the default repository and branch", () => {
-        cy.createProjectWithFixture("gold");
+      it("shows the commit history for another branch", () => {
         cy.pick("revision-selector").click();
         cy.get('[data-branch="dev"]').click();
-        cy.pick("sidebar", "profile").click();
-        cy.pick("project-list", "project-list-entry-gold").click();
-        cy.pick("revision-selector").contains("master");
+        // Wait for the commit tab to be updated
+        cy.pick("horizontal-menu", "Commits", "counter").contains("8");
+        cy.pick("horizontal-menu", "Commits").click();
+
+        cy.pick("commits-page").should("exist");
+        cy.pick("commit-teaser")
+          .contains("Merge pull request #4 from FintanH/fintan")
+          .should("not.exist");
+        cy.pick("commit-teaser").contains("Commit on the dev branch").click();
+        cy.pick("commit-header")
+          .contains("Commit 27acd68c7504755aa11023300890bb85bbd69d45")
+          .should("exist");
       });
     });
   });
 
-  context("source-tree", () => {
-    it("shows files and directories", () => {
-      cy.pick("source-tree").within(() => {
-        // directories
-        cy.contains("bin").should("exist");
-
-        // files
-        cy.contains("README.md").should("exist");
-
-        // hidden files
-        cy.contains(".i-am-well-hidden").should("exist");
-      });
-    });
-
-    it("doesn't interfere with the horizontal menu item active state", () => {
-      cy.pick("horizontal-menu", "Source")
-        .get("p")
-        .should("have.class", "active");
-
-      cy.pick("source-tree").within(() => {
-        cy.pick("expand-text").click();
-        cy.contains("arrows.txt").click();
-        cy.contains("arrows.txt").should("have.class", "active");
-      });
-
-      cy.pick("horizontal-menu", "Source")
-        .get("p")
-        .should("have.class", "active");
-
-      cy.pick("file-source", "file-header").contains("platinum").click();
-
-      cy.pick("horizontal-menu", "Source")
-        .get("p")
-        .should("have.class", "active");
-    });
-
-    it("allows navigating the tree structure", () => {
-      cy.pick("source-tree").within(() => {
-        // Traverse deeply nested folders.
-        cy.pick("expand-this").click();
-        cy.pick("expand-is").click();
-        cy.pick("expand-a").click();
-        cy.pick("expand-really").click();
-        cy.pick("expand-deeply").click();
-        cy.pick("expand-nested").click();
-        cy.pick("expand-directory").click();
-        cy.pick("expand-tree").click();
-
-        // Open a file within nested folders.
-        cy.contains(".gitkeep").click();
-        cy.contains(".gitkeep").should("have.class", "active");
-
-        // Preserve expanded folder state when selecting a different file.
-        cy.scrollTo("top");
-        cy.pick("expand-text").click();
-        cy.contains("arrows.txt").click();
-        cy.contains("arrows.txt").should("have.class", "active");
-        cy.contains(".gitkeep").should("not.have.class", "active");
-      });
-    });
-
-    it("highlights the selected file", () => {
-      cy.pick("source-tree").within(() => {
-        cy.contains(".i-am-well-hidden").should("not.have.class", "active");
-        cy.contains(".i-am-well-hidden").click();
-        cy.contains(".i-am-well-hidden").should("have.class", "active");
-      });
-    });
-
-    context("when clicking on a file name", () => {
-      context("for non-binary files", () => {
-        it("shows the contents of the file", () => {
-          cy.pick("source-tree").within(() => {
-            cy.pick("expand-src").click();
-            cy.contains("Eval.hs").click();
-          });
-
-          // the file path is shown in the header
-          cy.contains("src / Eval.hs").should("exist");
-
-          // file contents are shown
-          cy.contains("module Radicle.Lang.Eval").should("exist");
-
-          // line numbers are shown
-          cy.contains("1\n2\n3\n4\n5\n").should("exist");
-
-          cy.scrollTo("bottom");
-          // the scrollbar allows us to reach the bottom of the file
-          cy.contains("callFn f' vs'").should("be.inViewport");
+  context("source code browsing", () => {
+    context("relative timestamps", () => {
+      context("when the timeframe is less than a day", () => {
+        it("shows timeframe in hours", () => {
+          cy.clock(Date.parse("5 dec 2019"));
+          cy.pick("revision-selector").click();
+          cy.get('[data-tag="v0.5.0"]').click();
+          cy.contains("9 hours ago").should("exist");
         });
       });
 
-      context("for binary files", () => {
-        it("does not render the binary content", () => {
-          cy.pick("source-tree").within(() => {
-            cy.pick("expand-bin").click();
-            cy.contains("ls").click();
+      context("when the timeframe is less than 2 days", () => {
+        it("shows timeframe in days", () => {
+          cy.clock(Date.parse("6 dec 2019"));
+          cy.pick("revision-selector").click();
+          cy.get('[data-tag="v0.5.0"]').click();
+          cy.contains("1 day ago").should("exist");
+        });
+      });
+
+      context("when the timeframe is less than a week", () => {
+        it("shows timeframe in days", () => {
+          cy.clock(Date.parse("10 dec 2019"));
+          cy.pick("revision-selector").click();
+          cy.get('[data-tag="v0.5.0"]').click();
+          cy.contains("5 days ago").should("exist");
+        });
+      });
+
+      context("when the timeframe is more than a week", () => {
+        it("shows timeframe in weeks", () => {
+          cy.clock(Date.parse("15 dec 2019"));
+          cy.pick("revision-selector").click();
+          cy.get('[data-tag="v0.5.0"]').click();
+          cy.contains("1 week ago").should("exist");
+        });
+      });
+
+      context("when the timeframe is more than 2 weeks", () => {
+        it("shows timeframe in weeks", () => {
+          cy.clock(Date.parse("21 dec 2019"));
+          cy.pick("revision-selector").click();
+          cy.get('[data-tag="v0.5.0"]').click();
+          cy.contains("2 weeks ago").should("exist");
+        });
+      });
+    });
+
+    context("when the Source menu item is selected in project top-bar", () => {
+      it("expands a tree starting at the root of the repo", () => {
+        cy.pick("source-tree").within(() => {
+          cy.contains("src").should("exist");
+          cy.contains("README.md").should("exist");
+        });
+      });
+
+      it("shows readme file for the latest revision", () => {
+        // the default revision is selected
+        cy.get('[data-cy=revision-selector][data-revision="master"]').should(
+          "exist"
+        );
+
+        // there is a commit teaser
+        cy.pick("commit-teaser").contains("Alexander Simmerl").should("exist");
+        cy.pick("commit-teaser")
+          .contains(
+            "Merge pull request #4 from FintanH/fintan/update-readme-no-sig"
+          )
+          .should("exist");
+        cy.pick("commit-teaser").contains("223aaf8").should("exist");
+
+        // the readme is shown
+        cy.pick("file-source").within(() => {
+          cy.contains("README.md").should("exist");
+        });
+      });
+    });
+
+    context("page view", () => {
+      context("when we're looking at the project root", () => {
+        context("when there is a README file", () => {
+          it("shows the README file", () => {
+            // It contains the commit teaser for the latest commit.
+            cy.pick("project-screen", "commit-teaser").contains("223aaf8");
+            cy.pick("project-screen", "commit-teaser").contains(
+              "Merge pull request #4"
+            );
+            cy.pick("project-screen", "commit-teaser").contains(
+              "Alexander Simmerl"
+            );
+
+            cy.pick("project-screen", "file-source").contains("README.md");
+            cy.pick("project-screen", "file-source").contains(
+              "This repository is a data source for the Upstream front-end tests and the radicle-surf unit tests."
+            );
+
+            // Going to a different path and then switching back to the root path
+            // shows the README again.
+            cy.pick("source-tree").within(() => {
+              cy.contains(".i-am-well-hidden").click();
+            });
+            cy.pick("project-screen", "file-source").contains(
+              "platinum / .i-am-well-hidden"
+            );
+            cy.pick("project-screen", "file-source")
+              .contains("platinum")
+              .click();
+            cy.pick("project-screen", "file-source").contains("README.md");
+
+            cy.pick("source-tree").within(() => {
+              cy.contains(".i-too-am-hidden").click();
+            });
+            cy.pick("project-screen", "file-source").contains(
+              "platinum / .i-too-am-hidden"
+            );
+            cy.pick("project-screen", "file-source", "root-link").click();
+            cy.pick("project-screen", "file-source").contains("README.md");
+
+            // Switching between different revisions shows the correct README
+            cy.pick("revision-selector").click();
+            cy.get('.revision-dropdown [data-branch="dev"]').click();
+            cy.pick("project-screen", "file-source").contains("README.md");
+            cy.pick("project-screen", "file-source").contains(
+              "This repository is a data source for the Upstream front-end tests."
+            );
           });
+        });
+      });
 
-          // the file path is shown in the header
-          cy.contains("bin / ls").should("exist");
+      context("revision selector", () => {
+        it("allows switching to a different branch", () => {
+          cy.pick("revision-selector").click();
+          cy.get('.revision-dropdown [data-branch="dev"]').click();
+          cy.contains("here-we-are-on-a-dev-branch.lol").should("exist");
 
-          // it instead shows a message
-          cy.contains("Binary content").should("exist");
+          cy.pick("revision-selector").click();
+          cy.get('.revision-dropdown [data-branch="master"]').click();
+          cy.contains("here-we-are-on-a-dev-branch.lol").should("not.exist");
+        });
+
+        it("allows switching to a different tag", () => {
+          cy.pick("revision-selector").click();
+          cy.get('.revision-dropdown [data-tag="v0.4.0"]').click();
+          cy.contains("test-file-deletion.txt").should("exist");
+
+          cy.pick("revision-selector").click();
+          cy.get('.revision-dropdown [data-tag="v0.5.0"]').click();
+          cy.contains("test-file-deletion.txt").should("not.exist");
+        });
+
+        it("does not crash on a page reload", () => {
+          cy.pick("revision-selector").click();
+          cy.get('.revision-dropdown [data-branch="dev"]').click();
+
+          cy.reload();
+
+          // Make sure the revision selector still loads.
+          cy.contains(".i-too-am-hidden").should("exist");
+        });
+      });
+
+      context("peer selector", () => {
+        // TODO(sos): unskip when we have a proxy testnet
+        it.skip("highlights the selected peer", () => {
+          cy.pick("peer-selector").click();
+          // Default peer is highlighted.
+          cy.get('.peer-dropdown [data-peer-handle="cloudhead"]').should(
+            "have.class",
+            "selected"
+          );
+          // Switch to another peer
+          cy.get('.peer-dropdown [data-peer-handle="abbey"]').click();
+          cy.pick("peer-selector").click();
+          // Selected peer is highlighted.
+          cy.get('.peer-dropdown [data-peer-handle="abbey"]').should(
+            "have.class",
+            "selected"
+          );
+        });
+
+        // TODO(sos): unskip when we have a proxy testnet
+        it.skip("updates the revision selector", () => {
+          cy.pick("revision-selector").click();
+          // Default revision is highlighted.
+          cy.get('.revision-dropdown [data-branch="master"]').should(
+            "have.class",
+            "selected"
+          );
+          cy.get('.revision-dropdown [data-branch="dev"]').click();
+          // Switch to another peer
+          cy.pick("peer-selector").click();
+          cy.get('.peer-dropdown [data-peer-handle="abbey"]').click();
+
+          cy.pick("revision-selector").contains("master");
+          cy.pick("revision-selector", "branch-icon").should("exist");
+
+          cy.pick("peer-selector").click();
+          cy.get('.peer-dropdown [data-peer-handle="cloudhead"]').click();
+          cy.pick("revision-selector").click();
+          cy.get('.revision-dropdown [data-tag="v0.1.0"]').click();
+
+          cy.pick("revision-selector").contains("v0.1.0");
+          cy.pick("revision-selector", "tag-icon").should("exist");
+
+          cy.pick("revision-selector").click();
+          // Previous selection is highlighted.
+          cy.get('.revision-dropdown [data-tag="v0.1.0"]').should(
+            "have.class",
+            "selected"
+          );
+        });
+      });
+
+      context("when switching between projects", () => {
+        it("opens the selected project on the default repository and branch", () => {
+          cy.createProjectWithFixture("gold");
+          cy.pick("revision-selector").click();
+          cy.get('[data-branch="dev"]').click();
+          cy.pick("sidebar", "profile").click();
+          cy.pick("project-list", "project-list-entry-gold").click();
+          cy.pick("revision-selector").contains("master");
+        });
+      });
+    });
+
+    context("source-tree", () => {
+      it("shows files and directories", () => {
+        cy.pick("source-tree").within(() => {
+          // directories
+          cy.contains("bin").should("exist");
+
+          // files
+          cy.contains("README.md").should("exist");
+
+          // hidden files
+          cy.contains(".i-am-well-hidden").should("exist");
+        });
+      });
+
+      it("doesn't interfere with the horizontal menu item active state", () => {
+        cy.pick("horizontal-menu", "Source")
+          .get("p")
+          .should("have.class", "active");
+
+        cy.pick("source-tree").within(() => {
+          cy.pick("expand-text").click();
+          cy.contains("arrows.txt").click();
+          cy.contains("arrows.txt").should("have.class", "active");
+        });
+
+        cy.pick("horizontal-menu", "Source")
+          .get("p")
+          .should("have.class", "active");
+
+        cy.pick("file-source", "file-header").contains("platinum").click();
+
+        cy.pick("horizontal-menu", "Source")
+          .get("p")
+          .should("have.class", "active");
+      });
+
+      it("allows navigating the tree structure", () => {
+        cy.pick("source-tree").within(() => {
+          // Traverse deeply nested folders.
+          cy.pick("expand-this").click();
+          cy.pick("expand-is").click();
+          cy.pick("expand-a").click();
+          cy.pick("expand-really").click();
+          cy.pick("expand-deeply").click();
+          cy.pick("expand-nested").click();
+          cy.pick("expand-directory").click();
+          cy.pick("expand-tree").click();
+
+          // Open a file within nested folders.
+          cy.contains(".gitkeep").click();
+          cy.contains(".gitkeep").should("have.class", "active");
+
+          // Preserve expanded folder state when selecting a different file.
+          cy.scrollTo("top");
+          cy.pick("expand-text").click();
+          cy.contains("arrows.txt").click();
+          cy.contains("arrows.txt").should("have.class", "active");
+          cy.contains(".gitkeep").should("not.have.class", "active");
+        });
+      });
+
+      it("highlights the selected file", () => {
+        cy.pick("source-tree").within(() => {
+          cy.contains(".i-am-well-hidden").should("not.have.class", "active");
+          cy.contains(".i-am-well-hidden").click();
+          cy.contains(".i-am-well-hidden").should("have.class", "active");
+        });
+      });
+
+      context("when clicking on a file name", () => {
+        context("for non-binary files", () => {
+          it("shows the contents of the file", () => {
+            cy.pick("source-tree").within(() => {
+              cy.pick("expand-src").click();
+              cy.contains("Eval.hs").click();
+            });
+
+            // the file path is shown in the header
+            cy.contains("src / Eval.hs").should("exist");
+
+            // file contents are shown
+            cy.contains("module Radicle.Lang.Eval").should("exist");
+
+            // line numbers are shown
+            cy.contains("1\n2\n3\n4\n5\n").should("exist");
+
+            cy.scrollTo("bottom");
+            // the scrollbar allows us to reach the bottom of the file
+            cy.contains("callFn f' vs'").should("be.inViewport");
+          });
+        });
+
+        context("for binary files", () => {
+          it("does not render the binary content", () => {
+            cy.pick("source-tree").within(() => {
+              cy.pick("expand-bin").click();
+              cy.contains("ls").click();
+            });
+
+            // the file path is shown in the header
+            cy.contains("bin / ls").should("exist");
+
+            // it instead shows a message
+            cy.contains("Binary content").should("exist");
+          });
         });
       });
     });

--- a/cypress/integration/user_profile.spec.js
+++ b/cypress/integration/user_profile.spec.js
@@ -1,28 +1,30 @@
-before(() => {
-  cy.resetAllState();
-  cy.onboardUser("cloudhead");
-  cy.createProjectWithFixture("platinum", "Best project ever.", "master", [
-    "ele",
-    "abbey",
-  ]);
-});
+context("user profile", () => {
+  before(() => {
+    cy.resetAllState();
+    cy.onboardUser("cloudhead");
+    cy.createProjectWithFixture("platinum", "Best project ever.", "master", [
+      "ele",
+      "abbey",
+    ]);
+  });
 
-context("visitor view profile page", () => {
-  // TODO(sos): unskip when we have a proxy testnet
-  it.skip("opens from the peer selector with the correct data", () => {
-    // Go to the project source page
-    cy.visit("./public/index.html#/profile/projects");
-    cy.contains("platinum").click();
-    cy.contains("Source").click();
+  context("visitor view profile page", () => {
+    // TODO(sos): unskip when we have a proxy testnet
+    it.skip("opens from the peer selector with the correct data", () => {
+      // Go to the project source page
+      cy.visit("./public/index.html#/profile/projects");
+      cy.contains("platinum").click();
+      cy.contains("Source").click();
 
-    // Pick a user from the peer selector
-    cy.pick("peer-selector").click();
-    cy.get(".peer-dropdown").pick("abbey").click();
+      // Pick a user from the peer selector
+      cy.pick("peer-selector").click();
+      cy.get(".peer-dropdown").pick("abbey").click();
 
-    cy.pick("header").should("exist");
+      cy.pick("header").should("exist");
 
-    // Check for the correct data
-    cy.pick("entity-name").contains("abbey");
-    cy.pick("project-list").contains("platinum").should("exist");
+      // Check for the correct data
+      cy.pick("entity-name").contains("abbey");
+      cy.pick("project-list").contains("platinum").should("exist");
+    });
   });
 });


### PR DESCRIPTION
Wrap each spec file in its own context as recommended [here](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Run-all-specs) and [here](https://glebbahmutov.com/blog/run-all-specs/#solution).

Otherwise when clicking the `Run all specs` button the `before` and `beforeEach` blocks of each spec file would get executed in the beginning of the run.