### PR TITLE
fix(proxy): do not drop event tasks

### DIFF
--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -116,11 +116,11 @@ async fn run_rigging(
 
     let subscriptions = notification::Subscriptions::default();
     let peer_subscriptions = subscriptions.clone();
-    let seeds_store = ctx.store().clone();
+    let server_ctx = ctx.clone();
 
     let server = async move {
         log::info!("starting API");
-        let api = http::api(ctx.clone(), subscriptions.clone());
+        let api = http::api(server_ctx, subscriptions.clone());
         let (_, server) = warp::serve(api).try_bind_with_graceful_shutdown(
             ([127, 0, 0, 1], PORT),
             async move {
@@ -159,6 +159,7 @@ async fn run_rigging(
         tasks.push(peer.map_err(RunError::from).boxed());
 
         if let Some(seeds_sender) = seeds_sender {
+            let seeds_store = ctx.store().clone();
             let seeds_event_task = coco::SpawnAbortable::new(async move {
                 let mut last_seeds: Vec<seed::Seed> = vec![];
                 let mut timer = tokio::time::interval(Duration::from_secs(1));

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -112,7 +112,7 @@ async fn run_rigging(
 
     if let Some(seeds_sender) = seeds_sender {
         let seeds_store = ctx.store().clone();
-        coco::SpawnAbortable::new(async move {
+        let _seeds_event_task = coco::SpawnAbortable::new(async move {
             let mut last_seeds: Vec<seed::Seed> = vec![];
             let mut timer = tokio::time::interval(Duration::from_secs(1));
 
@@ -155,7 +155,7 @@ async fn run_rigging(
     };
 
     if let Some(peer) = peer {
-        coco::SpawnAbortable::new({
+        let _peer_event_task = coco::SpawnAbortable::new({
             let mut peer_events = peer.subscribe();
 
             async move {

--- a/proxy/coco/src/spawn_abortable.rs
+++ b/proxy/coco/src/spawn_abortable.rs
@@ -26,7 +26,7 @@ pub enum Error {
 /// Stop-gap until we can abort [`JoinHandle`]s directly:
 /// tokio-rs@cbb14a7bb9a13363e1abee8caff2bad1f996c263
 #[allow(clippy::missing_docs_in_private_items)]
-#[must_use]
+#[must_use = "keep the task running"]
 pub struct SpawnAbortable<T> {
     join_handle: JoinHandle<Result<T, future::Aborted>>,
     abort_handle: future::AbortHandle,

--- a/proxy/coco/src/spawn_abortable.rs
+++ b/proxy/coco/src/spawn_abortable.rs
@@ -26,6 +26,7 @@ pub enum Error {
 /// Stop-gap until we can abort [`JoinHandle`]s directly:
 /// tokio-rs@cbb14a7bb9a13363e1abee8caff2bad1f996c263
 #[allow(clippy::missing_docs_in_private_items)]
+#[must_use]
 pub struct SpawnAbortable<T> {
     join_handle: JoinHandle<Result<T, future::Aborted>>,
     abort_handle: future::AbortHandle,


### PR DESCRIPTION
Closes #1191
Closes #1208

Only the initial event (set up in the `local_peer_event` endpoint) was sent to the event stream. All subsequent events were not broadcasted since the tasks in `run_rigging` (process.rs) were immediately dropped.