### PR TITLE
fix(ui): Increase hit area for sidebar buttons

### DIFF
--- a/ui/DesignSystem/Component/ConnectionStatusIndicator.svelte
+++ b/ui/DesignSystem/Component/ConnectionStatusIndicator.svelte
@@ -50,26 +50,26 @@
   <div>
     {#if status.type === StatusType.Online}
       <Tooltip value={`You’re connected to ${peerCount(status.connected)}`}>
-        <div class="item indicator" data-cy="search">
+        <div class="item indicator" data-cy="connection-status">
           <Icon.Network />
         </div>
       </Tooltip>
     {:else if status.type === StatusType.Syncing}
       <Tooltip
         value={`Syncing with ${peerCount(status.syncs)} to get new content from your network`}>
-        <div class="item indicator" data-cy="search">
+        <div class="item indicator" data-cy="connection-status">
           <Syncing />
         </div>
       </Tooltip>
     {:else if status.type === StatusType.Offline || status.type === StatusType.Started}
       <Tooltip value="You’re not connected to any peers">
-        <div class="item indicator" data-cy="search">
+        <div class="item indicator" data-cy="connection-status">
           <Offline />
         </div>
       </Tooltip>
     {:else if status.type === StatusType.Stopped}
       <Tooltip value="The app couldn't start your peer">
-        <div class="item indicator" data-cy="search">
+        <div class="item indicator" data-cy="connection-status">
           <Offline style="fill: var(--color-negative);" />
         </div>
       </Tooltip>

--- a/ui/DesignSystem/Component/ConnectionStatusIndicator.svelte
+++ b/ui/DesignSystem/Component/ConnectionStatusIndicator.svelte
@@ -18,12 +18,31 @@
 </script>
 
 <style>
-  a {
+  .item {
+    width: var(--sidebar-width);
+    height: 32px;
+    margin-bottom: 16px;
+    position: relative;
     display: flex;
-    align-items: center;
     justify-content: center;
-    width: 100%;
-    height: 100%;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .indicator:hover:before {
+    position: absolute;
+    content: "";
+    width: 4px;
+    height: 32px;
+    background-color: var(--color-foreground-level-5);
+    top: 0px;
+    left: 0px;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
+  .indicator :global(div:hover svg) {
+    fill: var(--color-secondary);
   }
 </style>
 
@@ -31,32 +50,28 @@
   <div>
     {#if status.type === StatusType.Online}
       <Tooltip value={`You’re connected to ${peerCount(status.connected)}`}>
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
+        <div class="item indicator" data-cy="search">
           <Icon.Network />
-        </a>
+        </div>
       </Tooltip>
     {:else if status.type === StatusType.Syncing}
       <Tooltip
         value={`Syncing with ${peerCount(status.syncs)} to get new content from your network`}>
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
+        <div class="item indicator" data-cy="search">
           <Syncing />
-        </a>
+        </div>
       </Tooltip>
     {:else if status.type === StatusType.Offline || status.type === StatusType.Started}
       <Tooltip value="You’re not connected to any peers">
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
+        <div class="item indicator" data-cy="search">
           <Offline />
-        </a>
+        </div>
       </Tooltip>
     {:else if status.type === StatusType.Stopped}
       <Tooltip value="The app couldn't start your peer">
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
+        <div class="item indicator" data-cy="search">
           <Offline style="fill: var(--color-negative);" />
-        </a>
+        </div>
       </Tooltip>
     {/if}
   </div>

--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -131,7 +131,7 @@
       on:click|stopPropagation={() => modal.toggle(path.search())}>
       <Tooltip value="Navigate to a project">
         <!-- svelte-ignore a11y-missing-attribute -->
-        <a style="cursor: default;">
+        <a>
           <Icon.MagnifyingGlass />
         </a>
       </Tooltip>

--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-  import { location, link } from "svelte-spa-router";
+  import { location, push } from "svelte-spa-router";
 
   import type { Identity } from "../../src/identity";
   import * as modal from "../../src/modal";
@@ -111,9 +111,11 @@
     <li
       class="item indicator"
       data-cy="profile"
-      class:active={path.active(path.profile(), $location, true)}>
+      class:active={path.active(path.profile(), $location, true)}
+      on:click|stopPropagation={() => push(path.profileProjects())}>
       <Tooltip value={identity.metadata.handle}>
-        <a href={path.profileProjects()} use:link>
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a>
           <Avatar
             size="regular"
             avatarFallback={identity.avatarFallback}
@@ -129,7 +131,7 @@
       on:click|stopPropagation={() => modal.toggle(path.search())}>
       <Tooltip value="Navigate to a project">
         <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
+        <a style="cursor: default;">
           <Icon.MagnifyingGlass />
         </a>
       </Tooltip>
@@ -141,9 +143,11 @@
     <li
       class="item indicator"
       data-cy="settings"
-      class:active={path.active(path.settings(), $location)}>
+      class:active={path.active(path.settings(), $location)}
+      on:click|stopPropagation={() => push(path.settings())}>
       <Tooltip value="Settings">
-        <a href={path.settings()} use:link>
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a>
           <Icon.Settings />
         </a>
       </Tooltip>

--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -89,68 +89,48 @@
     border-bottom-right-radius: 4px;
   }
 
-  .indicator :global(li:hover svg) {
+  .indicator :global(div:hover svg) {
     fill: var(--color-secondary);
   }
 
   .indicator.active :global(svg) {
     fill: var(--color-secondary);
   }
-
-  a {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-  }
 </style>
 
 <div class="wrapper" data-cy="sidebar">
-  <ul class="top">
-    <li
-      class="item indicator"
-      data-cy="profile"
-      class:active={path.active(path.profile(), $location, true)}
-      on:click|stopPropagation={() => push(path.profileProjects())}>
-      <Tooltip value={identity.metadata.handle}>
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
-          <Avatar
-            size="regular"
-            avatarFallback={identity.avatarFallback}
-            variant="circle" />
-        </a>
-      </Tooltip>
-    </li>
-  </ul>
-  <ul class="bottom">
-    <li
-      class="item indicator"
-      data-cy="search"
-      on:click|stopPropagation={() => modal.toggle(path.search())}>
-      <Tooltip value="Navigate to a project">
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
-          <Icon.MagnifyingGlass />
-        </a>
-      </Tooltip>
-    </li>
-    <li class="item indicator" data-cy="search">
-      <!-- svelte-ignore a11y-missing-attribute -->
-      <ConnectionStatusIndicator />
-    </li>
-    <li
-      class="item indicator"
-      data-cy="settings"
-      class:active={path.active(path.settings(), $location)}
-      on:click|stopPropagation={() => push(path.settings())}>
-      <Tooltip value="Settings">
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a>
-          <Icon.Settings />
-        </a>
-      </Tooltip>
-    </li>
-  </ul>
+  <div class="top">
+    <Tooltip value={identity.metadata.handle}>
+      <div
+        class="item indicator"
+        data-cy="profile"
+        class:active={path.active(path.profile(), $location, true)}
+        on:click|stopPropagation={() => push(path.profileProjects())}>
+        <Avatar
+          size="regular"
+          avatarFallback={identity.avatarFallback}
+          variant="circle" />
+      </div>
+    </Tooltip>
+  </div>
+  <div class="bottom">
+    <Tooltip value="Navigate to a project">
+      <div
+        class="item indicator"
+        data-cy="search"
+        on:click|stopPropagation={() => modal.toggle(path.search())}>
+        <Icon.MagnifyingGlass />
+      </div>
+    </Tooltip>
+    <ConnectionStatusIndicator />
+    <Tooltip value="Settings">
+      <div
+        class="item indicator"
+        data-cy="settings"
+        class:active={path.active(path.settings(), $location)}
+        on:click|stopPropagation={() => push(path.settings())}>
+        <Icon.Settings />
+      </div>
+    </Tooltip>
+  </div>
 </div>


### PR DESCRIPTION
This increases the clickable area of sidebar items to the size where the indicator shows up.  (closes #664 and #1296)
![sidebar-hover](https://user-images.githubusercontent.com/2326909/100365010-2b9ff000-2fff-11eb-9817-3f2b23dcebb4.gif)
