### PR TITLE
feat(ui): introduce structured error logging

### DIFF
--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -3,9 +3,9 @@
 
   import * as hotkeys from "./src/hotkeys.ts";
   import "./src/localPeer.ts";
-  import * as notification from "./src/notification.ts";
   import * as path from "./src/path.ts";
   import * as remote from "./src/remote.ts";
+  import * as error from "./src/error.ts";
   import { fetch, session as store, Status } from "./src/session.ts";
 
   import {
@@ -78,8 +78,7 @@
       break;
 
     case remote.Status.Error:
-      console.error($store.error);
-      notification.error("Session could not be fetched");
+      error.show($store.error);
       break;
   }
 </script>
@@ -101,7 +100,7 @@
 <NotificationFaucet />
 <Theme />
 
-<Remote {store} context="session">
+<Remote {store} context="session" disableErrorLogging={true}>
   <Router {routes} />
 
   <div slot="loading" class="error">

--- a/ui/DesignSystem/Component/Remote.svelte
+++ b/ui/DesignSystem/Component/Remote.svelte
@@ -1,7 +1,6 @@
 <script lang="typescript">
   import type { Readable } from "svelte/store";
 
-  import * as error from "../../src/error";
   import * as notification from "../../src/notification";
   import * as remote from "../../src/remote";
 
@@ -11,27 +10,23 @@
   export let store: Readable<remote.Data<any>>;
   export let context: string | undefined = undefined;
 
-  // Shorthand for casting these states
-  type ErrorState = { status: remote.Status.Error; error: error.Error };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type SuccessState = { status: remote.Status.Success; data: any };
 
   // If no error slot was provided, svelte will instantiate the fallback div
   let noErrorSlotProvided: HTMLDivElement;
 
-  $: if ($store.status === remote.Status.Error && !!noErrorSlotProvided) {
-    console.error("Remote error", ($store as ErrorState).error);
-    notification.error(($store as ErrorState).error.message);
+  let storeValue: remote.Data<any>;
+  $: storeValue = $store;
+
+  $: if (storeValue.status === remote.Status.Error && !!noErrorSlotProvided) {
+    console.error("Remote error", storeValue.error);
+    notification.error(storeValue.error.message);
   }
 
   $: data =
     $store.status === remote.Status.Success
       ? ($store as SuccessState).data
-      : undefined;
-
-  $: remoteError =
-    $store.status === remote.Status.Error
-      ? ($store as ErrorState).error
       : undefined;
 </script>
 
@@ -49,8 +44,8 @@
   {:else}
     <slot {data} />
   {/if}
-{:else if $store.status === remote.Status.Error}
-  <slot name="error" error={remoteError}>
+{:else if storeValue.status === remote.Status.Error}
+  <slot name="error" error={storeValue.error}>
     <div bind:this={noErrorSlotProvided} />
   </slot>
 {/if}

--- a/ui/DesignSystem/Component/Remote.svelte
+++ b/ui/DesignSystem/Component/Remote.svelte
@@ -10,16 +10,23 @@
   export let store: Readable<remote.Data<any>>;
   export let context: string | undefined = undefined;
 
+  export let disableErrorLogging: boolean = false;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type SuccessState = { status: remote.Status.Success; data: any };
 
   // If no error slot was provided, svelte will instantiate the fallback div
   let noErrorSlotProvided: HTMLDivElement;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let storeValue: remote.Data<any>;
   $: storeValue = $store;
 
-  $: if (storeValue.status === remote.Status.Error && !!noErrorSlotProvided) {
+  $: if (
+    storeValue.status === remote.Status.Error &&
+    !!noErrorSlotProvided &&
+    !disableErrorLogging
+  ) {
     console.error("Remote error", storeValue.error);
     notification.error(storeValue.error.message);
   }

--- a/ui/Screen/Onboarding.svelte
+++ b/ui/Screen/Onboarding.svelte
@@ -2,12 +2,11 @@
   import { fade, fly } from "svelte/transition";
 
   import { withRetry } from "../src/api.ts";
-  import * as notification from "../src/notification.ts";
   import { State } from "../src/onboarding.ts";
   import { createIdentity } from "../src/identity.ts";
   import * as screen from "../src/screen.ts";
   import * as session from "../src/session.ts";
-  import * as urn from "../src/urn.ts";
+  import * as error from "../src/error";
 
   import Welcome from "./Onboarding/Welcome.svelte";
   import EnterName from "./Onboarding/EnterName.svelte";
@@ -46,12 +45,17 @@
       // Retry until the API is up
       identity = await withRetry(() => createIdentity({ handle }), 200);
       state = State.SuccessView;
-    } catch (error) {
+    } catch (err) {
       animateBackward();
       state = State.EnterName;
-      notification.error(
-        `Could not create identity: ${urn.shorten(error.message)}`
-      );
+      error.show({
+        code: "create-identity-failed",
+        message: `Could not create identity`,
+        details: {
+          handle,
+        },
+        source: error.fromException(err),
+      });
     } finally {
       screen.unlock();
       createIdentityInProgress = false;

--- a/ui/Screen/Profile/Projects.svelte
+++ b/ui/Screen/Profile/Projects.svelte
@@ -39,6 +39,6 @@
   </div>
 
   <div slot="error" let:error>
-    <Error message={error && error.message} />
+    <Error message={error.message} />
   </div>
 </Remote>

--- a/ui/Screen/UserProfile/Projects.svelte
+++ b/ui/Screen/UserProfile/Projects.svelte
@@ -20,6 +20,6 @@
   <ProjectList {projects} userUrn={params.urn} on:select={select} />
 
   <div slot="error" let:error>
-    <Error message={error && error.message} />
+    <Error message={error.message} />
   </div>
 </Remote>

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -75,7 +75,7 @@ export const setFatal = (fatalError: FatalError): void => {
 ipc.listenProxyError(proxyError => {
   log({
     code: Code.UnexpectedProxyExit,
-    message: "Proxy process exicted unexpectedly",
+    message: "Proxy process exited unexpectedly",
     details: { proxyError },
   });
   setFatal({ kind: FatalErrorKind.ProxyExit, data: proxyError });

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -2,22 +2,48 @@ import * as notification from "./notification";
 import * as ipc from "./ipc";
 import * as svelteStore from "svelte/store";
 
-export enum Variant {
-  EntityExists = "ENTITY_EXISTS",
-  GitError = "GIT_ERROR",
-  NotFound = "NOT_FOUND",
-}
-
 export interface Error {
+  // A code in kebab-case for easy identification of the error.
+  //
+  // This should not include interpolated data.
+  code: string;
+  // Message that is displayed to the user if the error is shown.
   message: string;
-  variant: Variant;
+  // An optional stack trace
+  stack?: string;
+  // Arbitrary additional information associated with the error
+  details?: unknown;
+  // The error that caused this error
+  source?: Error;
 }
 
-export const show = (message: string, context: unknown): void => {
-  console.error({ message, context });
+// Turn a Javascript `Error` into our `Error`.
+//
+// Uses the code `unknown-exception`.
+export const fromException = (exception: globalThis.Error): Error => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const details = Object.assign({}, exception) as any;
+  details.name = exception.name;
+  return {
+    code: "unknown-exception",
+    message: exception.message,
+    stack: exception.stack,
+    details,
+  };
+};
 
-  notification.error(message, true, "Copy error", () => {
-    ipc.copyToClipboard(JSON.stringify({ message, context }, null, 2));
+// Log an error to the console.
+export const log = (error: Error): void => {
+  const { message, ...rest } = error;
+  console.error(message, rest);
+};
+
+// Show an error notification and log the error to the console
+export const show = (error: Error): void => {
+  log(error);
+
+  notification.error(error.message, true, "Copy error", () => {
+    ipc.copyToClipboard(JSON.stringify(error, null, 2));
   });
 };
 
@@ -32,7 +58,11 @@ export const setFatal = (): void => {
 };
 
 ipc.listenProxyError(proxyError => {
-  console.error("Proxy process exited", { proxyError });
+  log({
+    code: "unexpected-proxy-exit",
+    message: "Proxy process exicted unexpectedly",
+    details: { proxyError },
+  });
   setFatal();
 });
 

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -3,10 +3,8 @@ import * as ipc from "./ipc";
 import * as svelteStore from "svelte/store";
 
 export interface Error {
-  // A code in kebab-case for easy identification of the error.
-  //
-  // This should not include interpolated data.
-  code: string;
+  // A unique code for easy identification of the error.
+  code: Code;
   // Message that is displayed to the user if the error is shown.
   message: string;
   // An optional stack trace
@@ -17,6 +15,13 @@ export interface Error {
   source?: Error;
 }
 
+export enum Code {
+  SessionFetchFailure = "SessionFetchFailure",
+  ProjectRequestFailure = "ProjectRequestFailure",
+  UnexpectedProxyExit = "UnexpectedProxyExit",
+  UnknownException = "UnknownException",
+}
+
 // Turn a Javascript `Error` into our `Error`.
 //
 // Uses the code `unknown-exception`.
@@ -25,7 +30,7 @@ export const fromException = (exception: globalThis.Error): Error => {
   const details = Object.assign({}, exception) as any;
   details.name = exception.name;
   return {
-    code: "unknown-exception",
+    code: Code.UnknownException,
     message: exception.message,
     stack: exception.stack,
     details,
@@ -59,7 +64,7 @@ export const setFatal = (): void => {
 
 ipc.listenProxyError(proxyError => {
   log({
-    code: "unexpected-proxy-exit",
+    code: Code.UnexpectedProxyExit,
     message: "Proxy process exicted unexpectedly",
     details: { proxyError },
   });

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -80,9 +80,10 @@ export const fetchFollowing = (): void => {
 export const showNotificationsForFailedProjects = async (): Promise<void> => {
   const failedProjects = await project.fetchFailed();
   failedProjects.forEach(failedProject => {
-    error.show(
-      `The project ${failedProject.metadata.name} could not be loaded`,
-      failedProject
-    );
+    error.show({
+      code: "Project failed to load",
+      message: `The project ${failedProject.metadata.name} could not be loaded`,
+      details: failedProject,
+    });
   });
 };

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -81,7 +81,7 @@ export const showNotificationsForFailedProjects = async (): Promise<void> => {
   const failedProjects = await project.fetchFailed();
   failedProjects.forEach(failedProject => {
     error.show({
-      code: "project-request-failure",
+      code: error.Code.ProjectRequestFailure,
       message: `The project ${failedProject.metadata.name} could not be loaded`,
       details: failedProject,
     });

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -81,7 +81,7 @@ export const showNotificationsForFailedProjects = async (): Promise<void> => {
   const failedProjects = await project.fetchFailed();
   failedProjects.forEach(failedProject => {
     error.show({
-      code: "Project failed to load",
+      code: "project-request-failure",
       message: `The project ${failedProject.metadata.name} could not be loaded`,
       details: failedProject,
     });

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -88,7 +88,7 @@ const fetchSession = async (): Promise<void> => {
     }
 
     sessionStore.error({
-      code: "session-fetch-failure",
+      code: error.Code.SessionFetchFailure,
       message: "Failed to load the session",
       source: error.fromException(err),
     });

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -73,7 +73,6 @@ interface UpdateSettings extends event.Event<Kind> {
 type Msg = ClearCache | Fetch | UpdateSettings;
 
 const fetchSession = async (): Promise<void> => {
-  // return fetchSessionRetry().catch(sessionStore.error);
   try {
     const ses = await api.withRetry(() => api.get<SessionData>(`session`), 200);
     sessionStore.success({ status: Status.UnsealedSession, ...ses });


### PR DESCRIPTION
This change introduce structured error logging and applies it in a couple of places. Part of #1187.

The design of the `Error` interface is very similar to Rust errors and arises from the following needs:
* A stable identifier for errors (`code`)
* A message we can display to the user (`message`)
* Structured details that provide more information about the error (`details`)
* A stack trace if available (`stack`)
* Layering of error chains (`source`)

~~I’ve decided not to make `code` an enum. Having a centralized place that lists all errors does not help us with debugging. When debugging we need to look at the place where the error originated which can easily be found be grepping for the error code. In addition such a centralized place would make it more cumbersome to add new errors since the list of error would always need to be updated.~~

Errors are shown to the user as notifications (`error.show`). The error message is displayed to the user and the full error can be copied to the clipboard. In addition we also log the error to the console which allows us to debug it during development.

As a follow-up to this PR we will apply the error logging and showing in more places.