### PR TITLE
refactor(ui): remove expand icon from dropdown items

### DIFF
--- a/ui/Screen/Project/PeerSelector.svelte
+++ b/ui/Screen/Project/PeerSelector.svelte
@@ -90,7 +90,7 @@
   .peer {
     display: flex;
     color: var(--color-foreground-level-6);
-    padding: 0 0.5rem;
+    padding: 0 2.5rem 0 0.5rem;
     height: 2.5rem;
     user-select: none;
     align-items: center;

--- a/ui/Screen/Project/PeerSelector.svelte
+++ b/ui/Screen/Project/PeerSelector.svelte
@@ -200,9 +200,6 @@
                 <Icon.ArrowBoxUpRight />
               </div>
             </Tooltip>
-          {:else}
-            <Icon.ChevronUpDown
-              style="margin-left: 0.5rem; vertical-align: bottom; fill: var(--color-foreground-level-4)" />
           {/if}
         </div>
       {/each}


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-upstream/issues/1289

| content narrower than header | content wider than header|
|---------------------------|-------------------------------|
| ![one](https://user-images.githubusercontent.com/158411/99766929-663af180-2b02-11eb-9aed-3568eacef715.gif) | ![two](https://user-images.githubusercontent.com/158411/99766942-6affa580-2b02-11eb-8a8c-dc7a197c2f23.gif) |

~~Optionally we could add~~ I added a fixed padding to avoid the dropdown from "jumping" when the content is narrower than the header:

| content narrower than header | content wider than header|
|---------------------------|-------------------------------|
| ![pad-one](https://user-images.githubusercontent.com/158411/99767195-ef522880-2b02-11eb-8e30-84eb0ac252b7.gif) | ![pad-two](https://user-images.githubusercontent.com/158411/99767201-f1b48280-2b02-11eb-8f1e-693ac818ec25.gif) |

```diff
diff --git a/ui/Screen/Project/PeerSelector.svelte b/ui/Screen/Project/PeerSelector.svelte
index 8355bf56..dccda34e 100644
--- a/ui/Screen/Project/PeerSelector.svelte
+++ b/ui/Screen/Project/PeerSelector.svelte
@@ -90,7 +90,7 @@
   .peer {
     display: flex;
     color: var(--color-foreground-level-6);
-    padding: 0 0.5rem;
+    padding: 0 2.5rem 0 0.5rem;
     height: 2.5rem;
     user-select: none;
     align-items: center;
```