### PR TITLE
fix: correct path in reset script

### DIFF
--- a/scripts/reset-state.sh
+++ b/scripts/reset-state.sh
@@ -21,7 +21,7 @@ elif [ "$platform" == "Linux" ]; then
         "$config_home/radicle"
         "$config_home/radicle-upstream"
         "$data_home/radicle"
-        "$config_home/radicle-upstream"
+        "$data_home/radicle-upstream"
     );
 else
     echo "Unsupported platform $platform"


### PR DESCRIPTION
Looks to be a copy-paste error where the same path was deleted twice.