### PR TITLE
chore: git-ignore ./sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cypress/fixtures/example.json
 cypress/workspace
 proxy/**/target
 proxy/**/*.rs.bk
+sandbox


### PR DESCRIPTION
We use the `sandbox` for local development artifacts in [`feat/funding`](#975), where it is git-ignored. At the moment, we place a `.local-ethereum-account` in there with the environment dev address in use for development/playing around. Calling it `sandbox` seemed both appropriate and generic enough to use for other needs.

It would be handy to have it already git-ignored on master to avoid having to move it in and out of the repository every time I switch branches.

