### PR TITLE
fix(ui): transaction center not collapsing

### DIFF
--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -11,16 +11,26 @@
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let element: any;
   let expand = false;
+  let initialized = false;
+
+  // The set of transaction hashes that have already been displayed
+  // in the expanded transaction stack.
+  let displayedTxs: Set<string> = new Set();
+
+  if (!initialized) {
+    displayedTxs = new Set(transactions.map(tx => tx.hash));
+    initialized = false;
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const toggleStack = (ev: any) => {
     expand = expand
       ? false
       : element === ev.target || element.contains(ev.target);
+    transactions.forEach(tx => displayedTxs.add(tx.hash));
   };
 
-  $: expand =
-    expand || transactions.some(tx => tx.status === TxStatus.AwaitingInclusion);
+  $: expand = expand || transactions.some(tx => !displayedTxs.has(tx.hash));
   $: negative = transactions.some(tx => tx.status === TxStatus.Rejected);
 </script>
 

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -11,16 +11,10 @@
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let element: any;
   let expand = false;
-  let initialized = false;
 
   // The set of transaction hashes that have already been displayed
   // in the expanded transaction stack.
-  let displayedTxs: Set<string> = new Set();
-
-  if (!initialized) {
-    displayedTxs = new Set(transactions.map(tx => tx.hash));
-    initialized = false;
-  }
+  const displayedTxs: Set<string> = new Set(transactions.map(tx => tx.hash));
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const toggleStack = (ev: any) => {

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -21,10 +21,16 @@
     expand = expand
       ? false
       : element === ev.target || element.contains(ev.target);
-    transactions.forEach(tx => displayedTxs.add(tx.hash));
   };
 
-  $: expand = expand || transactions.some(tx => !displayedTxs.has(tx.hash));
+  $: {
+    const newTxs = transactions.filter(tx => !displayedTxs.has(tx.hash));
+    if (newTxs.length > 0) {
+      expand = true;
+      newTxs.forEach(tx => displayedTxs.add(tx.hash));
+    }
+  }
+
   $: negative = transactions.some(tx => tx.status === TxStatus.Rejected);
 </script>
 


### PR DESCRIPTION
This was an issue experienced by everyone on the Funding demo last Friday.

The issue is that the way we are resolving whether to expand (or to keep it expanded) the transaction centre is by reactively checking whether it is expanded already or if there are ongoing transactions.

While developing against a local node, this wasn't noticeable since their transactions are included in blocks and marked as completed fairly quickly.

The solution proposed here involves "marking" transactions that the user has already had displayed in the expanded tx center as "displayed" so that we can figure out whether or not there are new transactions to be shown (when one is just created) and display it if so. 
