### PR TITLE
refactor: improve local peer notifications

### DIFF
--- a/proxy/api/src/main.rs
+++ b/proxy/api/src/main.rs
@@ -8,7 +8,7 @@ use tokio::{
 };
 
 use api::{config, context, env, http, notification, session};
-use coco::{keystore, seed, signer, Peer, RunConfig, SyncConfig};
+use coco::{convert::MaybeFrom as _, keystore, seed, signer, Peer, RunConfig, SyncConfig};
 
 /// Flags accepted by the proxy binary.
 #[derive(Clone, Copy)]
@@ -95,11 +95,10 @@ async fn run(
 
         async move {
             loop {
-                if let coco::PeerEvent::StatusChanged(old, new) = peer_events.recv().await.unwrap()
+                if let Some(notification) =
+                    notification::Notification::maybe_from(peer_events.recv().await.unwrap())
                 {
-                    peer_subscriptions
-                        .broadcast(notification::Notification::LocalPeerStatusChanged(old, new))
-                        .await
+                    peer_subscriptions.broadcast(notification).await
                 }
             }
         }

--- a/proxy/api/src/notification.rs
+++ b/proxy/api/src/notification.rs
@@ -26,18 +26,25 @@ pub enum Notification {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum LocalPeer {
+    /// Transition between two statuses occurred.
     #[serde(rename_all = "camelCase")]
-    StatusChanged { old: PeerStatus, new: PeerStatus },
+    StatusChanged {
+        /// The [`PeerStatus`] before.
+        old: PeerStatus,
+        /// The new [`PeerStatus`].
+        new: PeerStatus,
+    },
 }
 
 impl fmt::Display for LocalPeer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StatusChanged => write!(f, "LOCAL_PEER_STATUS_CHANGED"),
+            Self::StatusChanged { .. } => write!(f, "LOCAL_PEER_STATUS_CHANGED"),
         }
     }
 }
 
+#[allow(clippy::wildcard_enum_match_arm)]
 impl MaybeFrom<PeerEvent> for Notification {
     fn maybe_from(event: PeerEvent) -> Option<Self> {
         match event {

--- a/proxy/api/src/notification.rs
+++ b/proxy/api/src/notification.rs
@@ -12,8 +12,7 @@ use std::{
 use serde::Serialize;
 use tokio::sync::{mpsc, RwLock};
 
-use coco::convert::MaybeFrom;
-use coco::{PeerEvent, PeerStatus};
+use coco::{convert::MaybeFrom, PeerEvent, PeerStatus};
 
 /// Significant events happening during proxy runtime.
 #[derive(Clone, Debug)]
@@ -50,7 +49,7 @@ impl MaybeFrom<PeerEvent> for Notification {
         match event {
             PeerEvent::StatusChanged(old, new) => {
                 Some(Self::LocalPeer(LocalPeer::StatusChanged { old, new }))
-            }
+            },
             _ => None,
         }
     }

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -47,7 +47,7 @@ pub use radicle_surf::{
 
 pub mod config;
 pub mod control;
-mod convert;
+pub mod convert;
 pub mod git_helper;
 mod identifier;
 pub use identifier::Identifier;

--- a/ui/src/localPeer.ts
+++ b/ui/src/localPeer.ts
@@ -39,7 +39,8 @@ enum EventKind {
 
 interface StatusChanged {
   kind: EventKind.StatusChanged;
-  status: Status;
+  old: Status;
+  new: Status;
 }
 
 export type PeerEvent = StatusChanged;
@@ -50,11 +51,12 @@ export const status = statusStore.readable;
 
 statusStore.start(() => {
   const source = new EventSource(
-    "http://localhost:8080/v1/notifications/local_peer_status"
+    "http://localhost:8080/v1/notifications/local_peer_events"
   );
 
   source.addEventListener(EventKind.StatusChanged, (event: Event): void => {
-    statusStore.success(JSON.parse((event as MessageEvent).data));
+    const changed = JSON.parse((event as MessageEvent).data);
+    statusStore.success(changed.new);
   });
 
   return (): void => source.close();


### PR DESCRIPTION
Follow-up to #1035 #1046 to streamline the notification infrastructue
and translation of peer events. This is in preparation to surface more
events to give uesrs insight into the operations of their local peers.