### PR TITLE
build: automate macOS package notarization

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -419,13 +419,10 @@ To perform a release run: `git checkout master && yarn release` and follow the
 instructions.
 
 Once the release PR branch is merged into master a build will be triggered on
-Buildkite, this will build Upstream for both Linux and macOS. When the build
-has completed you can download binaries for your platform [here][ar].
+Buildkite, this will build Upstream for both Linux and macOS (unsigned).
 
-Make sure to update the links to those binaries on the
-[radicle.xyz download page][rd] and rebuild/deploy the website.
-
-This is what a typical release looks like:
+<details>
+<summary>This is what a typical release looks like</summary>
 
 ```sh
 $ git checkout master
@@ -463,6 +460,7 @@ Finalizing release v0.0.11:
 
 Release v0.0.11 successfully completed! 👏 🎉 🚀
 ```
+</details>
 
 ## Quality assurance
 
@@ -476,13 +474,82 @@ which contains a QA checklist. Before publishing packages for a wider audience
 someone from the team goes through the checklist and manually tests the app,
 afterwards the team can evaluate whether the release is up to our standards.
 
-**Title:** `QA: v0.0.14 macOS`\
+**Title:** `QA: v0.0.11 macOS`\
 **Body** [QA.md][qa]
 
-**Title:** `QA: v0.0.14 Linux`\
+**Title:** `QA: v0.0.11 Linux`\
 **Body:** [QA.md][qa]
 
+## Publishing a release
 
+Once a release has passed QA, it is ready to be published. This involves a
+couple of manual steps since the macOS release has to be signed and notarized
+on a developer's macOS machine.
+
+If you haven't already, please set up an Apple developer account and signing
+certificates, see [Setting up Apple notarization][an] for more details.
+
+To build, sign and notarize a macOS dmg package of the latest version run the
+following commands:
+
+```
+cd radicle-upstream
+git checkout v0.0.11
+
+CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \
+APPLE_ID="XXXXXXX@monadic.xyz" \
+APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \
+yarn dist
+```
+
+Where:
+  - `CSC_NAME` is the name of the signing certificate
+  - `APPLE_ID` is the developer's Apple developer ID
+  - `APPLE_ID_PASSWORD` is an app specific token generated from your Apple ID
+    in the developer portal
+
+**Note**: building a release might take a while, especially the notarization
+step, because it has to upload the final package to the Apple notarization
+server. Make sure you're on a stable internet connection.
+
+Once the package is built, signed and notarized you should upload it to our
+Google Cloud Platform under
+[`builds.radicle.xyz/releases/radicle-upstream/v0.1.4`][gp].
+
+You should also copy the Linux `.AppImage` and `.snap` packages to the same
+location. You can get them from the [CI build][ar] on Buildkite.
+
+After all the packages are uploaded, update the links to those binaries on the
+[radicle.xyz download page][rd] and rebuild/deploy the website.
+
+The final step is to announce the new release on our public channels:
+  - https://twitter.com/radicle
+  - https://radicle.community/c/announcements
+
+Here's a template for the annoucement:
+
+```
+Radicle Upstream v0.0.11 is out! 🎉
+
+All the changes that went into this release, you'll find here:
+  https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md#0011-2020-05-25
+
+And here are packages for all our supported platforms:
+  - macOS:
+    https://storage.googleapis.com/builds.radicle.xyz/releases/radicle-upstream/0.1.4/radicle-upstream-0.1.3.dmg
+  - Linux:
+    https://storage.googleapis.com/builds.radicle.xyz/releases/radicle-upstream/0.1.4/radicle-upstream-0.1.3.AppImage
+    https://storage.googleapis.com/builds.radicle.xyz/releases/radicle-upstream/0.1.4/radicle-upstream-0.1.3.snap
+
+For support you can reach us here:
+  https://radicle.community/c/help
+  https://matrix.radicle.community/#/room/#support:radicle.community
+
+If you encounter a bug, please open an issue here:
+  https://github.com/radicle-dev/radicle-upstream/issues
+```
+
+[an]: #setting-up-apple-notarization
 [ar]: https://buildkite.com/monadic/radicle-upstream/builds?branch=master
 [bk]: https://buildkite.com/monadic/radicle-upstream
 [cb]: https://doc.rust-lang.org/cargo/
@@ -495,6 +562,7 @@ afterwards the team can evaluate whether the release is up to our standards.
 [eb]: https://github.com/electron-userland/electron-builder
 [el]: https://www.electronjs.org
 [gc]: https://cloud.google.com/sdk/docs/quickstart-macos
+[gp]: https://console.cloud.google.com/storage/browser/builds.radicle.xyz/releases/radicle-upstream
 [hb]: https://github.com/github/hub
 [hu]: https://github.com/typicode/husky
 [ls]: https://github.com/okonet/lint-staged

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -520,7 +520,8 @@ You should also copy the Linux `.AppImage` and `.snap` packages to the same
 location. You can get them from the [CI build][ar] on Buildkite.
 
 After all the packages are uploaded, update the links to those binaries on the
-[radicle.xyz download page][rd] and rebuild/deploy the website.
+[radicle.xyz download][rd] and [docs.radicle.xyz/docs/getting-started][gs]
+pages and rebuild/deploy the websites.
 
 The final step is to announce the new release on our public channels:
   - https://twitter.com/radicle
@@ -563,6 +564,7 @@ If you encounter a bug, please open an issue here:
 [el]: https://www.electronjs.org
 [gc]: https://cloud.google.com/sdk/docs/quickstart-macos
 [gp]: https://console.cloud.google.com/storage/browser/builds.radicle.xyz/releases/radicle-upstream
+[gs]: https://docs.radicle.xyz/docs/getting-started
 [hb]: https://github.com/github/hub
 [hu]: https://github.com/typicode/husky
 [ls]: https://github.com/okonet/lint-staged

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -421,7 +421,7 @@ Prerequisites:
       **Note:** this can only be created via the company account holder
 
 
-## Creating a release
+## Preparing a release
 
 Before you begin: install the [`hub`][hb] cli tool. We use `hub` in our release
 automation script to create a pull-request off of a release branch and later

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -405,8 +405,23 @@ build times. If you need to update this image, proceed as follows:
 7. Commit changes to `Dockerfile` and `pipeline.yaml`. Pushing the changes will
    create a new branch and build the updated image.
 
+## Setting up Apple notarization
 
-## Releases
+To [allow macOS Gatekeeper recognise our Upstream packages as genuine][so],
+which allows the user to install and open Upstream without unnecessary
+[security warnings][sw], we have to [sign and notarize][sn] our macOS packages.
+
+Prerequisites:
+  - a paid Apple developer account registered to our company
+  - an Apple ID token for allowing the notarization script to run in behalf of
+    our developer acocunt
+    - [Account Manage][ma] -> APP-SPECIFIC PASSWORDS -> Generate password…
+  - a valid "Developer ID Application" certificate
+    - [Certificates Add][ca] -> Developer ID Application
+      **Note:** this can only be created via the company account holder account
+
+
+## Creating a release
 
 Before you begin: install the [`hub`][hb] cli tool. We use `hub` in our release
 automation script to create a pull-request off of a release branch and later
@@ -553,6 +568,7 @@ If you encounter a bug, please open an issue here:
 [an]: #setting-up-apple-notarization
 [ar]: https://buildkite.com/monadic/radicle-upstream/builds?branch=master
 [bk]: https://buildkite.com/monadic/radicle-upstream
+[ca]: https://developer.apple.com/account/resources/certificates/add
 [cb]: https://doc.rust-lang.org/cargo/
 [cc]: https://www.conventionalcommits.org/en/v1.0.0
 [cg]: https://radicle.community/t/color-system/166
@@ -568,6 +584,7 @@ If you encounter a bug, please open an issue here:
 [hb]: https://github.com/github/hub
 [hu]: https://github.com/typicode/husky
 [ls]: https://github.com/okonet/lint-staged
+[ma]: https://appleid.apple.com/account/manage
 [on]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Excluding-and-Including-Tests
 [pr]: https://prettier.io
 [qa]: QA.md
@@ -576,6 +593,9 @@ If you encounter a bug, please open an issue here:
 [rs]: https://github.com/radicle-dev/radicle-surf/
 [rt]: https://doc.rust-lang.org/book/ch11-01-writing-tests.html
 [se]: https://svelte.dev
+[sn]: https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution
+[so]: https://support.apple.com/en-us/HT202491
 [sv]: https://github.com/conventional-changelog/standard-version
+[sw]: https://support.apple.com/en-gb/guide/mac-help/mh40616/mac
 [tp]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [wa]: https://github.com/seanmonstar/warp

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -529,7 +529,7 @@ server. Make sure you're on a stable internet connection.
 
 Once the package is built, signed and notarized you should upload it to our
 Google Cloud Platform under
-[`builds.radicle.xyz/releases/radicle-upstream/v0.1.4`][gp].
+[`builds.radicle.xyz/releases/radicle-upstream/v0.0.11`][gp].
 
 You should also copy the Linux `.AppImage` and `.snap` packages to the same
 location. You can get them from the [CI build][ar] on Buildkite.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -407,18 +407,18 @@ build times. If you need to update this image, proceed as follows:
 
 ## Setting up Apple notarization
 
-To [allow macOS Gatekeeper recognise our Upstream packages as genuine][so],
+To [allow macOS Gatekeeper to recognise our Upstream packages as genuine][so],
 which allows the user to install and open Upstream without unnecessary
 [security warnings][sw], we have to [sign and notarize][sn] our macOS packages.
 
 Prerequisites:
-  - a paid Apple developer account registered to our company
-  - an Apple ID token for allowing the notarization script to run in behalf of
-    our developer acocunt
+  - a paid Apple developer account registered to Monadic
+  - an Apple ID token for allowing the notarization script to run on behalf of
+    our developer account
     - [Account Manage][ma] -> APP-SPECIFIC PASSWORDS -> Generate password…
   - a valid "Developer ID Application" certificate
     - [Certificates Add][ca] -> Developer ID Application
-      **Note:** this can only be created via the company account holder account
+      **Note:** this can only be created via the company account holder
 
 
 ## Creating a release
@@ -433,11 +433,11 @@ does a request to GitHub, like so: `hub api`.
 To perform a release run: `git checkout master && yarn release` and follow the
 instructions.
 
-Once the release PR branch is merged into master a build will be triggered on
+Once the release PR branch is merged into master, a build will be triggered on
 Buildkite, this will build Upstream for both Linux and macOS (unsigned).
 
 <details>
-<summary>This is what a typical release looks like</summary>
+<summary>Commands to prepare a release</summary>
 
 ```sh
 $ git checkout master

--- a/builder/entitlements.mac.plist
+++ b/builder/entitlements.mac.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/builder/notarize.js
+++ b/builder/notarize.js
@@ -1,0 +1,30 @@
+const { notarize } = require("electron-notarize");
+
+exports.default = async function notarizeApp(context) {
+  if (process.env.NOTARIZE !== "true") {
+    return;
+  }
+
+  if (context.electronPlatformName !== "darwin") {
+    throw new Error("Notarization must be performad on macOS!");
+  }
+
+  if (
+    !(
+      process.env.APPLE_ID &&
+      process.env.APPLE_ID_PASSWORD &&
+      process.env.CSC_NAME
+    )
+  ) {
+    throw new Error(
+      "APPLE_ID, APPLE_ID_PASSWORD and CSC_NAME env variables must be set!"
+    );
+  }
+
+  return await notarize({
+    appBundleId: process.env.npm_package_build_appId,
+    appPath: `${context.appOutDir}/${context.packager.appInfo.productFilename}.app`,
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_ID_PASSWORD,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "cypress": "^5.6.0",
     "electron": "^11.0.1",
     "electron-builder": "^22.9.1",
+    "electron-notarize": "^1.0.0",
     "eslint": "^7.13.0",
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-no-only-tests": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "url": "https://github.com/radicle-dev/radicle-upstream.git"
   },
   "build": {
-    "appId": "radicle-upstream.monadic.xyz",
+    "appId": "xyz.radicle.radicle-upstream",
     "artifactName": "${name}-${version}.${ext}",
+    "afterSign": "builder/notarize.js",
     "files": [
       "public/**/*",
       "native/**/*"
@@ -52,7 +53,11 @@
     "mac": {
       "target": [
         "dmg"
-      ]
+      ],
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "builder/entitlements.mac.plist",
+      "entitlementsInherit": "builder/entitlements.mac.plist"
     }
   },
   "main": "./native/main.comp.js",
@@ -121,6 +126,7 @@
     "wait:test": "wait-on tcp:17246 && yarn rollup:build && yarn cypress:run; status=$?; [ \"$CI\" = true ] && kill `pidof api`; exit $status",
     "wait:debug": "wait-on tcp:17246 && yarn cypress:open",
     "dist": "rm -rf ./dist && mkdir ./dist && yarn proxy:clean && yarn rollup:clean && yarn rollup:build && yarn proxy:build:release && cp proxy/target/release/api dist/proxy && cp proxy/target/release/git-remote-rad dist && electron-builder --publish never",
+    "dist:notarize": "NOTARIZE=true yarn dist",
     "electron:start": "wait-on ./public/bundle.js && wait-on ./native/main.comp.js && wait-on tcp:17246 && NODE_ENV=development electron .",
     "svelte:check": "svelte-check",
     "svelte:check:watch": "svelte-check --watch",

--- a/scripts/reset-state.sh
+++ b/scripts/reset-state.sh
@@ -9,8 +9,8 @@ if [ "$platform" == "Darwin" ]; then
         "$HOME/Library/Application Support/Radicle Upstream"
         "$HOME/Library/Application Support/xyz.radicle.radicle"
         "$HOME/Library/Application Support/xyz.radicle.radicle-upstream"
-        "$HOME/Library/Preferences/radicle-upstream.monadic.xyz.plist"
-        "$HOME/Library/Saved Application State/radicle-upstream.monadic.xyz.savedState"
+        "$HOME/Library/Preferences/xyz.radicle.radicle-upstream.plist"
+        "$HOME/Library/Saved Application State/xyz.radicle.radicle-upstream.savedState"
     );
 elif [ "$platform" == "Linux" ]; then
     config_home="${XDG_CONFIG_HOME:-$HOME/.config}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,6 +2541,14 @@ electron-builder@^22.9.1:
     update-notifier "^4.1.1"
     yargs "^16.0.3"
 
+electron-notarize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-1.0.0.tgz#bc925b1ccc3f79e58e029e8c4706572b01a9fd8f"
+  integrity sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
+
 electron-publish@22.9.1:
   version "22.9.1"
   resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.9.1.tgz#7cc76ac4cc53efd29ee31c1e5facb9724329068e"


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-upstream/issues/1306
Closes: https://github.com/radicle-dev/radicle-upstream/issues/1350

TODO:
  - [x] configure electron-builder to sign binaries
  - [x] automate dmg notarization
  - [x] update release ceremony in `DEVELOPMENT.md`
  - [x] document how to set up Apple accounts and how to get signing certificates
  - [x] update [Getting Started section](https://github.com/radicle-dev/radicle-docs/blob/master/docs/getting-started.md#on-macos) in radicle-docs