### PR TITLE
refactor(ui): use TypeScript in settings screen

### DIFF
--- a/ui/DesignSystem/Component/SegmentedControl.svelte
+++ b/ui/DesignSystem/Component/SegmentedControl.svelte
@@ -1,13 +1,18 @@
-<script>
+<script lang="typescript">
   import { createEventDispatcher } from "svelte";
   const dispatch = createEventDispatcher();
 
-  // Currently active option.
-  export let active = null;
-  // The available options.
-  export let options = null;
+  interface Option {
+    value: string;
+    title: string;
+  }
 
-  const onClick = option => {
+  // Currently active option.
+  export let active: string;
+  // The available options.
+  export let options: Option[];
+
+  const onClick = (option: Option) => {
     dispatch("select", option.value);
     currentlyActive = option.value;
   };

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -1,5 +1,5 @@
-<script>
-  import { getContext, onMount } from "svelte";
+<script lang="typescript">
+  import { getContext } from "svelte";
 
   import {
     settings,
@@ -7,10 +7,11 @@
     addSeed,
     removeSeed,
     updateAppearance,
-  } from "../src/session.ts";
-  import { themeOptions } from "../src/settings.ts";
-  import * as path from "../src/path.ts";
-  import * as modal from "../src/modal.ts";
+  } from "../src/session";
+  import type { UnsealedSession } from "../src/session";
+  import { themeOptions } from "../src/settings";
+  import * as path from "../src/path";
+  import * as modal from "../src/modal";
   import { getVersion } from "../src/ipc";
 
   import { Button, Icon, Input } from "../DesignSystem/Primitive";
@@ -21,10 +22,10 @@
     StyledCopyable,
   } from "../DesignSystem/Component";
 
-  const updateTheme = event =>
+  const updateTheme = (event: CustomEvent) =>
     updateAppearance({ ...$settings.appearance, theme: event.detail });
 
-  let seedInputValue;
+  let seedInputValue = "";
 
   const submitSeed = async () => {
     if (await addSeed(seedInputValue)) {
@@ -36,13 +37,13 @@
     seedValidation.reset();
   }
 
-  let version;
+  let version = "";
 
-  onMount(async () => {
+  (async () => {
     version = await getVersion();
-  });
+  })();
 
-  const session = getContext("session");
+  const session = getContext("session") as UnsealedSession;
 </script>
 
 <style>


### PR DESCRIPTION
We use TypeScript in the settings screen and the `SegmentedControl` component.

We also remove the use of `onMount`. It is not necessary to delay the call to `getVersion` until after the component has mounted.