### PR TITLE
refactor(ui): notifications with multiple actions

### DIFF
--- a/ui/DesignSystem/Component/Copyable.svelte
+++ b/ui/DesignSystem/Component/Copyable.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="typescript">
   import type { SvelteComponent } from "svelte";
 
   import { copyToClipboard } from "../../src/ipc";
@@ -27,7 +27,7 @@
     const content = copyContent.length ? copyContent : slotContent.textContent;
     if (content) copyToClipboard(content.trim());
 
-    notification.info(notificationText);
+    notification.info({ message: notificationText });
 
     copied = true;
 

--- a/ui/DesignSystem/Component/Notification.svelte
+++ b/ui/DesignSystem/Component/Notification.svelte
@@ -1,17 +1,15 @@
 <script lang="typescript">
-  import { createEventDispatcher } from "svelte";
-
   import { Level } from "../../src/notification";
-
+  import type { Notification } from "../../src/notification";
   import { Icon } from "../Primitive";
 
-  const dispatch = createEventDispatcher();
+  export let notification: Notification;
+  export let style = "";
 
-  export let style: string | undefined;
-  export let level = Level.Info;
-  export let showIcon = false;
-  export let message: string;
-  export let actionText: string | null = null;
+  const icon =
+    notification.level === Level.Info
+      ? Icon.InfoCircle
+      : Icon.ExclamationCircle;
 </script>
 
 <style>
@@ -31,7 +29,7 @@
     background-color: var(--color-foreground);
   }
 
-  .notification.info :global(svg) {
+  .info :global(svg) {
     fill: var(--color-background);
   }
 
@@ -40,7 +38,7 @@
     background-color: var(--color-negative);
   }
 
-  .notification.error :global(svg) {
+  .error :global(svg) {
     fill: var(--color-background);
   }
 
@@ -48,39 +46,38 @@
     padding: 0 8px 0 8px;
   }
 
-  .close {
+  .action {
     cursor: pointer;
     margin-right: 8px;
     padding-left: 8px;
     user-select: none;
-    border-left: 1px solid;
   }
 
-  .close.error {
-    border-color: var(--color-negative-level-2);
+  .action-divider {
+    align-self: stretch;
+    width: 1px;
   }
 
-  .close.info {
-    border-color: var(--color-foreground-level-6);
+  .error .action-divider {
+    background-color: var(--color-negative-level-2);
+  }
+
+  .info .action-divider {
+    background-color: var(--color-foreground-level-6);
   }
 </style>
 
-<div class={`notification ${level.toLowerCase()}`} {style}>
-  {#if showIcon}
-    <svelte:component
-      this={level === Level.Info ? Icon.InfoCircle : Icon.ExclamationCircle}
-      style="margin-left: 8px; height: 24px" />
+<div class={`notification ${notification.level.toLowerCase()}`} {style}>
+  {#if notification.showIcon}
+    <svelte:component this={icon} style="margin-left: 8px; height: 24px" />
   {/if}
 
-  <p class="message typo-overflow-ellipsis">{message}</p>
+  <p class="message typo-overflow-ellipsis">{notification.message}</p>
 
-  {#if actionText}
-    <div
-      class={`close ${level.toLowerCase()}`}
-      on:click={() => {
-        dispatch('action');
-      }}>
-      <p class="typo-text-bold">{actionText}</p>
+  {#each notification.actions as action}
+    <div class="action-divider" />
+    <div class="action typo-text-bold" on:click={action.handler}>
+      {action.label}
     </div>
-  {/if}
+  {/each}
 </div>

--- a/ui/DesignSystem/Component/NotificationFaucet.svelte
+++ b/ui/DesignSystem/Component/NotificationFaucet.svelte
@@ -1,11 +1,11 @@
-<script>
+<script lang="typescript">
   import { blur } from "svelte/transition";
   import { flip } from "svelte/animate";
-  import { store } from "../../src/notification.ts";
+  import { store } from "../../src/notification";
 
   import Notification from "./Notification.svelte";
 
-  export let style = null;
+  export let style = "";
 </script>
 
 <style>
@@ -28,12 +28,7 @@
       style="max-width: 95%;"
       animate:flip
       transition:blur={{ duration: 300 }}>
-      <Notification
-        showIcon={notification.showIcon}
-        level={notification.level}
-        message={notification.message}
-        actionText={notification.actionText}
-        on:action={notification.actionHandler} />
+      <Notification {notification} />
     </div>
   {/each}
 </div>

--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -75,9 +75,9 @@
       });
 
       push(path.project(response.urn));
-      notification.info(
-        `Project ${response.metadata.name} successfully created`
-      );
+      notification.info({
+        message: `Project ${response.metadata.name} successfully created`,
+      });
     } catch (err) {
       push(path.profileProjects());
       error.show({

--- a/ui/Modal/Search.svelte
+++ b/ui/Modal/Search.svelte
@@ -73,7 +73,9 @@
   $: if ($request.status === remote.Status.Success) {
     reset();
     push(path.profileFollowing());
-    notification.info("You’ll be notified when this project has been found.");
+    notification.info({
+      message: "You’ll be notified when this project has been found.",
+    });
     dispatch("hide");
   }
 

--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -19,7 +19,7 @@
 
   const copyToClipboard = (text: string) => {
     ipc.copyToClipboard(text);
-    notification.info("Copied to your clipboard");
+    notification.info({ message: "Copied to your clipboard" });
     copied = true;
     setTimeout(() => {
       copied = false;

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -131,6 +131,24 @@
       value: 2,
     },
   ];
+
+  const infoNotification = params => {
+    return {
+      level: notification.Level.Info,
+      message: params.message,
+      showIcon: params.showIcon || false,
+      actions: params.actions || [],
+    };
+  };
+
+  const errorNotification = params => {
+    return {
+      level: notification.Level.Error,
+      message: params.message,
+      showIcon: params.showIcon || false,
+      actions: params.actions || [],
+    };
+  };
 </script>
 
 <style>
@@ -631,50 +649,48 @@
 
     <Section title="Notifications" subTitle="Info, Warnings and Errors">
       <Swatch>
-        <Notification message="Snackbar" />
-      </Swatch>
-
-      <Swatch>
-        <Notification message="Snackbar with icon" showIcon={true} />
-      </Swatch>
-
-      <Swatch>
-        <Notification message="Snackbar with" actionText="Action" />
+        <Notification
+          notification={infoNotification({ message: 'Snackbar' })} />
       </Swatch>
 
       <Swatch>
         <Notification
-          message="Snackbar with icon and"
-          showIcon={true}
-          actionText="Action" />
+          notification={infoNotification({
+            message: 'Info with icon',
+            showIcon: true,
+          })} />
       </Swatch>
 
       <Swatch>
         <Notification
-          level={notification.Level.Error}
-          message="Just plain error" />
+          notification={errorNotification({ message: 'Just plain error' })} />
       </Swatch>
 
       <Swatch>
         <Notification
-          level={notification.Level.Error}
-          message="Error with icon"
-          showIcon={true} />
+          notification={errorNotification({
+            message: 'Error with icon',
+            showIcon: true,
+          })} />
       </Swatch>
 
       <Swatch>
         <Notification
-          level={notification.Level.Error}
-          message="Error with"
-          actionText="Action" />
+          notification={errorNotification({
+            message: 'Error with one action',
+            actions: [{ label: 'Action', handler: () => {} }],
+          })} />
       </Swatch>
 
       <Swatch>
         <Notification
-          level={notification.Level.Error}
-          message="Error with icon and"
-          showIcon={true}
-          actionText="Action" />
+          notification={errorNotification({
+            message: 'Error with two actions',
+            actions: [
+              { label: 'Action 1', handler: () => {} },
+              { label: 'Action 2', handler: () => {} },
+            ],
+          })} />
       </Swatch>
     </Section>
 

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -52,14 +52,18 @@
         peer.identity.peerId
       );
 
-      notification.info(
-        `${project.metadata.name} checked out to ${path}`,
-        true,
-        "Open folder",
-        () => {
-          openPath(path);
-        }
-      );
+      notification.info({
+        message: `${project.metadata.name} checked out to ${path}`,
+        showIcon: true,
+        actions: [
+          {
+            label: "Open folder",
+            handler: () => {
+              openPath(path);
+            },
+          },
+        ],
+      });
     } catch (err) {
       error.show({
         code: error.Code.ProjectCheckoutFailure,

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -63,8 +63,17 @@ export const log = (error: Error): void => {
 export const show = (error: Error): void => {
   log(error);
 
-  notification.error(error.message, true, "Copy error", () => {
-    ipc.copyToClipboard(JSON.stringify(error, null, 2));
+  notification.error({
+    message: error.message,
+    showIcon: true,
+    actions: [
+      {
+        label: "Copy error",
+        handler: () => {
+          ipc.copyToClipboard(JSON.stringify(error, null, 2));
+        },
+      },
+    ],
   });
 };
 

--- a/ui/src/localPeer.ts
+++ b/ui/src/localPeer.ts
@@ -120,17 +120,20 @@ eventStore.subscribe((event: Event | null): void => {
 
   switch (event.type) {
     case EventType.RequestCloned:
-      notifiation.info(
-        `Project for "${event.urn}" found and cloned.`,
-        false,
-        "Show Project",
-        () => push(path.project(event.urn))
-      );
+      notifiation.info({
+        message: `Project for "${event.urn}" found and cloned.`,
+        actions: [
+          {
+            label: "Show Project",
+            handler: () => push(path.project(event.urn)),
+          },
+        ],
+      });
 
       break;
 
     case EventType.RequestTimedOut:
-      notifiation.error(`Search for "${event.urn}" failed.`);
+      notifiation.error({ message: `Search for "${event.urn}" failed.` });
 
       break;
   }

--- a/ui/src/notification.ts
+++ b/ui/src/notification.ts
@@ -1,155 +1,83 @@
 import { Readable, derived, get, writable } from "svelte/store";
 
 import * as config from "./config";
-import * as event from "./event";
-
-// TYPES
-type ID = number;
 
 export enum Level {
   Error = "ERROR",
   Info = "INFO",
 }
 
-type ActionHandler = () => void;
-
-interface Notification {
-  id: ID;
-  level: Level;
-  showIcon: boolean;
+export interface NotificationParams {
   message: string;
-  actionText: string | false;
-  actionHandler: ActionHandler | false;
+  showIcon?: boolean;
+  // A list of actions to show as part of the notification. If not
+  // provided a default action to close the notification will be shown.
+  actions?: Action[];
 }
 
-type Notifications = Notification[];
+export interface Notification {
+  readonly id: number;
+  readonly level: Level;
+  readonly showIcon: boolean;
+  readonly message: string;
+  readonly actions: readonly Action[];
+}
 
-// STATE
+export interface Action {
+  readonly label: string;
+  readonly handler: () => void;
+}
+
 const notificationsStore = writable<Notification[]>([]);
-export const store: Readable<Notifications> = derived(
+
+export const store: Readable<Notification[]> = derived(
   notificationsStore,
-  (state: Notifications) => state
+  (state: Notification[]) => state
 );
 
-// EVENTS
-enum Kind {
-  Remove = "REMOVE",
-  ShowError = "SHOW_ERROR",
-  ShowInfo = "SHOW_INFO",
-}
-
-interface Remove extends event.Event<Kind> {
-  kind: Kind.Remove;
-  id: ID;
-}
-
-interface ShowError extends event.Event<Kind> {
-  kind: Kind.ShowError;
-  message: string;
-  showIcon: boolean;
-  actionText: string | false;
-  actionHandler: ActionHandler | false;
-}
-
-interface ShowInfo extends event.Event<Kind> {
-  kind: Kind.ShowInfo;
-  message: string;
-  showIcon: boolean;
-  actionText: string | false;
-  actionHandler: ActionHandler | false;
-}
-
-type Msg = Remove | ShowError | ShowInfo;
-
-const filter = (id: ID): void => {
-  const notifications = get(notificationsStore).filter(
-    (n: Notification) => n.id !== id
-  );
-  notificationsStore.set(notifications);
+const closeAction: Action = {
+  label: "Close",
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  handler: () => {},
 };
 
-const show = (
-  level: Level,
-  showIcon: boolean,
-  message: string,
-  actionText: string | false,
-  actionHandler: ActionHandler | false
-): void => {
+const show = (level: Level, params: NotificationParams): void => {
   const id = Math.random();
+  const showIcon = params.showIcon || false;
+
+  let actions = params.actions || [closeAction];
+  actions = actions.map(action => ({
+    label: action.label,
+    handler: () => {
+      action.handler();
+      remove(id);
+    },
+  }));
+
   const notification = {
     id,
     level,
-    message,
+    message: params.message,
     showIcon,
-    actionText,
-    actionHandler: () => {
-      if (actionHandler) {
-        actionHandler();
-      }
-
-      remove(id);
-    },
+    actions,
   };
 
   notificationsStore.update(notifications => [notification, ...notifications]);
 
   setTimeout(() => {
-    filter(id);
+    remove(id);
   }, config.NOTIFICATION_TIMEOUT);
 };
 
-const update = (msg: Msg): void => {
-  switch (msg.kind) {
-    case Kind.ShowError:
-      show(
-        Level.Error,
-        msg.showIcon,
-        msg.message,
-        msg.actionText,
-        msg.actionHandler
-      );
+export const error = (params: NotificationParams): void =>
+  show(Level.Error, params);
 
-      break;
+export const info = (params: NotificationParams): void =>
+  show(Level.Info, params);
 
-    case Kind.ShowInfo:
-      show(
-        Level.Info,
-        msg.showIcon,
-        msg.message,
-        msg.actionText,
-        msg.actionHandler
-      );
-
-      break;
-
-    case Kind.Remove:
-      filter(msg.id);
-
-      break;
-  }
+const remove = (id: number): void => {
+  const notifications = get(notificationsStore).filter(
+    (n: Notification) => n.id !== id
+  );
+  notificationsStore.set(notifications);
 };
-
-const remove = (id: ID): void =>
-  event.create<Kind, Msg>(Kind.Remove, update)({ id });
-
-export const error = (
-  message: string,
-  showIcon: boolean = false,
-  actionText: string | false = "Close",
-  actionHandler: ActionHandler | false = false
-): void =>
-  event.create<Kind, Msg>(
-    Kind.ShowError,
-    update
-  )({ message, showIcon, actionText, actionHandler });
-
-export const info = (
-  message: string,
-  showIcon: boolean = false,
-  actionText: string | false = "Close",
-  actionHandler: ActionHandler | false = false
-): void =>
-  event.create<Kind, Msg>(
-    Kind.ShowInfo,
-    update
-  )({ message, showIcon, actionText, actionHandler });


### PR DESCRIPTION
* Notifications can now have multiple actions
* The action divider in notifications now covers the whole notification height. Fixes #1270.
* The `notification.info` and `notification.error` functions now take parameter objects as a single argument instead of multiple arguments. This provides a cleaner API with respect to default values.
* We eliminate the event logic from notifications to simplify the code