### PR TITLE
chore(ci): build packages on tag builds

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -68,7 +68,7 @@ echo "--- Run proxy tests"
 echo "--- Starting proxy daemon and runing app tests"
 time ELECTRON_ENABLE_LOGGING=1 yarn test
 
-if [[ "${BUILDKITE_BRANCH:-}" == "master" ]]; then
+if [[ "${BUILDKITE_BRANCH:-}" == "master" || -n "${BUILDKITE_TAG:-}" ]]; then
   echo "--- Packaging and uploading app binaries"
   time yarn dist
 fi

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -537,10 +537,12 @@ gsutil cp dist/radicle-upstream-0.1.2.dmg gs://releases.radicle.xyz
 To be able to upload packages to the GCS bucket you will need the appropriate
 permissions. Reach out to a co-worker if you don’t have them.
 
-You should also copy the Linux `.AppImage` and `.snap` packages to the same
-location. You can get them from the [CI build][ar] on Buildkite. Then run
+After this you also need to obtain and upload the Linux packages.
 
 ```bash
+curl -sSLO https://builds.radicle.xyz/radicle-upstream/v0.1.2/radicle-upstream-0.1.2.AppImage
+curl -sSLO https://builds.radicle.xyz/radicle-upstream/v0.1.2/radicle-upstream-0.1.2.snap
+
 gsutil cp \
   radicle-upstream-0.1.2.AppImage \
   radicle-upstream-0.1.2.snap \
@@ -579,7 +581,6 @@ If you encounter a bug, please open an issue here:
 ```
 
 [an]: #setting-up-apple-notarization
-[ar]: https://buildkite.com/monadic/radicle-upstream/builds?branch=master
 [bk]: https://buildkite.com/monadic/radicle-upstream
 [ca]: https://developer.apple.com/account/resources/certificates/add
 [cb]: https://doc.rust-lang.org/cargo/


### PR DESCRIPTION
We build the packages on tag builds so that they can easily be downloaded.