### PR TITLE
Improve funding-related bits

### DIFF
--- a/ui/Modal/Funding/Pool/Withdraw.svelte
+++ b/ui/Modal/Funding/Pool/Withdraw.svelte
@@ -28,7 +28,7 @@
     validation = balanceValidationStore(balance);
   }
 
-  $: amountStore.set(amount ? amount.toString() : "");
+  $: amountStore.set(amount);
   $: {
     if ($amountStore && $amountStore.length > 0) validatingAmount = true;
     if (validatingAmount) validation.validate($amountStore);

--- a/ui/Modal/Transaction.svelte
+++ b/ui/Modal/Transaction.svelte
@@ -9,6 +9,7 @@
   import TxSpinner from "../DesignSystem/Component/Transaction/Spinner.svelte";
   import Summary from "../DesignSystem/Component/Transaction/Summary.svelte";
 
+  import { ellipsed } from "../src/style";
   import {
     selectedStore,
     store as txs,
@@ -160,7 +161,15 @@
       <div class="section">
         <div class="row">
           <p>Transaction ID</p>
-          <p class="typo-text-small-mono">{tx.hash.slice(0, 20)}</p>
+          <p class="typo-text-small-mono">
+            <Copyable
+              showIcon={false}
+              styleContent={false}
+              copyContent={tx.to}
+              notificationText="Address copied to the clipboard">
+              {ellipsed(tx.hash, 12)}
+            </Copyable>
+          </p>
         </div>
         <div class="row">
           <p>Status</p>

--- a/ui/Modal/Transaction.svelte
+++ b/ui/Modal/Transaction.svelte
@@ -165,7 +165,7 @@
             <Copyable
               showIcon={false}
               styleContent={false}
-              copyContent={tx.to}
+              copyContent={tx.hash}
               notificationText="Address copied to the clipboard">
               {ellipsed(tx.hash, 12)}
             </Copyable>

--- a/ui/Screen/Funding/Pool/Outgoing/Support.svelte
+++ b/ui/Screen/Funding/Pool/Outgoing/Support.svelte
@@ -41,7 +41,7 @@
 
   let validatingBudget = false;
   $: budgetValidation = monthlyContributionValidationStore();
-  $: budgetStore.set(budget ? budget.toString() : "");
+  $: budgetStore.set(budget);
   $: {
     if ($budgetStore && $budgetStore.length > 0) validatingBudget = true;
     if (validatingBudget) budgetValidation.validate($budgetStore);
@@ -69,11 +69,12 @@
   });
 
   $: thereAreChanges =
-    !BigNumber.from(budget).eq(data.amountPerBlock) ||
-    receivers.size !== data.receivers.size ||
-    [...receivers.entries()].find(
-      ([address, weight]) => data.receivers.get(address) !== weight
-    );
+    fundingPool.isValidBigNumber(budget) &&
+    (!BigNumber.from(budget).eq(data.amountPerBlock) ||
+      receivers.size !== data.receivers.size ||
+      [...receivers.entries()].find(
+        ([address, weight]) => data.receivers.get(address) !== weight
+      ));
 
   function leaveEditMode(): void {
     editing = false;

--- a/ui/src/funding/pool.ts
+++ b/ui/src/funding/pool.ts
@@ -339,7 +339,7 @@ export function isValidBigNumber(value: string): boolean {
   try {
     BigNumber.from(value);
     return true;
-  } catch (_) {
+  } catch {
     return false;
   }
 }

--- a/ui/src/funding/pool.ts
+++ b/ui/src/funding/pool.ts
@@ -294,7 +294,10 @@ export const balanceValidationStore = (
 ): validation.ValidationStore => {
   return validation.createValidationStore(constraints.topUpAmount, [
     {
-      promise: amount => Promise.resolve(BigNumber.from(balance).gte(amount)),
+      promise: amount =>
+        Promise.resolve(
+          isValidBigNumber(amount) && BigNumber.from(balance).gte(amount)
+        ),
       validationMessage: "Insufficient balance",
     },
   ]);
@@ -327,4 +330,16 @@ function newSetOfReceivers(current: Receivers, changes: Receivers): Receivers {
   return new Map(
     [...merged].filter(([_address, status]) => status != ReceiverStatus.Removed)
   );
+}
+
+// Check whether the given value can be converted to `ethers.BigNumber`.
+// N.B: ethers.BigNumber.isBigNumber doesn't work as expected:
+// https://github.com/ethers-io/ethers.js/blob/master/packages/bignumber/src.ts/bignumber.ts#L285
+export function isValidBigNumber(value: string): boolean {
+  try {
+    BigNumber.from(value);
+    return true;
+  } catch (_) {
+    return false;
+  }
 }


### PR DESCRIPTION
Three small funding-related improvements:

1. Validate that a given input value can be converted to `BigNumber` before doing so.
     To reproduce, on master go to any place where you can input/edit a funding-related numeric value (top up,  withdraw, edit support) and enter `9f` e.g. The app will crash as there will be an underlying attempt to convert that input to `BigNumber` which fails by throwing. We fix that here by first validating the input to be a valid BigNumber.

2. We make the transaction hash in the Transaction modal copyable. This is helpful to verify the status of a tx in, for example, etherscan.

3. Other small things like avoiding calling toString on a string value.