### PR TITLE
chore(proxy): update librad deps

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "nonempty 0.6.0",
  "pretty_assertions",
  "pretty_env_logger",
+ "radicle-git-ext",
  "radicle-git-helpers",
  "radicle-keystore",
  "radicle-surf",
@@ -1229,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=85c2fadd91255a187fab6763504198c7f4dbb36d#85c2fadd91255a187fab6763504198c7f4dbb36d"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=cb7703226647999f967b86a403be32a4a40b3299#cb7703226647999f967b86a403be32a4a40b3299"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -1257,7 +1258,10 @@ dependencies = [
  "num_cpus",
  "percent-encoding 2.1.0",
  "quinn",
+ "radicle-git-ext",
  "radicle-keystore",
+ "radicle-macros",
+ "radicle-std-ext",
  "rand",
  "rand_pcg",
  "rcgen",
@@ -1472,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78c60039650ff12e140ae867ef5299a58e19dded4d334c849dc7177083667e2"
+checksum = "2cdffa0234be468d0598066308d42867e6b846103964f214aab88e8531546f46"
 dependencies = [
  "base-x",
  "data-encoding",
@@ -1897,9 +1901,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "radicle-git-ext"
+version = "0.1.0"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=cb7703226647999f967b86a403be32a4a40b3299#cb7703226647999f967b86a403be32a4a40b3299"
+dependencies = [
+ "git2",
+ "multibase",
+ "multihash",
+ "percent-encoding 2.1.0",
+ "radicle-std-ext",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "radicle-git-helpers"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=85c2fadd91255a187fab6763504198c7f4dbb36d#85c2fadd91255a187fab6763504198c7f4dbb36d"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=cb7703226647999f967b86a403be32a4a40b3299#cb7703226647999f967b86a403be32a4a40b3299"
 dependencies = [
  "anyhow",
  "git2",
@@ -1928,6 +1946,21 @@ dependencies = [
  "serde_cbor",
  "thiserror",
 ]
+
+[[package]]
+name = "radicle-macros"
+version = "0.1.0"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=cb7703226647999f967b86a403be32a4a40b3299#cb7703226647999f967b86a403be32a4a40b3299"
+dependencies = [
+ "quote",
+ "radicle-git-ext",
+ "syn",
+]
+
+[[package]]
+name = "radicle-std-ext"
+version = "0.1.0"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=cb7703226647999f967b86a403be32a4a40b3299#cb7703226647999f967b86a403be32a4a40b3299"
 
 [[package]]
 name = "radicle-surf"

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
-use coco::git;
+use coco::git_ext;
 
 use crate::context;
 
@@ -116,7 +116,7 @@ pub struct CreateInput {
     /// Long form outline.
     description: String,
     /// Configured default branch.
-    default_branch: git::ext::OneLevel,
+    default_branch: git_ext::OneLevel,
     /// Create and track fake peers
     fake_peers: Option<Vec<String>>,
 }

--- a/proxy/coco/Cargo.toml
+++ b/proxy/coco/Cargo.toml
@@ -30,11 +30,15 @@ features = [ "json-value" ]
 
 [dependencies.librad]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "85c2fadd91255a187fab6763504198c7f4dbb36d"
+rev = "cb7703226647999f967b86a403be32a4a40b3299"
+
+[dependencies.radicle-git-ext]
+git = "https://github.com/radicle-dev/radicle-link.git"
+rev = "cb7703226647999f967b86a403be32a4a40b3299"
 
 [dependencies.radicle-git-helpers]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "85c2fadd91255a187fab6763504198c7f4dbb36d"
+rev = "cb7703226647999f967b86a403be32a4a40b3299"
 
 [dependencies.radicle-surf]
 version = "0.5.0"

--- a/proxy/coco/src/control.rs
+++ b/proxy/coco/src/control.rs
@@ -3,10 +3,11 @@
 use std::{convert::TryFrom, env, io, path};
 
 use librad::{
-    git::ext::{OneLevel, RefLike},
+    git_ext::OneLevel,
     keys,
     meta::{entity, project as librad_project},
     peer::PeerId,
+    reflike,
 };
 use radicle_surf::vcs::git::git2;
 
@@ -289,5 +290,5 @@ pub fn clone_platinum(platinum_into: impl AsRef<path::Path>) -> Result<(), Error
 /// Default reference name for testing purposes.
 #[must_use]
 pub fn default_branch() -> OneLevel {
-    OneLevel::from(RefLike::try_from("master").expect("failed to parse 'master'"))
+    OneLevel::from(reflike!("master"))
 }

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -38,6 +38,8 @@ pub use librad::{
     uri::{self, RadUrn as Urn},
 };
 
+pub use radicle_git_ext as git_ext;
+
 pub use radicle_git_helpers::remote_helper;
 
 pub use radicle_surf::{

--- a/proxy/coco/src/project.rs
+++ b/proxy/coco/src/project.rs
@@ -1,6 +1,6 @@
 //! Project creation data and functions.
 
-use librad::git::ext::OneLevel;
+use librad::git_ext::OneLevel;
 use radicle_surf::vcs::git::git2;
 
 use crate::config;

--- a/proxy/coco/src/project/checkout.rs
+++ b/proxy/coco/src/project/checkout.rs
@@ -8,11 +8,11 @@ use std::{
 pub use librad::meta::project::Project;
 use librad::{
     git::{
-        ext::{OneLevel, RefLike, RefspecPattern},
         include,
         local::url::LocalUrl,
         types::{remote::Remote, FlatRef, Force},
     },
+    git_ext::{OneLevel, RefLike, RefspecPattern},
     peer::PeerId,
     uri::RadUrn,
 };

--- a/proxy/coco/src/project/create.rs
+++ b/proxy/coco/src/project/create.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use librad::{
     git::{
-        ext::{OneLevel, RefLike},
         local::url::LocalUrl,
         types::{remote::Remote, FlatRef},
     },
+    git_ext::{OneLevel, RefLike},
     keys,
     meta::{entity, project},
 };
@@ -372,11 +372,9 @@ impl Create<Repo> {
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom as _;
-
     use assert_matches::assert_matches;
 
-    use librad::git::ext::{OneLevel, RefLike};
+    use librad::{git_ext::OneLevel, reflike};
 
     use super::*;
 
@@ -390,9 +388,7 @@ mod test {
 
         let create = Create {
             description: "Radicle".to_string(),
-            default_branch: OneLevel::from(
-                RefLike::try_from("radicle").expect("failed to parse ref"),
-            ),
+            default_branch: OneLevel::from(reflike!("radicle")),
             repo: Repo::New {
                 name: "exists".to_string(),
                 path: tmpdir.path().to_path_buf(),
@@ -411,9 +407,7 @@ mod test {
 
         let create = Create {
             description: "Radicle".to_string(),
-            default_branch: OneLevel::from(
-                RefLike::try_from("radicle").expect("failed to parse ref"),
-            ),
+            default_branch: OneLevel::from(reflike!("radicle")),
             repo: Repo::New {
                 name: "exists".to_string(),
                 path: tmpdir.path().to_path_buf(),

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -4,13 +4,13 @@ use std::{convert::TryFrom as _, net::SocketAddr, path::PathBuf, sync::Arc, time
 
 use librad::{
     git::{
-        ext::{OneLevel, RefLike},
         include::Include,
         local::{transport, url::LocalUrl},
         refs::Refs,
         repo, storage,
         types::{namespace, NamespacedRef, Single},
     },
+    git_ext::{OneLevel, RefLike},
     keys,
     meta::{entity, project as librad_project, user},
     net::peer::PeerApi,
@@ -759,11 +759,10 @@ mod test {
     use std::{convert::TryFrom as _, env, path::PathBuf, process::Command};
 
     use librad::{
-        git::{
-            ext::{OneLevel, RefLike},
-            storage,
-        },
+        git::storage,
+        git_ext::{OneLevel, RefLike},
         keys::SecretKey,
+        reflike,
     };
 
     use crate::{config, control, project, signer};
@@ -777,9 +776,7 @@ mod test {
                 name: "fakie-nose-kickflip-backside-180-to-handplant".to_string(),
             },
             description: "rad git tricks".to_string(),
-            default_branch: OneLevel::from(
-                RefLike::try_from("dope").expect("failed to parse 'power'"),
-            ),
+            default_branch: OneLevel::from(reflike!("dope")),
         }
     }
 
@@ -790,9 +787,7 @@ mod test {
                 name: "radicalise".to_string(),
             },
             description: "the people".to_string(),
-            default_branch: OneLevel::from(
-                RefLike::try_from("power").expect("failed to parse 'power'"),
-            ),
+            default_branch: OneLevel::from(reflike!("power")),
         }
     }
 

--- a/proxy/coco/src/state/error.rs
+++ b/proxy/coco/src/state/error.rs
@@ -50,7 +50,7 @@ pub enum Error {
 
     /// Failed to parse a reference.
     #[error(transparent)]
-    ReferenceName(#[from] librad::git::ext::reference::name::Error),
+    ReferenceName(#[from] librad::git_ext::reference::name::Error),
 
     /// Repo error.
     #[error(transparent)]
@@ -110,5 +110,5 @@ pub mod storage {
 /// Re-export the underlying [`blob::Error`] so that consumers don't need to add `librad` as a
 /// dependency to match on the variant. Instead, they can import `coco::state::error::blob`.
 pub mod blob {
-    pub use librad::git::ext::blob::Error;
+    pub use librad::git_ext::blob::Error;
 }

--- a/proxy/coco/tests/common.rs
+++ b/proxy/coco/tests/common.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, path::PathBuf, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use futures::{future, StreamExt as _};
 use tokio::{
@@ -8,11 +8,11 @@ use tokio::{
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use librad::{
-    git::ext::{OneLevel, RefLike},
+    git_ext::OneLevel,
     keys::SecretKey,
     net::protocol::ProtocolEvent,
     peer::PeerId,
-    signer,
+    reflike, signer,
     uri::{RadUrl, RadUrn},
 };
 
@@ -140,7 +140,7 @@ pub fn radicle_project(path: PathBuf) -> project::Create<project::Repo> {
             name: "radicalise".to_string(),
         },
         description: "the people".to_string(),
-        default_branch: OneLevel::from(RefLike::try_from("power").unwrap()),
+        default_branch: OneLevel::from(reflike!("power")),
     }
 }
 
@@ -152,6 +152,6 @@ pub fn shia_le_pathbuf(path: PathBuf) -> project::Create<project::Repo> {
             name: "just".to_string(),
         },
         description: "do".to_string(),
-        default_branch: OneLevel::from(RefLike::try_from("it").unwrap()),
+        default_branch: OneLevel::from(reflike!("it")),
     }
 }


### PR DESCRIPTION
With these changes we get some fixes, specifically urn_context.
We also get the changes to have a sub-workspace that is re-exported
as git_ext, and also the very useful macro `reflike!`