### PR TITLE
fix(proxy): only save most recent logs from proxy

### DIFF
--- a/cypress/integration/routing.spec.ts
+++ b/cypress/integration/routing.spec.ts
@@ -63,17 +63,16 @@ context("routing", () => {
           data: {
             status: 1,
             signal: null,
-            stdout: "STDOUT",
-            stderr: "STDERR",
+            output: "OUTPUT",
           },
         });
       });
       commands.pick("blue-screen-of-death").should("exist");
-      commands.pick("proxy-log").should("contain", "STDERR");
+      commands.pick("proxy-log").should("contain", "OUTPUT");
       commands.pick("proxy-log-copy-clipboard").click();
 
       ipcStub.getStubs().then(stubs => {
-        expect(stubs.getClipboard()).to.eq("STDERR");
+        expect(stubs.getClipboard()).to.eq("OUTPUT");
       });
     });
 
@@ -85,17 +84,16 @@ context("routing", () => {
           data: {
             status: 1,
             signal: null,
-            stdout: "STDOUT",
-            stderr: "STDERR",
+            output: "OUTPUT",
           },
         });
       });
       commands.pick("blue-screen-of-death").should("exist");
-      commands.pick("proxy-log").should("contain", "STDERR");
+      commands.pick("proxy-log").should("contain", "OUTPUT");
       commands.pick("proxy-log-copy-clipboard").click();
 
       ipcStub.getStubs().then(stubs => {
-        expect(stubs.getClipboard()).to.eq("STDERR");
+        expect(stubs.getClipboard()).to.eq("OUTPUT");
       });
     });
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  roots: ["<rootDir>/ui/src"],
+  roots: ["<rootDir>/ui/src", "<rootDir>/native"],
   transform: {
     "^.+\\.ts$": "ts-jest",
   },

--- a/native/ipc-types.ts
+++ b/native/ipc-types.ts
@@ -12,8 +12,7 @@ export enum MainMessageKind {
 export interface ProxyError {
   status: number | null;
   signal: NodeJS.Signals | null;
-  stdout: string;
-  stderr: string;
+  output: string;
 }
 
 // Message kinds sent from the renderer to the main process.

--- a/native/main.ts
+++ b/native/main.ts
@@ -7,7 +7,7 @@ import {
   shell,
 } from "electron";
 import path from "path";
-import { execFile, ChildProcess } from "child_process";
+import { ProxyProcessManager } from "./proxy-process-manager";
 import { RendererMessage, MainMessage, MainMessageKind } from "./ipc-types";
 
 const isDev = process.env.NODE_ENV === "development";
@@ -91,7 +91,7 @@ class WindowManager {
 }
 
 const windowManager = new WindowManager();
-let proxyProcess: ChildProcess | undefined;
+const proxyProcessManager = new ProxyProcessManager(proxyPath, [], !isDev);
 
 ipcMain.handle(RendererMessage.DIALOG_SHOWOPENDIALOG, async () => {
   const window = windowManager.window;
@@ -145,50 +145,25 @@ const openExternalLink = (url: string): void => {
   }
 };
 
-const startProxy = () => {
-  if (isDev) {
-    return;
-  }
-
-  proxyProcess = execFile(proxyPath, [], (error, stdout, stderr) => {
-    let status = null;
-    let signal = null;
-    if (error) {
-      status = error.code === undefined ? null : error.code;
-      signal = error.signal === undefined ? null : error.signal;
-    } else {
-      status = 0;
-    }
-
-    console.error(
-      "Proxy process exited with status code %s and signal %s",
-      status,
-      signal
-    );
-
-    windowManager.sendMessage({
-      kind: MainMessageKind.PROXY_ERROR,
-      data: {
-        status,
-        signal,
-        stdout,
-        stderr,
-      },
-    });
-  });
-};
-
 app.on("will-quit", () => {
-  if (proxyProcess) {
-    proxyProcess.kill();
-  }
+  proxyProcessManager.kill();
 });
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on("ready", () => {
-  startProxy();
+  proxyProcessManager.run().then(({ status, signal, output: stdout }) => {
+    windowManager.sendMessage({
+      kind: MainMessageKind.PROXY_ERROR,
+      data: {
+        status,
+        signal,
+        stdout,
+        stderr: "",
+      },
+    });
+  });
 
   if (isDev) {
     setupWatcher();

--- a/native/main.ts
+++ b/native/main.ts
@@ -91,7 +91,12 @@ class WindowManager {
 }
 
 const windowManager = new WindowManager();
-const proxyProcessManager = new ProxyProcessManager(proxyPath, [], !isDev);
+const proxyProcessManager = new ProxyProcessManager({
+  proxyPath,
+  proxyArgs: [],
+  enabled: !isDev,
+  lineLimit: 500,
+});
 
 ipcMain.handle(RendererMessage.DIALOG_SHOWOPENDIALOG, async () => {
   const window = windowManager.window;

--- a/native/main.ts
+++ b/native/main.ts
@@ -153,14 +153,13 @@ app.on("will-quit", () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on("ready", () => {
-  proxyProcessManager.run().then(({ status, signal, output: stdout }) => {
+  proxyProcessManager.run().then(({ status, signal, output }) => {
     windowManager.sendMessage({
       kind: MainMessageKind.PROXY_ERROR,
       data: {
         status,
         signal,
-        stdout,
-        stderr: "",
+        output,
       },
     });
   });

--- a/native/proxy-process-manager.test.ts
+++ b/native/proxy-process-manager.test.ts
@@ -1,0 +1,52 @@
+import * as lodash from "lodash";
+import { ProxyProcessManager } from "./proxy-process-manager";
+
+["stdout", "stderr"].forEach(output => {
+  it(`collects and writes ${output}`, async () => {
+    const redirection = output == "stderr" ? "1>&2" : "";
+    const manager = new ProxyProcessManager(
+      "sh",
+      [
+        "-c",
+        `x=0; while [ $x -lt 300 ]; do echo "$x" ${redirection}; : $(( x++ )); done`,
+      ],
+      true
+    );
+
+    let processOutput = "";
+    const outputStream = output === "stdout" ? process.stdout : process.stderr;
+    const write = jest
+      .spyOn(outputStream, "write")
+      .mockImplementation(chunk => {
+        processOutput += chunk;
+        return true;
+      });
+    const result = await manager.run();
+    write.mockRestore();
+
+    expect(result.status).toBe(0);
+
+    const lines = result.output.split("\n");
+
+    expect(lines.length).toBe(200);
+
+    expect(lines[0]).toBe("100");
+    expect(lines.pop()).toBe("299");
+
+    expect(processOutput).toEqual(`${lodash.range(0, 300).join("\n")}\n`);
+  });
+});
+
+it("returns exit code", async () => {
+  const manager = new ProxyProcessManager("sh", ["-c", "exit 50"], true);
+  const result = await manager.run();
+  expect(result.status).toBe(50);
+});
+
+it("returns the signal", async () => {
+  const manager = new ProxyProcessManager("sleep", ["1"], true);
+  const resultPromise = manager.run();
+  manager.kill();
+  const result = await resultPromise;
+  expect(result.signal).toBe("SIGTERM");
+});

--- a/native/proxy-process-manager.test.ts
+++ b/native/proxy-process-manager.test.ts
@@ -4,14 +4,15 @@ import { ProxyProcessManager } from "./proxy-process-manager";
 ["stdout", "stderr"].forEach(output => {
   it(`collects and writes ${output}`, async () => {
     const redirection = output == "stderr" ? "1>&2" : "";
-    const manager = new ProxyProcessManager(
-      "sh",
-      [
+    const manager = new ProxyProcessManager({
+      proxyPath: "sh",
+      proxyArgs: [
         "-c",
-        `x=0; while [ $x -lt 300 ]; do echo "$x" ${redirection}; x=$(( x + 1 )); done`,
+        `x=0; while [ $x -lt 30 ]; do echo "$x" ${redirection}; x=$(( x + 1 )); done`,
       ],
-      true
-    );
+      enabled: true,
+      lineLimit: 20,
+    });
 
     let processOutput = "";
     const outputStream = output === "stdout" ? process.stdout : process.stderr;
@@ -28,23 +29,33 @@ import { ProxyProcessManager } from "./proxy-process-manager";
 
     const lines = result.output.split("\n");
 
-    expect(lines.length).toBe(200);
+    expect(lines.length).toBe(20);
 
-    expect(lines[0]).toBe("100");
-    expect(lines.pop()).toBe("299");
+    expect(lines[0]).toBe("10");
+    expect(lines.pop()).toBe("29");
 
-    expect(processOutput).toEqual(`${lodash.range(0, 300).join("\n")}\n`);
+    expect(processOutput).toEqual(`${lodash.range(0, 30).join("\n")}\n`);
   });
 });
 
 it("returns exit code", async () => {
-  const manager = new ProxyProcessManager("sh", ["-c", "exit 50"], true);
+  const manager = new ProxyProcessManager({
+    proxyPath: "sh",
+    proxyArgs: ["-c", "exit 50"],
+    enabled: true,
+    lineLimit: 1,
+  });
   const result = await manager.run();
   expect(result.status).toBe(50);
 });
 
 it("returns the signal", async () => {
-  const manager = new ProxyProcessManager("sleep", ["1"], true);
+  const manager = new ProxyProcessManager({
+    proxyPath: "sleep",
+    proxyArgs: ["1"],
+    enabled: true,
+    lineLimit: 1,
+  });
   const resultPromise = manager.run();
   manager.kill();
   const result = await resultPromise;

--- a/native/proxy-process-manager.test.ts
+++ b/native/proxy-process-manager.test.ts
@@ -8,7 +8,7 @@ import { ProxyProcessManager } from "./proxy-process-manager";
       "sh",
       [
         "-c",
-        `x=0; while [ $x -lt 300 ]; do echo "$x" ${redirection}; : $(( x++ )); done`,
+        `x=0; while [ $x -lt 300 ]; do echo "$x" ${redirection}; x=$(( x + 1 )); done`,
       ],
       true
     );

--- a/native/proxy-process-manager.ts
+++ b/native/proxy-process-manager.ts
@@ -1,0 +1,108 @@
+import { spawn, ChildProcess } from "child_process";
+import { CircularBuffer } from "mnemonist";
+
+export interface ProcessResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  // The last 200 lines of stdout and stderr combined.
+  output: string;
+}
+
+// The `ProxyProcessManager` runs and kills the proxy process and allows us to
+// obtain the process result when the process exits.
+//
+// Stdout and stderr of the child process are forwarded to stdout and
+// stderr of this process. The lines of both these streams are also
+// written to a circular buffer with a capacity of 200 lines.
+export class ProxyProcessManager {
+  private childProcess: ChildProcess | undefined;
+  private proxyPath: string;
+  private proxyArgs: string[];
+  private enabled: boolean;
+
+  // Create a new ProxyProcessManager.
+  //
+  // `proxyPath` is the path to the executable and `proxyArgs` are the command
+  // line arguments.
+  //
+  // If `enabled` is set to false no proxy, is started and `run()` never
+  // finishes.
+  constructor(proxyPath: string, proxyArgs: string[], enabled: boolean) {
+    this.proxyPath = proxyPath;
+    this.proxyArgs = proxyArgs;
+    this.enabled = enabled;
+  }
+
+  // Run the proxy process and return `ProcessResult` when it exits.
+  //
+  // Throws an error if a process is already running.
+  async run(): Promise<ProcessResult> {
+    if (!this.enabled) {
+      return new Promise(() => undefined);
+    }
+
+    if (this.childProcess !== undefined) {
+      throw new Error("Proxy process already started");
+    }
+    const outputBuffer = new CircularBuffer<string>(Array, 200);
+
+    const childProcess = spawn(this.proxyPath, this.proxyArgs, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    this.childProcess = childProcess;
+
+    let stdoutBuf = "";
+    // We know that `stdout` is set because of the `stdio` spawn options
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    childProcess.stdout!.on("data", (chunk: Buffer) => {
+      process.stdout.write(chunk);
+      const split = chunk.toString("utf8").split("\n");
+      split[0] = stdoutBuf + split[0];
+      stdoutBuf = split.pop() || "";
+      for (const line of split) {
+        outputBuffer.push(line);
+      }
+    });
+
+    let stderrBuf = "";
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    childProcess.stderr!.on("data", (chunk: Buffer) => {
+      process.stderr.write(chunk);
+      const split = chunk.toString("utf8").split("\n");
+      split[0] = stderrBuf + split[0];
+      stderrBuf = split.pop() || "";
+      for (const line of split) {
+        outputBuffer.push(line);
+      }
+    });
+
+    const [status, signal] = await new Promise(resolve => {
+      childProcess.on("exit", (status, signal) => {
+        this.childProcess = undefined;
+        resolve([status, signal]);
+      });
+    });
+
+    let output = Array.from(outputBuffer).join("\n");
+    if (stderrBuf) {
+      output = `${output}\n${stderrBuf}`;
+    }
+    if (stdoutBuf) {
+      output = `${output}\n${stdoutBuf}`;
+    }
+
+    return {
+      status,
+      signal,
+      output,
+    };
+  }
+
+  // Kill the process if it is running. Do nothing otherwise.
+  kill(): void {
+    if (this.childProcess) {
+      this.childProcess.kill();
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@rollup/plugin-typescript": "^6.1.0",
     "@tsconfig/svelte": "^1.0.10",
     "@types/jest": "^26.0.15",
+    "@types/lodash": "^4.14.165",
     "@types/marked": "^1.2.0",
     "@types/node": "^14.14.8",
     "@types/sinon": "^9.0.8",
@@ -80,6 +81,7 @@
     "husky": ">=4.3.0",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.1",
+    "lodash": "^4.17.20",
     "npm-run-all": "^4.1.5",
     "patch-package": "^6.2.2",
     "prettier": "^2.1.2",
@@ -143,6 +145,7 @@
   "dependencies": {
     "@types/qs": "^6.9.5",
     "marked": "^1.2.4",
+    "mnemonist": "^0.38.0",
     "pure-svg-code": "^1.0.6",
     "timeago.js": "^4.0.2",
     "twemoji": "13.0.1",

--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -98,10 +98,10 @@
       <Button style="display: flex; color: #fff;" on:click={tweet}>
         Reach out for support
       </Button>
-      {#if $fatalError.kind === 'PROXY_EXIT' && $fatalError.data.stderr}
+      {#if $fatalError.kind === 'PROXY_EXIT' && $fatalError.data.output}
         <div class="proxy-log-container">
           <code data-cy="proxy-log" class="proxy-log typo-mono-semi-bold">
-            {$fatalError.data.stderr}
+            {$fatalError.data.output}
           </code>
           <Button
             dataCy="proxy-log-copy-clipboard"

--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -107,7 +107,7 @@
             dataCy="proxy-log-copy-clipboard"
             style="position: sticky; bottom: 0; margin-left: auto;"
             variant="secondary"
-            on:click={() => copyToClipboard($fatalError.data.stderr)}
+            on:click={() => copyToClipboard($fatalError.data.output)}
             icon={copyIcon}>
             Copy to clipboard
           </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,6 +806,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
 "@types/marked@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-1.2.0.tgz#75e1e444386ad7cdd6d788c91be4977111eda231"
@@ -4901,7 +4906,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -5222,6 +5227,13 @@ mkdirp@^0.5.1, mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
+mnemonist@^0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.0.tgz#ea1c32c22f26956dab7a8c5acc56c03b802b9b50"
+  integrity sha512-OrqILDYOEGVFooAbGid3/P9jdjWuZONlGHVyjfZnvg65+ZQ/QM5dOms+yADY/WURd1NFhCqjf/VJGFlnJToLJQ==
+  dependencies:
+    obliterator "^1.6.1"
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
@@ -5458,6 +5470,11 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
We change how the proxy process is spawned. Instead of saving all output of the process in a buffer we only save the 200 most recent lines. In addition we forward all of the proxy’s output to the main process output. This allows us to see the proxy logs when starting the app from the terminal.

To implement this we introduce the `ProxyProcessManager` which encapsulates this behavior. The logic for line buffering the output of the process suffers from duplication. I’ve experimented with some abstractions but they were all to complicated and did not add enough value.

Fixes #1359