### PR TITLE
fix(ui): use alternative support channel link

### DIFF
--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -27,7 +27,8 @@
   };
 
   const support = () => {
-    window.location.href = "https://matrix.to/#/#support:radicle.community";
+    window.location.href =
+      "https://matrix.radicle.community/#/room/#support:radicle.community";
   };
 </script>
 


### PR DESCRIPTION
The second `#` in the url still get's encoded, but the link works as expected nevertheless. 
This is a quick fix. As we allow to open urls from eg readme's of projects, this might cause other problems. After timeboxed investigation on this I was not able to find out why this is not properly decoded or how the encoding could be prevented. 

Closes #1483 

Signed-off-by: Merle Breitkreuz <merle@monadic.xyz>