### PR TITLE
fix(ui): prevent FollowToggle flickering

### DIFF
--- a/ui/DesignSystem/Component/FollowToggle.svelte
+++ b/ui/DesignSystem/Component/FollowToggle.svelte
@@ -8,6 +8,13 @@
   export let disabled: boolean = false;
   export let following: boolean = false;
 
+  // Set this to true if you don't want the button to toggle.
+  //
+  // Useful for when the button triggers an action that removes the component
+  // containing this button -- it prevents a visual flicker of the button just
+  // before it disappears.
+  export let actAsButton: boolean = false;
+
   const dispatch = createEventDispatcher();
 
   let hovering: boolean = false;
@@ -17,8 +24,11 @@
   const click = () => {
     if (disabled) return;
 
-    following = !following;
-    dispatch(following ? "follow" : "unfollow");
+    dispatch(!following ? "follow" : "unfollow");
+
+    if (!actAsButton) {
+      following = !following;
+    }
   };
 
   const mouseenter = () => {

--- a/ui/Modal/ManagePeers/Peer.svelte
+++ b/ui/Modal/ManagePeers/Peer.svelte
@@ -68,6 +68,7 @@
     {:else}
       <FollowToggle
         following
+        actAsButton
         on:unfollow={() => {
           dispatch('unfollow', { projectUrn, peerId: peer.peerId });
         }} />

--- a/ui/Modal/ManagePeers/PeerFollowRequest.svelte
+++ b/ui/Modal/ManagePeers/PeerFollowRequest.svelte
@@ -40,6 +40,7 @@
 
   <FollowToggle
     following
+    actAsButton
     on:unfollow={() => {
       dispatch('cancel', { projectUrn, peerId: peer.peerId });
     }} />

--- a/ui/Modal/Search.svelte
+++ b/ui/Modal/Search.svelte
@@ -150,7 +150,10 @@
       <div slot="error" style="padding: 1.5rem;">
         <div class="header typo-header-3">
           <span class="id">{id}</span>
-          <FollowToggle on:follow={follow} style="margin-left: 1rem;" />
+          <FollowToggle
+            actAsButton
+            on:follow={follow}
+            style="margin-left: 1rem;" />
         </div>
 
         <p style="color: var(--color-foreground-level-6);">

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -767,6 +767,29 @@
       </Swatch>
 
       <Swatch>
+        <FollowToggle
+          actAsButton
+          on:follow={() => {
+            console.log('follow');
+          }}
+          on:unfollow={() => {
+            console.log('unfollow');
+          }} />
+      </Swatch>
+
+      <Swatch>
+        <FollowToggle
+          following
+          actAsButton
+          on:follow={() => {
+            console.log('follow');
+          }}
+          on:unfollow={() => {
+            console.log('unfollow');
+          }} />
+      </Swatch>
+
+      <Swatch>
         <SupportButton />
       </Swatch>
 


### PR DESCRIPTION
When unfollowing a remote or when searching for a project and clicking `Follow`, the button would toggle to the opposite state for a brief time while the screen removes the component. This caused a visual flicker.

Before:
![slomo-flicker](https://user-images.githubusercontent.com/158411/97986668-54571000-1dda-11eb-8d47-56e5ff6a9692.gif)

After:
![slomo-noflicker](https://user-images.githubusercontent.com/158411/97986681-57ea9700-1dda-11eb-811f-2b55c3c9a506.gif)
