### PR TITLE
fix(proxy): persist TimedOut state

### DIFF
--- a/proxy/coco/src/request.rs
+++ b/proxy/coco/src/request.rs
@@ -333,12 +333,3 @@ impl<T> Request<Cloning, T> {
         }
     }
 }
-
-/// Due to the lack of higher-kinded types we have to write our own specific sequence here that
-/// works with a `Result` embedded in an `Either`.
-fn sequence_result<A, B, E>(either: Either<A, Result<B, E>>) -> Result<Either<A, B>, E> {
-    match either {
-        Either::Left(a) => Ok(Either::Left(a)),
-        Either::Right(r) => Ok(Either::Right(r?)),
-    }
-}


### PR DESCRIPTION
Fixes #1023 

We never persisted the TimedOut state when we encountered one, instead
returning it directly as an error.
This PR fixes that by first persisting the TimedOut state during a
transition and then returning it as an error. We can confirm the
persistence in the test cases for when we reach a timeout.