### PR TITLE
fix(ui): increase clickable are in sidebar

### DIFF
--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -142,7 +142,7 @@
       class="item indicator"
       data-cy="settings"
       class:active={path.active(path.settings(), $location)}>
-      <Tooltip value="Settings">
+      <Tooltip value="Settings" style="width: 100%; height: 100%">
         <a href={path.settings()} use:link>
           <Icon.Settings />
         </a>

--- a/ui/DesignSystem/Component/Tooltip.svelte
+++ b/ui/DesignSystem/Component/Tooltip.svelte
@@ -3,7 +3,7 @@
   import { calculatePosition, Visibility } from "../../src/tooltip";
 
   export let value = "";
-
+  export let style = "";
   export let position: CSSPosition = CSSPosition.Right;
 
   let container: Element | null = null;
@@ -93,6 +93,7 @@
   <div
     bind:this={container}
     data-cy="tooltip"
+    {style}
     on:mouseenter={show}
     on:mouseleave={hide}>
     <slot />


### PR DESCRIPTION
We increase the clickable area in the sidebar so that it cover the whole
`li` element. The `li` element provides the affordance via the hover
style and the cursor pointer.