### PR TITLE
fix(ui): don't show stats that equal zero

### DIFF
--- a/ui/DesignSystem/Component/Header/Large.svelte
+++ b/ui/DesignSystem/Component/Header/Large.svelte
@@ -108,19 +108,25 @@
         {/if}
         {#if stats}
           <div class="project-stats" data-cy="project-stats">
-            <div class="project-stat-item">
-              <Icon.Branch />
-              <p>
-                {stats.branches === 1 ? `1 Branch` : `${stats.branches} Branches`}
-              </p>
-            </div>
-            <span class="typo-mono-bold project-stat-separator">•</span>
-            <div class="project-stat-item">
-              <Icon.User />
-              <p>
-                {stats.contributors === 1 ? `1 Contributor` : `${stats.contributors} Contributors`}
-              </p>
-            </div>
+            {#if stats.branches > 0}
+              <div class="project-stat-item">
+                <Icon.Branch />
+                <p>
+                  {stats.branches === 1 ? `1 Branch` : `${stats.branches} Branches`}
+                </p>
+              </div>
+            {/if}
+            {#if stats.branches > 0 && stats.contributors > 0}
+              <span class="typo-mono-bold project-stat-separator">•</span>
+            {/if}
+            {#if stats.contributors > 0}
+              <div class="project-stat-item">
+                <Icon.User />
+                <p>
+                  {stats.contributors === 1 ? `1 Contributor` : `${stats.contributors} Contributors`}
+                </p>
+              </div>
+            {/if}
           </div>
         {/if}
       </div>

--- a/ui/DesignSystem/Component/Header/Large.svelte
+++ b/ui/DesignSystem/Component/Header/Large.svelte
@@ -108,7 +108,7 @@
         {/if}
         {#if stats}
           <div class="project-stats" data-cy="project-stats">
-            {#if stats.branches > 0}
+            {#if stats && stats.branches > 0}
               <div class="project-stat-item">
                 <Icon.Branch />
                 <p>
@@ -116,10 +116,10 @@
                 </p>
               </div>
             {/if}
-            {#if stats.branches > 0 && stats.contributors > 0}
+            {#if stats && stats.branches > 0 && stats.contributors > 0}
               <span class="typo-mono-bold project-stat-separator">•</span>
             {/if}
-            {#if stats.contributors > 0}
+            {#if stats && stats.contributors > 0}
               <div class="project-stat-item">
                 <Icon.User />
                 <p>

--- a/ui/DesignSystem/Component/Stats.svelte
+++ b/ui/DesignSystem/Component/Stats.svelte
@@ -37,10 +37,12 @@
 
 <div class="stats" {style}>
   {#each formattedStats as stat}
-    <span class="stat">
-      <svelte:component this={stat.icon} style="margin-right: 4px;" />
-      <p class="typo-text-mono-bold">{stat.count}</p>
-      <slot />
-    </span>
+    {#if stat.count > 0}
+      <span class="stat">
+        <svelte:component this={stat.icon} style="margin-right: 4px;" />
+        <p class="typo-text-mono-bold">{stat.count}</p>
+        <slot />
+      </span>
+    {/if}
   {/each}
 </div>


### PR DESCRIPTION
This is a workaround for #1223, until we figure out the underlying issue in surf.

- missing branches in project screen
  <img width="1552" alt="Screenshot 2020-11-20 at 06 12 22" src="https://user-images.githubusercontent.com/158411/99761902-8f09b980-2af7-11eb-88f1-4500ead2b315.png">
- missing branches in "Following" tab
  <img width="1552" alt="Screenshot 2020-11-20 at 06 13 03" src="https://user-images.githubusercontent.com/158411/99761909-9335d700-2af7-11eb-8a1b-005c9a4b9ecd.png">
- all stats available in "Following" tab
  <img width="1552" alt="Screenshot 2020-11-20 at 06 13 14" src="https://user-images.githubusercontent.com/158411/99761911-93ce6d80-2af7-11eb-93d3-3aa8282c8cbd.png">
- all stats available in project screen
  <img width="1552" alt="Screenshot 2020-11-20 at 06 13 18" src="https://user-images.githubusercontent.com/158411/99761912-94670400-2af7-11eb-8bc5-287a7edce943.png">
