### PR TITLE
fix(proxy): check waiting room has urn

### DIFF
--- a/proxy/coco/src/peer/run_state.rs
+++ b/proxy/coco/src/peer/run_state.rs
@@ -564,6 +564,11 @@ impl RunState {
                     val: Gossip { urn, .. },
                 })),
             ) => {
+                // This message is uninteresting to the waiting room
+                if !self.waiting_room.has(&urn) {
+                    return vec![];
+                }
+
                 match self.waiting_room.found(
                     RadUrl {
                         urn: urn.clone(),

--- a/proxy/coco/src/request/waiting_room.rs
+++ b/proxy/coco/src/request/waiting_room.rs
@@ -126,6 +126,11 @@ impl<T, D> WaitingRoom<T, D> {
         }
     }
 
+    /// Check that the `WaitingRoom` has the given `urn`.
+    pub fn has(&self, urn: &RadUrn) -> bool {
+        self.requests.contains_key(&urn.id)
+    }
+
     /// Get the underlying [`SomeRequest`] for the given `urn`.
     ///
     /// Returns `None` if there is no such request.


### PR DESCRIPTION
Fixes #1154 

During gossip announcements of Has, we would always mark the RadUrn as
Found in the WaitingRoom, but the WaitingRoom might not necessarily have
been looking for this RadUrn. So we first check that the WaitingRoom
indeed `has` the RadUrn before continuing on.