### PR TITLE
fix(proxy): partial project lists

### DIFF
--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -21,7 +21,8 @@
     clippy::missing_inline_in_public_items,
     clippy::multiple_crate_versions,
     clippy::or_fun_call,
-    clippy::shadow_reuse
+    clippy::shadow_reuse,
+    clippy::similar_names
 )]
 
 mod avatar;


### PR DESCRIPTION
Fixes #1118 

When listing projects we don't want a single project to be a show-stopper
for the rest of the projects. So we capture the failures, logging them
as warnings, and create a failure list.