### PR TITLE
refactor(proxy): Avoid confusing errors in http route matching

### DIFF
--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -20,6 +20,7 @@ fn create_project_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("create-project")
+        .and(warp::post())
         .and(super::with_context_unsealed(ctx.clone()))
         .and(super::with_owner_guard(ctx))
         .and(warp::body::json())
@@ -31,6 +32,7 @@ fn reset_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("reset")
+        .and(warp::get())
         .and(super::with_context(ctx))
         .and_then(handler::reset)
 }
@@ -40,6 +42,7 @@ fn seal_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("seal")
+        .and(warp::get())
         .and(super::with_context(ctx))
         .and_then(handler::seal)
 }

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -17,8 +17,9 @@ pub fn filters(ctx: context::Context) -> BoxedFilter<(impl Reply,)> {
 fn create_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    http::with_context_unsealed(ctx)
+    path::end()
         .and(warp::post())
+        .and(http::with_context_unsealed(ctx))
         .and(warp::body::json())
         .and_then(handler::create)
 }
@@ -27,9 +28,10 @@ fn create_filter(
 fn get_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    http::with_context_unsealed(ctx)
+    path::param::<coco::Urn>()
+        .and(warp::path::end())
         .and(warp::get())
-        .and(path::param::<coco::Urn>())
+        .and(http::with_context_unsealed(ctx))
         .and_then(handler::get)
 }
 
@@ -37,9 +39,9 @@ fn get_filter(
 fn list_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    http::with_context_unsealed(ctx)
+    path::end()
+        .and(http::with_context_unsealed(ctx))
         .and(warp::get())
-        .and(path::end())
         .and_then(handler::list)
 }
 
@@ -68,7 +70,7 @@ mod handler {
     }
 
     /// Get the [`identity::Identity`] for the given `id`.
-    pub async fn get(ctx: context::Unsealed, id: coco::Urn) -> Result<impl Reply, Rejection> {
+    pub async fn get(id: coco::Urn, ctx: context::Unsealed) -> Result<impl Reply, Rejection> {
         let id = identity::get(&ctx.state, id.clone()).await?;
         Ok(reply::json(&id))
     }

--- a/proxy/api/src/http/project/request.rs
+++ b/proxy/api/src/http/project/request.rs
@@ -16,10 +16,10 @@ pub fn filters(ctx: context::Context) -> BoxedFilter<(impl Reply,)> {
 fn cancel_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    http::with_context_unsealed(ctx)
-        .and(warp::delete())
-        .and(path::param::<coco::Urn>())
+    path::param::<coco::Urn>()
         .and(path::end())
+        .and(http::with_context_unsealed(ctx))
+        .and(warp::delete())
         .and_then(handler::cancel)
 }
 
@@ -27,10 +27,10 @@ fn cancel_filter(
 fn create_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    http::with_context_unsealed(ctx)
-        .and(warp::put())
-        .and(path::param::<coco::Urn>())
+    path::param::<coco::Urn>()
         .and(path::end())
+        .and(warp::put())
+        .and(http::with_context_unsealed(ctx))
         .and_then(handler::create)
 }
 
@@ -38,9 +38,9 @@ fn create_filter(
 fn list_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    http::with_context_unsealed(ctx)
+    path::end()
         .and(warp::get())
-        .and(path::end())
+        .and(http::with_context_unsealed(ctx))
         .and_then(handler::list)
 }
 
@@ -54,8 +54,8 @@ mod handler {
 
     /// Abort search for an ongoing request.
     pub async fn cancel(
-        mut ctx: context::Unsealed,
         urn: coco::Urn,
+        mut ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
         ctx.peer_control
             .cancel_project_request(&urn, Instant::now())
@@ -70,8 +70,8 @@ mod handler {
     /// FIXME(xla): Endpoint ought to return `201` if the request was newly created, otherwise
     /// `200` if there was a request present for the urn.
     pub async fn create(
-        mut ctx: context::Unsealed,
         urn: coco::Urn,
+        mut ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
         let request = ctx.peer_control.request_project(&urn, Instant::now()).await;
 

--- a/proxy/api/src/http/session.rs
+++ b/proxy/api/src/http/session.rs
@@ -15,8 +15,8 @@ pub fn filters(ctx: context::Context) -> BoxedFilter<(impl Reply,)> {
 fn get_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    warp::get()
-        .and(path::end())
+    path::end()
+        .and(warp::get())
         .and(http::with_context(ctx))
         .and_then(handler::get)
 }
@@ -26,8 +26,8 @@ fn update_settings_filter(
     ctx: context::Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path("settings")
-        .and(warp::post())
         .and(path::end())
+        .and(warp::post())
         .and(http::with_context_unsealed(ctx))
         .and(warp::body::json())
         .and_then(handler::update_settings)


### PR DESCRIPTION
We apply the following rules to the order of HTTP routing filters:

1. Path matchers come first
2. Path matchers must be terminated with `path::end()` or `path::tail()`
3. Method matchers come after path matchers
4. State guards (like `with_unsealed_context`) come after method matchers.

This prevents the following issues:

* We always get a 404 when a path does not match. Without the proper ordering we could get a 405 (method not allowed) or a 403 (not authorized) which would mask the fact that the path was wrong.
* We run the expensive state guards at most once per request since the path-method combination is now uniquely matched. Before, if the state guard was at the beginning we would run it for every route that was combined with `or`.
* We enforce exact matches on paths so that we don’t have redundant segments in our path. Before, for example, `/projects/<urn>/checkout/garbage` was matched.