### PR TITLE
chore: add links update to `DEVELOPMENT.md`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -421,6 +421,8 @@ instructions.
 Once the release PR branch is merged into master a build will be triggered on
 Buildkite, this will build Upstream for both Linux and macOS. When the build
 has completed you can download binaries for your platform [here][ar].
+Make sure to update the links to those binaries on the [radicle.xyz download page](https://github.com/radicle-dev/radicle.xyz/blob/julien/master/pages/downloads.html.mustache)
+and rebuild/deploy the website.
 
 This is what a typical release looks like:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -421,6 +421,7 @@ instructions.
 Once the release PR branch is merged into master a build will be triggered on
 Buildkite, this will build Upstream for both Linux and macOS. When the build
 has completed you can download binaries for your platform [here][ar].
+
 Make sure to update the links to those binaries on the
 [radicle.xyz download page][rd] and rebuild/deploy the website.
 
@@ -483,7 +484,6 @@ afterwards the team can evaluate whether the release is up to our standards.
 
 
 [ar]: https://buildkite.com/monadic/radicle-upstream/builds?branch=master
-[rd]: https://radicle.xyz/downloads.html
 [bk]: https://buildkite.com/monadic/radicle-upstream
 [cb]: https://doc.rust-lang.org/cargo/
 [cc]: https://www.conventionalcommits.org/en/v1.0.0
@@ -501,6 +501,7 @@ afterwards the team can evaluate whether the release is up to our standards.
 [on]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Excluding-and-Including-Tests
 [pr]: https://prettier.io
 [qa]: QA.md
+[rd]: https://radicle.xyz/downloads.html
 [rl]: https://github.com/radicle-dev/radicle-link
 [rs]: https://github.com/radicle-dev/radicle-surf/
 [rt]: https://doc.rust-lang.org/book/ch11-01-writing-tests.html

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -421,8 +421,8 @@ instructions.
 Once the release PR branch is merged into master a build will be triggered on
 Buildkite, this will build Upstream for both Linux and macOS. When the build
 has completed you can download binaries for your platform [here][ar].
-Make sure to update the links to those binaries on the [radicle.xyz download page](https://github.com/radicle-dev/radicle.xyz/blob/julien/master/pages/downloads.html.mustache)
-and rebuild/deploy the website.
+Make sure to update the links to those binaries on the
+[radicle.xyz download page][rd] and rebuild/deploy the website.
 
 This is what a typical release looks like:
 
@@ -483,6 +483,7 @@ afterwards the team can evaluate whether the release is up to our standards.
 
 
 [ar]: https://buildkite.com/monadic/radicle-upstream/builds?branch=master
+[rd]: https://radicle.xyz/downloads.html
 [bk]: https://buildkite.com/monadic/radicle-upstream
 [cb]: https://doc.rust-lang.org/cargo/
 [cc]: https://www.conventionalcommits.org/en/v1.0.0


### PR DESCRIPTION
Reminds us to update the download links on the radicle.xyz website when a new release is made.

*note:* The link doesn't work right now cause the website hasn't been updated but it will work as soon as we merge.