### PR TITLE
Nuno/overlap free footer

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -30,6 +30,7 @@ a {
   --content-min-width: 30rem;
   --content-padding: 2rem;
   --content-max-width: 90rem;
+  --transaction-center-width: 17.2rem;
 }
 
 .lock-screen > * {

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -4,6 +4,7 @@
   import * as hotkeys from "./src/hotkeys.ts";
   import { isExperimental } from "./src/ipc";
   import "./src/localPeer.ts";
+  import { showing as showingModal } from "./src/modal.ts";
   import * as path from "./src/path.ts";
   import * as remote from "./src/remote.ts";
   import * as error from "./src/error.ts";
@@ -19,6 +20,7 @@
   import Hotkeys from "./Hotkeys.svelte";
   import Theme from "./Theme.svelte";
 
+  import Footer from "./App/Footer.svelte";
   import TransactionCenter from "./App/TransactionCenter.svelte";
 
   import Blank from "./Screen/Blank.svelte";
@@ -119,12 +121,15 @@
 <Bsod />
 <Hotkeys />
 <ModalOverlay {modalRoutes} />
-<NotificationFaucet />
 <Theme />
 
-{#if isExperimental() && sessionIsUnsealed && $location !== path.designSystemGuide()}
-  <TransactionCenter />
-{/if}
+<Footer>
+  <NotificationFaucet />
+
+  {#if isExperimental() && sessionIsUnsealed && $location !== path.designSystemGuide() && !$showingModal}
+    <TransactionCenter />
+  {/if}
+</Footer>
 
 <Remote {store} context="session" disableErrorLogging={true}>
   <Router {routes} />

--- a/ui/App/Footer.svelte
+++ b/ui/App/Footer.svelte
@@ -1,0 +1,19 @@
+<style>
+  #footer {
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    gap: var(--content-padding);
+
+    position: fixed;
+    bottom: var(--content-padding);
+    left: var(--sidebar-width);
+    width: calc(100vw - var(--sidebar-width));
+    padding: 0 var(--content-padding);
+    z-index: 1001;
+  }
+</style>
+
+<div id="footer">
+  <slot />
+</div>

--- a/ui/App/TransactionCenter.svelte
+++ b/ui/App/TransactionCenter.svelte
@@ -15,9 +15,6 @@
 
 <style>
   .transaction-center {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
     z-index: 50;
   }
 </style>

--- a/ui/App/TransactionCenter.svelte
+++ b/ui/App/TransactionCenter.svelte
@@ -13,14 +13,6 @@
   };
 </script>
 
-<style>
-  .transaction-center {
-    z-index: 50;
-  }
-</style>
-
 {#if $transactions.length > 0}
-  <div class="transaction-center">
-    <Center on:select={onSelect} transactions={$transactions} />
-  </div>
+  <Center on:select={onSelect} transactions={$transactions} />
 {/if}

--- a/ui/DesignSystem/Component/NotificationFaucet.svelte
+++ b/ui/DesignSystem/Component/NotificationFaucet.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <style>
-  .wrapper {
+  .notification-faucet {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -19,7 +19,7 @@
   }
 </style>
 
-<div class="wrapper" {style}>
+<div class="notification-faucet" {style}>
   {#each $store as notification (notification.id)}
     <div
       data-cy="notification"

--- a/ui/DesignSystem/Component/NotificationFaucet.svelte
+++ b/ui/DesignSystem/Component/NotificationFaucet.svelte
@@ -13,11 +13,9 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    position: fixed;
-    bottom: 2rem;
+    flex: 1;
+
     z-index: 1001;
-    left: var(--sidebar-width);
-    width: calc(100vw - var(--sidebar-width));
   }
 </style>
 

--- a/ui/DesignSystem/Component/NotificationFaucet.svelte
+++ b/ui/DesignSystem/Component/NotificationFaucet.svelte
@@ -14,8 +14,6 @@
     flex-direction: column;
     align-items: center;
     flex: 1;
-
-    z-index: 1001;
   }
 </style>
 

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -42,7 +42,7 @@
     box-shadow: var(--elevation-medium);
     cursor: pointer;
     height: 3.5rem;
-    min-width: 17.2rem;
+    width: var(--transaction-center-width);
     overflow: hidden;
     transition: height 360ms ease;
     user-select: none;

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -1,4 +1,4 @@
-import { derived, get, writable } from "svelte/store";
+import { derived, get, writable, Readable } from "svelte/store";
 
 type ModalOverlay =
   | { show: true; route: string }
@@ -21,3 +21,5 @@ export const toggle = (route: string): void => {
 
   overlayStore.set({ show: true, route });
 };
+
+export const showing: Readable<boolean> = derived(store, $store => $store.show);


### PR DESCRIPTION
Fixes #1568 following option 4.

This also improves things by:

+ having `NotificationFaucet` and `TransactionCenter` under the same parent grants equal margins, instead of duplicating them
+ `NotificationFaucet` takes as much space as there is available, instead of us calculating it which doesn't work for both when there is and there isn't a `TransactionCenter`
+ Seamless responsiveness

The only caveat I found for this option was to hide the transaction centre when a modal is being shown, which is not evasive at all imo.

