### PR TITLE
fix(ci): prevent concurrent builds on master branch

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,18 +1,25 @@
-steps:
-  - label: "Test and package app on Linux"
-    command: ".buildkite/run.sh"
-    agents:
-      production: "true"
-      platform: "linux"
-    timeout_in_minutes: 60
-    env:
-      DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.4.0"
-      SHARED_MASTER_CACHE: true
-    artifact_paths:
-      - "dist/*.AppImage"
-      - "dist/*.snap"
-      - "cypress/screenshots/**/*.png"
+.test-linux: &test-linux
+  label: "Test and package app on Linux"
+  command: ".buildkite/run.sh"
+  agents:
+    production: "true"
+    platform: "linux"
+  timeout_in_minutes: 60
+  env:
+    DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.4.0"
+    SHARED_MASTER_CACHE: true
+  artifact_paths:
+    - "dist/*.AppImage"
+    - "dist/*.snap"
+    - "cypress/screenshots/**/*.png"
 
+steps:
+  - branches: master
+    concurrency: 1
+    concurrency_group: master
+    <<: *test-linux
+  - branches: "!master"
+    <<: *test-linux
   - label: "Test and package app on macOS"
     if: build.branch == 'master'
     command: ".buildkite/run.sh"


### PR DESCRIPTION
I’ve properly enabled shared master caches in our CI builds. (Although this option was enabled in `.buildkite/pipeline.yaml` it was not enabled in the buildkite project config). To prevent issues with concurrent master builds we need to restrict concurrency. See
https://github.com/radicle-dev/infra/tree/master/ci#shared-master-cache for details.