### PR TITLE
fix(ui): show correct projects for users

### DIFF
--- a/ui/Screen/Profile/Projects.svelte
+++ b/ui/Screen/Profile/Projects.svelte
@@ -1,10 +1,10 @@
-<script lang="ts">
+<script lang="typescript">
   import { getContext } from "svelte";
   import { push } from "svelte-spa-router";
 
   import * as modal from "../../src/modal";
   import * as path from "../../src/path";
-  import { projects as projectsStore } from "../../src/project";
+  import { fetchList, projects as store } from "../../src/project";
   import type { Project } from "../../src/project";
 
   import {
@@ -14,17 +14,18 @@
     Remote,
   } from "../../DesignSystem/Component";
 
+  const session = getContext("session");
+
   const create = () => {
     modal.toggle(path.newProject());
   };
+  const select = ({ detail: project }: { detail: Project }) =>
+    push(path.projectSource(project.id));
 
-  const select = (event: { detail: Project }) =>
-    push(path.projectSource(event.detail.id));
-
-  const session = getContext("session");
+  fetchList();
 </script>
 
-<Remote store={projectsStore} let:data={projects}>
+<Remote {store} let:data={projects}>
   {#if projects.length > 0}
     <ProjectList {projects} urn={session.identity.urn} on:select={select} />
   {:else}

--- a/ui/Screen/UserProfile.svelte
+++ b/ui/Screen/UserProfile.svelte
@@ -1,7 +1,8 @@
-<script lang="ts">
+<script lang="typescript">
   import Router from "svelte-spa-router";
 
   import * as path from "../src/path";
+  import { fetchUser, user as store } from "../src/userProfile";
 
   import {
     Header,
@@ -10,17 +11,16 @@
     SidebarLayout,
   } from "../DesignSystem/Component";
   import { Icon } from "../DesignSystem/Primitive";
-  import { fetch, identity as store } from "../src/identity";
 
   import Projects from "./UserProfile/Projects.svelte";
   import NotFound from "./NotFound.svelte";
+
   export let params: { urn: string };
 
   const screenRoutes = {
     "/user/:urn/projects": Projects,
     "*": NotFound,
   };
-
   const topbarMenuItems = [
     {
       icon: Icon.ChevronLeftRight,
@@ -30,7 +30,7 @@
     },
   ];
 
-  $: fetch({ urn: params.urn });
+  fetchUser(params.urn);
 </script>
 
 <SidebarLayout>

--- a/ui/Screen/UserProfile/Projects.svelte
+++ b/ui/Screen/UserProfile/Projects.svelte
@@ -1,28 +1,25 @@
-<script>
+<script lang="typescript">
   import { push } from "svelte-spa-router";
 
-  import * as path from "../../src/path.ts";
-  import {
-    fetchUserList,
-    projects as projectsStore,
-  } from "../../src/project.ts";
+  import * as path from "../../src/path";
+  import type { Project } from "../../src/project";
+  import { fetchProjects, projects as store } from "../../src/userProfile";
 
   import { Error, ProjectList, Remote } from "../../DesignSystem/Component";
 
-  export let params = null;
+  export let params: { urn: string };
 
-  const select = event => {
-    const project = event.detail;
+  const select = ({ detail: project }: { detail: Project }) => {
     push(path.projectSource(project.id));
   };
 
-  $: fetchUserList({ urn: params.urn });
+  fetchProjects(params.urn);
 </script>
 
-<Remote store={projectsStore} let:data={projects}>
+<Remote {store} let:data={projects}>
   <ProjectList {projects} urn={params.urn} on:select={select} />
 
   <div slot="error" let:error>
-    <Error message={error.message} />
+    <Error message={error && error.message} />
   </div>
 </Remote>

--- a/ui/src/__mocks__/api.ts
+++ b/ui/src/__mocks__/api.ts
@@ -10,7 +10,7 @@ type MockedResponse =
   | source.LocalState
   | null;
 
-export const upstreamProjectMock: project.Project = {
+const upstreamProjectMock: project.Project = {
   id: "%rad:git:hwd1yregn1xe4krjs5h7ag5ceut9rwmjssr8e8t4pw6nrwdxgc761o3x4sa",
   shareableEntityIdentifier: "sos@{}",
   metadata: {

--- a/ui/src/__mocks__/api.ts
+++ b/ui/src/__mocks__/api.ts
@@ -10,7 +10,7 @@ type MockedResponse =
   | source.LocalState
   | null;
 
-const upstreamProjectMock: project.Project = {
+export const upstreamProjectMock: project.Project = {
   id: "%rad:git:hwd1yregn1xe4krjs5h7ag5ceut9rwmjssr8e8t4pw6nrwdxgc761o3x4sa",
   shareableEntityIdentifier: "sos@{}",
   metadata: {
@@ -27,7 +27,7 @@ const upstreamProjectMock: project.Project = {
   },
 };
 
-export const surfProjectMock: project.Project = {
+const surfProjectMock: project.Project = {
   id: "%rad:git:hwd1yref66p4r3z1prxwdjr7ig6ihhrfzsawnc6us4zxtapfukrf6r7mupw",
   shareableEntityIdentifier: "sos@{}",
   metadata: {

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -1,5 +1,4 @@
 import * as api from "./api";
-import * as event from "./event";
 import * as remote from "./remote";
 
 // TYPES
@@ -26,42 +25,16 @@ export interface Identity {
 const creationStore = remote.createStore<Identity>();
 export const store = creationStore.readable;
 
-const identityStore = remote.createStore<Identity>();
-export const identity = identityStore.readable;
-
-// EVENTS
-enum Kind {
-  Fetch = "FETCH",
-}
-
-interface Fetch extends event.Event<Kind> {
-  kind: Kind.Fetch;
-  urn: string;
-}
-
-type Msg = Fetch;
-
 interface CreateInput {
   handle: string;
   passphrase: string;
 }
 
-export const fetch = event.create<Kind, Msg>(Kind.Fetch, update);
-
-function update(msg: Msg): void {
-  switch (msg.kind) {
-    case Kind.Fetch:
-      identityStore.loading();
-      api
-        .get<Identity>(`identities/${msg.urn}`)
-        .then(identityStore.success)
-        .catch(identityStore.error);
-      break;
-  }
-}
-
 export const createIdentity = (input: CreateInput): Promise<Identity> => {
   return api.post<CreateInput, Identity>("identities", input);
+};
+export const fetch = (urn: string): Promise<Identity> => {
+  return api.get<Identity>(`identities/${urn}`);
 };
 
 // MOCK

--- a/ui/src/project.test.ts
+++ b/ui/src/project.test.ts
@@ -114,21 +114,3 @@ describe("fetching a project", () => {
     });
   });
 });
-
-describe("fetching a list of projects for user profile", () => {
-  it("creates and updates a store", () => {
-    const store = project.projects;
-
-    expect(get(store)).toEqual({ status: remote.Status.Loading });
-
-    // Store doesn't fetch until it has a subscriber
-    store.subscribe(() => null);
-
-    process.nextTick(() => {
-      expect(get(store)).toEqual({
-        status: remote.Status.Success,
-        data: [upstreamProjectMock, surfProjectMock],
-      });
-    });
-  });
-});

--- a/ui/src/project.test.ts
+++ b/ui/src/project.test.ts
@@ -5,11 +5,7 @@ import * as project from "./project";
 import * as remote from "./remote";
 import { DEFAULT_BRANCH_FOR_NEW_PROJECTS } from "./config";
 
-import {
-  localStateMock,
-  surfProjectMock,
-  upstreamProjectMock,
-} from "./__mocks__/api";
+import { localStateMock, upstreamProjectMock } from "./__mocks__/api";
 
 jest.mock("./api");
 

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -71,7 +71,6 @@ enum Kind {
   Fetch = "FETCH",
   FetchList = "FETCH_LIST",
   FetchTracked = "FETCH_TRACKED",
-  FetchUser = "FETCH_USER",
   FetchLocalState = "FETCH_LOCAL_STATE",
 }
 
@@ -98,11 +97,6 @@ interface FetchTracked extends event.Event<Kind> {
   kind: Kind.FetchTracked;
 }
 
-interface FetchUser extends event.Event<Kind> {
-  kind: Kind.FetchUser;
-  urn: string;
-}
-
 interface FetchLocalState extends event.Event<Kind> {
   kind: Kind.FetchLocalState;
   path: string;
@@ -114,8 +108,7 @@ type Msg =
   | Fetch
   | FetchList
   | FetchLocalState
-  | FetchTracked
-  | FetchUser;
+  | FetchTracked;
 
 // REQUEST INPUTS
 interface CreateInput {
@@ -171,13 +164,6 @@ const update = (msg: Msg): void => {
         .then(localStateStore.success)
         .catch(localStateStore.error);
       break;
-
-    case Kind.FetchUser:
-      projectsStore.loading();
-      api
-        .get<Projects>(`projects/user/${msg.urn}`)
-        .then(projectsStore.success)
-        .catch(projectsStore.error);
   }
 };
 
@@ -203,7 +189,6 @@ export const checkout = (
 
 export const fetch = event.create<Kind, Msg>(Kind.Fetch, update);
 export const fetchList = event.create<Kind, Msg>(Kind.FetchList, update);
-export const fetchUserList = event.create<Kind, Msg>(Kind.FetchUser, update);
 export const fetchLocalState = event.create<Kind, Msg>(
   Kind.FetchLocalState,
   update
@@ -215,11 +200,11 @@ export const clearLocalState = event.create<Kind, Msg>(
   update
 );
 
-// Fetch initial list when the store has been subcribed to for the first time.
-projectsStore.start(fetchList);
+export const fetchUserList = (urn: string): Promise<Project[]> => {
+  return api.get<Projects>(`projects/user/${urn}`);
+};
 
 // NEW PROJECT
-
 export const localStateError = writable<string>("");
 export const defaultBranch = writable<string>(DEFAULT_BRANCH_FOR_NEW_PROJECTS);
 

--- a/ui/src/userProfile.ts
+++ b/ui/src/userProfile.ts
@@ -1,0 +1,20 @@
+import * as identity from "./identity";
+import * as project from "./project";
+import * as remote from "./remote";
+
+const projectsStore = remote.createStore<project.Project[]>();
+export const projects = projectsStore.readable;
+
+const userStore = remote.createStore<identity.Identity>();
+export const user = userStore.readable;
+
+export const fetchProjects = (urn: string): void => {
+  project
+    .fetchUserList(urn)
+    .then(projectsStore.success)
+    .catch(projectsStore.error);
+};
+
+export const fetchUser = (urn: string): void => {
+  identity.fetch(urn).then(userStore.success).catch(userStore.error);
+};


### PR DESCRIPTION
The underlying issue was an automatic preloading on store initialisation
which fetched the owners projects. It would override the list of fetched
projects for the accessed user profile. To avoid similar subtle bugs
when building up data to satisfy the screen, all stores for the
UserProfile screen and its fragments are isolated into their own ts file
with a streamlined public api.

Fixes #1100