### PR TITLE
fix(proxy): always overwrite git helper with latest one

### DIFF
--- a/proxy/coco/src/git_helper.rs
+++ b/proxy/coco/src/git_helper.rs
@@ -13,13 +13,6 @@ pub enum Error {
 /// Filename of the git helper binary.
 pub const GIT_REMOTE_RAD: &str = "git-remote-rad";
 
-/// Check if a path contains an executable file.
-fn is_executable(path: &std::path::PathBuf) -> Result<bool, Error> {
-    let metadata = path.metadata()?;
-    let permissions = metadata.permissions();
-    Ok(permissions.mode() & 0o111 != 0)
-}
-
 /// Checks if the git-remote-rad helper is in a stable location and has the
 /// executable flag, if not copies the executable to the right place.
 ///
@@ -30,19 +23,16 @@ fn is_executable(path: &std::path::PathBuf) -> Result<bool, Error> {
 ///   * Could not create the path to binary directory.
 ///   * Could not copy helper executable to the binary directory.
 pub fn setup(src_dir: &path::PathBuf, dst_dir: &path::PathBuf) -> Result<(), Error> {
-    log::info!("Making sure git-remote-rad helper is set up");
-
     let helper_bin_src = src_dir.join(GIT_REMOTE_RAD);
     let helper_bin_dst = dst_dir.join(GIT_REMOTE_RAD);
 
-    if helper_bin_dst.exists() && is_executable(&helper_bin_dst)? {
-        log::debug!("Git helper already exists at: {:?}", helper_bin_dst);
-        return Ok(());
-    }
-
     fs::create_dir_all(dst_dir)?;
     fs::copy(helper_bin_src, helper_bin_dst.clone())?;
-    log::debug!("Copied git-remote-rad helper to: {:?}", helper_bin_dst);
+    let mut permissions = helper_bin_dst.metadata()?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&helper_bin_dst, permissions)?;
+
+    log::info!("Copied git remote helper to: {:?}", helper_bin_dst);
 
     Ok(())
 }
@@ -53,84 +43,19 @@ mod test {
 
     use super::Error;
 
-    // when the ~/.radicle/bin directory doesn't exist at all
     #[tokio::test]
-    async fn setup_creates_destination_directory_if_none_exists() -> Result<(), Error> {
+    async fn ensure_setup_sets_up_remote_helper() -> Result<(), Error> {
         let tmp_src_dir = tempfile::tempdir().expect("failed to create source tempdir");
         let src_git_helper_bin_path = tmp_src_dir.path().join(super::GIT_REMOTE_RAD);
         let file = fs::File::create(src_git_helper_bin_path.clone())
             .expect("failed to create mock binary");
         let mut src_permissions = file.metadata()?.permissions();
-        src_permissions.set_mode(0o755);
+        src_permissions.set_mode(0o644);
 
         fs::set_permissions(src_git_helper_bin_path, src_permissions)?;
 
         let tmp_dst_dir = tempfile::tempdir().expect("failed to create destination tempdir");
         let dst_full_path = tmp_dst_dir.path().join(".radicle/bin");
-        super::setup(&tmp_src_dir.path().to_path_buf(), &dst_full_path)?;
-
-        let dst_git_helper_bin_path = dst_full_path.join(super::GIT_REMOTE_RAD);
-
-        let dst_metadata = dst_git_helper_bin_path.metadata()?;
-        let dst_permissions = dst_metadata.permissions();
-        assert_eq!(dst_permissions.mode(), 0o100_755);
-
-        Ok(())
-    }
-
-    // the ~/.radicle/bin directory exists, but there is no helper binary in it
-    #[tokio::test]
-    async fn setup_copies_binary_if_none_exists() -> Result<(), Error> {
-        let tmp_src_dir = tempfile::tempdir().expect("failed to create source tempdir");
-        let src_git_helper_bin_path = tmp_src_dir.path().join(super::GIT_REMOTE_RAD);
-        let file = fs::File::create(src_git_helper_bin_path.clone())
-            .expect("failed to create mock binary");
-        let mut src_permissions = file.metadata()?.permissions();
-        src_permissions.set_mode(0o755);
-
-        fs::set_permissions(src_git_helper_bin_path, src_permissions)?;
-
-        let tmp_dst_dir = tempfile::tempdir().expect("failed to create destination tempdir");
-
-        let dst_full_path = tmp_dst_dir.path().join(".radicle/bin");
-        fs::create_dir_all(dst_full_path.clone())?;
-
-        super::setup(&tmp_src_dir.path().to_path_buf(), &dst_full_path)?;
-
-        let dst_git_helper_bin_path = dst_full_path.join(super::GIT_REMOTE_RAD);
-
-        let dst_metadata = dst_git_helper_bin_path.metadata()?;
-        let dst_permissions = dst_metadata.permissions();
-        assert_eq!(dst_permissions.mode(), 0o100_755);
-
-        Ok(())
-    }
-
-    // the ~/.radicle/bin directory exists, and the binary is present, but not executable
-    #[tokio::test]
-    async fn setup_makes_binary_executable() -> Result<(), Error> {
-        let tmp_src_dir = tempfile::tempdir().expect("failed to create source tempdir");
-        let src_git_helper_bin_path = tmp_src_dir.path().join(super::GIT_REMOTE_RAD);
-        let file = fs::File::create(src_git_helper_bin_path.clone())
-            .expect("failed to create mock binary");
-        let mut src_permissions = file.metadata()?.permissions();
-        src_permissions.set_mode(0o755);
-
-        fs::set_permissions(src_git_helper_bin_path, src_permissions)?;
-
-        let tmp_dst_dir = tempfile::tempdir().expect("failed to create destination tempdir");
-
-        let dst_full_path = tmp_dst_dir.path().join(".radicle/bin");
-        fs::create_dir_all(dst_full_path.clone())?;
-
-        let dst_file_path = dst_full_path.join(super::GIT_REMOTE_RAD);
-        let dst_file =
-            fs::File::create(dst_file_path.clone()).expect("failed to create mock binary");
-        let mut dst_permissions = dst_file.metadata()?.permissions();
-        dst_permissions.set_mode(0o644);
-
-        fs::set_permissions(dst_file_path, dst_permissions)?;
-
         super::setup(&tmp_src_dir.path().to_path_buf(), &dst_full_path)?;
 
         let dst_git_helper_bin_path = dst_full_path.join(super::GIT_REMOTE_RAD);


### PR DESCRIPTION
Ensure we're always running the most recent git remote helper.

Closes: https://github.com/radicle-dev/radicle-upstream/issues/1198.