### PR TITLE
fix(ui) fix BSOD overflow scroll bug

### DIFF
--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -3,7 +3,6 @@
   import type * as svelteStore from "svelte/store";
 
   import { Button, Emoji, Icon } from "../DesignSystem/Primitive";
-  import { Fullscreen } from "../DesignSystem/Component";
 
   import * as notification from "../src/notification";
   import * as ipc from "../src/ipc";
@@ -38,6 +37,18 @@
   }
 
   .container {
+    background-color: var(--color-secondary);
+    height: 100vh;
+    width: 100vw;
+    position: fixed;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: scroll;
+  }
+
+  .content {
     height: 100%;
     padding: 5rem;
 
@@ -47,6 +58,7 @@
     flex-direction: column;
     color: #fff; /* I know... but this design doesn't work in dark mode. */
   }
+
   .proxy-log-container {
     background: #e3e3ff;
 
@@ -72,10 +84,8 @@
 </style>
 
 {#if $fatalError !== null}
-  <Fullscreen
-    escapable={false}
-    style="background-color: var(--color-secondary); z-index: 200;">
-    <div class="container" data-cy="blue-screen-of-death">
+  <div class="container">
+    <div class="content" data-cy="blue-screen-of-death">
       <Emoji emoji="🧻" size="huge" style="margin-bottom: 1.5rem;" />
       <p style="width: 321px; text-align: center">
         {#if $fatalError.kind === 'SESSION'}
@@ -104,5 +114,5 @@
         </div>
       {/if}
     </div>
-  </Fullscreen>
+  </div>
 {/if}


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-upstream/issues/1337.

For testing use this diff, clicking on any copyable link will open the BSOD:
```diff
diff --git a/native/main.ts b/native/main.ts
index 1b55c15c..4f5dde50 100644
--- a/native/main.ts
+++ b/native/main.ts
@@ -111,6 +111,16 @@ ipcMain.handle(RendererMessage.DIALOG_SHOWOPENDIALOG, async () => {
 });

 ipcMain.handle(RendererMessage.CLIPBOARD_WRITETEXT, async (_event, text) => {
+  console.log("PROXY_ERRRO sending");
+  windowManager.sendMessage({
+    kind: MainMessageKind.PROXY_ERROR,
+    data: {
+      status: 1,
+      signal: null,
+      stdout: "STDOUT",
+      stderr: "STDERR",
+    },
+  });
   clipboard.writeText(text);
 });
```
![fix](https://user-images.githubusercontent.com/158411/100218101-8f99ba00-2f14-11eb-9de4-1df5ddb4f1b6.gif)
