### PR TITLE
fix(ci): fail after rollup warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "svelte:check": "svelte-check",
     "svelte:check:watch": "svelte-check --watch",
     "rollup:clean": "rm -rf public/bundle.* && rm -f native/main.comp.js",
-    "rollup:build": "yarn rollup:clean && rollup -c",
+    "rollup:build": "yarn rollup:clean && rollup -c --failAfterWarnings",
     "rollup:watch": "yarn rollup:clean && rollup -c -w",
     "typescript:check": "tsc --noEmit && tsc --noEmit --project cypress && svelte-check",
     "proxy:build": "cd proxy && cargo build --all-features --all-targets",


### PR DESCRIPTION
CI now fails when the rollup build produces warnings.

The motivation for this was a [change][1] that imported a type into a Svelte file. This was accepted by `svelte-check` but made `rollup -c -w` fail. It [produced a warning][2] for `rollup -c`.

[1]: https://github.com/radicle-dev/radicle-upstream/pull/1501/commits/9d05a9c5226a77fc29b7b5907901f50ff4fd9817
[2]: https://buildkite.com/monadic/radicle-upstream/builds/7106#b58d91d2-5a95-4d61-90c6-811b4e88c037/298-325