### PR TITLE
fix(ui): make stats component reactive

### DIFF
--- a/ui/DesignSystem/Component/Stats.svelte
+++ b/ui/DesignSystem/Component/Stats.svelte
@@ -1,13 +1,13 @@
-<script>
+<script lang="typescript">
   import { Icon } from "../Primitive";
 
-  export let contributors = null;
-  export let branches = null;
-  export let commits = null;
+  export let contributors: number;
+  export let branches: number;
+  export let commits: number;
 
-  export let style = null;
+  export let style = "";
 
-  const formattedStats = [
+  $: formattedStats = [
     { icon: Icon.Branch, count: branches },
     { icon: Icon.Commit, count: commits },
     { icon: Icon.User, count: contributors },

--- a/ui/src/localPeer.ts
+++ b/ui/src/localPeer.ts
@@ -140,7 +140,6 @@ export const requestEvents: Readable<RequestEvent | null> = derived(
       case EventType.RequestQueried:
       case EventType.RequestTimedOut:
       case EventType.RequestCreated:
-        console.log({ event });
         return event;
 
       default:


### PR DESCRIPTION
We make the stats component reactive so that changes in the props are reflected in the rendered dom.