### PR TITLE
refactor(proxy): simplify `CreateRequest` control input

### DIFF
--- a/proxy/coco/src/peer/run_state/input.rs
+++ b/proxy/coco/src/peer/run_state/input.rs
@@ -66,7 +66,7 @@ pub enum Control {
     CreateRequest(
         RadUrn,
         Instant,
-        Option<oneshot::Sender<waiting_room::Created<Instant>>>,
+        oneshot::Sender<waiting_room::Created<Instant>>,
     ),
     /// Request a project search.
     GetRequest(RadUrn, oneshot::Sender<Option<SomeRequest<Instant>>>),

--- a/proxy/coco/src/peer/subroutines.rs
+++ b/proxy/coco/src/peer/subroutines.rs
@@ -125,7 +125,7 @@ impl Subroutines {
                             Input::Control(input::Control::ListRequests(sender))
                         },
                         control::Request::StartSearch(urn, time, sender) => {
-                            Input::Control(input::Control::CreateRequest(urn, time, Some(sender)))
+                            Input::Control(input::Control::CreateRequest(urn, time, sender))
                         },
                     })
                     .boxed(),


### PR DESCRIPTION
This is something I discovered while investigating #1279.

`input::Control::CreateRequest` now always holds a response sender instead of it being optional. The `None` case was only used in the tests and the variant is now aligned with the other `input::Control` variants.

This also allows us to simplify the tests. We remove any assertions on the command output being empty,