### PR TITLE
fix(ui): make manage remotes modal consistent with peer selector

### DIFF
--- a/cypress/integration/project/peer_management.spec.js
+++ b/cypress/integration/project/peer_management.spec.js
@@ -15,10 +15,6 @@ context("project peer management", () => {
       .contains("li", "secretariat / platinum")
       .within(() => {
         cy.contains("maintainer").should("exist");
-        cy.pick("follow-toggle").contains("Following").should("exist");
-        cy.pick("follow-toggle").trigger("mouseenter");
-        cy.pick("follow-toggle").should("have.class", "disabled");
-        cy.pick("tooltip").contains("Can't unfollow your own remote");
       });
   });
 
@@ -35,7 +31,7 @@ context("project peer management", () => {
     cy.pick("follow-button").click();
 
     cy.pick("pending-peers")
-      .contains("li", "hynsej…iuzk4c / platinum")
+      .contains("li", "hynsejpd…keiuzk4c")
       .within(() => {
         cy.pick("follow-toggle").contains("Following").should("exist");
         cy.pick("follow-toggle").trigger("mouseenter");
@@ -62,11 +58,11 @@ context("project peer management", () => {
 
     // Allows deleting a peer follow request.
     cy.pick("pending-peers")
-      .contains("li", "hynsej…iuzk4c / platinum")
+      .contains("li", "hynsejpd…keiuzk4c")
       .within(() => {
         cy.pick("follow-toggle").click();
       });
 
-    cy.contains("li", "hynsej…iuzk4c / platinum").should("not.exist");
+    cy.contains("li", "hynsejpd…keiuzk4c").should("not.exist");
   });
 });

--- a/ui/DesignSystem/Component/AdditionalActionsDropdown.svelte
+++ b/ui/DesignSystem/Component/AdditionalActionsDropdown.svelte
@@ -134,7 +134,7 @@
       <div out:fade={{ duration: 100 }} class="modal" hidden={!expanded}>
         {#if headerTitle}
           <div class="header">
-            <StyledCopyable value={headerTitle} truncate />
+            <StyledCopyable value={headerTitle} />
           </div>
         {/if}
 

--- a/ui/DesignSystem/Component/Copyable.svelte
+++ b/ui/DesignSystem/Component/Copyable.svelte
@@ -44,14 +44,13 @@
     cursor: pointer;
     display: inline-flex;
     white-space: nowrap;
-    width: 100%;
   }
 
   .basic {
     display: flex;
     min-height: 24px;
     width: 100%;
-    padding: 0 0 0 4px;
+    padding-left: 0.25rem;
   }
 
   .content {

--- a/ui/DesignSystem/Component/StyledCopyable.svelte
+++ b/ui/DesignSystem/Component/StyledCopyable.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import Copyable from "./Copyable.svelte";
   import Hoverable from "./Hoverable.svelte";
-  import { Icon } from "../Primitive";
 
+  export let style = "";
   export let value: string;
   export let notificationText = "Copied to your clipboard";
   export let truncate: boolean = false;
+  export let expandable: boolean = true;
 
-  const [head, tail] = value.split(/(.{6}).*(.{6})/).filter(Boolean);
+  const [head, tail] = value.split(/(.{8}).*(.{8})/).filter(Boolean);
 
   let hover = false;
 </script>
@@ -15,25 +16,22 @@
 <style>
   .wrapper {
     display: flex;
-    justify-content: center;
     position: relative;
   }
 </style>
 
 <Hoverable bind:hovering={hover}>
-  <div class="wrapper">
+  <div class="wrapper" {style}>
     <Copyable
       style="align-items: center; color: var(--color-foreground-level-6)"
       copyContent={value}
       {notificationText}
       styleContent={hover}
       showIcon={true}>
-      {#if !truncate || hover}
+      {#if !truncate || (expandable && hover)}
         <p class="typo-text-small-mono">{value}</p>
       {:else}
-        <p class="typo-text-small-mono">{head}</p>
-        <Icon.EllipsisSmall />
-        <p class="typo-text-small-mono">{tail}</p>
+        <p class="typo-text-small-mono">{head}…{tail}</p>
       {/if}
     </Copyable>
   </div>

--- a/ui/Modal/ManagePeers.svelte
+++ b/ui/Modal/ManagePeers.svelte
@@ -5,9 +5,11 @@
     addPeer,
     pendingPeers,
     peerSelection,
+    PeerType,
     peerValidation,
     project as store,
     removePeer,
+    Role,
   } from "../src/project";
   import type { Urn } from "../src/urn";
 
@@ -103,7 +105,7 @@
       {#if data.peers.length > 0}
         <List
           dataCy="followed-peers"
-          items={data.peers}
+          items={data.peers.filter(peer => !(peer.type === PeerType.Local && peer.role === Role.Tracker))}
           let:item={peer}
           styleHoverState={false}
           style="width: 100%; margin: 1.5rem 0 0; padding: 0;">

--- a/ui/Modal/ManagePeers.svelte
+++ b/ui/Modal/ManagePeers.svelte
@@ -11,6 +11,7 @@
     removePeer,
     Role,
   } from "../src/project";
+  import type { User } from "../src/project";
   import type { Urn } from "../src/urn";
 
   import { Button, Input } from "../DesignSystem/Primitive";
@@ -39,6 +40,13 @@
   const unfollowPeer = (projectUrn: Urn, peerId: PeerId) => {
     removePeer(projectUrn, peerId);
     peerValidation.reset();
+  };
+
+  // Don't show our own peer in the list unless we have published something.
+  const filteredPeers = (peers: [User]) => {
+    return peers.filter(peer => {
+      return !(peer.type === PeerType.Local && peer.role === Role.Tracker);
+    });
   };
 </script>
 
@@ -105,7 +113,7 @@
       {#if data.peers.length > 0}
         <List
           dataCy="followed-peers"
-          items={data.peers.filter(peer => !(peer.type === PeerType.Local && peer.role === Role.Tracker))}
+          items={filteredPeers(data.peers)}
           let:item={peer}
           styleHoverState={false}
           style="width: 100%; margin: 1.5rem 0 0; padding: 0;">

--- a/ui/Modal/ManagePeers/Peer.svelte
+++ b/ui/Modal/ManagePeers/Peer.svelte
@@ -53,22 +53,20 @@
       {peer.identity.peerId}
     </p>
   </div>
-  {#if peer.type === PeerType.Local}
-    <Tooltip position={CSSPosition.Top} value="Can't unfollow your own remote">
-      <FollowToggle disabled following expanded />
-    </Tooltip>
-  {:else if peer.role === Role.Maintainer}
-    <Tooltip
-      position={CSSPosition.Top}
-      value="Can't unfollow the maintainer's remote">
-      <FollowToggle disabled following expanded />
-    </Tooltip>
-  {:else}
-    <FollowToggle
-      following
-      expanded
-      on:untrack={() => {
-        dispatch('unfollow', { projectUrn, peerId: peer.peerId });
-      }} />
+  {#if peer.type !== PeerType.Local}
+    {#if peer.role === Role.Maintainer}
+      <Tooltip
+        position={CSSPosition.Top}
+        value="Can't unfollow the maintainer's remote">
+        <FollowToggle disabled following expanded />
+      </Tooltip>
+    {:else}
+      <FollowToggle
+        following
+        expanded
+        on:unfollow={() => {
+          dispatch('unfollow', { projectUrn, peerId: peer.peerId });
+        }} />
+    {/if}
   {/if}
 </div>

--- a/ui/Modal/ManagePeers/Peer.svelte
+++ b/ui/Modal/ManagePeers/Peer.svelte
@@ -9,7 +9,12 @@
   import { PeerType, Role } from "../../src/project";
 
   import { Avatar } from "../../DesignSystem/Primitive";
-  import { Badge, FollowToggle, Tooltip } from "../../DesignSystem/Component";
+  import {
+    Badge,
+    FollowToggle,
+    StyledCopyable,
+    Tooltip,
+  } from "../../DesignSystem/Component";
 
   export let peer: User;
   export let projectUrn: Urn;
@@ -47,11 +52,11 @@
         <Badge style="margin-left: 0.5rem" variant={BadgeType.Maintainer} />
       {/if}
     </div>
-    <p
-      class="typo-text typo-overflow-ellipsis"
-      style="color: var(--color-foreground-level-5); padding-top: 0.5rem;">
-      {peer.identity.peerId}
-    </p>
+    <StyledCopyable
+      style="margin: 0.5rem 0 0 -0.25rem;"
+      truncate
+      expandable={false}
+      value={peer.peerId} />
   </div>
   {#if peer.type !== PeerType.Local}
     {#if peer.role === Role.Maintainer}

--- a/ui/Modal/ManagePeers/PeerFollowRequest.svelte
+++ b/ui/Modal/ManagePeers/PeerFollowRequest.svelte
@@ -4,15 +4,13 @@
   import type { Urn } from "../../src/urn";
   import type { User } from "../../src/project";
 
-  import { FollowToggle } from "../../DesignSystem/Component";
+  import { FollowToggle, StyledCopyable } from "../../DesignSystem/Component";
 
   export let peer: User;
   export let projectName: string;
   export let projectUrn: Urn;
 
   const dispatch = createEventDispatcher();
-
-  const [head, tail] = peer.peerId.split(/(.{6}).*(.{6})/).filter(Boolean);
 </script>
 
 <style>
@@ -31,9 +29,15 @@
 <div class="peer-request" data-cy="peer-request">
   <div class="left" style="max-width: 22em">
     <p class="typo-text-bold" style="color: var(--color-foreground-level-6);">
-      {head}…{tail} / {projectName}
+      {projectName}
     </p>
+    <StyledCopyable
+      style="margin: 0.5rem 0 0 -0.25rem;"
+      truncate
+      expandable={false}
+      value={peer.peerId} />
   </div>
+
   <FollowToggle
     expanded
     following

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -755,6 +755,14 @@
         <StyledCopyable
           value="hwd1yre8ttugonm77udfkti4ou89p4e37gdebmj3o544hzrg3r8dupn8hmr"
           notificationText="The hash was copied to your clipboard"
+          truncate
+          expandable={false} />
+      </Swatch>
+
+      <Swatch>
+        <StyledCopyable
+          value="hwd1yre8ttugonm77udfkti4ou89p4e37gdebmj3o544hzrg3r8dupn8hmr"
+          notificationText="The hash was copied to your clipboard"
           truncate />
       </Swatch>
 


### PR DESCRIPTION
The "Manage remotes" modal now:
- mimics the peer selector for tracked peers exactly
- doesn't show the `Follow` button for our own peer
- truncates all `PeerId`s and makes them copyable

Also fixed a bug where it was not possible to unfollow a tracked peer which is neither a maintainer nor our own peer.

![demo](https://user-images.githubusercontent.com/158411/97737845-d5ae5a00-1add-11eb-9b33-173035585b29.gif)

Closes: #1144.