### PR TITLE
refactor(ui): start new projects with a "main" branch

### DIFF
--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -1,4 +1,4 @@
 export const HIDDEN_BRANCHES = ["rad/contributor", "rad/project"];
-export const DEFAULT_BRANCH_FOR_NEW_PROJECTS = "master";
+export const DEFAULT_BRANCH_FOR_NEW_PROJECTS = "main";
 export const NOTIFICATION_TIMEOUT = 8000; // ms
 export const FADE_DURATION = 200;


### PR DESCRIPTION
This change has the following implications:

- starting a new project without an existing repository will initialise the created repository with a default `main` branch:
<img width="50%" alt="Screenshot 2020-10-20 at 10 44 05" src="https://user-images.githubusercontent.com/158411/96562581-39a47780-12c1-11eb-8372-a922abeb8efb.png">

- creating a project using an existing repository which doesn't have a `main` branch will fall back to the first branch in the list (`master` won't be selected):

<img width="50%" alt="Screenshot 2020-10-20 at 10 45 24" src="https://user-images.githubusercontent.com/158411/96562728-6062ae00-12c1-11eb-89f1-8d78dfe4fc7e.png">

- creating a project using an existing repository which has a `main` branch will pre-select `main` as the default branch:
<img width="50%" alt="Screenshot 2020-10-20 at 10 46 55" src="https://user-images.githubusercontent.com/158411/96563084-d36c2480-12c1-11eb-8108-ce138c32034c.png">


Closes: https://github.com/radicle-dev/radicle-upstream/issues/1058.