### PR TITLE
chore(ci): run master build on preview agent

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -20,6 +20,11 @@ steps:
     <<: *test-linux
   - branches: "!master"
     <<: *test-linux
+  - branches: "master"
+    <<: *test-linux
+    label: "Test and package app on Linux (preview)"
+    agents:
+      queue: agent-preview
   - label: "Test and package app on macOS"
     if: build.branch == 'master'
     command: ".buildkite/run.sh"


### PR DESCRIPTION
We run the master build on our new `preview` buildkite agent. This allows us to see if this project builds on the new agent. After some time we can then use the new agents to run all the builds and increase the number of parallel builds.