### PR TITLE
feat(ui): extend effect of enter key in onboarding

### DIFF
--- a/ui/Screen/Onboarding/EnterName.svelte
+++ b/ui/Screen/Onboarding/EnterName.svelte
@@ -10,6 +10,7 @@
 
   export let handle = "";
 
+  let nameInput: HTMLInputElement;
   let beginValidation = false;
 
   const validationStore = onboarding.createHandleValidationStore();
@@ -36,12 +37,18 @@
   }
 
   const next = () => {
-    if (!allowNext) return;
+    if (!allowNext) {
+      nameInput.focus();
+      return;
+    }
 
     beginValidation = true;
     validationStore.validate(handle);
 
-    if (!validationPasses()) return;
+    if (!validationPasses()) {
+      nameInput.focus();
+      return;
+    }
 
     dispatch("next", handle);
   };
@@ -79,6 +86,8 @@
   }
 </style>
 
+<svelte:window on:keydown={onKeydown} />
+
 <div class="container" data-cy="enter-name-screen">
   <div>
     <h1>
@@ -93,6 +102,7 @@
     <Input.Text
       autofocus
       placeholder="Enter a display name (e.g. coolprogrammer3000)"
+      bind:inputElement={nameInput}
       bind:value={handle}
       on:keydown={onKeydown}
       dataCy="handle-input"

--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -12,6 +12,7 @@
 
   const dispatch = createEventDispatcher();
 
+  let passphraseInput;
   let repeatedPassphraseInput;
   let passphrase;
   let repeatedPassphrase;
@@ -89,6 +90,24 @@
     if (!ran && allowNext) {
       ran = true;
       dispatch("next", passphrase);
+    } else {
+      repeatedPassphraseInput.focus();
+    }
+  };
+
+  const onKeydown = event => {
+    switch (event.code) {
+      case "Enter":
+        if (passphrase.length === 0) {
+          passphraseInput.focus();
+          break;
+        } else if (repeatedPassphrase.length === 0) {
+          repeatedPassphraseInput.focus();
+          break;
+        } else {
+          next();
+          break;
+        }
     }
   };
 </script>
@@ -122,6 +141,8 @@
   }
 </style>
 
+<svelte:window on:keydown={onKeydown} />
+
 <div class="container" data-cy="enter-passphrase-screen">
   <div>
     <h1>Next, you'll need a passphrase.</h1>
@@ -136,6 +157,7 @@
     </p>
 
     <Input.Password
+      bind:inputElement={passphraseInput}
       on:enter={() => {
         repeatedPassphraseInput.focus();
       }}


### PR DESCRIPTION
Closes #1416

Navigates or refocuses the inputs in the onboarding flow on `enter` on unfocused input. Navigates when all validations pass or focuses on the appropriate input when they fail.