### PR TITLE
fix(ui): improve error code for backend termination

### DIFF
--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -16,6 +16,7 @@ export interface Error {
 }
 
 export enum Code {
+  BackendTerminated = "BackendTerminated",
   CommitFetchFailure = "CommitFetchFailure",
   KeyStoreUnsealFailure = "KeyStoreUnsealFailure",
   LocalStateFetchFailure = "LocalStateFetchFailure",
@@ -25,7 +26,6 @@ export enum Code {
   RemoteStoreError = "RemoteStoreError",
   SessionFetchFailure = "SessionFetchFailure",
   SessionSettingsUpdateFailure = "SessionSettingsUpdateFailure",
-  UnexpectedProxyExit = "UnexpectedProxyExit",
   UnhandledError = "UnhandledError",
   UnhandledRejection = "UnhandledRejection",
   UnknownException = "UnknownException",
@@ -83,7 +83,7 @@ export const setFatal = (fatalError: FatalError): void => {
 
 ipc.listenProxyError(proxyError => {
   log({
-    code: Code.UnexpectedProxyExit,
+    code: Code.BackendTerminated,
     message: "Proxy process exited unexpectedly",
     details: { proxyError },
   });


### PR DESCRIPTION
We change the error code `UnexpectedProxyExit` to `BackendTerminated` as
discussed on the docs [1].

[1]: https://github.com/radicle-dev/radicle-docs/pull/21#discussion_r522785330