### PR TITLE
fix(proxy): extensive validation

### DIFF
--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -108,17 +108,35 @@ pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
                         create::validation::Error::AlreadExists(_) => {
                             (StatusCode::CONFLICT, "PATH_EXISTS", err.to_string())
                         },
+                        create::validation::Error::EmptyExistingPath(_) => {
+                            (StatusCode::BAD_REQUEST, "EMPTY_PATH", err.to_string())
+                        },
+                        create::validation::Error::Git(_) => (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "GIT_ERROR",
+                            err.to_string(),
+                        ),
+                        create::validation::Error::MissingDefaultBranch { .. } => (
+                            StatusCode::BAD_REQUEST,
+                            "MISSING_DEFAULT_BRANCH",
+                            err.to_string(),
+                        ),
+                        create::validation::Error::MissingUrl => {
+                            (StatusCode::BAD_REQUEST, "MISSING_URL", err.to_string())
+                        },
                         create::validation::Error::PathDoesNotExist(_) => (
                             StatusCode::NOT_FOUND,
                             "PATH_DOES_NOT_EXIST",
                             err.to_string(),
                         ),
-
                         create::validation::Error::NotARepo(_) => {
                             (StatusCode::BAD_REQUEST, "NOT_A_REPO", err.to_string())
                         },
                         create::validation::Error::Io(err) => {
                             (StatusCode::BAD_REQUEST, "IO_ERROR", err.to_string())
+                        },
+                        create::validation::Error::UrlMismatch { .. } => {
+                            (StatusCode::BAD_REQUEST, "URL_MISMATCH", err.to_string())
                         },
                     },
                     coco::state::Error::Storage(state::error::storage::Error::AlreadyExists(

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -157,7 +157,7 @@ mod handler {
     pub async fn create(
         ctx: context::Unsealed,
         owner: coco::user::User,
-        input: coco::project::Create<coco::project::Repo>,
+        input: coco::project::Create,
     ) -> Result<impl Reply, Rejection> {
         let meta = ctx
             .state

--- a/proxy/coco/src/keystore.rs
+++ b/proxy/coco/src/keystore.rs
@@ -108,10 +108,10 @@ impl Keystorage<Memory> {
 }
 
 /// Synonym for an error when interacting with a file-backed store for [`librad::keys`].
-type FileError = file::Error<SecretBoxError<Infallible>, keys::IntoSecretKeyError>;
+pub type FileError = file::Error<SecretBoxError<Infallible>, keys::IntoSecretKeyError>;
 
 /// Synonym for an error when interacting with a memory store for [`librad::keys`].
-type MemoryError = memory::Error<SecretBoxError<Infallible>, keys::IntoSecretKeyError>;
+pub type MemoryError = memory::Error<SecretBoxError<Infallible>, keys::IntoSecretKeyError>;
 
 /// The [`Keystorage`] can result in two kinds of errors depending on what storage you're using.
 #[derive(Debug, thiserror::Error)]

--- a/proxy/coco/src/peer/run_state.rs
+++ b/proxy/coco/src/peer/run_state.rs
@@ -248,7 +248,7 @@ pub enum Status {
     },
 }
 
-/// Set of knobs to change the behaviour of the [`RunState`].
+/// Set of knobs to change the behaviour of the `RunState`.
 #[derive(Default)]
 pub struct Config {
     /// Set of knobs to alter announce behaviour.

--- a/proxy/coco/src/project/create.rs
+++ b/proxy/coco/src/project/create.rs
@@ -78,26 +78,22 @@ impl Repo {
 /// The data required for creating a new project.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Create<R> {
+pub struct Create {
     /// Description of the project we want to create.
     pub description: String,
     /// The default branch name for the project.
     pub default_branch: OneLevel,
-    /// The [`Repo`] to create with. It's left as a generic parameter so that we can have
-    /// `Create<Repo>` and `Create<ValidatedRepo>` for that sweet type safety.
-    pub repo: R,
+    /// What kind of working copy we're working with, i.e. new or existing.
+    pub repo: Repo,
 }
 
-impl Create<Repo> {
-    #![allow(clippy::use_self)]
-    /// Validate `Create<Repo>` into a `Create<ValidatedRepo>`. This ensures that we have valid
+impl Create {
+    /// Validate `Create` into a [`validation::Repository`]. This ensures that we have valid
     /// paths when we attempt to create the working copy.
-    ///
-    /// It needs to be called before using [`Create::setup_repo`].
     ///
     /// # Errors
     ///
-    /// See [`Repo::validate`]
+    /// See [`validation::Repository::validate`]
     pub fn validate(self, url: LocalUrl) -> Result<validation::Repository, validation::Error> {
         Ok(validation::Repository::validate(
             self.repo,
@@ -132,12 +128,12 @@ impl Create<Repo> {
 
 // Clippy is stupid and doesn't realise the `Create`s here are different types than `Self`.
 #[allow(clippy::use_self)]
-impl Create<Repo> {
+impl Create {
     /// Transforms into an existing project.
     #[must_use]
-    pub fn into_existing(self) -> Create<Repo> {
+    pub fn into_existing(self) -> Self {
         let path = self.repo.full_path();
-        Create {
+        Self {
             repo: Repo::Existing { path },
             description: self.description,
             default_branch: self.default_branch,

--- a/proxy/coco/src/project/create.rs
+++ b/proxy/coco/src/project/create.rs
@@ -1,55 +1,23 @@
-use std::{marker::PhantomData, path::PathBuf};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
 use librad::{
-    git::{
-        local::url::LocalUrl,
-        types::{remote::Remote, FlatRef},
-    },
-    git_ext::{OneLevel, RefLike},
+    git::local::url::LocalUrl,
+    git_ext::OneLevel,
     keys,
     meta::{entity, project},
 };
 use radicle_surf::vcs::git::git2;
 
-use crate::{config, user::User};
+use crate::user::User;
 
 /// Validation Errors
-pub mod validation {
-    use std::{io, path::PathBuf};
-
-    /// Errors that occur when validating a [`super::Repo`]'s path.
-    #[derive(Debug, thiserror::Error)]
-    pub enum Error {
-        /// The path already existed when trying to create a new project.
-        #[error("the path provided '{0}' already exists")]
-        AlreadExists(PathBuf),
-
-        /// The path was expected to exist already but does not.
-        #[error("the path provided '{0}' does not exist when it was expected to")]
-        PathDoesNotExist(PathBuf),
-
-        /// The path was expected to point to a git repository but it did not.
-        #[error("the path '{0}' does not point to an existing repository")]
-        NotARepo(PathBuf),
-
-        /// When trying to inspect a path, and I/O error occurred.
-        #[error(transparent)]
-        Io(#[from] io::Error),
-    }
-}
+pub mod validation;
 
 /// Errors that occur when attempting to create a working copy of a project.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// An existing project is being created, but we couldn't get the `name` of the project, i.e.
-    /// the final suffix of the file path.
-    #[error(
-        "the existing path provided '{0}' was empty, and we could not get the project name from it"
-    )]
-    EmptyExistingPath(PathBuf),
-
     /// Internal git error while trying to create the project.
     #[error(transparent)]
     Git(#[from] git2::Error),
@@ -57,17 +25,6 @@ pub enum Error {
     /// Entity meta error.
     #[error(transparent)]
     Meta(#[from] entity::Error),
-
-    /// Configured default branch for the project is missing.
-    #[error(
-        "the default branch '{branch}' supplied was not found for the repository at '{repo_path}'"
-    )]
-    MissingDefaultBranch {
-        /// The repository path we're setting up.
-        repo_path: PathBuf,
-        /// The default branch that was expected to be found.
-        branch: String,
-    },
 
     /// An error occurred while validating input.
     #[error(transparent)]
@@ -98,56 +55,15 @@ impl Repo {
     /// # Errors
     ///
     ///   * The existing path provided was empty, so we could not get the project's name.
-    pub fn project_name(&self) -> Result<String, Error> {
+    pub fn project_name(&self) -> Result<String, validation::Error> {
         match self {
             Self::Existing { path } => path
                 .components()
                 .next_back()
                 .and_then(|component| component.as_os_str().to_str())
                 .map(ToString::to_string)
-                .ok_or_else(|| Error::EmptyExistingPath(path.to_path_buf())),
+                .ok_or_else(|| validation::Error::EmptyExistingPath(path.to_path_buf())),
             Self::New { name, .. } => Ok(name.to_string()),
-        }
-    }
-
-    /// Validate `Repo` into a [`ValidatedRepo`], ensuring that path passes certain criteria. These
-    /// criteria are documented in the **Errors** section.
-    ///
-    /// # Errors
-    ///
-    ///   * If we have `Repo::Existing` and the path does not exist
-    ///   * If we have `Repo::Existing` and the path does not point to a repository
-    ///   * If we have `Repo::New` and the path already exists
-    pub fn validate(self) -> Result<ValidatedRepo, validation::Error> {
-        match self {
-            Self::Existing { path } => {
-                if !path.exists() {
-                    return Err(validation::Error::PathDoesNotExist(path));
-                }
-
-                // TODO(finto): This may be too permissive. Need to look into git errors.
-                if git2::Repository::open(path.clone()).is_err() {
-                    return Err(validation::Error::NotARepo(path));
-                }
-
-                Ok(ValidatedRepo(Self::Existing { path }))
-            },
-            Self::New { name, path } => {
-                let repo_path = path.join(name.clone());
-
-                if repo_path.is_file() {
-                    return Err(validation::Error::AlreadExists(repo_path));
-                }
-
-                if repo_path.exists()
-                    && repo_path.is_dir()
-                    && repo_path.read_dir()?.next().is_some()
-                {
-                    return Err(validation::Error::AlreadExists(repo_path));
-                }
-
-                Ok(ValidatedRepo(Self::New { name, path }))
-            },
         }
     }
 
@@ -156,73 +72,6 @@ impl Repo {
         match self {
             Self::Existing { path } => path.to_path_buf(),
             Self::New { name, path } => path.join(name),
-        }
-    }
-}
-
-/// A `Repo` that has passed through validation, using [`Repo::validate`].
-#[derive(Debug)]
-pub struct ValidatedRepo(Repo);
-
-impl ValidatedRepo {
-    /// If we pass `Existing`, we're opening a repository at the provided path.
-    ///
-    /// If we pass `New`, we're creating a repository in the provided directory path, where the new
-    /// folder is called after `name`. We also write an initial commit to the repository to set it
-    /// up for browsing.
-    ///
-    /// # Errors
-    ///
-    ///   * Failed to find the repository at the provided path.
-    ///   * Failed to initialise the repository.
-    pub fn create(
-        &self,
-        description: &str,
-        default_branch: &OneLevel,
-    ) -> Result<git2::Repository, Error> {
-        match &self {
-            Self(Repo::Existing { .. }) => {
-                let path = self.0.full_path();
-                log::debug!("Setting up existing repository @ '{}'", path.display());
-                git2::Repository::open(path).map_err(Error::from)
-            },
-            Self(Repo::New { .. }) => {
-                let path = self.0.full_path();
-
-                log::debug!("Setting up new repository @ '{}'", path.display());
-                let mut options = git2::RepositoryInitOptions::new();
-                options.no_reinit(true);
-                options.mkpath(true);
-                options.description(description);
-                options.initial_head(default_branch.as_str());
-
-                let repo = git2::Repository::init_opts(path, &options)?;
-                // First use the config to initialize a commit signature for the user.
-                let sig = repo.signature()?;
-                // Now let's create an empty tree for this commit
-                let tree_id = {
-                    let mut index = repo.index()?;
-
-                    // For our purposes, we'll leave the index empty for now.
-                    index.write_tree()?
-                };
-                {
-                    let tree = repo.find_tree(tree_id)?;
-                    // Normally creating a commit would involve looking up the current HEAD
-                    // commit and making that be the parent of the initial commit, but here this
-                    // is the first commit so there will be no parent.
-                    repo.commit(
-                        Some(&format!("refs/heads/{}", default_branch.as_str())),
-                        &sig,
-                        &sig,
-                        "Initial commit",
-                        &tree,
-                        &[],
-                    )?;
-                }
-
-                Ok(repo)
-            },
         }
     }
 }
@@ -250,49 +99,12 @@ impl Create<Repo> {
     /// # Errors
     ///
     /// See [`Repo::validate`]
-    pub fn validate(self) -> Result<Create<ValidatedRepo>, validation::Error> {
-        Ok(Create {
-            description: self.description,
-            default_branch: self.default_branch,
-            repo: self.repo.validate()?,
-        })
-    }
-}
-
-impl Create<ValidatedRepo> {
-    /// Initialise the [`git2::Repository`] for the project found at `urn` in the `monorepo`.
-    ///
-    /// # Errors
-    ///
-    ///   * Failed to setup the repository
-    ///   * Failed to build the project entity
-    pub fn setup_repo(&self, url: LocalUrl) -> Result<git2::Repository, Error> {
-        // Validate again to make sure nothing bad has snuck in
-        let _ = self.repo.0.clone().validate()?;
-
-        let repo = self.repo.create(&self.description, &self.default_branch)?;
-
-        // Test if the repo has setup rad remote.
-        match repo.find_remote(config::RAD_REMOTE) {
-            Ok(mut remote) => {
-                // Send a warning if the remote urls don't match
-                if let Some(remote_url) = remote.url() {
-                    if remote_url == url.to_string() {
-                        Self::push_default(&mut remote, &self.default_branch)?;
-                    } else {
-                        log::warn!("Remote URL Mismatch: '{}' /= '{}'", remote_url, url);
-                        log::warn!("Deleting original '{}' remote", config::RAD_REMOTE);
-                        repo.remote_delete(config::RAD_REMOTE)?;
-                        Self::setup_remote(&repo, url, &self.default_branch)?;
-                    }
-                };
-            },
-            Err(_err) => {
-                Self::setup_remote(&repo, url, &self.default_branch)?;
-            },
-        }
-
-        Ok(repo)
+    pub fn validate(self, url: LocalUrl) -> Result<validation::Repository, validation::Error> {
+        Ok(validation::Repository::validate(
+            self.repo,
+            url,
+            self.default_branch,
+        )?)
     }
 
     /// Build a [`project::Project`], where the provided [`User`] is the owner, and the set of
@@ -306,7 +118,7 @@ impl Create<ValidatedRepo> {
         owner: &User,
         key: keys::PublicKey,
     ) -> Result<project::Project<entity::Draft>, Error> {
-        let name = self.repo.0.project_name()?;
+        let name = self.repo.project_name()?;
         let project = project::Project::<entity::Draft>::create(name, owner.urn())?
             .to_builder()
             .set_description(self.description.clone())
@@ -316,42 +128,6 @@ impl Create<ValidatedRepo> {
             .build()?;
 
         Ok(project)
-    }
-
-    /// Equips a repository with a rad remote for the given id. If the directory at the given path
-    /// is not managed by git yet we initialise it first.
-    fn setup_remote(
-        repo: &git2::Repository,
-        url: LocalUrl,
-        default_branch: &OneLevel,
-    ) -> Result<(), Error> {
-        if let Err(err) = repo.resolve_reference_from_short_name(default_branch.as_str()) {
-            log::error!("error while trying to find default branch: {:?}", err);
-            return Err(Error::MissingDefaultBranch {
-                repo_path: repo.path().to_path_buf(),
-                branch: default_branch.as_str().to_string(),
-            });
-        }
-
-        log::debug!("Creating rad remote");
-        let remote = Remote::rad_remote(url, None);
-        let mut git_remote = remote.create(repo)?;
-
-        Self::push_default(&mut git_remote, default_branch)?;
-
-        log::debug!("Setting upstream to default branch");
-        super::set_rad_upstream(repo, default_branch)?;
-
-        Ok(())
-    }
-
-    /// Push the default branch to the provided remote.
-    fn push_default(remote: &mut git2::Remote, default_branch: &OneLevel) -> Result<(), Error> {
-        let default: FlatRef<RefLike, _> =
-            FlatRef::head(PhantomData, None, default_branch.clone().into());
-        log::debug!("Pushing default branch '{}'", default);
-        remote.push(&[default.to_string()], None)?;
-        Ok(())
     }
 }
 
@@ -374,13 +150,25 @@ impl Create<Repo> {
 mod test {
     use assert_matches::assert_matches;
 
-    use librad::{git_ext::OneLevel, reflike};
+    use librad::{
+        git_ext::OneLevel,
+        hash::Hash,
+        keys::SecretKey,
+        peer::PeerId,
+        reflike,
+        uri::{self, RadUrn},
+    };
 
     use super::*;
 
     #[test]
     fn validation_fails_on_non_empty_existing_directory() -> Result<(), Box<dyn std::error::Error>>
     {
+        let peer_id = PeerId::from(SecretKey::new());
+        let url = LocalUrl::from_urn(
+            RadUrn::new(Hash::hash(b"geez"), uri::Protocol::Git, uri::Path::empty()),
+            peer_id,
+        );
         let tmpdir = tempfile::tempdir().expect("failed to create tmp dir");
         let exists = tmpdir.path().join("exists");
         std::fs::create_dir(exists.clone())?;
@@ -394,13 +182,21 @@ mod test {
                 path: tmpdir.path().to_path_buf(),
             },
         };
-        assert_matches!(create.validate(), Err(validation::Error::AlreadExists(_)));
+        assert_matches!(
+            create.validate(url).err(),
+            Some(validation::Error::AlreadExists(_))
+        );
 
         Ok(())
     }
 
     #[test]
     fn validation_succeeds_on_empty_existing_directory() -> Result<(), Box<dyn std::error::Error>> {
+        let peer_id = PeerId::from(SecretKey::new());
+        let url = LocalUrl::from_urn(
+            RadUrn::new(Hash::hash(b"geez"), uri::Protocol::Git, uri::Path::empty()),
+            peer_id,
+        );
         let tmpdir = tempfile::tempdir().expect("failed to create tmp dir");
         let exists = tmpdir.path().join("exists");
         std::fs::create_dir(exists)?;
@@ -413,7 +209,7 @@ mod test {
                 path: tmpdir.path().to_path_buf(),
             },
         };
-        assert_matches!(create.validate(), Ok(_));
+        assert!(create.validate(url).is_ok());
 
         Ok(())
     }

--- a/proxy/coco/src/project/create.rs
+++ b/proxy/coco/src/project/create.rs
@@ -12,7 +12,6 @@ use radicle_surf::vcs::git::git2;
 
 use crate::user::User;
 
-/// Validation Errors
 pub mod validation;
 
 /// Errors that occur when attempting to create a working copy of a project.

--- a/proxy/coco/src/project/create/validation.rs
+++ b/proxy/coco/src/project/create/validation.rs
@@ -1,3 +1,6 @@
+//! Validation logic for safely checking that a [`super::Repo`] is valid before setting up the
+//! working copy.
+
 use std::{io, marker::PhantomData, path::PathBuf};
 
 use librad::{
@@ -144,7 +147,7 @@ impl Repository {
                     url,
                     default_branch,
                 })
-            }
+            },
             super::Repo::New { name, path } => {
                 let repo_path = path.join(name.clone());
 
@@ -165,7 +168,7 @@ impl Repository {
                     url,
                     default_branch,
                 })
-            }
+            },
         }
     }
 
@@ -188,7 +191,7 @@ impl Repository {
                 );
                 Self::setup_remote(&repo, url, &default_branch)?;
                 Ok(repo)
-            }
+            },
             Self::New {
                 path,
                 name,
@@ -230,7 +233,7 @@ impl Repository {
                 Self::setup_remote(&repo, url, &default_branch)?;
 
                 Ok(repo)
-            }
+            },
         }
     }
 

--- a/proxy/coco/src/project/create/validation.rs
+++ b/proxy/coco/src/project/create/validation.rs
@@ -49,7 +49,7 @@ pub enum Error {
     },
 
     /// The `rad` remote was found but it did not have a URL.
-    #[error("the `rad` exists but is missing its url field")]
+    #[error("the `rad` remote exists but is missing its url field")]
     MissingUrl,
 
     /// The path was expected to point to a git repository but it did not.

--- a/proxy/coco/src/project/create/validation.rs
+++ b/proxy/coco/src/project/create/validation.rs
@@ -1,0 +1,296 @@
+use std::{io, marker::PhantomData, path::PathBuf};
+
+use librad::{
+    git::{
+        local::url::LocalUrl,
+        types::{remote::Remote, FlatRef},
+    },
+    git_ext::{self, OneLevel, RefLike},
+    std_ext::result::ResultExt as _,
+};
+use radicle_surf::vcs::git::git2;
+
+use crate::config;
+
+/// Errors that occur when validating a [`super::Repo`]'s path.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The path already existed when trying to create a new project.
+    #[error("the path provided '{0}' already exists")]
+    AlreadExists(PathBuf),
+
+    /// An existing project is being created, but we couldn't get the `name` of the project, i.e.
+    /// the final suffix of the file path.
+    #[error(
+        "the existing path provided '{0}' was empty, and we could not get the project name from it"
+    )]
+    EmptyExistingPath(PathBuf),
+
+    /// An error occurred in `git2` that we could not handle.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// When trying to inspect a path, and I/O error occurred.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// Configured default branch for the project is missing.
+    #[error(
+        "the default branch '{branch}' supplied was not found for the repository at '{repo_path}'"
+    )]
+    MissingDefaultBranch {
+        /// The repository path we're setting up.
+        repo_path: PathBuf,
+        /// The default branch that was expected to be found.
+        branch: String,
+    },
+
+    /// The `rad` remote was found but it did not have a URL.
+    #[error("the `rad` exists but is missing its url field")]
+    MissingUrl,
+
+    /// The path was expected to point to a git repository but it did not.
+    #[error("the path '{0}' does not point to an existing repository")]
+    NotARepo(PathBuf),
+
+    /// The path was expected to exist already but does not.
+    #[error("the path provided '{0}' does not exist when it was expected to")]
+    PathDoesNotExist(PathBuf),
+
+    /// The `rad` remote was found, but the URL did not match the URL we were expecting.
+    #[error("the `rad` remote was found but the url field does not match the provided url, found: '{found}' expected: '{expected}'")]
+    UrlMismatch {
+        /// The expected URL of the `rad` remote.
+        expected: String,
+        /// The URL that was found for the `rad` remote.
+        found: String,
+    },
+}
+
+/// A `Repository` represents the validated information for setting up a working copy.
+///
+/// We can get a `Repository` by calling [`Repository::validate`].
+pub enum Repository {
+    /// The existing repository.
+    Existing {
+        /// Le [`git2::Repository`] that exists.
+        repo: git2::Repository,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+    },
+    /// A new repository will be created with using these fields.
+    New {
+        /// The path to the working copy.
+        path: PathBuf,
+        /// The name of the project.
+        name: String,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+    },
+}
+
+impl Repository {
+    /// Validate a [`super::Repo`] to construct a `Repository`.
+    ///
+    /// This ensures that when setting up a working copy, that there should be no errors.
+    /// The following are validated for each case:
+    ///
+    /// **Existing**:
+    ///   * The path provided should exist
+    ///   * The path provided should have at least one components, which forms the name of the
+    ///   project. E.g. `Developer/radicle-upstream` is the directory and `radicle-upstream` is the
+    ///   project name.
+    ///   * The path leads to a git repository
+    ///   * The default branch passed exists in the repository
+    ///   * If a `rad` remote exists, that it: a. Has a url b. If it does have a url, that it
+    ///     matches the one provided here
+    ///
+    /// **New**:
+    ///   * The path provided does not exist a. If it does exist, it should be a directory and it
+    ///     should be empty
+    ///
+    /// # Errors
+    ///
+    /// If any of the criteria outlined above are violated, this will result in an [`Error`].
+    pub fn validate(
+        repo: super::Repo,
+        url: LocalUrl,
+        default_branch: OneLevel,
+    ) -> Result<Self, Error> {
+        match repo {
+            super::Repo::Existing { path } => {
+                if !path.exists() {
+                    return Err(Error::PathDoesNotExist(path));
+                }
+
+                let _ = path
+                    .components()
+                    .next_back()
+                    .and_then(|component| component.as_os_str().to_str())
+                    .map(ToString::to_string)
+                    .ok_or_else(|| Error::EmptyExistingPath(path.to_path_buf()))?;
+
+                let repo = git2::Repository::open(path.clone())
+                    .or_matches(git_ext::is_not_found_err, || Err(Error::NotARepo(path)))?;
+
+                let _ = Self::existing_branch(&repo, &default_branch)?;
+                let _ = Self::existing_remote(&repo, &url)?;
+                Ok(Self::Existing {
+                    repo,
+                    url,
+                    default_branch,
+                })
+            }
+            super::Repo::New { name, path } => {
+                let repo_path = path.join(name.clone());
+
+                if repo_path.is_file() {
+                    return Err(Error::AlreadExists(repo_path));
+                }
+
+                if repo_path.exists()
+                    && repo_path.is_dir()
+                    && repo_path.read_dir()?.next().is_some()
+                {
+                    return Err(Error::AlreadExists(repo_path));
+                }
+
+                Ok(Self::New {
+                    name,
+                    path,
+                    url,
+                    default_branch,
+                })
+            }
+        }
+    }
+
+    /// Initialise the [`git2::Repository`] for the project found at `urn` in the `monorepo`.
+    ///
+    /// # Errors
+    ///
+    ///   * Failed to setup the repository
+    ///   * Failed to build the project entity
+    pub fn setup_repo(self, description: &str) -> Result<git2::Repository, Error> {
+        match self {
+            Self::Existing {
+                repo,
+                url,
+                default_branch,
+            } => {
+                log::debug!(
+                    "Setting up existing repository @ '{}'",
+                    repo.path().display()
+                );
+                Self::setup_remote(&repo, url, &default_branch)?;
+                Ok(repo)
+            }
+            Self::New {
+                path,
+                name,
+                url,
+                default_branch,
+            } => {
+                let path = path.join(name);
+                log::debug!("Setting up new repository @ '{}'", path.display());
+                let mut options = git2::RepositoryInitOptions::new();
+                options.no_reinit(true);
+                options.mkpath(true);
+                options.description(description);
+                options.initial_head(default_branch.as_str());
+
+                let repo = git2::Repository::init_opts(path, &options)?;
+                // First use the config to initialize a commit signature for the user.
+                let sig = repo.signature()?;
+                // Now let's create an empty tree for this commit
+                let tree_id = {
+                    let mut index = repo.index()?;
+
+                    // For our purposes, we'll leave the index empty for now.
+                    index.write_tree()?
+                };
+                {
+                    let tree = repo.find_tree(tree_id)?;
+                    // Normally creating a commit would involve looking up the current HEAD
+                    // commit and making that be the parent of the initial commit, but here this
+                    // is the first commit so there will be no parent.
+                    repo.commit(
+                        Some(&format!("refs/heads/{}", default_branch.as_str())),
+                        &sig,
+                        &sig,
+                        "Initial commit",
+                        &tree,
+                        &[],
+                    )?;
+                }
+                Self::setup_remote(&repo, url, &default_branch)?;
+
+                Ok(repo)
+            }
+        }
+    }
+
+    /// Equips a repository with a rad remote for the given id. If the directory at the given path
+    /// is not managed by git yet we initialise it first.
+    fn setup_remote(
+        repo: &git2::Repository,
+        url: LocalUrl,
+        default_branch: &OneLevel,
+    ) -> Result<(), Error> {
+        let _ = Self::existing_branch(repo, default_branch)?;
+
+        log::debug!("Creating rad remote");
+        let mut git_remote = Self::existing_remote(repo, &url)?
+            .map_or_else(|| Remote::rad_remote(url, None).create(repo), Ok)?;
+        Self::push_default(&mut git_remote, default_branch)?;
+
+        log::debug!("Setting upstream to default branch");
+        crate::project::set_rad_upstream(repo, default_branch)?;
+
+        Ok(())
+    }
+
+    /// Push the default branch to the provided remote.
+    fn push_default(remote: &mut git2::Remote, default_branch: &OneLevel) -> Result<(), Error> {
+        let default: FlatRef<RefLike, _> =
+            FlatRef::head(PhantomData, None, default_branch.clone().into());
+        log::debug!("Pushing default branch '{}'", default);
+        remote.push(&[default.to_string()], None)?;
+        Ok(())
+    }
+
+    fn existing_branch<'a>(
+        repo: &'a git2::Repository,
+        default_branch: &OneLevel,
+    ) -> Result<git2::Reference<'a>, Error> {
+        repo.resolve_reference_from_short_name(default_branch.as_str())
+            .or_matches(git_ext::is_not_found_err, || {
+                Err(Error::MissingDefaultBranch {
+                    repo_path: repo.path().to_path_buf(),
+                    branch: default_branch.as_str().to_string(),
+                })
+            })
+    }
+
+    fn existing_remote<'a>(
+        repo: &'a git2::Repository,
+        url: &LocalUrl,
+    ) -> Result<Option<git2::Remote<'a>>, Error> {
+        match repo.find_remote(config::RAD_REMOTE) {
+            Err(err) if git_ext::is_not_found_err(&err) => Ok(None),
+            Err(err) => Err(err.into()),
+            Ok(remote) => match remote.url() {
+                None => Err(Error::MissingUrl),
+                Some(remote_url) if remote_url != url.to_string() => Err(Error::UrlMismatch {
+                    expected: url.to_string(),
+                    found: remote_url.to_string(),
+                }),
+                Some(_) => Ok(Some(remote)),
+            },
+        }
+    }
+}

--- a/proxy/coco/src/project/create/validation.rs
+++ b/proxy/coco/src/project/create/validation.rs
@@ -33,7 +33,7 @@ pub enum Error {
     #[error(transparent)]
     Git(#[from] git2::Error),
 
-    /// When trying to inspect a path, and I/O error occurred.
+    /// When trying to inspect a path, an I/O error occurred.
     #[error(transparent)]
     Io(#[from] io::Error),
 
@@ -83,7 +83,7 @@ pub enum Repository {
         /// The default branch the repository should be set up with.
         default_branch: OneLevel,
     },
-    /// A new repository will be created with using these fields.
+    /// A new repository will be created using these fields.
     New {
         /// The path to the working copy.
         path: PathBuf,
@@ -104,17 +104,18 @@ impl Repository {
     ///
     /// **Existing**:
     ///   * The path provided should exist
-    ///   * The path provided should have at least one components, which forms the name of the
+    ///   * The path provided should have at least one component, which forms the name of the
     ///   project. E.g. `Developer/radicle-upstream` is the directory and `radicle-upstream` is the
     ///   project name.
     ///   * The path leads to a git repository
     ///   * The default branch passed exists in the repository
-    ///   * If a `rad` remote exists, that it: a. Has a url b. If it does have a url, that it
-    ///     matches the one provided here
+    ///   * If a `rad` remote exists, that it:
+    ///         * Has a url field
+    ///         * If it does have a url field, that it matches the one provided here
     ///
     /// **New**:
-    ///   * The path provided does not exist a. If it does exist, it should be a directory and it
-    ///     should be empty
+    ///   * The path provided does not exist:
+    ///         * If it does exist, it should be a directory and it should be empty
     ///
     /// # Errors
     ///
@@ -172,12 +173,11 @@ impl Repository {
         }
     }
 
-    /// Initialise the [`git2::Repository`] for the project found at `urn` in the `monorepo`.
+    /// Initialise the [`git2::Repository`].
     ///
     /// # Errors
     ///
     ///   * Failed to setup the repository
-    ///   * Failed to build the project entity
     pub fn setup_repo(self, description: &str) -> Result<git2::Repository, Error> {
         match self {
             Self::Existing {

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -770,7 +770,7 @@ mod test {
 
     use super::{Error, State};
 
-    fn fakie_project(path: PathBuf) -> project::Create<project::Repo> {
+    fn fakie_project(path: PathBuf) -> project::Create {
         project::Create {
             repo: project::Repo::New {
                 path,
@@ -781,7 +781,7 @@ mod test {
         }
     }
 
-    fn radicle_project(path: PathBuf) -> project::Create<project::Repo> {
+    fn radicle_project(path: PathBuf) -> project::Create {
         project::Create {
             repo: project::Repo::New {
                 path,

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -493,7 +493,7 @@ impl State {
     pub async fn init_project(
         &self,
         owner: &User,
-        project: project::Create<project::Repo>,
+        project: project::Create,
     ) -> Result<librad_project::Project<entity::Draft>, Error> {
         let mut meta = project.build(owner, self.signer.public_key().into())?;
         meta.sign_by_user(&self.signer, owner)?;

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -762,11 +762,11 @@ impl From<&State> for Seed {
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod test {
-    use std::{convert::TryFrom as _, env, path::PathBuf, process::Command};
+    use std::{env, path::PathBuf};
 
     use librad::{
         git::storage,
-        git_ext::{OneLevel, RefLike},
+        git_ext::OneLevel,
         keys::SecretKey,
         reflike,
     };
@@ -970,89 +970,6 @@ mod test {
         user_handles.sort();
 
         assert_eq!(user_handles, vec!["cloudhead", "kalt"],);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn create_with_existing_remote_with_reset() -> Result<(), Box<dyn std::error::Error>> {
-        use radicle_surf::vcs::git::Branch;
-
-        let tmp_dir = tempfile::tempdir().expect("failed to create tempdir");
-        let repo_path = tmp_dir.path().join("radicle");
-        let key = SecretKey::new();
-        let signer = signer::BoxedSigner::from(key);
-        let config = config::default(key, tmp_dir.path())?;
-        let (api, _run_loop) = config.try_into_peer().await?.accept()?;
-        let state = State::new(api, signer);
-
-        let kalt = state.init_owner("kalt").await?;
-
-        let fakie = state
-            .init_project(&kalt, fakie_project(repo_path.clone()))
-            .await?;
-
-        assert!(repo_path.join(fakie.name()).exists());
-
-        // Simulate resetting the monorepo
-        let tmp_dir = tempfile::tempdir().expect("failed to create tempdir");
-        let key = SecretKey::new();
-        let signer = signer::BoxedSigner::from(key);
-        let config = config::default(key, tmp_dir.path())?;
-        let (api, _run_loop) = config.try_into_peer().await?.accept()?;
-        let state = State::new(api, signer);
-
-        // Create fakie project from the existing directory above.
-        let kalt = state.init_owner("kalt").await?;
-        let fakie = state
-            .init_project(&kalt, fakie_project(repo_path).into_existing())
-            .await?;
-
-        // Attempt to initialise a browser to ensure we can look at branches in the project
-        let branch = state.find_default_branch(fakie.urn()).await?;
-        let branches = state
-            .with_browser(branch, |browser| {
-                Ok(browser
-                    .list_branches(None)
-                    .map_err(crate::source::Error::from)?)
-            })
-            .await?;
-
-        assert_eq!(branches, vec![Branch::local("dope")]);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn create_with_existing_remote() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempfile::tempdir().expect("failed to create tempdir");
-        let repo_path = tmp_dir.path().join("radicle");
-        let key = SecretKey::new();
-        let signer = signer::BoxedSigner::from(key);
-        let config = config::default(key, tmp_dir.path())?;
-        let (api, _run_loop) = config.try_into_peer().await?.accept()?;
-        let state = State::new(api, signer);
-
-        let kalt = state.init_owner("kalt").await?;
-        let fakie = state
-            .init_project(&kalt, fakie_project(repo_path.clone()))
-            .await?;
-        let fake_fakie = repo_path.join("fake-fakie");
-        let copy = Command::new("cp")
-            .arg("-rf")
-            .arg(repo_path.join(fakie.name()))
-            .arg(fake_fakie.clone())
-            .status()
-            .expect("failed to copy directory");
-
-        assert!(copy.success());
-
-        let fake_fakie = project::Create {
-            repo: project::Repo::Existing { path: fake_fakie },
-            description: "".to_string(),
-            default_branch: OneLevel::from(RefLike::try_from(fakie.default_branch())?),
-        };
-        let _fake_fakie = state.init_project(&kalt, fake_fakie).await?;
 
         Ok(())
     }

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -764,12 +764,7 @@ impl From<&State> for Seed {
 mod test {
     use std::{env, path::PathBuf};
 
-    use librad::{
-        git::storage,
-        git_ext::OneLevel,
-        keys::SecretKey,
-        reflike,
-    };
+    use librad::{git::storage, git_ext::OneLevel, keys::SecretKey, reflike};
 
     use crate::{config, control, project, signer};
 

--- a/proxy/coco/tests/common.rs
+++ b/proxy/coco/tests/common.rs
@@ -133,7 +133,7 @@ pub fn init_logging() {
 }
 
 #[allow(dead_code)]
-pub fn radicle_project(path: PathBuf) -> project::Create<project::Repo> {
+pub fn radicle_project(path: PathBuf) -> project::Create {
     project::Create {
         repo: project::Repo::New {
             path,
@@ -145,7 +145,7 @@ pub fn radicle_project(path: PathBuf) -> project::Create<project::Repo> {
 }
 
 #[allow(dead_code)]
-pub fn shia_le_pathbuf(path: PathBuf) -> project::Create<project::Repo> {
+pub fn shia_le_pathbuf(path: PathBuf) -> project::Create {
     project::Create {
         repo: project::Repo::New {
             path,


### PR DESCRIPTION
Fixes #1135
Fixes #822 

* Pushed all validation logic into `project::create::validation`
* A `Repo` must be now validated into a `validation::Repository` which has passed the checks
* Then a working copy can be safely set up (we check for the validations again, just to be sure)