### PR TITLE
fix(ui): remove unused props

### DIFF
--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -109,13 +109,12 @@
   ];
 
   const dropdownOptions1 = [
-    { variant: "text", value: "1", title: "Option 1" },
+    { value: "1", title: "Option 1" },
     {
-      variant: "text",
       value: "2",
       title: "Longer option keeps going",
     },
-    { variant: "text", value: "3", title: "Option 3" },
+    { value: "3", title: "Option 3" },
   ];
 
   const segmentedControlOptions = [
@@ -449,6 +448,7 @@
         <Input.Text
           placeholder="Enter user name"
           style="width: 100%"
+          showLeftItem={true}
           validation={{ status: ValidationStatus.Loading }}
           value="user123">
           <div slot="left">
@@ -459,10 +459,9 @@
 
       <Swatch>
         <Input.Text
-          avatarFallback={avatarFallback2}
           placeholder="Enter user name."
           style="width: 100%"
-          valid={false}
+          showLeftItem={true}
           validation={{ status: ValidationStatus.Error, message: 'Id already taken' }}
           value="myUser">
           <div slot="left">

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -205,7 +205,6 @@
                 <StyledCopyable value={seed} />
                 <Icon.Cross
                   on:click={() => removeSeed(seed)}
-                  variant="medium"
                   style="margin-left: 1.5rem; cursor:pointer;" />
               </div>
             {/each}


### PR DESCRIPTION
Removes some props that were leftover from older iterations from the design system guide and settings page which were causing warnings.

<img width="580" alt="Screenshot 2020-11-13 at 17 25 45" src="https://user-images.githubusercontent.com/16262137/99097467-f693a680-25d7-11eb-809d-ebceeb6b2102.png">
