### PR TITLE
Replace `Instant` usage by `SystemTime`

### DIFF
--- a/proxy/api/src/http/project/request.rs
+++ b/proxy/api/src/http/project/request.rs
@@ -46,7 +46,7 @@ fn list_filter(
 
 /// Request handlers for initiating searches for projects on the network.
 mod handler {
-    use std::time::Instant;
+    use std::time::SystemTime;
 
     use warp::{http::StatusCode, reply, Rejection, Reply};
 
@@ -58,7 +58,7 @@ mod handler {
         mut ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
         ctx.peer_control
-            .cancel_project_request(&urn, Instant::now())
+            .cancel_project_request(&urn, SystemTime::now())
             .await
             .map_err(error::Error::from)?;
 
@@ -73,7 +73,10 @@ mod handler {
         urn: coco::Urn,
         mut ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
-        let request = ctx.peer_control.request_project(&urn, Instant::now()).await;
+        let request = ctx
+            .peer_control
+            .request_project(&urn, SystemTime::now())
+            .await;
 
         Ok(reply::json(&request))
     }
@@ -88,7 +91,7 @@ mod handler {
 
 #[cfg(test)]
 mod test {
-    use std::time::Instant;
+    use std::time::SystemTime;
 
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -108,7 +111,10 @@ mod test {
             coco::uri::Path::empty(),
         );
 
-        let _request = ctx.peer_control.request_project(&urn, Instant::now()).await;
+        let _request = ctx
+            .peer_control
+            .request_project(&urn, SystemTime::now())
+            .await;
         let res = request()
             .method("DELETE")
             .path(&format!("/{}", urn))
@@ -158,7 +164,10 @@ mod test {
             coco::uri::Path::empty(),
         );
 
-        let want = ctx.peer_control.request_project(&urn, Instant::now()).await;
+        let want = ctx
+            .peer_control
+            .request_project(&urn, SystemTime::now())
+            .await;
         let res = request().method("GET").path("/").reply(&api).await;
 
         http::test::assert_response(&res, StatusCode::OK, |have| {

--- a/proxy/coco/src/peer/control.rs
+++ b/proxy/coco/src/peer/control.rs
@@ -1,6 +1,6 @@
 //! Inspect state and perform actions on a running peer.
 
-use std::time::Instant;
+use std::time::SystemTime;
 
 use either::Either;
 use tokio::sync::{mpsc, oneshot};
@@ -21,21 +21,21 @@ pub enum Request {
     /// Cancel an ongoing project search.
     CancelSearch(
         RadUrn,
-        Instant,
-        oneshot::Sender<Result<Option<request::SomeRequest<Instant>>, waiting_room::Error>>,
+        SystemTime,
+        oneshot::Sender<Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>>,
     ),
     /// Get a project search.
     GetSearch(
         RadUrn,
-        oneshot::Sender<Option<request::SomeRequest<Instant>>>,
+        oneshot::Sender<Option<request::SomeRequest<SystemTime>>>,
     ),
     /// List all project searches.
-    ListSearches(oneshot::Sender<Vec<request::SomeRequest<Instant>>>),
+    ListSearches(oneshot::Sender<Vec<request::SomeRequest<SystemTime>>>),
     /// Initiate a search for a project on the network.
     StartSearch(
         RadUrn,
-        Instant,
-        oneshot::Sender<waiting_room::Created<Instant>>,
+        SystemTime,
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
     ),
 }
 
@@ -47,23 +47,23 @@ pub enum Response {
 
     /// Response to a cancel project search request.
     CancelSearch(
-        oneshot::Sender<Result<Option<request::SomeRequest<Instant>>, waiting_room::Error>>,
-        Result<Option<request::SomeRequest<Instant>>, waiting_room::Error>,
+        oneshot::Sender<Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>>,
+        Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>,
     ),
     /// Response to get project search request.
     GetSearch(
-        oneshot::Sender<Option<request::SomeRequest<Instant>>>,
-        Option<request::SomeRequest<Instant>>,
+        oneshot::Sender<Option<request::SomeRequest<SystemTime>>>,
+        Option<request::SomeRequest<SystemTime>>,
     ),
     /// Response to list project searches request.
     ListSearches(
-        oneshot::Sender<Vec<request::SomeRequest<Instant>>>,
-        Vec<request::SomeRequest<Instant>>,
+        oneshot::Sender<Vec<request::SomeRequest<SystemTime>>>,
+        Vec<request::SomeRequest<SystemTime>>,
     ),
     /// Response to a start project search request.
     StartSearch(
-        oneshot::Sender<waiting_room::Created<Instant>>,
-        waiting_room::Created<Instant>,
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
+        waiting_room::Created<SystemTime>,
     ),
 }
 
@@ -101,8 +101,8 @@ impl Control {
     pub async fn cancel_project_request(
         &mut self,
         urn: &RadUrn,
-        timestamp: Instant,
-    ) -> Result<Option<request::SomeRequest<Instant>>, waiting_room::Error> {
+        timestamp: SystemTime,
+    ) -> Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error> {
         let (sender, receiver) = oneshot::channel();
 
         self.sender
@@ -117,8 +117,8 @@ impl Control {
     pub async fn get_project_request(
         &mut self,
         urn: &RadUrn,
-    ) -> Option<request::SomeRequest<Instant>> {
-        let (sender, receiver) = oneshot::channel::<Option<request::SomeRequest<Instant>>>();
+    ) -> Option<request::SomeRequest<SystemTime>> {
+        let (sender, receiver) = oneshot::channel::<Option<request::SomeRequest<SystemTime>>>();
 
         self.sender
             .send(Request::GetSearch(urn.clone(), sender))
@@ -129,8 +129,8 @@ impl Control {
     }
 
     /// Initiate a new reuest for the list of existing project requests.
-    pub async fn get_project_requests(&mut self) -> Vec<request::SomeRequest<Instant>> {
-        let (sender, receiver) = oneshot::channel::<Vec<request::SomeRequest<Instant>>>();
+    pub async fn get_project_requests(&mut self) -> Vec<request::SomeRequest<SystemTime>> {
+        let (sender, receiver) = oneshot::channel::<Vec<request::SomeRequest<SystemTime>>>();
 
         self.sender
             .send(Request::ListSearches(sender))
@@ -144,9 +144,9 @@ impl Control {
     pub async fn request_project(
         &mut self,
         urn: &RadUrn,
-        timestamp: Instant,
-    ) -> request::SomeRequest<Instant> {
-        let (sender, receiver) = oneshot::channel::<waiting_room::Created<Instant>>();
+        timestamp: SystemTime,
+    ) -> request::SomeRequest<SystemTime> {
+        let (sender, receiver) = oneshot::channel::<waiting_room::Created<SystemTime>>();
 
         self.sender
             .send(Request::StartSearch(urn.clone(), timestamp, sender))

--- a/proxy/coco/src/peer/run_state/command.rs
+++ b/proxy/coco/src/peer/run_state/command.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
 use librad::{
     peer::PeerId,
@@ -18,7 +18,7 @@ pub enum Command {
     /// Update the include file for the provided `RadUrn`.
     Include(RadUrn),
     /// Tell the subroutine to persist the `WaitingRoom`.
-    PersistWaitingRoom(WaitingRoom<Instant, Duration>),
+    PersistWaitingRoom(WaitingRoom<SystemTime, Duration>),
     /// Fulfill request commands.
     Request(Request),
     /// Initiate a full sync with `PeerId`.

--- a/proxy/coco/src/peer/run_state/input.rs
+++ b/proxy/coco/src/peer/run_state/input.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::SystemTime;
 
 use tokio::sync::oneshot;
 
@@ -56,19 +56,19 @@ pub enum Control {
     /// Cancel an ongoing project search.
     CancelRequest(
         RadUrn,
-        Instant,
-        oneshot::Sender<Result<Option<SomeRequest<Instant>>, waiting_room::Error>>,
+        SystemTime,
+        oneshot::Sender<Result<Option<SomeRequest<SystemTime>>, waiting_room::Error>>,
     ),
     /// Initiate a new project search on the network.
     CreateRequest(
         RadUrn,
-        Instant,
-        oneshot::Sender<waiting_room::Created<Instant>>,
+        SystemTime,
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
     ),
     /// Request a project search.
-    GetRequest(RadUrn, oneshot::Sender<Option<SomeRequest<Instant>>>),
+    GetRequest(RadUrn, oneshot::Sender<Option<SomeRequest<SystemTime>>>),
     /// Request the list of project searches.
-    ListRequests(oneshot::Sender<Vec<SomeRequest<Instant>>>),
+    ListRequests(oneshot::Sender<Vec<SomeRequest<SystemTime>>>),
 }
 
 /// Request event for projects requested from the network.

--- a/proxy/coco/src/peer/subroutines.rs
+++ b/proxy/coco/src/peer/subroutines.rs
@@ -5,7 +5,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::{Duration, SystemTime},
 };
 
 use futures::stream::{BoxStream, FuturesUnordered, SelectAll, StreamExt as _};
@@ -298,7 +298,7 @@ async fn control_respond(cmd: control::Response) {
     };
 }
 
-async fn persist_waiting_room(waiting_room: WaitingRoom<Instant, Duration>, store: kv::Store) {
+async fn persist_waiting_room(waiting_room: WaitingRoom<SystemTime, Duration>, store: kv::Store) {
     match waiting_room::save(&store, waiting_room) {
         Ok(()) => log::debug!("Successfully persisted the waiting room"),
         Err(err) => log::debug!("Error while persisting the waiting room: {}", err),

--- a/proxy/coco/src/peer/waiting_room.rs
+++ b/proxy/coco/src/peer/waiting_room.rs
@@ -1,6 +1,6 @@
 //! Persist the `WaitingRoom` to a k/v store.
 
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
 use kv::Codec as _;
 
@@ -26,9 +26,9 @@ pub enum Error {
 ///
 /// * if the [`kv::Bucket`] can't be accessed
 /// * if the access of the key in the [`kv::Bucket`] fails
-pub fn load(store: &kv::Store) -> Result<Option<WaitingRoom<Instant, Duration>>, Error> {
+pub fn load(store: &kv::Store) -> Result<Option<WaitingRoom<SystemTime, Duration>>, Error> {
     let bucket = store
-        .bucket::<&'static str, kv::Json<WaitingRoom<Instant, Duration>>>(Some(BUCKET_NAME))?;
+        .bucket::<&'static str, kv::Json<WaitingRoom<SystemTime, Duration>>>(Some(BUCKET_NAME))?;
     Ok(bucket.get(KEY_NAME)?.map(kv::Json::to_inner))
 }
 
@@ -39,9 +39,12 @@ pub fn load(store: &kv::Store) -> Result<Option<WaitingRoom<Instant, Duration>>,
 /// * if the [`kv::Bucket`] can't be accessed
 /// * if the storage of the new updates fails
 #[allow(clippy::implicit_hasher)]
-pub fn save(store: &kv::Store, waiting_room: WaitingRoom<Instant, Duration>) -> Result<(), Error> {
+pub fn save(
+    store: &kv::Store,
+    waiting_room: WaitingRoom<SystemTime, Duration>,
+) -> Result<(), Error> {
     let bucket = store
-        .bucket::<&'static str, kv::Json<WaitingRoom<Instant, Duration>>>(Some(BUCKET_NAME))?;
+        .bucket::<&'static str, kv::Json<WaitingRoom<SystemTime, Duration>>>(Some(BUCKET_NAME))?;
     bucket
         .set(KEY_NAME, kv::Json(waiting_room))
         .map_err(Error::from)

--- a/proxy/coco/src/request.rs
+++ b/proxy/coco/src/request.rs
@@ -7,10 +7,7 @@
 // See https://github.com/rust-lang/rust-clippy/issues/4859 for more information.
 #![allow(clippy::use_self)]
 
-use std::{
-    collections::HashMap,
-    ops::{Deref, Sub},
-};
+use std::{collections::HashMap, ops::Deref};
 
 use either::Either;
 use serde::{Deserialize, Serialize};
@@ -96,15 +93,9 @@ impl<S, T> Request<S, T> {
         &self.urn
     }
 
-    /// Get the elapsed time between the `timestamp` provided and the current timestamp of the
-    /// `Request`.
-    ///
-    /// Note that it's expected that the `timestamp` is later than the `Request`'s timestamp.
-    pub fn elapsed(&self, timestamp: T) -> T::Output
-    where
-        T: Sub<T> + Clone,
-    {
-        timestamp - self.timestamp.clone()
+    /// Get the the current timestamp of the `Request`.
+    pub const fn timestamp(&self) -> &T {
+        &self.timestamp
     }
 
     /// Transition this `Request` into an `Cancelled` state. We can only transition a particular

--- a/proxy/coco/src/request/existential.rs
+++ b/proxy/coco/src/request/existential.rs
@@ -5,8 +5,6 @@
 // much.
 #![allow(clippy::wildcard_enum_match_arm)]
 
-use std::ops::Sub;
-
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -142,20 +140,16 @@ impl<T> SomeRequest<T> {
         }
     }
 
-    /// Get the [`Request::elapsed`] time between the `timestamp` provided and the current timestamp
-    /// of the underlying `Request`.
-    pub fn elapsed(&self, timestamp: T) -> T::Output
-    where
-        T: Sub<T> + Clone,
-    {
+    /// Get the current timestamp of the underlying `Request`.
+    pub const fn timestamp(&self) -> &T {
         match self {
-            SomeRequest::Created(request) => request.elapsed(timestamp),
-            SomeRequest::Requested(request) => request.elapsed(timestamp),
-            SomeRequest::Found(request) => request.elapsed(timestamp),
-            SomeRequest::Cloning(request) => request.elapsed(timestamp),
-            SomeRequest::Cloned(request) => request.elapsed(timestamp),
-            SomeRequest::Cancelled(request) => request.elapsed(timestamp),
-            SomeRequest::TimedOut(request) => request.elapsed(timestamp),
+            SomeRequest::Created(request) => request.timestamp(),
+            SomeRequest::Requested(request) => request.timestamp(),
+            SomeRequest::Found(request) => request.timestamp(),
+            SomeRequest::Cloning(request) => request.timestamp(),
+            SomeRequest::Cloned(request) => request.timestamp(),
+            SomeRequest::Cancelled(request) => request.timestamp(),
+            SomeRequest::TimedOut(request) => request.timestamp(),
         }
     }
 

--- a/proxy/coco/src/request/waiting_room.rs
+++ b/proxy/coco/src/request/waiting_room.rs
@@ -415,7 +415,7 @@ impl<T, D> WaitingRoom<T, D> {
         let requested = self
             .filter_by_state(RequestState::Requested)
             .find(move |(_, request)| {
-                request.timestamp().clone() + backoff(request.attempts().queries) < timestamp
+                request.timestamp().clone() + backoff(request.attempts().queries) <= timestamp
             });
 
         created.or(requested).map(|(urn, _request)| urn)

--- a/proxy/coco/src/request/waiting_room.rs
+++ b/proxy/coco/src/request/waiting_room.rs
@@ -5,9 +5,10 @@
 #![allow(clippy::wildcard_enum_match_arm)]
 
 use std::{
+    cmp::PartialOrd,
     collections::HashMap,
     convert::TryFrom,
-    ops::{Mul, Sub},
+    ops::{Add, Mul},
 };
 
 use either::Either;
@@ -150,17 +151,6 @@ impl<T, D> WaitingRoom<T, D> {
     /// Otherwise, it will return `None` if no such request existed.
     pub fn remove(&mut self, urn: &RadUrn) -> Option<SomeRequest<T>> {
         self.requests.remove(&urn.id)
-    }
-
-    /// Get the [`Request::elapsed`] time between the `timestamp` provided and the current timestamp
-    /// of the underlying `Request`.
-    ///
-    /// If the `urn` could not be found then `None` is returned.
-    pub fn elapsed(&self, urn: &RadUrn, timestamp: T) -> Option<D>
-    where
-        T: Sub<T, Output = D> + Clone,
-    {
-        Some(self.get(urn)?.elapsed(timestamp))
     }
 
     /// This will return the request for the given `urn` if one exists in the `WaitingRoom`.
@@ -414,7 +404,7 @@ impl<T, D> WaitingRoom<T, D> {
     ///     than the `delta` provided in the [`Config`].
     pub fn next_query(&self, timestamp: T) -> Option<RadUrn>
     where
-        T: Sub<T, Output = D> + Clone,
+        T: Add<D, Output = T> + PartialOrd + Clone,
         D: Mul<u32, Output = D> + Ord + Clone,
     {
         let backoff = |tries: Queries| match tries {
@@ -425,7 +415,7 @@ impl<T, D> WaitingRoom<T, D> {
         let requested = self
             .filter_by_state(RequestState::Requested)
             .find(move |(_, request)| {
-                request.elapsed(timestamp.clone()) >= backoff(request.attempts().queries)
+                request.timestamp().clone() + backoff(request.attempts().queries) < timestamp
             });
 
         created.or(requested).map(|(urn, _request)| urn)

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
 use futures::{future, StreamExt as _};
 use tokio::time::timeout;
@@ -159,7 +159,7 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
         alice_state.init_project(&alice, project).await?.urn()
     };
 
-    bob_control.request_project(&urn, Instant::now()).await;
+    bob_control.request_project(&urn, SystemTime::now()).await;
 
     requested(query_listener, &urn).await?;
     assert_cloned(clone_listener, &urn.clone().into_rad_url(alice_peer_id)).await?;


### PR DESCRIPTION
`Instant` is not really usable across processes, `serde_millis` attempts
to serialize and deserialize it, but on some systems it can be
impossible to deserialize an `Instant` that refers to a time before the
process started, or other arbitrary restrictions.

To retain compatibility with existing serialized data `serde_millis` is
still used for the `SystemTime` serialization; `serde`'s default
serialization is as an object containing seconds + nanoseconds, whereas
`serde_millis` serializes both `SystemTime` and `Instant` as
milliseconds since the epoch:

    {
      "system_time": {
        "secs_since_epoch": 1607698287,
        "nanos_since_epoch": 925641420
      },
      "serde_millis_system_time": 1607698287925,
      "serde_millis_instant": 1607698287925
    }

fixes #1433 hopefully