### PR TITLE
fix(proxy): ensure commit propagation

### DIFF
--- a/proxy/coco/src/peer/announcement.rs
+++ b/proxy/coco/src/peer/announcement.rs
@@ -116,6 +116,9 @@ pub async fn run(state: &State, store: &kv::Store) -> Result<Updates, Error> {
     let old = load(store)?;
     let new = build(state).await?;
     let updates = diff(&old, &new);
+    // println!("OLD: {:?}", old);
+    // println!("NEW: {:?}", new);
+    // println!("UPDATED: {:?}", updates);
 
     announce(state, updates.iter()).await;
 

--- a/proxy/coco/src/peer/run_state.rs
+++ b/proxy/coco/src/peer/run_state.rs
@@ -246,7 +246,7 @@ pub enum Status {
 }
 
 /// Set of knobs to change the behaviour of the [`RunState`].
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Config {
     /// Set of knobs to alter announce behaviour.
     pub announce: AnnounceConfig,
@@ -257,6 +257,7 @@ pub struct Config {
 }
 
 /// Set of knobs to alter announce behaviour.
+#[derive(Clone)]
 pub struct AnnounceConfig {
     /// Determines how often the announcement subroutine should be run.
     pub interval: Duration,
@@ -271,6 +272,7 @@ impl Default for AnnounceConfig {
 }
 
 /// Set of knobs to alter sync behaviour.
+#[derive(Clone)]
 pub struct SyncConfig {
     /// Number of peers that a full sync is attempted with upon startup.
     pub max_peers: usize,
@@ -291,6 +293,7 @@ impl Default for SyncConfig {
 }
 
 /// Set of knobs to alter the [`WaitingRoom`] behvaviour.
+#[derive(Clone)]
 pub struct WaitingRoomConfig {
     /// Interval at which to query the [`WaitingRoom`] for ready requests.
     pub interval: Duration,

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use futures::{future, StreamExt as _};
 use tokio::time::timeout;
 
-use librad::net::{gossip, protocol::ProtocolEvent};
+use librad::{net::{gossip, peer::Rev, protocol::ProtocolEvent}, uri};
 use radicle_surf::vcs::git::git2;
 
 use coco::{config, seed::Seed, AnnounceConfig, RunConfig};
@@ -180,13 +180,8 @@ async fn can_hear_commits() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let seed_tmp_dir = tempfile::tempdir()?;
-    let (seed_peer, seed_state) =
-        build_peer(&seed_tmp_dir, run_config.clone()).await?;
-    let _seed = {
-        seed_state
-            .init_owner("seedling.xyz")
-            .await?
-    };
+    let (seed_peer, seed_state) = build_peer(&seed_tmp_dir, run_config.clone()).await?;
+    let _seed = { seed_state.init_owner("seedling.xyz").await? };
 
     let bob_tmp_dir = tempfile::tempdir()?;
     let bob_repo_path = bob_tmp_dir.path().join("radicle");
@@ -201,6 +196,7 @@ async fn can_hear_commits() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
     let bob = bob_state.init_owner("bob").await?;
 
+    /*
     let eve_tmp_dir = tempfile::tempdir()?;
     let (eve_peer, eve_state) = build_peer_with_seeds(
         &eve_tmp_dir,
@@ -212,21 +208,25 @@ async fn can_hear_commits() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
     let _eve = eve_state.init_owner("eve").await?;
+    */
+
+    println!("{:?}", seed_tmp_dir);
+    println!("{:?}", bob_tmp_dir);
+    // println!("{:?}", eve_tmp_dir);
 
     let seed_events = seed_peer.subscribe();
     let bob_events = bob_peer.subscribe();
     tokio::task::spawn(seed_peer.into_running());
     tokio::task::spawn(bob_peer.into_running());
+    /*
     tokio::task::spawn(eve_peer.into_running());
+    */
 
     let project = bob_state
-        .init_project(
-            &bob,
-            shia_le_pathbuf(bob_repo_path.clone()),
-        )
+        .init_project(&bob, shia_le_pathbuf(bob_repo_path.clone()))
         .await?;
 
-    let project = {
+    let _ = {
         let seed_peer_id = seed_state.peer_id();
         let seed_addr = seed_state.listen_addr();
         let bob_peer_id = bob_state.peer_id();
@@ -237,11 +237,15 @@ async fn can_hear_commits() -> Result<(), Box<dyn std::error::Error>> {
             )
             .await
             .expect("unable to clone project");
+        seed_state.track(urn.clone(), bob_peer_id.clone()).await?;
+        /*
         let urn = eve_state
             .clone_project(urn.into_rad_url(seed_peer_id), vec![seed_addr].into_iter())
             .await
             .expect("unable to clone project");
+        eve_state.track(urn.clone(), bob_peer_id).await?;
         eve_state.get_project(urn.clone(), None).await?
+        */
     };
 
     let commit_id = {
@@ -258,8 +262,7 @@ async fn can_hear_commits() -> Result<(), Box<dyn std::error::Error>> {
                 repo.find_tree(oid)?
             };
 
-            let author =
-                git2::Signature::now(bob.name(), &format!("{}@example.com", bob.name()))?;
+            let author = git2::Signature::now(bob.name(), &format!("{}@example.com", bob.name()))?;
             repo.commit(
                 Some(&format!("refs/heads/{}", project.default_branch())),
                 &author,
@@ -270,38 +273,64 @@ async fn can_hear_commits() -> Result<(), Box<dyn std::error::Error>> {
             )?
         };
 
+        // TODO(finto): Wait on Results
         let mut rad = repo.find_remote(config::RAD_REMOTE)?;
         rad.push(&[&format!("refs/heads/{}", project.default_branch())], None)?;
         commit_id
     };
+    println!("COMMIT ID: {}", commit_id);
 
-    let announced = bob_events
-        .into_stream()
-        .filter_map(|res| match res.unwrap() {
-            coco::PeerEvent::Announced(updates) if updates.len() == 1 => future::ready(Some(())),
-            _ => future::ready(None),
-        })
-        .map(|_| ());
-    tokio::pin!(announced);
-    timeout(Duration::from_secs(1), announced.next()).await?;
+    {
+        let announced = bob_events.into_stream().take_while(|res| {
+            let mut branch = project.urn();
+            branch.path = librad::uri::Path::parse(format!("{}", project.default_branch()))
+                .expect("failed to parse branch name");
 
-    let bob_peer_id = bob_state.peer_id();
+            {
+                let expected = (branch, commit_id.into());
+                match res.as_ref().unwrap() {
+                    coco::PeerEvent::Announced(updates) if updates.contains(&expected) => {
+                        future::ready(false)
+                    },
+                    _ => future::ready(true),
+                }
+            }
+        });
+        let _ = timeout(Duration::from_secs(1), announced.collect::<Vec<_>>()).await?;
+    }
+
     let seed_heard = seed_events
         .into_stream()
-        .filter_map(|res| match res.unwrap() {
+        .take_while(|res| match res.as_ref().unwrap() {
             coco::PeerEvent::Protocol(ProtocolEvent::Gossip(gossip::Info::Has(gossip)))
-                if gossip.provider.peer_id == bob_peer_id =>
+                if gossip.val.rev == Some(Rev::Git(commit_id)) =>
             {
-                future::ready(Some(()))
+                future::ready(false)
             },
-            _ => future::ready(None),
-        })
-        .map(|_| ());
-    tokio::pin!(seed_heard);
-    timeout(Duration::from_secs(1), seed_heard.next()).await?;
+            _ => future::ready(true),
+        });
+    println!("{:?}", timeout(Duration::from_secs(1), seed_heard.collect::<Vec<_>>()).await?);
 
-    assert!(seed_state.has_commit(project.urn(), commit_id).await?, "seed is missing the commit");
-    assert!(eve_state.has_commit(project.urn(), commit_id).await?, "eve is missing the commit");
+    let branch = uri::RadUrn {
+        path: uri::Path::parse(format!(
+            "refs/remotes/{}/heads/{}",
+            bob_state.peer_id(),
+            project.default_branch()
+        ))
+        .expect("failed to parse branch name"),
+        ..project.urn().clone()
+    };
+
+    assert!(
+        seed_state.has_commit(branch.clone(), commit_id).await?,
+        "seed is missing the commit"
+    );
+    /*
+    assert!(
+        eve_state.has_commit(branch, commit_id).await?,
+        "eve is missing the commit"
+    );
+    */
 
     Ok(())
 }


### PR DESCRIPTION
We set up a test to try to understand how commit propagation is working.

The set up is as follows:
* One seed peer
* Two peers that use the seed peer as a seed
* The seed clones bob's project
* Eve clones from the seed
* Bob commits a change and announces it

The outcome should be that the seed and eve have the commit.