### PR TITLE
fix(proxy): clean up long-running notifications

### DIFF
--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -107,11 +107,17 @@ async fn run(
 
     let server = async move {
         log::info!("... API");
-        let api = http::api(ctx, subscriptions, killswitch, enable_fixture_creation);
+        let api = http::api(
+            ctx,
+            subscriptions.clone(),
+            killswitch,
+            enable_fixture_creation,
+        );
         let (_, server) = warp::serve(api).try_bind_with_graceful_shutdown(
             ([127, 0, 0, 1], 8080),
             async move {
                 poisonpill.recv().await;
+                subscriptions.clear().await;
             },
         )?;
 

--- a/proxy/api/src/notification.rs
+++ b/proxy/api/src/notification.rs
@@ -37,6 +37,11 @@ impl Subscriptions {
             .retain(|_id, sender| sender.send(notification.clone()).is_ok());
     }
 
+    /// Drop all stored senders, which terminates associated receivers and their streams.
+    pub async fn clear(&self) {
+        self.subs.write().await.clear();
+    }
+
     /// Set up a new subscription, ready to receive [`Notification`].
     pub async fn subscribe(&self) -> mpsc::UnboundedReceiver<Notification> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);

--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -12,16 +12,13 @@
 
   let peerState;
 
-  // FIXME(rudolfs): cypress tests break when EventSource is initialised.
-  if (!window["Cypress"]) {
-    const sse = new EventSource(
-      "http://localhost:8080/v1/notifications/local_peer_status"
-    );
+  const sse = new EventSource(
+    "http://localhost:8080/v1/notifications/local_peer_status"
+  );
 
-    sse.addEventListener("LOCAL_PEER_STATUS_CHANGED", event => {
-      peerState = JSON.parse(event.data);
-    });
-  }
+  sse.addEventListener("LOCAL_PEER_STATUS_CHANGED", event => {
+    peerState = JSON.parse(event.data);
+  });
 </script>
 
 <style>


### PR DESCRIPTION
When introducing long-running sse subscriptions for notifications the
server stopped responding to shutdown signals. This prevented a proper
reload of the stack, which cypress integration tests depend on. In order
to terminate handlers spinning on notification subscriptions the
shutdown forces a clear of all stored senders.