### PR TITLE
refactor(tests): Enforce success responses from test helpers

### DIFF
--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -1,21 +1,26 @@
 context("routing", () => {
+  beforeEach(() => {
+    cy.resetProxyState();
+    cy.visit("./public/index.html");
+  });
+
   context("session persistancy", () => {
     context("first time app start with no stored session data", () => {
       it("opens on the identity creation wizard", () => {
-        cy.resetProxyState();
-        cy.visit("./public/index.html");
         cy.pick("get-started-button").should("exist");
       });
     });
 
     context("when there is an identity stored in the session", () => {
+      beforeEach(() => {
+        cy.onboardUser();
+      });
+
       context(
         "when there is no additional routing information stored in the browser location",
         () => {
           it("opens the app on the profile screen", () => {
-            cy.onboardUser();
             cy.visit("./public/index.html");
-
             cy.location().should(loc => {
               expect(loc.hash).to.eq("#/profile/projects");
             });
@@ -27,7 +32,6 @@ context("routing", () => {
         "when there is additional routing information stored in the browser location",
         () => {
           it("resumes the app from the browser location", () => {
-            cy.onboardUser();
             cy.visit("./public/index.html");
 
             cy.pick("sidebar", "settings").click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,7 +1,7 @@
 Cypress.Commands.add("resetProxyState", async () => {
   console.log("Reset Proxy state");
-  await fetch("http://localhost:8080/v1/control/reset");
-  await fetch("http://localhost:8080/v1/keystore/unseal", {
+  await fetchOk("http://localhost:8080/v1/control/reset");
+  await fetchOk("http://localhost:8080/v1/keystore/unseal", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -14,7 +14,7 @@ Cypress.Commands.add("resetProxyState", async () => {
 });
 
 Cypress.Commands.add("sealKeystore", async () => {
-  await fetch("http://localhost:8080/v1/control/seal");
+  await fetchOk("http://localhost:8080/v1/control/seal");
 });
 
 Cypress.Commands.add("pick", (...ids) => {
@@ -30,7 +30,7 @@ Cypress.Commands.add(
     defaultBranch = "master",
     fakePeers = []
   ) =>
-    await fetch("http://localhost:8080/v1/control/create-project", {
+    await fetchOk("http://localhost:8080/v1/control/create-project", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -46,7 +46,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add("onboardUser", async (handle = "secretariat") => {
-  await fetch("http://localhost:8080/v1/keystore/unseal", {
+  await fetchOk("http://localhost:8080/v1/keystore/unseal", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -56,7 +56,7 @@ Cypress.Commands.add("onboardUser", async (handle = "secretariat") => {
       passphrase: "radicle-upstream",
     }),
   });
-  await fetch("http://localhost:8080/v1/identities", {
+  await fetchOk("http://localhost:8080/v1/identities", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -67,3 +67,16 @@ Cypress.Commands.add("onboardUser", async (handle = "secretariat") => {
     }),
   });
 });
+
+/**
+ * Invokes `fetch` and assert that the response status code is 2xx.
+ * Throws an error otherwise.
+ */
+async function fetchOk(url, opts) {
+  const response = await fetch(url, opts);
+  if (response.ok) {
+    return response;
+  } else {
+    throw new Error(`Invalid response code ${response.status}`);
+  }
+}


### PR DESCRIPTION
We now enforce that the requests made in test helpers return with a success status code. Otherwise we throw an error and fail the tests.

This requires us to fix some of the routing tests.