### PR TITLE
feat(ui): show proxy logs when proxy crashes

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -177,7 +177,7 @@
 
 ### Proxy Error
 
-- [ ] Kill the proxy process while the app is running.
-- [ ] The app should show the blue screen with the proxy logs.
+- [ ] Killing the proxy process while the app is running shows a blue error
+      screen with the proxy logs.
 
 [re]: https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md

--- a/QA.md
+++ b/QA.md
@@ -175,5 +175,9 @@
 - [ ] All documented shortcuts (a list is provided by pressing `?`) work
 - [ ] Only one modal is allowed at a time (no modal stacking possible)
 
+### Proxy Error
+
+- [ ] Kill the proxy process while the app is running.
+- [ ] The app should show the blue screen with the proxy logs.
 
 [re]: https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md

--- a/cypress/integration/routing.spec.ts
+++ b/cypress/integration/routing.spec.ts
@@ -63,12 +63,18 @@ context("routing", () => {
           data: {
             status: 1,
             signal: null,
-            stdout: "",
-            stderr: "",
+            stdout: "STDOUT",
+            stderr: "STDERR",
           },
         });
       });
       commands.pick("blue-screen-of-death").should("exist");
+      commands.pick("proxy-log").should("contain", "STDERR");
+      commands.pick("proxy-log-copy-clipboard").click();
+
+      ipcStub.getStubs().then(stubs => {
+        expect(stubs.getClipboard()).to.eq("STDERR");
+      });
     });
 
     it("shows blue screen of death if there is a proxy error after onboarding", () => {
@@ -79,12 +85,18 @@ context("routing", () => {
           data: {
             status: 1,
             signal: null,
-            stdout: "",
-            stderr: "",
+            stdout: "STDOUT",
+            stderr: "STDERR",
           },
         });
       });
       commands.pick("blue-screen-of-death").should("exist");
+      commands.pick("proxy-log").should("contain", "STDERR");
+      commands.pick("proxy-log-copy-clipboard").click();
+
+      ipcStub.getStubs().then(stubs => {
+        expect(stubs.getClipboard()).to.eq("STDERR");
+      });
     });
   });
 });

--- a/cypress/support/ipc-stub.ts
+++ b/cypress/support/ipc-stub.ts
@@ -12,7 +12,9 @@ interface ElectronStubs {
   [RendererMessage.GET_VERSION]: sinon.SinonStub;
   [RendererMessage.DIALOG_SHOWOPENDIALOG]: sinon.SinonStub;
   [RendererMessage.OPEN_PATH]: sinon.SinonStub;
+  [RendererMessage.CLIPBOARD_WRITETEXT]: (text: string) => void;
   sendMessage: (message: MainMessage) => void;
+  getClipboard: () => string;
 }
 
 declare global {
@@ -27,6 +29,7 @@ declare global {
 // See `../../native/preload.js`.
 export function setup(window: Window): void {
   const ipcRendererMessages = new EventEmitter();
+  let clipboard = "";
   const electronStubs: ElectronStubs = {
     [RendererMessage.GET_VERSION]: sinon
       .stub()
@@ -37,9 +40,13 @@ export function setup(window: Window): void {
     [RendererMessage.OPEN_PATH]: sinon
       .stub()
       .throws(new Error("not implemented")),
+    [RendererMessage.CLIPBOARD_WRITETEXT]: (text: string) => {
+      clipboard = text;
+    },
     sendMessage: (message: MainMessage) => {
       ipcRendererMessages.emit("message", undefined, message);
     },
+    getClipboard: () => clipboard,
   };
 
   window.electronStubs = electronStubs;

--- a/cypress/support/ipc-stub.ts
+++ b/cypress/support/ipc-stub.ts
@@ -54,7 +54,8 @@ export function setup(window: Window): void {
   window.electron = {
     ipcRenderer: {
       invoke: (msg, params) => {
-        return electronStubs[msg](params);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return electronStubs[msg](params as any);
       },
       on: ipcRendererMessages.on.bind(ipcRendererMessages),
     },

--- a/native/main.ts
+++ b/native/main.ts
@@ -11,7 +11,7 @@ import { execFile, ChildProcess } from "child_process";
 import { RendererMessage, MainMessage, MainMessageKind } from "./ipc-types";
 
 const isDev = process.env.NODE_ENV === "development";
-const proxyPath = path.join(__dirname, "../../proxy");
+const proxyPath = path.join(__dirname, "../proxy/target/debug/api");
 
 // The default value of app.allowRendererProcessReuse is deprecated, it is
 // currently "false".  It will change to be "true" in Electron 9.  For more

--- a/native/main.ts
+++ b/native/main.ts
@@ -11,7 +11,7 @@ import { execFile, ChildProcess } from "child_process";
 import { RendererMessage, MainMessage, MainMessageKind } from "./ipc-types";
 
 const isDev = process.env.NODE_ENV === "development";
-const proxyPath = path.join(__dirname, "../proxy/target/debug/api");
+const proxyPath = path.join(__dirname, "../../proxy");
 
 // The default value of app.allowRendererProcessReuse is deprecated, it is
 // currently "false".  It will change to be "true" in Electron 9.  For more

--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
-  import { Button, Emoji } from "../DesignSystem/Primitive";
+  import { Button, Emoji, Icon } from "../DesignSystem/Primitive";
   import { Fullscreen } from "../DesignSystem/Component";
-  import { fatalError } from "../src/error";
+  import * as ipc from "../src/ipc";
+  import * as error from "../src/error";
+  import * as svelteStore from "svelte/store";
+
+  // We have to circumvent the type checker because svelte cannot
+  // narrow types using `if` statements.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fatalError: svelteStore.Readable<any> = error.fatalError;
 
   const tweet = () => {
     window.location.href = "https://radicle.community/c/support/13";
@@ -14,29 +21,71 @@
   }
 
   .container {
+    height: 100%;
+    padding: 5rem;
+
     display: flex;
-    text-align: center;
     justify-content: center;
     align-items: center;
     flex-direction: column;
     color: #fff; /* I know... but this design doesn't work in dark mode. */
   }
+  .proxy-log-container {
+    background: #e3e3ff;
+
+    max-width: 100%;
+    min-width: 40em;
+    max-height: 20vh;
+    overflow: scroll;
+
+    margin-top: 2rem;
+    border-radius: 8px;
+    padding: 0.9em;
+  }
+
+  .proxy-log {
+    display: block;
+    color: #5555ff;
+    font-size: 14px;
+    white-space: pre-wrap;
+    line-height: 1.4;
+
+    max-width: 100%;
+  }
 </style>
 
-{#if $fatalError}
+{#if $fatalError !== null}
   <Fullscreen
     escapable={false}
-    style="background-color: var(--color-secondary); z-index: 200;"
-    contentStyle="display: flex; width: 312px; align-items: center;">
+    style="background-color: var(--color-secondary); z-index: 200;">
     <div class="container" data-cy="blue-screen-of-death">
       <Emoji emoji="🧻" size="huge" style="margin-bottom: 1.5rem;" />
-      <p>
-        We're not totally sure what's going on, but we can't load the app right
-        now because the background process won't start up.
+      <p style="width: 321px; text-align: center">
+        {#if $fatalError.kind === 'SESSION'}
+          We're not totally sure what's going on, but we can't load the app
+        {:else if $fatalError.kind === 'PROXY_EXIT'}
+          Hmm, looks like the app can’t be loaded right now because the backend
+          has crashed or it isn’t starting.
+        {/if}
       </p>
       <Button style="display: flex; color: #fff;" on:click={tweet}>
         Reach out for support
       </Button>
+      {#if $fatalError.kind === 'PROXY_EXIT' && $fatalError.data.stderr}
+        <div class="proxy-log-container">
+          <code data-cy="proxy-log" class="proxy-log typo-mono-semi-bold">
+            {$fatalError.data.stderr}
+          </code>
+          <Button
+            dataCy="proxy-log-copy-clipboard"
+            style="position: sticky; bottom: 0; margin-left: auto;"
+            variant="secondary"
+            on:click={() => ipc.copyToClipboard($fatalError.data.stderr)}
+            icon={Icon.Copy}>
+            Copy to clipboard
+          </Button>
+        </div>
+      {/if}
     </div>
   </Fullscreen>
 {/if}

--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { SvelteComponent } from "svelte";
-  import * as svelteStore from "svelte/store";
+  import type * as svelteStore from "svelte/store";
 
   import { Button, Emoji, Icon } from "../DesignSystem/Primitive";
   import { Fullscreen } from "../DesignSystem/Component";

--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -1,14 +1,31 @@
 <script lang="ts">
+  import type { SvelteComponent } from "svelte";
+  import * as svelteStore from "svelte/store";
+
   import { Button, Emoji, Icon } from "../DesignSystem/Primitive";
   import { Fullscreen } from "../DesignSystem/Component";
+
+  import * as notification from "../src/notification";
   import * as ipc from "../src/ipc";
   import * as error from "../src/error";
-  import * as svelteStore from "svelte/store";
 
   // We have to circumvent the type checker because svelte cannot
   // narrow types using `if` statements.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fatalError: svelteStore.Readable<any> = error.fatalError;
+
+  let copied = false;
+  let copyIcon: typeof SvelteComponent;
+  $: copyIcon = copied ? Icon.Check : Icon.Copy;
+
+  const copyToClipboard = (text: string) => {
+    ipc.copyToClipboard(text);
+    notification.info("Copied to your clipboard");
+    copied = true;
+    setTimeout(() => {
+      copied = false;
+    }, 2000);
+  };
 
   const tweet = () => {
     window.location.href = "https://radicle.community/c/support/13";
@@ -80,8 +97,8 @@
             dataCy="proxy-log-copy-clipboard"
             style="position: sticky; bottom: 0; margin-left: auto;"
             variant="secondary"
-            on:click={() => ipc.copyToClipboard($fatalError.data.stderr)}
-            icon={Icon.Copy}>
+            on:click={() => copyToClipboard($fatalError.data.stderr)}
+            icon={copyIcon}>
             Copy to clipboard
           </Button>
         </div>

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -23,12 +23,12 @@ export const show = (message: string, context: unknown): void => {
 
 // Fatal application errors that trigger a blue screen
 export type FatalError =
-  | { kind: FatalErrorKind.SESSION }
-  | { kind: FatalErrorKind.PROXY_EXIT; data: ipc.ProxyError };
+  | { kind: FatalErrorKind.Session }
+  | { kind: FatalErrorKind.ProxyExit; data: ipc.ProxyError };
 
 export enum FatalErrorKind {
-  SESSION = "SESSION",
-  PROXY_EXIT = "PROXY_EXIT",
+  Session = "SESSION",
+  ProxyExit = "PROXY_EXIT",
 }
 
 const fatalErrorWritable: svelteStore.Writable<FatalError | null> = svelteStore.writable(
@@ -43,7 +43,7 @@ export const setFatal = (fatalError: FatalError): void => {
 
 ipc.listenProxyError(proxyError => {
   console.error("Proxy process exited", { proxyError });
-  setFatal({ kind: FatalErrorKind.PROXY_EXIT, data: proxyError });
+  setFatal({ kind: FatalErrorKind.ProxyExit, data: proxyError });
 });
 
 // Value is `true` if there was a fatal error

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -21,20 +21,30 @@ export const show = (message: string, context: unknown): void => {
   });
 };
 
-const fatalErrorWritable: svelteStore.Writable<boolean> = svelteStore.writable(
-  false
+// Fatal application errors that trigger a blue screen
+export type FatalError =
+  | { kind: FatalErrorKind.SESSION }
+  | { kind: FatalErrorKind.PROXY_EXIT; data: ipc.ProxyError };
+
+export enum FatalErrorKind {
+  SESSION = "SESSION",
+  PROXY_EXIT = "PROXY_EXIT",
+}
+
+const fatalErrorWritable: svelteStore.Writable<FatalError | null> = svelteStore.writable(
+  null
 );
 
 // Notify the app that there was a fatal error and show the blue screen
 // of death.
-export const setFatal = (): void => {
-  fatalErrorWritable.set(true);
+export const setFatal = (fatalError: FatalError): void => {
+  fatalErrorWritable.set(fatalError);
 };
 
 ipc.listenProxyError(proxyError => {
   console.error("Proxy process exited", { proxyError });
-  setFatal();
+  setFatal({ kind: FatalErrorKind.PROXY_EXIT, data: proxyError });
 });
 
 // Value is `true` if there was a fatal error
-export const fatalError: svelteStore.Readable<boolean> = fatalErrorWritable;
+export const fatalError: svelteStore.Readable<FatalError | null> = fatalErrorWritable;

--- a/ui/src/ipc.ts
+++ b/ui/src/ipc.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../native/preload.d.ts" />
 import * as ipcTypes from "../../native/ipc-types";
 
-export { ProxyError } from "../../native/ipc-types";
+export type { ProxyError } from "../../native/ipc-types";
 
 // We have to be able to select empty directories when we create new
 // projects. Unfortunately we can't use the HTML5 open dialog via

--- a/ui/src/ipc.ts
+++ b/ui/src/ipc.ts
@@ -2,6 +2,8 @@
 /// <reference path="../../native/preload.d.ts" />
 import * as ipcTypes from "../../native/ipc-types";
 
+export { ProxyError } from "../../native/ipc-types";
+
 // We have to be able to select empty directories when we create new
 // projects. Unfortunately we can't use the HTML5 open dialog via
 // <input type="file"> for this. Although it lets us select directories,

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -35,7 +35,9 @@ export const session = sessionStore.readable;
 
 sessionStore.subscribe(data => {
   if (data.status === remote.Status.Error) {
-    error.setFatal();
+    error.setFatal({
+      kind: error.FatalErrorKind.SESSION,
+    });
   }
 });
 

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -36,7 +36,7 @@ export const session = sessionStore.readable;
 sessionStore.subscribe(data => {
   if (data.status === remote.Status.Error) {
     error.setFatal({
-      kind: error.FatalErrorKind.SESSION,
+      kind: error.FatalErrorKind.Session,
     });
   }
 });


### PR DESCRIPTION
Closes #1095

When the proxy crashes or does not start we show `stderr` of the proxy
process.

Follow-up:

- Interlace `stderr` and `stdout` to show the full output.