### PR TITLE
chore: improve transaction error capture

### DIFF
--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -372,7 +372,7 @@ export function convertError(e: globalThis.Error, label: string): error.Error {
   if (e.message.includes("gas")) {
     code = error.Code.InsufficientGas;
     message = "you seem to have insufficient gas to cover this transaction.";
-  } else if (e.message.includes("Failed or Rejected Request")) {
+  } else if (e.message.toLowerCase().includes("rejected request")) {
     code = error.Code.FailedOrRejectedTransaction;
     message =
       "you have rejected this transaction or it has failed for some unkown reason.";


### PR DESCRIPTION
The new way to capture rejected requests works well for a couple of
wallets I have tried, since it works lowercased and only captures two
words.