### PR TITLE
fix(proxy): return tracking remotes as contributor

### DIFF
--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -622,7 +622,7 @@ impl State {
                         if project.maintainers().contains(&user.urn()) {
                             peer::Status::replicated(peer::Role::Maintainer, user)
                         } else {
-                            peer::Status::replicated(peer::Role::Tracker, user)
+                            peer::Status::replicated(peer::Role::Contributor, user)
                         }
                     } else {
                         peer::Status::NotReplicated


### PR DESCRIPTION
Since #1080 constrainted the peer list correctly we had to fix the
incorrect role assigned. Can't think of a case where the remote peer can
be of type `Tracker` at this point.

Fixes #1297