### PR TITLE
fix(dev): use locally installed ethers-cli

### DIFF
--- a/scripts/ethereum-dev-node.sh
+++ b/scripts/ethereum-dev-node.sh
@@ -5,7 +5,7 @@
 
 set -eumo pipefail
 
-node_modules/.bin/ganache-cli \
+npx ganache-cli \
   --mnemonic "image napkin cruise dentist name plunge crisp muscle nest floor vessel blush" \
   --defaultBalanceEther 1000 \
   "$@" &
@@ -24,7 +24,7 @@ echo "Deploying the Radicle Dev Contracts..."
 echo "Done"
 
 echo "Adding funds to your account..."
-ethers --rpc http://localhost:8545 --account-rpc 0 --yes send $(< ./sandbox/.local-eth-account) 10
+npx ethers --rpc http://localhost:8545 --account-rpc 0 --yes send $(< ./sandbox/.local-eth-account) 10
 echo "Done"
 
 fg %1


### PR DESCRIPTION
We don’t require `ethers` to be in PATH to run `./scripts/ethereum-dev-node.sh`. Instead we use the binary from the installed node modules.