### PR TITLE
refactor(proxy): move auth token logic into context

### DIFF
--- a/proxy/api/src/http/keystore.rs
+++ b/proxy/api/src/http/keystore.rs
@@ -1,7 +1,5 @@
 //! Endpoints for handling the keystore.
 
-use data_encoding::HEXLOWER;
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
@@ -46,12 +44,7 @@ mod handler {
         mut ctx: context::Context,
         input: super::UnsealInput,
     ) -> Result<impl Reply, Rejection> {
-        ctx.unseal_keystore(input.passphrase).await?;
-
-        let auth_token_lock = ctx.auth_token();
-        let mut auth_token = auth_token_lock.write().await;
-        let token = super::gen_token();
-        *auth_token = Some(token.clone());
+        let token = ctx.unseal_keystore(input.passphrase).await?;
         Ok(warp::reply::with_header(
             reply::with_status(reply(), StatusCode::NO_CONTENT),
             "Set-Cookie",
@@ -65,12 +58,7 @@ mod handler {
         mut ctx: context::Context,
         input: super::CreateInput,
     ) -> Result<impl Reply, Rejection> {
-        ctx.create_key(input.passphrase).await?;
-
-        let auth_token_lock = ctx.auth_token();
-        let mut auth_token = auth_token_lock.write().await;
-        let token = super::gen_token();
-        *auth_token = Some(token.clone());
+        let token = ctx.create_key(input.passphrase).await?;
         Ok(warp::reply::with_header(
             reply::with_status(reply(), StatusCode::NO_CONTENT),
             "Set-Cookie",
@@ -94,12 +82,6 @@ pub struct UnsealInput {
 pub struct CreateInput {
     /// Passphrase to encrypt the keystore with.
     passphrase: coco::keystore::SecUtf8,
-}
-
-/// Generates a random auth token.
-fn gen_token() -> String {
-    let randoms = rand::thread_rng().gen::<[u8; 32]>();
-    HEXLOWER.encode(&randoms)
 }
 
 /// Format the cookie header attributes.


### PR DESCRIPTION
We remove the logic that validates and generates auth tokens from the HTTP layer and consolidate it in `api::context`.