### PR TITLE
fix(ui): revert to default after untrack

### DIFF
--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -193,8 +193,21 @@ export const addPeer = async (
   return true;
 };
 
-export const removePeer = (projectId: Urn, remote: PeerId): void => {
-  untrackPeer(projectId, remote);
+export const removePeer = (projectId: Urn, peerId: PeerId): void => {
+  const screen = get(screenStore);
+
+  if (screen.status === remote.Status.Success) {
+    const { peerSelection, selectedPeer } = screen.data;
+
+    untrackPeer(projectId, peerId);
+
+    if (selectedPeer.peerId === peerId) {
+      screenStore.success({
+        ...screen.data,
+        selectedPeer: peerSelection[0],
+      });
+    }
+  }
 };
 
 const filterPeers = (peers: project.Peer[]): project.User[] => {


### PR DESCRIPTION
If the untracked peer/remote is the currently selected this change
reverts back to the default one, to avoid confusion.

Fixes #1210