### PR TITLE
refactor(tests): strict type-checking for cypress code

### DIFF
--- a/cypress/integration/project/checkout.spec.ts
+++ b/cypress/integration/project/checkout.spec.ts
@@ -2,7 +2,7 @@ import { ipcStub } from "../../support";
 import * as commands from "../../support/commands";
 
 context("project checkout", () => {
-  const withWorkspaceStub = callback => {
+  const withWorkspaceStub = (callback: (path: string) => void) => {
     cy.exec("pwd").then(result => {
       const pwd = result.stdout;
       const checkoutPath = `${pwd}/cypress/workspace/checkout`;

--- a/cypress/integration/project/creation.spec.ts
+++ b/cypress/integration/project/creation.spec.ts
@@ -2,7 +2,7 @@ import { ipcStub } from "../../support";
 import * as commands from "../../support/commands";
 
 context("project creation", () => {
-  const withEmptyDirectoryStub = callback => {
+  const withEmptyDirectoryStub = (callback: () => void) => {
     cy.exec("pwd").then(result => {
       const pwd = result.stdout;
       const emptyDirectoryPath = `${pwd}/cypress/workspace/empty-directory`;
@@ -21,7 +21,7 @@ context("project creation", () => {
     });
   };
 
-  const withNoCommitsRepositoryStub = callback => {
+  const withNoCommitsRepositoryStub = (callback: () => void) => {
     cy.exec("pwd").then(result => {
       const pwd = result.stdout;
       const noCommitsRepoPath = `${pwd}/cypress/workspace/no-commits-repo`;
@@ -42,7 +42,7 @@ context("project creation", () => {
     });
   };
 
-  const withPlatinumStub = callback => {
+  const withPlatinumStub = (callback: () => void) => {
     cy.exec("pwd").then(result => {
       const pwd = result.stdout;
       const platinumPath = `${pwd}/cypress/workspace/git-platinum-copy`;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -22,7 +22,7 @@ export const createProjectWithFixture = (
   name = "platinum",
   description = "Best project ever.",
   defaultBranch = "master",
-  fakePeers = []
+  fakePeers: string[] = []
 ): Cypress.Chainable<void> =>
   requestOk({
     url: "http://localhost:17246/v1/control/create-project",
@@ -69,8 +69,10 @@ export const onboardUser = (
 function requestOk(
   opts: Partial<Cypress.RequestOptions> & { url: string }
 ): Cypress.Chainable<void> {
-  return cy.request(opts).then(response => {
-    expect(response.status).to.be.within(200, 299, "Failed response");
-    return undefined;
-  });
+  return cy
+    .request(opts)
+    .then(response => {
+      expect(response.status).to.be.within(200, 299, "Failed response");
+    })
+    .wrap(undefined);
 }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,11 +1,8 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es2018",
     "lib": ["dom", "es6", "es7"],
-    "types": ["cypress", "node"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "allowSyntheticDefaultImports": true
+    "types": ["cypress", "node"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
The TypeScript project configuration for the cypress code now extends the main project configuration to achieve parity. This means that `strict` type-checking is now enabled, which requires some fixes.