### PR TITLE
chore(ci): don’t build snap images since they are broken

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -10,7 +10,6 @@
     SHARED_MASTER_CACHE: true
   artifact_paths:
     - "dist/*.AppImage"
-    - "dist/*.snap"
     - "cypress/screenshots/**/*.png"
 
 steps:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -112,7 +112,7 @@ We use [Cypress](https://www.cypress.io/) for integration tests and
 ### Building an Upstream package for your platform
 
 You can build and package Upstream with: `yarn dist`. The generated package
-will be in: `dist/` as `radicle-upstream-X.X.X.{dmg|AppImage|snap}`.
+will be in: `dist/` as `radicle-upstream-X.X.X.{dmg|AppImage}`.
 
 
 ### Scripts
@@ -537,13 +537,12 @@ gsutil cp dist/radicle-upstream-0.1.2.dmg gs://releases.radicle.xyz
 To be able to upload packages to the GCS bucket you will need the appropriate
 permissions. Reach out to a co-worker if you don’t have them.
 
-You should also copy the Linux `.AppImage` and `.snap` packages to the same
-location. You can get them from the [CI build][ar] on Buildkite. Then run
+You should also copy the Linux `.AppImage` package to the same location. You can
+get them from the [CI build][ar] on Buildkite. Then run
 
 ```bash
 gsutil cp \
   radicle-upstream-0.1.2.AppImage \
-  radicle-upstream-0.1.2.snap \
   gs://releases.radicle.xyz
 ```
 
@@ -568,7 +567,6 @@ And here are packages for all our supported platforms:
     https://releases.radicle.xyz/radicle-upstream-0.1.3.dmg
   - Linux:
     https://releases.radicle.xyz/radicle-upstream-0.1.3.AppImage
-    https://releases.radicle.xyz/radicle-upstream-0.1.3.Snap
 
 For support you can reach us here:
   https://radicle.community/c/help

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     ],
     "linux": {
       "target": [
-        "Appimage",
-        "snap"
+        "Appimage"
       ],
       "extraFiles": [
         {


### PR DESCRIPTION
Don’t build snap images since they are broken. See #1419 