### PR TITLE
chore(ui): update cypress

### DIFF
--- a/cypress/integration/onboarding.spec.ts
+++ b/cypress/integration/onboarding.spec.ts
@@ -99,7 +99,7 @@ context("onboarding", () => {
 
       it("starts validation after at least 2 characters are input", () => {
         commands.pick("handle-input").type("@");
-        commands.pick("validation-error-icon").should("not.be.visible");
+        commands.pick("validation-error-icon").should("not.exist");
         commands.pick("handle-input").type("@");
         commands.pick("validation-error-icon").should("be.visible");
       });

--- a/cypress/integration/project/checkout.spec.ts
+++ b/cypress/integration/project/checkout.spec.ts
@@ -45,17 +45,17 @@ context("project checkout", () => {
 
         // Dismiss the hint.
         commands.pick("close-hint-button").click();
-        commands.pick("remote-helper-hint").should("not.be.visible");
+        commands.pick("remote-helper-hint").should("not.exist");
         commands.pick("cancel-button").click();
 
         // Hint is still hidden when re-entering project creation
         commands.pick("new-project-button").click();
-        commands.pick("remote-helper-hint").should("not.be.visible");
+        commands.pick("remote-helper-hint").should("not.exist");
         commands.pick("cancel-button").click();
 
         // The hint is also hidden in the project creation modal.
         commands.pick("new-project-button").click();
-        commands.pick("remote-helper-hint").should("not.be.visible");
+        commands.pick("remote-helper-hint").should("not.exist");
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
     "chokidar": "^3.4.3",
-    "cypress": "^5.6.0",
+    "cypress": "^6.2.1",
     "electron": "^11.1.1",
     "electron-builder": "^22.9.1",
     "electron-notarize": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,10 +2207,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cypress@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.6.0.tgz#6781755c3ddfd644ce3179fcd7389176c0c82280"
-  integrity sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==
+cypress@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.2.1.tgz#27d5fbcf008c698c390fdb0c03441804176d06c4"
+  integrity sha512-OYkSgzA4J4Q7eMjZvNf5qWpBLR4RXrkqjL3UZ1UzGGLAskO0nFTi/RomNTG6TKvL3Zp4tw4zFY1gp5MtmkCZrA==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
Update Cypress from v5 to v6. The only breaking change we needed to fix was that the `not.visible` assertion now throws if the element does not exist. We change the affected occurrences to use the `not.exists` assertion.