### PR TITLE
fix(proxy): surf branches

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -193,6 +193,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +749,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
 name = "futures"
@@ -1287,7 +1305,7 @@ dependencies = [
  "minicbor",
  "multibase",
  "multihash",
- "nom",
+ "nom 5.1.2",
  "nonempty 0.5.0",
  "num_cpus",
  "percent-encoding 2.1.0",
@@ -1573,6 +1591,18 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4489ccc7d668957ddf64af7cd027c081728903afa6479d35da7e99bf5728f75f"
+dependencies = [
+ "bitvec",
  "lexical-core",
  "memchr",
  "version_check",
@@ -2031,18 +2061,24 @@ source = "git+https://github.com/radicle-dev/radicle-link.git?rev=e52b7867c39134
 
 [[package]]
 name = "radicle-surf"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb223cdd0832dcce4fdd8b654f322252e472e861957f79bb84297541a5ac1db9"
+checksum = "3657903d7f7f0680079bdcf7c965b930017f6428aee55eff0dade6510e04a40c"
 dependencies = [
  "either",
  "git2",
- "lazy_static",
+ "nom 6.0.0",
  "nonempty 0.5.0",
  "regex",
  "serde",
  "thiserror",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -2576,6 +2612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,6 +3149,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xml-rs"

--- a/proxy/coco/Cargo.toml
+++ b/proxy/coco/Cargo.toml
@@ -41,7 +41,7 @@ git = "https://github.com/radicle-dev/radicle-link.git"
 rev = "e52b7867c391343a176c0f9311f69607f9e6d3e3"
 
 [dependencies.radicle-surf]
-version = "0.5.0"
+version = "0.5"
 features = ["serialize"]
 
 [dev-dependencies]


### PR DESCRIPTION
There was an issue in `radicle-surf` where some branches would not parse correctly, for example `xla/handle-disconnect`.

This is now fixed in `surf` and pushed to crates.io as v0.5.1. So I relaxed the versioning in upstream so it's easier to get hot fixes like this in v0.5.