### PR TITLE
fix(proxy): urn warnings for upgrade

### DIFF
--- a/proxy/coco/src/project/create/validation.rs
+++ b/proxy/coco/src/project/create/validation.rs
@@ -377,10 +377,12 @@ impl Repository {
         match Remote::<LocalUrl>::find(repo, reflike!("rad")) {
             Err(remote::FindError::ParseUrl(_)) => {
                 log::warn!("an old/invalid URL was found when trying to load the `rad` remote");
-                log::warn!("we are going to rename the remote to `temp_rad` and create a new `rad` remote");
+                log::warn!(
+                    "we are going to rename the remote to `temp_rad` and create a new `rad` remote"
+                );
                 repo.remote_rename("rad", "temp_rad")?;
                 Ok(None)
-            }
+            },
             Err(err) => Err(err.into()),
             Ok(Some(remote)) if remote.url != *url => Err(Error::UrlMismatch {
                 expected: url.to_string(),

--- a/proxy/coco/src/project/create/validation.rs
+++ b/proxy/coco/src/project/create/validation.rs
@@ -378,9 +378,9 @@ impl Repository {
             Err(remote::FindError::ParseUrl(_)) => {
                 log::warn!("an old/invalid URL was found when trying to load the `rad` remote");
                 log::warn!(
-                    "we are going to rename the remote to `temp_rad` and create a new `rad` remote"
+                    "we are going to rename the remote to `rad_old` and create a new `rad` remote"
                 );
-                repo.remote_rename("rad", "temp_rad")?;
+                repo.remote_rename("rad", "rad_old")?;
                 Ok(None)
             },
             Err(err) => Err(err.into()),

--- a/proxy/coco/src/project/create/validation.rs
+++ b/proxy/coco/src/project/create/validation.rs
@@ -375,6 +375,12 @@ impl Repository {
         url: &LocalUrl,
     ) -> Result<Option<Remote<LocalUrl>>, Error> {
         match Remote::<LocalUrl>::find(repo, reflike!("rad")) {
+            Err(remote::FindError::ParseUrl(_)) => {
+                log::warn!("an old/invalid URL was found when trying to load the `rad` remote");
+                log::warn!("we are going to rename the remote to `temp_rad` and create a new `rad` remote");
+                repo.remote_rename("rad", "temp_rad")?;
+                Ok(None)
+            }
             Err(err) => Err(err.into()),
             Ok(Some(remote)) if remote.url != *url => Err(Error::UrlMismatch {
                 expected: url.to_string(),

--- a/ui/src/search.ts
+++ b/ui/src/search.ts
@@ -47,7 +47,7 @@ const VALID_URN_MATCH = /^rad:git:[1-9A-HJ-NP-Za-km-z]{37}/;
 const urnConstraints = {
   format: {
     pattern: VALID_URN_MATCH,
-    message: `Not a valid project URN`,
+    message: `Not a valid project URN, perhaps you're using an old URN?`,
   },
 };
 

--- a/ui/src/search.ts
+++ b/ui/src/search.ts
@@ -47,7 +47,7 @@ const VALID_URN_MATCH = /^rad:git:[1-9A-HJ-NP-Za-km-z]{37}/;
 const urnConstraints = {
   format: {
     pattern: VALID_URN_MATCH,
-    message: `Not a valid project URN, perhaps you're using an old URN?`,
+    message: `Not a valid project URN`,
   },
 };
 


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-upstream/issues/1560

For the existing remote, I realised that the URL won't parse full-stop. So I decided to handle this case specifically by renaming the existing remote, thus preserving the reference data. Then we create a fresh `rad` remote. A user can then copy any of their references over from `temp_rad` and remove it when they're done.

~For the search box, I'm not sure how to detect if it was an old URN and give a specific message in that case. So what I did here was give a small prompt that it might be an old URN. Maybe we could try document the differences in the community post.~