### PR TITLE
fix(proxy): block on checkout

### DIFF
--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -604,7 +604,9 @@ impl State {
                 }
             },
         };
-        checkout.run(ownership).map_err(Error::from)
+        tokio::task::spawn_blocking(move || checkout.run(ownership).map_err(Error::from))
+            .await
+            .expect("blocking checkout failed")
     }
 
     /// Prepare the include file for the given `project` with the latest tracked peers.


### PR DESCRIPTION
Since checkout uses `clone` under the hood, it's necessary that we block
on this IO operation. Otherwise we will end up in flakey test hell.