### PR TITLE
fix(proxy): remove seeds guard to enable reconnect

### DIFF
--- a/proxy/coco/src/config.rs
+++ b/proxy/coco/src/config.rs
@@ -136,19 +136,11 @@ impl discovery::Discovery for StreamDiscovery {
         let (mut sender, receiver) = mpsc::channel(1024);
 
         tokio::spawn(async move {
-            let mut last_seeds: Vec<seed::Seed> = vec![];
-
             while let Some(seeds) = self.seeds_receiver.recv().await {
-                if last_seeds == seeds {
-                    continue;
-                }
-
                 for seed in &seeds {
                     let pair = (seed.peer_id, vec![seed.addr]);
                     sender.send(pair).await.ok();
                 }
-
-                last_seeds = seeds;
             }
         });
 


### PR DESCRIPTION
The double sanity check prevented the reconnect behaviour introduced in #1316.