### PR TITLE
fix(ui): truncate notification messages to fit into view

### DIFF
--- a/ui/DesignSystem/Component/Notification.svelte
+++ b/ui/DesignSystem/Component/Notification.svelte
@@ -72,7 +72,7 @@
       style="margin-left: 8px; height: 24px" />
   {/if}
 
-  <p class="message">{message}</p>
+  <p class="message typo-overflow-ellipsis">{message}</p>
 
   {#if actionText}
     <div

--- a/ui/DesignSystem/Component/NotificationFaucet.svelte
+++ b/ui/DesignSystem/Component/NotificationFaucet.svelte
@@ -16,8 +16,8 @@
     position: fixed;
     bottom: 1.5rem;
     z-index: 1001;
-    left: 50%;
-    transform: translateX(-50%);
+    left: var(--sidebar-width);
+    width: calc(100vw - var(--sidebar-width));
   }
 </style>
 
@@ -25,6 +25,7 @@
   {#each $store as notification (notification.id)}
     <div
       data-cy="notification"
+      style="max-width: 95%;"
       animate:flip
       transition:blur={{ duration: 300 }}>
       <Notification


### PR DESCRIPTION
Closes #1266

Adds a max-width to the notifications and truncates the message if it is too long. Applies to all kinds of notifications.