### PR TITLE
chore(ui): bump twemoji dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,8 +143,8 @@
     "marked": "^1.1.1",
     "pure-svg-code": "^1.0.6",
     "timeago.js": "^4.0.2",
-    "twemoji": "^12.1.6",
-    "twemoji-svg-assets": "https://github.com/radicle-dev/twemoji-svg-assets.git#v12.1.6",
+    "twemoji": "13.0.1",
+    "twemoji-svg-assets": "https://github.com/radicle-dev/twemoji-svg-assets.git#v13.0.1",
     "validate.js": "^0.13.1"
   },
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7180,23 +7180,23 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twemoji-parser@12.1.3:
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-12.1.3.tgz#916c0153e77bd5f1011e7a99cbeacf52e43c9371"
-  integrity sha512-ND4LZXF4X92/PFrzSgGkq6KPPg8swy/U0yRw1k/+izWRVmq1HYi3khPwV3XIB6FRudgVICAaBhJfW8e8G3HC7Q==
+twemoji-parser@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-13.0.0.tgz#bd9d1b98474f1651dc174696b45cabefdfa405af"
+  integrity sha512-zMaGdskpH8yKjT2RSE/HwE340R4Fm+fbie4AaqjDa4H/l07YUmAvxkSfNl6awVWNRRQ0zdzLQ8SAJZuY5MgstQ==
 
-"twemoji-svg-assets@https://github.com/radicle-dev/twemoji-svg-assets.git#v12.1.6":
+"twemoji-svg-assets@https://github.com/radicle-dev/twemoji-svg-assets.git#v13.0.1":
   version "12.1.6"
-  resolved "https://github.com/radicle-dev/twemoji-svg-assets.git#1e0592f51ed08159cda6b4eb12c94598345544ad"
+  resolved "https://github.com/radicle-dev/twemoji-svg-assets.git#c80030e89ba7727181251536c514da2a1614115a"
 
-twemoji@^12.1.6:
-  version "12.1.6"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-12.1.6.tgz#3425427627a38ab5cae24e7690cecb691022479f"
-  integrity sha512-FIKi9Jne5IiDGDWekoANJ1a8ltUKVbJLEIR8XUpbFRDMqIPgLWnYgjeWZ1KOrdiTztRCAa9x4v+5w5OuiJOGVw==
+twemoji@13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-13.0.1.tgz#57ddc8bd86c8175c11376f5f9ab322a02e739c2d"
+  integrity sha512-mrTBq+XpCLM4zm76NJOjLHoQNV9mHdBt3Cba/T5lS1rxn8ArwpqE47mqTocupNlkvcLxoeZJjYSUW0DU5ZwqZg==
   dependencies:
     fs-extra "^8.0.1"
     jsonfile "^5.0.0"
-    twemoji-parser "12.1.3"
+    twemoji-parser "13.0.0"
     universalify "^0.1.2"
 
 type-check@^0.4.0, type-check@~0.4.0:


### PR DESCRIPTION
This also makes sure that the twemoji dependency is locked to a single
version, that is because we always need to update our twemoji-svg-assets
dependency in lock-step.

We get:
  - https://github.com/twitter/twemoji/releases/tag/v13.0.0
  - https://github.com/twitter/twemoji/releases/tag/v13.0.1

Remind everyone to run this after the PR is merged:
```
rm -rf public/twemoji/*.svg
rm -rf node_modules
yarn
```