### PR TITLE
build: rename binary to "Radicle Upstream"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "radicle-upstream",
+  "productName": "Radicle Upstream",
   "version": "0.0.17",
   "author": {
     "name": "radicle team",
@@ -14,6 +15,7 @@
   },
   "build": {
     "appId": "radicle-upstream.monadic.xyz",
+    "artifactName": "${name}-${version}.${ext}",
     "files": [
       "public/**/*",
       "native/**/*"


### PR DESCRIPTION
This renames the app binary from `radicle-upstream` to `Radicle Upstream`.
The package filename remains unchanged.

Refs: https://github.com/radicle-dev/radicle-docs/pull/26#discussion_r527079630.

<img width="652" alt="Screenshot 2020-11-20 at 08 54 32" src="https://user-images.githubusercontent.com/158411/99774992-dbacbf00-2b0e-11eb-8e41-f37aeba2873f.png">