### PR TITLE
fix(ui): list border overflow (#1447)

### DIFF
--- a/ui/DesignSystem/Component/List.svelte
+++ b/ui/DesignSystem/Component/List.svelte
@@ -19,10 +19,12 @@
     max-width: var(--content-max-width);
     padding: 0 var(--content-padding);
   }
+
   ul {
     width: 100%;
     border: 1px solid var(--color-foreground-level-2);
     border-radius: 8px;
+    overflow: hidden;
   }
 
   li {
@@ -40,11 +42,6 @@
 
   li:last-child {
     border-bottom: 0;
-    border-radius: 0 0 8px 8px;
-  }
-
-  li:first-child {
-    border-radius: 8px 8px 0 0;
   }
 </style>
 


### PR DESCRIPTION
Fixes #1447

Border radius of lists now just handled by the parent with overflow, rather than having border radius on children too.

![image](https://user-images.githubusercontent.com/35561611/101290850-9968ca80-37fc-11eb-8b93-f649910fdefb.png)