### PR TITLE
refactor(ui): change checkout button copy

### DIFF
--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -43,6 +43,10 @@
     selectPeer(peer);
   };
 
+  const isContributor = (userUrn: Urn, users: User[]): boolean => {
+    return users.map(u => u.identity.urn).includes(userUrn);
+  };
+
   // Initialise the screen by fetching the project and associated data.
   fetch(urn);
 </script>
@@ -70,6 +74,9 @@
         </div>
       </div>
     </Header.Large>
-    <Source {project} {selectedPeer} />
+    <Source
+      {project}
+      {selectedPeer}
+      isContributor={isContributor(session.identity.urn, peerSelection)} />
   </Remote>
 </SidebarLayout>

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -4,7 +4,7 @@
 
   import * as modal from "../src/modal";
   import * as path from "../src/path";
-  import { isMaintainer } from "../src/project";
+  import { isMaintainer, isContributor } from "../src/project";
   import type { User } from "../src/project";
   import { fetch, selectPeer, store } from "../src/screen/project";
   import type { UnsealedSession } from "../src/session";
@@ -43,10 +43,6 @@
     selectPeer(peer);
   };
 
-  const isContributor = (userUrn: Urn, users: User[]): boolean => {
-    return users.map(u => u.identity.urn).includes(userUrn);
-  };
-
   // Initialise the screen by fetching the project and associated data.
   fetch(urn);
 </script>
@@ -77,6 +73,6 @@
     <Source
       {project}
       {selectedPeer}
-      isContributor={isContributor(session.identity.urn, peerSelection)} />
+      isContributor={isContributor(peerSelection)} />
   </Remote>
 </SidebarLayout>

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -31,6 +31,7 @@
 
   export let project: Project;
   export let selectedPeer: User;
+  export let isContributor: boolean;
 
   const routes = {
     "/projects/:urn/source/code": Code,
@@ -109,6 +110,7 @@
     </div>
     <div slot="right">
       <CheckoutButton
+        {isContributor}
         on:checkout={ev => onCheckout(ev, project, selectedPeer)} />
     </div>
   </ActionBar>

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -110,7 +110,7 @@
     </div>
     <div slot="right">
       <CheckoutButton
-        {isContributor}
+        fork={!isContributor}
         on:checkout={ev => onCheckout(ev, project, selectedPeer)} />
     </div>
   </ActionBar>

--- a/ui/Screen/Project/Source/CheckoutButton.svelte
+++ b/ui/Screen/Project/Source/CheckoutButton.svelte
@@ -7,11 +7,16 @@
 
   import { dismissRemoteHelperHint, settings } from "../../../src/session.ts";
 
-  export let isContributor = false;
+  // Whether this button should be displayed as a "Fork" button.
+  export let fork = false;
 
   let checkoutPath;
   let expanded = false;
-  const caption = isContributor ? "Checkout" : "Fork";
+
+  const caption = fork ? "Fork" : "Checkout";
+  const helpText = fork
+    ? "Fork this project and checkout a working copy."
+    : "Checkout a working copy to your local disk.";
 
   const dispatch = createEventDispatcher();
   const hide = () => (expanded = false);
@@ -41,11 +46,7 @@
 
 <Overlay {expanded} on:hide={hide}>
   <div class="clone-dropdown" hidden={!expanded}>
-    <p style="margin-bottom: 0.5rem;">
-      {#if isContributor}
-        Checkout a working copy to your local disk.
-      {:else}Fork this project and checkout a working copy.{/if}
-    </p>
+    <p style="margin-bottom: 0.5rem;">{helpText}</p>
 
     <Input.Directory
       style="margin-bottom: 0.5rem;"
@@ -53,7 +54,7 @@
       buttonVariant="outline"
       bind:path={checkoutPath} />
 
-    {#if !isContributor}
+    {#if fork}
       <p>
         Your fork will be published under your identity, and visible to the
         network.
@@ -83,7 +84,7 @@
 
   <Button
     variant="transparent"
-    icon={isContributor ? Icon.ArrowBoxUpRight : Icon.Fork}
+    icon={fork ? Icon.Fork : Icon.ArrowBoxUpRight}
     on:click={toggleDropdown}
     dataCy="checkout-modal-toggle">
     {caption}

--- a/ui/Screen/Project/Source/CheckoutButton.svelte
+++ b/ui/Screen/Project/Source/CheckoutButton.svelte
@@ -7,8 +7,11 @@
 
   import { dismissRemoteHelperHint, settings } from "../../../src/session.ts";
 
+  export let isContributor = false;
+
   let checkoutPath;
   let expanded = false;
+  const caption = isContributor ? "Checkout" : "Fork";
 
   const dispatch = createEventDispatcher();
   const hide = () => (expanded = false);
@@ -39,7 +42,9 @@
 <Overlay {expanded} on:hide={hide}>
   <div class="clone-dropdown" hidden={!expanded}>
     <p style="margin-bottom: 0.5rem;">
-      Checkout a working copy to your local disk
+      {#if isContributor}
+        Checkout a working copy to your local disk.
+      {:else}Fork this project and checkout a working copy.{/if}
     </p>
 
     <Input.Directory
@@ -47,6 +52,13 @@
       placeholder="~/path/to/folder"
       buttonVariant="outline"
       bind:path={checkoutPath} />
+
+    {#if !isContributor}
+      <p>
+        Your fork will be published under your identity, and visible to the
+        network.
+      </p>
+    {/if}
 
     {#if $settings.appearance.hints.showRemoteHelper}
       <RemoteHelperHint on:hide={dismissRemoteHelperHint} />
@@ -64,16 +76,16 @@
         disabled={!checkoutPath}
         variant="secondary"
         style="margin-top: 1rem; width: 100%; display: block; text-align: center;">
-        Checkout
+        {caption}
       </Button>
     </Tooltip>
   </div>
 
   <Button
     variant="transparent"
-    icon={Icon.ArrowBoxUpRight}
+    icon={isContributor ? Icon.ArrowBoxUpRight : Icon.Fork}
     on:click={toggleDropdown}
     dataCy="checkout-modal-toggle">
-    Checkout
+    {caption}
   </Button>
 </Overlay>

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -408,3 +408,12 @@ export const repositoryPathValidationStore = (
 export const isMaintainer = (userUrn: Urn, project: Project): boolean => {
   return project.metadata.maintainers.includes(userUrn);
 };
+
+// Checks if any of the contributors in the list is the current user.
+export const isContributor = (users: User[]): boolean => {
+  return !!users.find(
+    u =>
+      u.type === PeerType.Local &&
+      (u.role === Role.Maintainer || u.role == Role.Contributor)
+  );
+};


### PR DESCRIPTION
Make it depend on whether we are a contributor already or not (ie. whether we already have a fork).

Closes #1239 

Looks like this now, if you don't already have a fork (otherwise looks the same as before):

![2020-11-19-184153_444x315_scrot](https://user-images.githubusercontent.com/40774/99703044-eaf02600-2a96-11eb-9bbf-d32d7f79725d.png)
