### PR TITLE
chore: remove unneeded release step

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -646,8 +646,6 @@ for all of the required steps:
 - [ ] wait until macOS and Linux QA is performed and passes
 - [ ] update radicle.xyz download links
   - [ ] deploy radicle.xyz
-- [ ] update docs.radicle.xyz download links
-  - [ ] deploy docs.radicle.xyz
 - [ ] announce new release on radicle.community
 - [ ] announce new release on the matrix #general:radicle.community channel
 - [ ] run script for updating version in auto-update notification


### PR DESCRIPTION
We point to our radicle.xyz download page from the docs as of:
https://github.com/radicle-dev/radicle-docs/pull/107.

Signed-off-by: Rūdolfs Ošiņš <rudolfs@osins.org>