### PR TITLE
docs: tidy up release docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -502,10 +502,10 @@ which contains a QA checklist. Before publishing packages for a wider audience
 someone from the team goes through the checklist and manually tests the app,
 afterwards the team can evaluate whether the release is up to our standards.
 
-**Title:** `QA: v0.0.11 macOS`\
+**Title:** `QA: vX.X.X macOS`\
 **Body** [QA.md][qa]
 
-**Title:** `QA: v0.0.11 Linux`\
+**Title:** `QA: vX.X.X Linux`\
 **Body:** [QA.md][qa]
 
 ## Publishing a release
@@ -522,7 +522,7 @@ following commands:
 
 ```
 cd radicle-upstream
-git checkout v0.0.11
+git checkout vX.X.X
 
 CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \
 APPLE_ID="XXXXXXX@monadic.xyz" \
@@ -543,7 +543,7 @@ Once the package is notarized you can upload it to the web using
 [`gsutil`][gs]:
 
 ```bash
-gsutil cp dist/radicle-upstream-0.0.11.dmg gs://releases.radicle.xyz
+gsutil cp dist/radicle-upstream-X.X.X.dmg gs://releases.radicle.xyz
 ```
 
 To be able to upload packages to the GCS bucket you will need the appropriate
@@ -554,8 +554,8 @@ After this you also need to obtain and upload the Linux package.
 FIXME(rudolfs): this doesn't work, we don't build images off of tags.
 
 ```bash
-curl -sSLO https://builds.radicle.xyz/radicle-upstream/v0.1.2/radicle-upstream-0.1.2.AppImage
-gsutil cp radicle-upstream-0.1.2.AppImage gs://releases.radicle.xyz
+curl -sSLO https://builds.radicle.xyz/radicle-upstream/vX.X.X/radicle-upstream-X.X.X.AppImage
+gsutil cp radicle-upstream-X.X.X.AppImage gs://releases.radicle.xyz
 ```
 
 After all the packages are uploaded, update the links to those binaries on the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -567,8 +567,11 @@ sure to update all the versions and links**):
 
   - https://radicle.community/c/announcements
     - subject:
-        Radicle Upstream vX.X.X is out! 🎉`
+
+        Radicle Upstream vX.X.X is out! 🎉
+
     - body text:
+
         # Radicle Upstream vX.X.X is out! 🎉
 
         You can find all the changelog for this release [here][1].

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -405,13 +405,30 @@ build times. If you need to update this image, proceed as follows:
 7. Commit changes to `Dockerfile` and `pipeline.yaml`. Pushing the changes will
    create a new branch and build the updated image.
 
-## Setting up Apple notarization
+## Releases
 
-To [allow macOS Gatekeeper to recognise our Upstream packages as genuine][so],
+### Prerequisites
+
+#### GitHub `hub` CLI tool
+
+Please install the [`hub`][hb] CLI tool, we use it in our release automation
+script to:
+  - create a pull-request off of a release branch;
+  - to merge the release branch into master;
+  - to close the pull-request.
+
+Then you'll have to create a _Personal access token_ for it in the
+[GitHub Developer settings][gs] page and authenticate the CLI tool once
+by running any command that does a request to GitHub, like so: `hub api`.
+You'll be asked to provide your GitHub login and the access token.
+
+#### Apple notarization
+
+To allow macOS Gatekeeper [to recognise][so] our Upstream packages as genuine,
 which allows the user to install and open Upstream without unnecessary
 [security warnings][sw], we have to [sign and notarize][sn] our macOS packages.
 
-Prerequisites:
+For this we need:
   - a paid Apple developer account registered to Monadic
   - an Apple ID token for allowing the notarization script to run on behalf of
     our developer account
@@ -420,15 +437,11 @@ Prerequisites:
     - [Certificates Add][ca] -> Developer ID Application
       **Note:** this can only be created via the company account holder
 
+Once you've created the _Developer ID Application_ certificate, download it
+locally and add it to your keychain by double cliking on the file.
+
 
 ## Preparing a release
-
-Before you begin: install the [`hub`][hb] cli tool. We use `hub` in our release
-automation script to create a pull-request off of a release branch and later
-for merging this branch into master and closing the pull-request.
-
-You'll also have to authenticate the hub cli once by running any command that
-does a request to GitHub, like so: `hub api`.
 
 To perform a release run: `git checkout master && yarn release` and follow the
 instructions.
@@ -499,10 +512,10 @@ afterwards the team can evaluate whether the release is up to our standards.
 
 Once a release has passed QA, it is ready to be published. This involves a
 couple of manual steps since the macOS release has to be signed and notarized
-on a developer's macOS machine.
+on a developer's **macOS** machine.
 
 If you haven't already, please set up an Apple developer account and signing
-certificates, see [Setting up Apple notarization][an] for more details.
+certificates, see [Apple notarization][an] for more details.
 
 To build, sign and notarize a macOS dmg package of the latest version run the
 following commands:
@@ -519,25 +532,26 @@ yarn dist
 
 Where:
   - `CSC_NAME` is the name of the signing certificate
-  - `APPLE_ID` is the developer's Apple developer ID
-  - `APPLE_ID_PASSWORD` is an app specific token generated from your Apple ID
-    in the developer portal
+  - `APPLE_ID` is your Apple developer ID
+  - `APPLE_ID_PASSWORD` is the app specific token generated from your Apple ID
 
 **Note**: building a release might take a while, especially the notarization
 step, because it has to upload the final package to the Apple notarization
 server. Make sure you're on a stable internet connection.
 
-Once the package is built, signed and notarized you can upload it to the web
-using [`gsutil`][gs]:
+Once the package is notarized you can upload it to the web using
+[`gsutil`][gs]:
 
 ```bash
-gsutil cp dist/radicle-upstream-0.1.2.dmg gs://releases.radicle.xyz
+gsutil cp dist/radicle-upstream-0.0.11.dmg gs://releases.radicle.xyz
 ```
 
 To be able to upload packages to the GCS bucket you will need the appropriate
 permissions. Reach out to a co-worker if you don’t have them.
 
 After this you also need to obtain and upload the Linux package.
+
+FIXME(rudolfs): this doesn't work, we don't build images off of tags.
 
 ```bash
 curl -sSLO https://builds.radicle.xyz/radicle-upstream/v0.1.2/radicle-upstream-0.1.2.AppImage
@@ -548,33 +562,66 @@ After all the packages are uploaded, update the links to those binaries on the
 [radicle.xyz download][rd] and [docs.radicle.xyz/docs/getting-started][gs]
 pages and rebuild/deploy the websites.
 
-The final step is to announce the new release on our public channels:
-  - https://twitter.com/radicle
+The final step is to announce the new release on our public channels (**make
+sure to update all the versions and links**):
+
   - https://radicle.community/c/announcements
+    - subject:
+        Radicle Upstream vX.X.X is out! 🎉`
+    - body text:
+        # Radicle Upstream vX.X.X is out! 🎉
 
-Here's a template for the annoucement:
+        You can find all the changelog for this release [here][1].
 
-```
-Radicle Upstream v0.0.11 is out! 🎉
+        Here are packages for all our supported platforms:
 
-All the changes that went into this release, you'll find here:
-  https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md#0011-2020-05-25
+        - [macOS][2]
+        - [Linux][3]
 
-And here are packages for all our supported platforms:
-  - macOS:
-    https://releases.radicle.xyz/radicle-upstream-0.1.3.dmg
-  - Linux:
-    https://releases.radicle.xyz/radicle-upstream-0.1.3.AppImage
+        For more information on how to use Radicle, check out our
+        [documentation][4].
 
-For support you can reach us here:
-  https://radicle.community/c/help
-  https://matrix.radicle.community/#/room/#support:radicle.community
+        For support, you can reach us in the [#support channel][5] of our Matrix
+        chat or in the #help category of this forum.
 
-If you encounter a bug, please open an issue here:
-  https://github.com/radicle-dev/radicle-upstream/issues
-```
+        If you encounter a bug, please [open an issue][6].
 
-[an]: #setting-up-apple-notarization
+        [1]: https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md#XXX-XXXX-XX-XX
+        [2]: https://releases.radicle.xyz/radicle-upstream-X.X.X.dmg
+        [3]: https://releases.radicle.xyz/radicle-upstream-X.X.X.AppImage
+        [4]: https://docs.radicle.xyz/docs/what-is-radicle.html
+        [5]: https://matrix.radicle.community/#/room/#support:radicle.community
+        [6]: https://github.com/radicle-dev/radicle-upstream/issues
+
+  - Post the following two lines on:
+    https://matrix.radicle.community/#/room/#general:radicle.community
+
+        Radicle Upstream vX.X.X is out! 🎉
+        https://radicle.community/t/radicle-upstream-vX-X-X-is-out
+
+## Checklist
+To avoid missing a step when performing a release, here's an ordered checklist
+for all of the required steps:
+
+- [ ] cut the release
+  - [ ] fix up `CHANGELOG.md` if there are any mistakes
+  - [ ] wait for the release PR to pass CI
+  - [ ] get 2 approvals for the release PR
+  - [ ] finalize the release
+- [ ] build and notarize macOS package
+- [ ] wait for release commit to build Linux packages on CI
+- [ ] upload Linux and macOS packages to releases.radicle.xyz
+- [ ] create macOS and Linux QA issues in the Upstream repo
+- [ ] wait until macOS and Linux QA is performed and passes
+- [ ] update radicle.xyz download links
+  - [ ] deploy radicle.xyz
+- [ ] update docs.radicle.xyz download links
+  - [ ] deploy docs.radicle.xyz
+- [ ] announce new release on radicle.community
+- [ ] announce new release on the matrix #general:radicle.community channel
+
+
+[an]: #apple-notarization
 [bk]: https://buildkite.com/monadic/radicle-upstream
 [ca]: https://developer.apple.com/account/resources/certificates/add
 [cb]: https://doc.rust-lang.org/cargo/
@@ -587,9 +634,10 @@ If you encounter a bug, please open an issue here:
 [eb]: https://github.com/electron-userland/electron-builder
 [el]: https://www.electronjs.org
 [gc]: https://cloud.google.com/sdk/docs/quickstart-macos
+[gg]: https://cloud.google.com/storage/docs/gsutil_install
 [gp]: https://console.cloud.google.com/storage/browser/builds.radicle.xyz/releases/radicle-upstream
 [gs]: https://github.com/radicle-dev/radicle-docs/blob/master/docs/getting-started.md
-[gg]: https://cloud.google.com/storage/docs/gsutil_install
+[gt]: https://github.com/settings/tokens
 [hb]: https://github.com/github/hub
 [hu]: https://github.com/typicode/husky
 [ls]: https://github.com/okonet/lint-staged

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -568,33 +568,33 @@ sure to update all the versions and links**):
   - https://radicle.community/c/announcements
     - subject:
 
-        Radicle Upstream vX.X.X is out! 🎉
+          Radicle Upstream vX.X.X is out! 🎉
 
     - body text:
 
-        # Radicle Upstream vX.X.X is out! 🎉
+          # Radicle Upstream vX.X.X is out! 🎉
 
-        You can find all the changelog for this release [here][1].
+          You can find all the changelog for this release [here][1].
 
-        Here are packages for all our supported platforms:
+          Here are packages for all our supported platforms:
 
-        - [macOS][2]
-        - [Linux][3]
+          - [macOS][2]
+          - [Linux][3]
 
-        For more information on how to use Radicle, check out our
-        [documentation][4].
+          For more information on how to use Radicle, check out our
+          [documentation][4].
 
-        For support, you can reach us in the [#support channel][5] of our Matrix
-        chat or in the #help category of this forum.
+          For support, you can reach us in the [#support channel][5] of our Matrix
+          chat or in the #help category of this forum.
 
-        If you encounter a bug, please [open an issue][6].
+          If you encounter a bug, please [open an issue][6].
 
-        [1]: https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md#XXX-XXXX-XX-XX
-        [2]: https://releases.radicle.xyz/radicle-upstream-X.X.X.dmg
-        [3]: https://releases.radicle.xyz/radicle-upstream-X.X.X.AppImage
-        [4]: https://docs.radicle.xyz/docs/what-is-radicle.html
-        [5]: https://matrix.radicle.community/#/room/#support:radicle.community
-        [6]: https://github.com/radicle-dev/radicle-upstream/issues
+          [1]: https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md#XXX-XXXX-XX-XX
+          [2]: https://releases.radicle.xyz/radicle-upstream-X.X.X.dmg
+          [3]: https://releases.radicle.xyz/radicle-upstream-X.X.X.AppImage
+          [4]: https://docs.radicle.xyz/docs/what-is-radicle.html
+          [5]: https://matrix.radicle.community/#/room/#support:radicle.community
+          [6]: https://github.com/radicle-dev/radicle-upstream/issues
 
   - Post the following two lines on:
     https://matrix.radicle.community/#/room/#general:radicle.community

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -438,7 +438,7 @@ For this we need:
       **Note:** this can only be created via the company account holder
 
 Once you've created the _Developer ID Application_ certificate, download it
-locally and add it to your keychain by double cliking on the file.
+locally and add it to your keychain by double clicking on the file.
 
 
 ## Preparing a release

--- a/QA.md
+++ b/QA.md
@@ -104,8 +104,8 @@
     - [ ] The button is now called _Checkout_ instead of _Fork_
     - [ ] Create a commit and publish your chages via `git rad push`
       - [ ] The published commit appears in the _Commits_ tab of the project
-  - [ ] Add a random (one that doesn't track the project) remote e.g.
-        `hync6jo9q9n4rfgag3o99gann391nsjhuq3oaemoe13oyn3gruwrgh`)
+  - [ ] Add a remote that doesn't track the project, e.g.
+        `hync6jo9q9n4rfgag3o99gann391nsjhuq3oaemoe13oyn3gruwrgh`
     - [ ] Shows the remote in the _Still looking…_ section
   - [ ] Clicking the _Unfollow_ button removes the remote
 

--- a/QA.md
+++ b/QA.md
@@ -105,9 +105,10 @@
     - [ ] The button is now called _Checkout_ instead of _Fork_
     - [ ] Create a commit and publish your chages via `git rad push`
       - [ ] The published commit appears in the _Commits_ tab of the project
-  - TODO: add other remotes
-  - TODO: remove remotes
-  - TODO: pull changes from a different remote (needs interaction with other peers)
+  - [ ] Add a random (one that doesn't track the project) remote e.g.
+        `hync6jo9q9n4rfgag3o99gann391nsjhuq3oaemoe13oyn3gruwrgh`)
+    - [ ] Shows the remote in the _Still looking…_ section
+  - [ ] Clicking the _Unfollow_ button removes the remote
 
 
 ### Lifecycle

--- a/QA.md
+++ b/QA.md
@@ -4,21 +4,23 @@
 
 - [ ] make sure you are installing into an environment with no old configuration
       and no user data
+
   <details>
     <summary>
-     ℹ How to set up a clean environemnt?
+      How to set up a clean environemnt?
     </summary>
+
 
     **Safe method**: use a temporary user account on your computer.
 
-    - on macOS
+    - on macOS:
       - if you are **not** using FileVault, switch to the "Guest User". You may
         have to enable this in "System Preferences -> Users & Groups".  When
         you're done, all data will be removed automatically.
       - if you **are** using FileVault, create a new user in "System
         Preferences -> Users & Groups". When you're done, you'll need to remove
         this user manually.
-    - on Linux
+    - on Linux:
       - create a new user with `sudo useradd -m qa`, and log into that account.
         When you're done, remove the user with `sudo userdel -r qa`.  _Note:
         "qa" is just an example user name, you can choose anything you like_
@@ -29,19 +31,22 @@
     or are using this in combination with the safe method (i.e. while logged
     in with a temporary user account).
   </details>
+
 - [ ] [download the binary package][bu]
 - [ ] install Upstream from the downloaded package
+
   <details>
     <summary>
-     ℹ How to install?
+      How to install?
     </summary>
 
-    - on macOS
+
+    - on macOS:
       1. open the `radicle-upstream-X.X.X.dmg` package
       2. install Upstream by dragging the `Radicle Upstream` binary to
          `/Applications`
       3. run `/Applications/Radicle Upstream.app` by double clicking it
-    - on Linux (AppImage)
+    - on Linux (AppImage):
       1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
       2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
          executing it from the terminal or clicking on it.

--- a/QA.md
+++ b/QA.md
@@ -24,9 +24,9 @@
 
      **Dangerous method**: Remove all directories manually
 
-     You can use [this script](./scripts/reset-state.sh). Make sure you have a
-     backup of your data, or are using this in combination with the safe method
-     (i.e. while logged in with a temporary user account).
+     You can use [this script][rs]. Make sure you have a backup of your data,
+     or are using this in combination with the safe method (i.e. while logged
+     in with a temporary user account).
 
 - [ ] download the binary package from the location provided above
 - [ ] install the binary package
@@ -183,4 +183,5 @@
 - [ ] Killing the proxy process while the app is running shows a blue error
       screen with the proxy logs.
 
-[re]: https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md
+
+[rs]: https://github.com/radicle-dev/radicle-upstream/blob/master/scripts/reset-state.sh

--- a/QA.md
+++ b/QA.md
@@ -1,43 +1,55 @@
-**OS version:** (eg. `Catalina 10.15.6` or `Ubuntu Xenial Xerus 16.04.1 LTS`)\
-**Link to build:** (eg. https://buildkite.com/monadic/radicle-upstream/builds/4727)
-
+**OS version:** (eg. `Catalina 10.15.6` or `Ubuntu Xenial Xerus 16.04.1 LTS`)
 
 ### Prerequisites
 
 - [ ] make sure you are installing into an environment with no old configuration
-      and user data
+      and no user data
 
-     **Safe method**: Use a temporary user account on your computer
+      <details>
+        <summary>
+         ℹ How to set up a clean environemnt?
+        </summary>
 
-     - on macOS:
-       - If you are **not** using FileVault, switch to the "Guest User". You
-         may have to enable this in "System Preferences -> Users & Groups".
-         When you're done, all data will be removed automatically.
-       - If you **are** using FileVault, create a new user in "System
-         Preferences -> Users & Groups". When you're done, you'll need to
-         remove this user manually.
-     - on Linux:
-       - Create a new user with `sudo useradd -m qa`, and log into that
-         account. When you're done, remove the user with `sudo userdel -r qa`.
-         _Note: "qa" is just an example user name, you can choose anything you
-         like_
+        **Safe method**: Use a temporary user account on your computer
 
-     **Dangerous method**: Remove all directories manually
+        - on macOS:
+         - If you are **not** using FileVault, switch to the "Guest User". You
+           may have to enable this in "System Preferences -> Users & Groups".
+           When you're done, all data will be removed automatically.
+         - If you **are** using FileVault, create a new user in "System
+           Preferences -> Users & Groups". When you're done, you'll need to
+           remove this user manually.
+        - on Linux:
+         - Create a new user with `sudo useradd -m qa`, and log into that
+           account. When you're done, remove the user with `sudo userdel -r qa`.
+           _Note: "qa" is just an example user name, you can choose anything you
+           like_
 
-     You can use [this script][rs]. Make sure you have a backup of your data,
-     or are using this in combination with the safe method (i.e. while logged
-     in with a temporary user account).
+        **Dangerous method**: Remove all directories manually
 
-- [ ] download the binary package from the location provided above
-- [ ] install the binary package
-  - on macOS:
-    1. open the `radicle-upstream-x.x.x.dmg` package
-    2. install Upstream by dragging the `radicle-upstream` binary to
-       `/Applications`
-  - on Linux (AppImage)
-    1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
-    2. Run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by executing it
-       from the terminal or clicking on it.
+        You can use [this script][rs]. Make sure you have a backup of your data,
+        or are using this in combination with the safe method (i.e. while logged
+        in with a temporary user account).
+      </details>
+
+- [ ] [download the binary package][bu]
+- [ ] install Upstream from the downloaded package
+
+      <details>
+        <summary>
+         ℹ How to install?
+        </summary>
+
+        - on macOS:
+          1. open the `radicle-upstream-X.X.X.dmg` package
+          2. install Upstream by dragging the `Radicle Upstream` binary to
+             `/Applications`
+          3. run `/Applications/Radicle Upstream.app` by double clicking it
+        - on Linux (AppImage)
+          1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
+          2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
+             executing it from the terminal or clicking on it.
+      </details>
 
 ### Packaging and distribution
 
@@ -177,3 +189,4 @@
 
 
 [rs]: https://github.com/radicle-dev/radicle-upstream/blob/master/scripts/reset-state.sh
+[bu]: http://releases.radicle.xyz/radicle-upstream-0.1.5.dmg

--- a/QA.md
+++ b/QA.md
@@ -4,43 +4,39 @@
 
 - [ ] make sure you are installing into an environment with no old configuration
       and no user data
-
   <details>
     <summary>
      ℹ How to set up a clean environemnt?
     </summary>
 
-    **Safe method**: Use a temporary user account on your computer
+    **Safe method**: use a temporary user account on your computer.
 
-    - on macOS:
-     - If you are **not** using FileVault, switch to the "Guest User". You
-       may have to enable this in "System Preferences -> Users & Groups".
-       When you're done, all data will be removed automatically.
-     - If you **are** using FileVault, create a new user in "System
-       Preferences -> Users & Groups". When you're done, you'll need to
-       remove this user manually.
-    - on Linux:
-     - Create a new user with `sudo useradd -m qa`, and log into that
-       account. When you're done, remove the user with `sudo userdel -r qa`.
-       _Note: "qa" is just an example user name, you can choose anything you
-       like_
+    - on macOS
+      - if you are **not** using FileVault, switch to the "Guest User". You may
+        have to enable this in "System Preferences -> Users & Groups".  When
+        you're done, all data will be removed automatically.
+      - if you **are** using FileVault, create a new user in "System
+        Preferences -> Users & Groups". When you're done, you'll need to remove
+        this user manually.
+    - on Linux
+      - create a new user with `sudo useradd -m qa`, and log into that account.
+        When you're done, remove the user with `sudo userdel -r qa`.  _Note:
+        "qa" is just an example user name, you can choose anything you like_
 
-    **Dangerous method**: Remove all directories manually
+    **Dangerous method**: remove all directories manually.
 
     You can use [this script][rs]. Make sure you have a backup of your data,
     or are using this in combination with the safe method (i.e. while logged
     in with a temporary user account).
   </details>
-
 - [ ] [download the binary package][bu]
 - [ ] install Upstream from the downloaded package
-
   <details>
     <summary>
      ℹ How to install?
     </summary>
 
-    - on macOS:
+    - on macOS
       1. open the `radicle-upstream-X.X.X.dmg` package
       2. install Upstream by dragging the `Radicle Upstream` binary to
          `/Applications`

--- a/QA.md
+++ b/QA.md
@@ -184,5 +184,5 @@
       screen with the proxy logs.
 
 
-[rs]: https://github.com/radicle-dev/radicle-upstream/blob/master/scripts/reset-state.sh
+[rs]: https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/scripts/reset-state.sh
 [bu]: http://releases.radicle.xyz/radicle-upstream-0.1.5.dmg

--- a/QA.md
+++ b/QA.md
@@ -34,13 +34,6 @@
     1. open the `radicle-upstream-x.x.x.dmg` package
     2. install Upstream by dragging the `radicle-upstream` binary to
        `/Applications`
-    3. open `/Applications` in finder, locate the `radicle-upstream` app and
-       right-click it, then select `Open` from the context menu, you should see
-       a dialog with two buttons `Move to Bin` and `Cancel`
-    4. dismiss the dialog by clicking `Cancel`, to bypass macOS security
-       measures which disallow running unsigned binaries, repeat the previous
-       step, now you should see three buttons: `Move to Bin`, `Open` and
-       `Cancel`, click `Open`
   - on Linux (AppImage)
     1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
     2. Run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by executing it

--- a/QA.md
+++ b/QA.md
@@ -84,8 +84,8 @@
     - the repeated passphrase is equal to the first one
     - all of the following example pairs should show a validation error:
       `1`/`1`, `12`/`12`, `123`/`123`, `supersecret`/`supersceret`
-- [ ] After passphrase input the identity is created and a copyable URN is
-      provided
+- [ ] After passphrase input the identity is created and a copyable Device ID
+      is provided
 - [ ] After completion we land on our profile page which contains a placeholder
       with instructions on how to create your first project
 
@@ -94,7 +94,7 @@
 
 - [ ] Preferences are persisted across app reboots
   - [ ] Color theme selection
-  - [ ] Peer entries
+  - [ ] Network seeds
   - [ ] Remote helper hint (in the Checkout and "New project" modals) is not
         shown after app restart once it is dismissed by clicking the `x` icon
         in the top right corner
@@ -129,8 +129,7 @@
   - [ ] Follow instructions in the UI to set up the path to the git helper in
         your shell
   - [ ] It's possible to create a new working copy from an existing project
-    - [ ] Pushing new commits to Radicle via `git push rad` work (temporary
-          password until we have passphrases: `radicle-upstream`)
+    - [ ] Pushing new commits to Radicle via `git push rad` work
     - [ ] Pulling changes work: make changes in the project folder you created
           in project creation, push them to Radicle with `git push rad`, switch
           to the checkout working directory, do a `git pull`

--- a/QA.md
+++ b/QA.md
@@ -1,133 +1,125 @@
 ## Prerequisites
 
-- [ ] make sure you are installing into an environment with no old
+- [ ] Make sure you are installing into an environment with no old
       configuration and no user data [ℹ️](#01)
-- [ ] make sure you have configured your name and email in git [ℹ️](#02)
-- [ ] [download][bu] the binary package
-- [ ] install Upstream from the downloaded package [ℹ️](#03)
+- [ ] Make sure you have configured your name and email in git [ℹ️](#02)
+- [ ] [Download][bu] the binary package
+- [ ] Install Upstream from the downloaded package [ℹ️](#03)
   - [ ] macOS Gatekeeper **does not** show the following message:
         _macOS cannot verify that this app is free from malware_
 
+
 ## QA checklist
 
-### Packaging and distribution
+### Packaging
 
-- [ ] Check that unreleased features are not visible in the UI
-  - [ ] Experimental features and developer helpers are not accessible
-    - Issues and Revisions tabs on the Project screen
-    - Wallets tab on the User Profile screen
-    - Design Sytem Guide is not listed in the shortcuts modal <kbd>?</kbd> and
-      the respective global hotkey is disabled <kbd>⌘</kbd>+<kbd>d</kbd>
-    - Tags are not visible in the revision selector on the Project Source
-      screen
 - [ ] App icon is shown correctly
-  - [ ] macOS: dock, <kbd>⌘</kbd> + <kbd>tab</kbd> task switcher, mounted dmg,
-        app icon, "About radicle-upstream" window
-  - [ ] Linux: dock, menu bar
-- [ ] Version in the Settings screen matches version in package filename
+  - macOS:
+    - [ ] Dock
+    - [ ] <kbd>⌘</kbd> + <kbd>tab</kbd> task switcher
+    - [ ] Mounted dmg
+    - [ ] App icon
+  - Linux:
+    - [ ] Dock
+    - [ ] Menu bar
 
 
 ### Onboarding
 
-- [ ] Always shown when no identity is set up
-  - [ ] First app start
-  - [ ] Subsequent app starts if the identity creation was not completed
-  - [ ] Can't exit onboarding before identity is created and global keyboard
-        shortcuts are disabled
-- [ ] It's possible to go to the next screen by pressing <kbd>enter</kbd> if
-      the input field validations allow it
-- [ ] Handle and passphrase validations work
-- [ ] After passphrase input the identity is created and a copyable Device ID
-      is provided
-- [ ] After completion we land on our profile page which contains a placeholder
-      with instructions on how to create your first project
+- [ ] Start Upstream
+  - on Linux: run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
+    executing it from the terminal or clicking on it
+  - on macOS: run `/Applications/Radicle Upstream.app` by double clicking it
+- [ ] Onboarding starts on the _Get started_ screen
+- [ ] Pressing <kbd>enter</kbd> leads to the next screen
+- [ ] Handle validations work
+- [ ] Passphrase validations work
+- [ ] On the _All set!_ screen clicking the _Device ID_ copies it to the
+      clipboard
+- [ ] Clicking the _Go to my projects_ button leads to the _Profile_ screen
+- [ ] Hovering the network icon in the sidebar shows
+      _You're connected to 1 peer_
+
+
+### Creating projects
+
+- [ ] Can create a new project with a new repository
+  - [ ] Validations work
+  - [ ] A placeholder is shown for the missing `README.md`
+- [ ] Can create a new project from a larger existing repository
+  - [ ] UI interaction is blocked while project creation is in progress
+  - [ ] `README.md` files are shown by default and markdown is rendered as HTML
+    - [ ] Links to external resources open in external browser
+    - [ ] Links to internal resources don't do anything
+  - [ ] Syntax highlighting works for source files (.toml, .sol, .ts, .svelte)
+  - [ ] Binary files show a placeholder
+  - [ ] It's possible to navigate to deeper hierarchies via the tree browser
+  - [ ] It's possible to select different branches
+  - [ ] Metadata and stats in UI reflect what is in the actual repository; here
+        are a couple commands that will help you get the numbers from
+        a repository [ℹ️](#04)
+  - [ ] Commit tab shows a list of all the commits in the branch that was
+        selected
+  - [ ] Clicking on a commit shows the commit metadata as well as the diff
+- [ ] No unreleased features are visible in the UI
+    - [ ] _Issues_ and _Revisions_ tabs on the Project screen
+    - [ ] _Wallets_ tab on the User Profile screen
+    - Tags are not visible in the revision selector on the _Project Source_
+      screen
 
 
 ### Settings
 
+- [ ] Links to external help resources open in an external browser
+- [ ] All documented shortcuts work. Press <kbd>?</kbd> to open the
+      _Keyboard shortcuts_ help screen.
+  - [ ] Only one modal is allowed at a time (no modal stacking possible)
+  - [ ] _Design Sytem Guide_ is not listed in the shortcuts modal
+        <kbd>?</kbd> and the respective global hotkey is disabled
+        <kbd>⌘</kbd>+<kbd>d</kbd>
+- [ ] The version number in the _Settings_ screen matches the version number in
+      package filename and in the _About Radicle Upstream_ dialog
+
+
+### Replicating projects
+
+- [ ] Replicate a project from seedling.radicle.xyz
+  - [ ] Pick a project from seedling.radicle.xyz and search for it by pasting
+        the `Radicle ID` of the project into the search bar by pressing
+        <kbd>⌘</kbd>+<kbd>p</kbd>, then click the _Follow_ button
+    - [ ] The project shows up in the _Following_ tab of the profile screen in
+          the waiting area
+    - [ ] After a while the project is replicated and moves out of the waiting
+          area
+    - [ ] When going to the Project source screen, the maintainer is selected
+          in the peer selector
+      - [ ] Your identity does not show up in the peer selector
+  - [ ] Set up the remote helper according to the instructions in the _Fork_
+        modal hint
+  - [ ] Fork the replicated project to a local directory
+    - [ ] The forked project should now appear in the _Projects_ tab of the
+          profile screen
+    - [ ] Your identity shows up in the peer selector and is selected by
+          default instead of the maintainer's identity
+    - [ ] The button is now called _Checkout_ instead of _Fork_
+    - [ ] Create a commit and publish your chages via `git rad push`
+      - [ ] The published commit appears in the _Commits_ tab of the project
+  - TODO: add other remotes
+  - TODO: remove remotes
+  - TODO: pull changes from a different remote (needs interaction with other peers)
+
+
+### Lifecycle
+
 - [ ] Preferences are persisted across app reboots
   - [ ] Color theme selection
-  - [ ] Network seeds
+  - [ ] Network seed changes
   - [ ] Remote helper hint (in the Checkout and "New project" modals) is not
         shown after app restart once it is dismissed by clicking the `x` icon
         in the top right corner
-- [ ] Links to external help resources open in an external browser
-
-
-### Projects
-
-- [ ] Can create a new project with a new repository
-  - [ ] Validations work
-- [ ] Can create a new project from an existing repository
-  - [ ] Adding larger projects don't crash the app
-  - [ ] UI interaction is blocked while project creation is in progress
-
-
-#### Working directory (from which a new project was initialised)
-
-- [ ] When pushing changes to Radicle via `git push rad` they should appear in
-      the app (a page refresh is still needed for the changes to show up)
-- [ ] Pulling changes from Radicle work (to test this you'll need to have a
-      checked out another working copy in a different folder)
-
-
-#### Checkout (a separate working copy)
-
-  - [ ] Follow instructions in the UI to set up the path to the git helper in
-        your shell
-  - [ ] It's possible to create a new working copy from an existing project
-    - [ ] Pushing new commits to Radicle via `git push rad` work
-    - [ ] Pulling changes work: make changes in the project folder you created
-          in project creation, push them to Radicle with `git push rad`, switch
-          to the checkout working directory, do a `git pull`
-
-
-#### Source browsing
-
-- [ ] Metadata and stats in UI reflect what is in the actual repository; here
-      are a couple commands that will help you get the numbers from
-      a repository:
-  - local branch count
-    `git branch | wc -l`
-  - all unique contributors across all branches
-    `git shortlog --summary --numbered --email --all`
-  - all unique contributors in a specific branch
-    `git shortlog --summary --numbered --email myfunkybranch`
-  - unique commit count across all branches
-    `git rev-list --all --count`
-  - commit count in a specific branch
-    `git rev-list --count myfunkybranch`
-- [ ] `README.md` files are shown by default and markdown is rendered as HTML
-  - [ ] Links to external resources open in external browser
-  - [ ] Links to internal resources don't do anything
-  - [ ] If the project doesn't have a `README.md`, a placeholder is shown
-- [ ] Syntax highlighting works for source files (.toml, .sol, .ts, .svelte)
-- [ ] Binary files show a placeholder
-- [ ] It's possible to navigate to deeper hierarchies via the tree browser
-- [ ] It's possible to select different branches
-
-
-#### Commit browsing
-
-- [ ] Commit tab shows a list of all the commits in the branch that was
-      selected
-- [ ] Clicking on a commit shows the commit metadata as well as the diff
-
-
-### Misc UI
-
-- [ ] Clicking on an identifier copies it to the clipboard
-
-
-#### Global keyboard shortcuts
-
-- [ ] All documented shortcuts (a list is provided by pressing `?`) work
-- [ ] Only one modal is allowed at a time (no modal stacking possible)
-
-### Proxy Error
-
 - [ ] Killing the proxy process while the app is running shows a blue error
-      screen with the proxy logs.
+      screen with the proxy logs
+  - [ ] Clicking the button copies the logs to the clipboard
 
 
 ## Hints
@@ -167,13 +159,30 @@ in with a temporary user account).
   1. open the `radicle-upstream-X.X.X.dmg` package
   2. install Upstream by dragging the `Radicle Upstream` binary to
      `/Applications`
-  3. run `/Applications/Radicle Upstream.app` by double clicking it
 
 **On Linux (AppImage):**
 
   1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
-  2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by executing it
-     from the terminal or clicking on it.
+
+
+### How to query repo stats from the CLI? <a href="#user-content-04" id="04">🔗</a>
+
+```
+  # local branch count
+  git branch | wc -l
+
+  # all unique contributors across all branches
+  git shortlog --summary --numbered --email --all
+
+  # all unique contributors in a specific branch
+  git shortlog --summary --numbered --email myfunkybranch
+
+  # unique commit count across all branches
+  git rev-list --all --count
+
+  # commit count in a specific branch
+  git rev-list --count myfunkybranch
+```
 
 
 

--- a/QA.md
+++ b/QA.md
@@ -2,8 +2,9 @@
 
 - [ ] make sure you are installing into an environment with no old
       configuration and no user data [ℹ️](#01)
+- [ ] make sure you have configured your name and email in git [ℹ️](#02)
 - [ ] [download][bu] the binary package
-- [ ] install Upstream from the downloaded package [ℹ️](#02)
+- [ ] install Upstream from the downloaded package [ℹ️](#03)
   - [ ] macOS Gatekeeper **does not** show the following message:
         _macOS cannot verify that this app is free from malware_
 
@@ -154,7 +155,12 @@ or are using this in combination with the safe method (i.e. while logged
 in with a temporary user account).
 
 
-### How to install? <a href="#user-content-02" id="02">🔗</a>
+### How to set up git? <a href="#user-content-02" id="02">🔗</a>
+    git config --global user.name "Mona Lisa"
+    git config --global user.email "email@example.com"
+
+
+### How to install? <a href="#user-content-03" id="03">🔗</a>
 
 **On macOS:**
 

--- a/QA.md
+++ b/QA.md
@@ -188,4 +188,4 @@ in with a temporary user account).
 
 
 [rs]: https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/scripts/reset-state.sh
-[bu]: https://releases.radicle.xyz/radicle-upstream-0.1.5.dmg
+[bu]: https://releases.radicle.xyz/radicle-upstream-X.X.X.dmg

--- a/QA.md
+++ b/QA.md
@@ -36,18 +36,6 @@
 - [ ] It's possible to go to the next screen by pressing <kbd>enter</kbd> if
       the input field validations allow it
 - [ ] Handle and passphrase validations work
-  - handle
-    - starts with a letter or digit
-    - is at least 2 characters long
-    - can contain the letters `a`-`z`, `A`-`Z`, digits `0`-`9` and special
-      characters `-`, `_`
-    - all of the following examples should show a validation error:
-      `_john`, `x`, `linu$$$`, `-moira`
-  - passphrase
-    - is at least 4 characters long
-    - the repeated passphrase is equal to the first one
-    - all of the following example pairs should show a validation error:
-      `1`/`1`, `12`/`12`, `123`/`123`, `supersecret`/`supersceret`
 - [ ] After passphrase input the identity is created and a copyable Device ID
       is provided
 - [ ] After completion we land on our profile page which contains a placeholder
@@ -68,13 +56,7 @@
 ### Projects
 
 - [ ] Can create a new project with a new repository
-  - [ ] Name validations work
-      - starts with a letter or digit
-      - is at least 2 characters long
-      - can contain the letters `a`-`z`, `A`-`Z`, digits `0`-`9` and special
-        characters `-`, `_`, `.`
-      - all of the following examples should show a validation error:
-        `1`, `-fancy-`, `_doh_`, `rx~pixels`, `💁👌🎍😍`
+  - [ ] Validations work
 - [ ] Can create a new project from an existing repository
   - [ ] Adding larger projects don't crash the app
   - [ ] UI interaction is blocked while project creation is in progress

--- a/QA.md
+++ b/QA.md
@@ -1,10 +1,13 @@
-### Prerequisites
+## Prerequisites
 
 - [ ] make sure you are installing into an environment with no old
       configuration and no user data [ℹ️](#01)
 - [ ] [download][bu] the binary package
 - [ ] install Upstream from the downloaded package [ℹ️](#02)
+  - [ ] macOS Gatekeeper **does not** show the following message:
+        _macOS cannot verify that this app is free from malware_
 
+## QA checklist
 
 ### Packaging and distribution
 

--- a/QA.md
+++ b/QA.md
@@ -64,7 +64,7 @@
 - [ ] No unreleased features are visible in the UI
     - [ ] _Issues_ and _Revisions_ tabs on the Project screen
     - [ ] _Wallets_ tab on the User Profile screen
-    - Tags are not visible in the revision selector on the _Project Source_
+    - [ ] Tags are not visible in the revision selector on the _Project Source_
       screen
 
 

--- a/QA.md
+++ b/QA.md
@@ -1,9 +1,10 @@
 ### Prerequisites
 
-- [ ] make sure you are installing into an environment with no old configuration
-      and no user data [ℹ️][01]
-- [ ] [download the binary package][bu]
-- [ ] install Upstream from the downloaded package [ℹ️][02]
+- [ ] make sure you are installing into an environment with no old
+      configuration and no user data [ℹ️](#01)
+- [ ] [download][bu] the binary package
+- [ ] install Upstream from the downloaded package [ℹ️](#02)
+
 
 ### Packaging and distribution
 
@@ -13,7 +14,8 @@
     - Wallets tab on the User Profile screen
     - Design Sytem Guide is not listed in the shortcuts modal <kbd>?</kbd> and
       the respective global hotkey is disabled <kbd>⌘</kbd>+<kbd>d</kbd>
-    - Tags are not visible in the revision selector on the Project Source screen
+    - Tags are not visible in the revision selector on the Project Source
+      screen
 - [ ] App icon is shown correctly
   - [ ] macOS: dock, <kbd>⌘</kbd> + <kbd>tab</kbd> task switcher, mounted dmg,
         app icon, "About radicle-upstream" window
@@ -146,7 +148,8 @@
 
 ### How to set up a clean environemnt? <a href="#user-content-01" id="01">🔗</a>
 
-- **Safe method**: use a temporary user account on your computer.
+**Safe method**: use a temporary user account on your computer.
+
   - on macOS:
     - if you are **not** using FileVault, switch to the "Guest User". You may
       have to enable this in "System Preferences -> Users & Groups".  When
@@ -159,24 +162,27 @@
       When you're done, remove the user with `sudo userdel -r qa`.  _Note:
       "qa" is just an example user name, you can choose anything you like_
 
-- **Dangerous method**: remove all directories manually.
+**Dangerous method**: remove all directories manually.
 
-  You can use [this script][rs]. Make sure you have a backup of your data,
-  or are using this in combination with the safe method (i.e. while logged
-  in with a temporary user account).
+You can use [this script][rs]. Make sure you have a backup of your data,
+or are using this in combination with the safe method (i.e. while logged
+in with a temporary user account).
 
 
 ### How to install? <a href="#user-content-02" id="02">🔗</a>
 
-- on macOS:
+**On macOS:**
+
   1. open the `radicle-upstream-X.X.X.dmg` package
   2. install Upstream by dragging the `Radicle Upstream` binary to
      `/Applications`
   3. run `/Applications/Radicle Upstream.app` by double clicking it
-- on Linux (AppImage):
+
+**On Linux (AppImage):**
+
   1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
-  2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
-     executing it from the terminal or clicking on it.
+  2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by executing it
+     from the terminal or clicking on it.
 
 
 

--- a/QA.md
+++ b/QA.md
@@ -32,8 +32,8 @@
   - on macOS: run `/Applications/Radicle Upstream.app` by double clicking it
 - [ ] Onboarding starts on the _Get started_ screen
 - [ ] Pressing <kbd>enter</kbd> leads to the next screen
-- [ ] Handle validations work
-- [ ] Passphrase validations work
+- [ ] Using `$$` as the _Display name_ shows a validation error
+- [ ] Entering two different passphrases shows a validation error
 - [ ] On the _All set!_ screen clicking the _Device ID_ copies it to the
       clipboard
 - [ ] Clicking the _Go to my projects_ button leads to the _Profile_ screen
@@ -44,7 +44,7 @@
 ### Creating projects
 
 - [ ] Can create a new project with a new repository
-  - [ ] Validations work
+  - [ ] Using `%%` for the project name shows a validation error
   - [ ] A placeholder is shown for the missing `README.md`
 - [ ] Can create a new project from a larger existing repository
   - [ ] UI interaction is blocked while project creation is in progress

--- a/QA.md
+++ b/QA.md
@@ -10,26 +10,24 @@
       How to set up a clean environemnt?
     </summary>
 
+    - **Safe method**: use a temporary user account on your computer.
+      - on macOS:
+        - if you are **not** using FileVault, switch to the "Guest User". You may
+          have to enable this in "System Preferences -> Users & Groups".  When
+          you're done, all data will be removed automatically.
+        - if you **are** using FileVault, create a new user in "System
+          Preferences -> Users & Groups". When you're done, you'll need to remove
+          this user manually.
+      - on Linux:
+        - create a new user with `sudo useradd -m qa`, and log into that account.
+          When you're done, remove the user with `sudo userdel -r qa`.  _Note:
+          "qa" is just an example user name, you can choose anything you like_
 
-    **Safe method**: use a temporary user account on your computer.
+    - **Dangerous method**: remove all directories manually.
 
-    - on macOS:
-      - if you are **not** using FileVault, switch to the "Guest User". You may
-        have to enable this in "System Preferences -> Users & Groups".  When
-        you're done, all data will be removed automatically.
-      - if you **are** using FileVault, create a new user in "System
-        Preferences -> Users & Groups". When you're done, you'll need to remove
-        this user manually.
-    - on Linux:
-      - create a new user with `sudo useradd -m qa`, and log into that account.
-        When you're done, remove the user with `sudo userdel -r qa`.  _Note:
-        "qa" is just an example user name, you can choose anything you like_
-
-    **Dangerous method**: remove all directories manually.
-
-    You can use [this script][rs]. Make sure you have a backup of your data,
-    or are using this in combination with the safe method (i.e. while logged
-    in with a temporary user account).
+      You can use [this script][rs]. Make sure you have a backup of your data,
+      or are using this in combination with the safe method (i.e. while logged
+      in with a temporary user account).
   </details>
 
 - [ ] [download the binary package][bu]
@@ -39,7 +37,6 @@
     <summary>
       How to install?
     </summary>
-
 
     - on macOS:
       1. open the `radicle-upstream-X.X.X.dmg` package

--- a/QA.md
+++ b/QA.md
@@ -55,9 +55,8 @@
   - [ ] Binary files show a placeholder
   - [ ] It's possible to navigate to deeper hierarchies via the tree browser
   - [ ] It's possible to select different branches
-  - [ ] Metadata and stats in UI reflect what is in the actual repository; here
-        are a couple commands that will help you get the numbers from
-        a repository [ℹ️](#04)
+  - [ ] Metadata and stats in UI reflect what is in the actual repository
+        [ℹ️](#04)
   - [ ] Commit tab shows a list of all the commits in the branch that was
         selected
   - [ ] Clicking on a commit shows the commit metadata as well as the diff

--- a/QA.md
+++ b/QA.md
@@ -77,8 +77,9 @@
   - [ ] _Design Sytem Guide_ is not listed in the shortcuts modal
         <kbd>?</kbd> and the respective global hotkey is disabled
         <kbd>⌘</kbd>+<kbd>d</kbd>
-- [ ] The version number in the _Settings_ screen matches the version number in
-      package filename and in the _About Radicle Upstream_ dialog
+- [ ] The version number in the _Settings_ screen matches:
+  - [ ] The version number in the package filename
+  - [ ] The version number in the _About Radicle Upstream_ dialog
 
 
 ### Replicating projects

--- a/QA.md
+++ b/QA.md
@@ -1,53 +1,9 @@
-**OS version:** (eg. `Catalina 10.15.6` or `Ubuntu Xenial Xerus 16.04.1 LTS`)
-
 ### Prerequisites
 
 - [ ] make sure you are installing into an environment with no old configuration
-      and no user data
-
-  <details>
-    <summary>
-      How to set up a clean environemnt?
-    </summary>
-
-    - **Safe method**: use a temporary user account on your computer.
-      - on macOS:
-        - if you are **not** using FileVault, switch to the "Guest User". You may
-          have to enable this in "System Preferences -> Users & Groups".  When
-          you're done, all data will be removed automatically.
-        - if you **are** using FileVault, create a new user in "System
-          Preferences -> Users & Groups". When you're done, you'll need to remove
-          this user manually.
-      - on Linux:
-        - create a new user with `sudo useradd -m qa`, and log into that account.
-          When you're done, remove the user with `sudo userdel -r qa`.  _Note:
-          "qa" is just an example user name, you can choose anything you like_
-
-    - **Dangerous method**: remove all directories manually.
-
-      You can use [this script][rs]. Make sure you have a backup of your data,
-      or are using this in combination with the safe method (i.e. while logged
-      in with a temporary user account).
-  </details>
-
+      and no user data [ℹ️][01]
 - [ ] [download the binary package][bu]
-- [ ] install Upstream from the downloaded package
-
-  <details>
-    <summary>
-      How to install?
-    </summary>
-
-    - on macOS:
-      1. open the `radicle-upstream-X.X.X.dmg` package
-      2. install Upstream by dragging the `Radicle Upstream` binary to
-         `/Applications`
-      3. run `/Applications/Radicle Upstream.app` by double clicking it
-    - on Linux (AppImage):
-      1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
-      2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
-         executing it from the terminal or clicking on it.
-  </details>
+- [ ] install Upstream from the downloaded package [ℹ️][02]
 
 ### Packaging and distribution
 
@@ -186,5 +142,43 @@
       screen with the proxy logs.
 
 
+## Hints
+
+### How to set up a clean environemnt? <a href="#user-content-01" id="01">🔗</a>
+
+- **Safe method**: use a temporary user account on your computer.
+  - on macOS:
+    - if you are **not** using FileVault, switch to the "Guest User". You may
+      have to enable this in "System Preferences -> Users & Groups".  When
+      you're done, all data will be removed automatically.
+    - if you **are** using FileVault, create a new user in "System
+      Preferences -> Users & Groups". When you're done, you'll need to remove
+      this user manually.
+  - on Linux:
+    - create a new user with `sudo useradd -m qa`, and log into that account.
+      When you're done, remove the user with `sudo userdel -r qa`.  _Note:
+      "qa" is just an example user name, you can choose anything you like_
+
+- **Dangerous method**: remove all directories manually.
+
+  You can use [this script][rs]. Make sure you have a backup of your data,
+  or are using this in combination with the safe method (i.e. while logged
+  in with a temporary user account).
+
+
+### How to install? <a href="#user-content-02" id="02">🔗</a>
+
+- on macOS:
+  1. open the `radicle-upstream-X.X.X.dmg` package
+  2. install Upstream by dragging the `Radicle Upstream` binary to
+     `/Applications`
+  3. run `/Applications/Radicle Upstream.app` by double clicking it
+- on Linux (AppImage):
+  1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
+  2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
+     executing it from the terminal or clicking on it.
+
+
+
 [rs]: https://raw.githubusercontent.com/radicle-dev/radicle-upstream/master/scripts/reset-state.sh
-[bu]: http://releases.radicle.xyz/radicle-upstream-0.1.5.dmg
+[bu]: https://releases.radicle.xyz/radicle-upstream-0.1.5.dmg

--- a/QA.md
+++ b/QA.md
@@ -5,51 +5,51 @@
 - [ ] make sure you are installing into an environment with no old configuration
       and no user data
 
-      <details>
-        <summary>
-         ℹ How to set up a clean environemnt?
-        </summary>
+  <details>
+    <summary>
+     ℹ How to set up a clean environemnt?
+    </summary>
 
-        **Safe method**: Use a temporary user account on your computer
+    **Safe method**: Use a temporary user account on your computer
 
-        - on macOS:
-         - If you are **not** using FileVault, switch to the "Guest User". You
-           may have to enable this in "System Preferences -> Users & Groups".
-           When you're done, all data will be removed automatically.
-         - If you **are** using FileVault, create a new user in "System
-           Preferences -> Users & Groups". When you're done, you'll need to
-           remove this user manually.
-        - on Linux:
-         - Create a new user with `sudo useradd -m qa`, and log into that
-           account. When you're done, remove the user with `sudo userdel -r qa`.
-           _Note: "qa" is just an example user name, you can choose anything you
-           like_
+    - on macOS:
+     - If you are **not** using FileVault, switch to the "Guest User". You
+       may have to enable this in "System Preferences -> Users & Groups".
+       When you're done, all data will be removed automatically.
+     - If you **are** using FileVault, create a new user in "System
+       Preferences -> Users & Groups". When you're done, you'll need to
+       remove this user manually.
+    - on Linux:
+     - Create a new user with `sudo useradd -m qa`, and log into that
+       account. When you're done, remove the user with `sudo userdel -r qa`.
+       _Note: "qa" is just an example user name, you can choose anything you
+       like_
 
-        **Dangerous method**: Remove all directories manually
+    **Dangerous method**: Remove all directories manually
 
-        You can use [this script][rs]. Make sure you have a backup of your data,
-        or are using this in combination with the safe method (i.e. while logged
-        in with a temporary user account).
-      </details>
+    You can use [this script][rs]. Make sure you have a backup of your data,
+    or are using this in combination with the safe method (i.e. while logged
+    in with a temporary user account).
+  </details>
 
 - [ ] [download the binary package][bu]
 - [ ] install Upstream from the downloaded package
 
-      <details>
-        <summary>
-         ℹ How to install?
-        </summary>
+  <details>
+    <summary>
+     ℹ How to install?
+    </summary>
 
-        - on macOS:
-          1. open the `radicle-upstream-X.X.X.dmg` package
-          2. install Upstream by dragging the `Radicle Upstream` binary to
-             `/Applications`
-          3. run `/Applications/Radicle Upstream.app` by double clicking it
-        - on Linux (AppImage)
-          1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
-          2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
-             executing it from the terminal or clicking on it.
-      </details>
+    - on macOS:
+      1. open the `radicle-upstream-X.X.X.dmg` package
+      2. install Upstream by dragging the `Radicle Upstream` binary to
+         `/Applications`
+      3. run `/Applications/Radicle Upstream.app` by double clicking it
+    - on Linux (AppImage)
+      1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
+      2. run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
+         executing it from the terminal or clicking on it.
+  </details>
 
 ### Packaging and distribution
 


### PR DESCRIPTION
Trying to strike a balance here between testing everything that is not covered by our test suite and keeping the QA checklist short simple enough to be doable for every release.

This PR:
  - adds a release checklist so we don't miss a step
  - adds templates for community announcements
  - shuffles the QA checklist around so it can be completed in one go without jumping around between sections

**Note:** I left out testing the peer selector and pulling changes from a new remote, because that would need extra coordination and would make the QA process even longer. Hope we can cover this case by tests soon.

Closes: #1345.