### PR TITLE
fix(ci): put timeout on proxy tests

### DIFF
--- a/.buildkite/run.sh
+++ b/.buildkite/run.sh
@@ -45,7 +45,7 @@ echo "--- Run proxy fmt"
 echo "--- Run proxy lints"
 (
   cd proxy
-  time timeout 4m cargo clippy --all --all-features --all-targets -Z unstable-options -- --deny warnings
+  time cargo clippy --all --all-features --all-targets -Z unstable-options -- --deny warnings
 )
 
 echo "--- Run app eslint checks"
@@ -62,7 +62,7 @@ echo "--- Run proxy tests"
   cd proxy
   export RUST_TEST_TIME_UNIT=2000,4000
   export RUST_TEST_TIME_INTEGRATION=2000,8000
-  time cargo test --all --all-features --all-targets -- -Z unstable-options --ensure-time
+  timeout 6m cargo test --all --all-features --all-targets -- -Z unstable-options --report-time
 )
 
 echo "--- Starting proxy daemon and runing app tests"


### PR DESCRIPTION
We’re using the `--ensure-time` option with `cargo test` to notify us when a test takes longer than the specified time. However, this does not abort the test suite and thus does not address #1378. To actually abort the test suite we are using the `timeout` command.

In addition we have the following changes
* We remove the `timeout` command from the lint step. This was committed by me accidently in #1379. We have never experienced issues with clippy timing out.
* We’re replacing the `--ensure-time` option with `--report-time`. We want to know how long tests take but not fail them since we have no expectations for the time they should take.