### PR TITLE
feat(ui): reduce number of retries after proxy restart

### DIFF
--- a/ui/Screen/Onboarding.svelte
+++ b/ui/Screen/Onboarding.svelte
@@ -44,7 +44,7 @@
       createIdentityInProgress = true;
       await session.createKeystore(passphrase);
       // Retry until the API is up
-      identity = await withRetry(() => createIdentity({ handle }), 200);
+      identity = await withRetry(() => createIdentity({ handle }), 100, 50);
       state = State.SuccessView;
     } catch (error) {
       animateBackward();

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -126,7 +126,7 @@ export const withRetry = async <T>(
     try {
       return await request();
     } catch (error) {
-      if (error.message !== "Failed to fetch" || retries > 0) {
+      if (error.message !== "Failed to fetch" || retries < 0) {
         throw error;
       }
     }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -119,13 +119,14 @@ const delay = (delay: number) => {
 
 export const withRetry = async <T>(
   request: () => Promise<T>,
-  delayTime: number
+  delayTime: number,
+  retries: number
 ): Promise<T> => {
-  for (let retries = 0; ; retries++) {
+  for (; ; retries--) {
     try {
       return await request();
     } catch (error) {
-      if (error.message !== "Failed to fetch" || retries > 200) {
+      if (error.message !== "Failed to fetch" || retries > 0) {
         throw error;
       }
     }

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -74,7 +74,7 @@ type Msg = ClearCache | Fetch | UpdateSettings;
 
 const fetchSessionRetry = async () => {
   return api
-    .withRetry(() => api.get<SessionData>(`session`), 200)
+    .withRetry(() => api.get<SessionData>(`session`), 100, 50)
     .then(ses =>
       sessionStore.success({ status: Status.UnsealedSession, ...ses })
     )


### PR DESCRIPTION
With #1153 the proxy restarts much quicker after the keystore is unsealed or created. This allows us to reduce the number of retries and fail earlier if the proxy does not start properly. (We now wait 5
seconds).

As part of this change we also adjust the signature of `withRetry`. Now the caller is able to control all timing related parameters.