### PR TITLE
fix(ui): Don't open window before app ready (#1516)

### DIFF
--- a/native/main.ts
+++ b/native/main.ts
@@ -193,5 +193,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("activate", () => {
-  windowManager.open();
+  if (app.isReady() && !windowManager.window) {
+    windowManager.open();
+  }
 });


### PR DESCRIPTION
Fixes #1516 

Simply checks if the app is ready on `activate` and also for good measure ensures explicitly that no window currently already exists before opening a new window.