### PR TITLE
fix(ui): reinitialize walletconnect on dismissed modal

### DIFF
--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,3 +1,7 @@
+## Radicle Funding
+
+Welcome to the developer's documentation on the Radicle Funding.
+
 ### Overview
 
 Three moving pieces back the Radicle Funding experiences:
@@ -23,10 +27,41 @@ approve or reject) on their connected wallet.
 These same transactions are provided and ran by the [Radicle Contracts][rc], our
 custom Ethereum smart-contracts.
 
+### Ethereum environments
 
-#### Development environment
+The funding experiences can take place in three different environments:
 
-In the development environment, we set up these three pieces as follows:
+1. `Local`
+
+  In this environment, the Radicle Contracts are deployed to development Ethereum
+  node running locally and we use a local test wallet that can communicate with it.
+  The "DAI" token used in this environment is our custom Radicle Token. See the
+  [local environment](#local-environment) section to learn how to get set up.
+
+
+2. `Ropsten`
+
+  In this environment, the app will plug itself with the Radicle Contracts deployed
+  in the Ropsten network and Infura is used as a service provider. We recommend that
+  you use a real wallet to ensure that we are testing using real-world conditions.
+
+  You will need fake Ropsten Eth (aka `rEth`) to pay the incurring transactions fees.
+  No real money will be charged.
+
+  As in the `Local` environment, here the "DAI" token used is also our custom Radicle
+  Token, deployed in the Ropsten network. Reach out to the team to get some Radicle
+  Tokens into your account.
+
+3. `Mainnet`
+
+  In this environment, to be introduced in the future once we are ready to go mainnet,
+  the wallet will plug itself to the Radicle Contracts (to be) deployed in the Ethereum
+  Mainnet. This environment is not currently supported.
+
+
+#### Local environment
+
+In the local environment, we set up these three pieces as follows:
 
 - A local WalletConnect test wallet instance
 
@@ -37,12 +72,12 @@ In the development environment, we set up these three pieces as follows:
 
 - A local ganache instance
 
-  Ganache provides a local Ethereum RPC client for testing and development. The
-  Radicle Contracts are deployed to this instance. Here, we also set an initial
+  Ganache provides a local Ethereum RPC client for testing and development. We deploy the
+  Radicle Contracts to this instance. Here, we also set an initial
   balance of the account we choose for development purposes.
 
-  For piece of mind, note that this instance has no connection to other networks
-  such as mainnet or testnet. Therefore, no real assets are ever used. Feel free
+  For peace of mind, note that this instance has no connection to other networks
+  such as mainnet or testnet. Therefore, no real assets used ever. Feel free
   to play around!
 
 ![Radicle Funding Development Set up][dev-setup]
@@ -76,7 +111,7 @@ tabs:
 
 - `npm run start` within `walletconnect-test-wallet`
 - `yarn ethereum:start` within `radicle-upstream`
-`RADICLE_UPSTREAM_EXPERIMENTAL=true yarn start` within `radicle-upstream`
+- `RADICLE_UPSTREAM_EXPERIMENTAL=true yarn start` within `radicle-upstream`
 - Once the app is running, enable the funding feature in the Upstream settings
 
 

--- a/package.json
+++ b/package.json
@@ -163,9 +163,11 @@
   "dependencies": {
     "@types/qs": "^6.9.5",
     "@types/uuid": "^8.3.0",
+    "@types/big.js": "^6.0.2",
     "@walletconnect/client": "^1.3.1",
+    "big.js": "^6.0.3",
     "browserify": "^17.0.0",
-    "ethers": "^5.0.23",
+    "ethers": "^5.0.24",
     "marked": "^2.0.0",
     "mnemonist": "^0.38.1",
     "pure-svg-code": "^1.0.6",

--- a/scripts/deploy-dev-contracts.js
+++ b/scripts/deploy-dev-contracts.js
@@ -37,6 +37,17 @@ async function main() {
     .readFileSync("sandbox/.local-eth-account", "utf-8")
     .trim();
 
+  const tokenDecimals = await contracts.rad.decimals();
+
   // Set the initial balance of the used erc20 token for the development account.
-  await (await contracts.rad.transfer(devEthAccount, 98765)).wait();
+  await (
+    await contracts.rad.transfer(
+      devEthAccount,
+      fromBaseUnit(98765, tokenDecimals)
+    )
+  ).wait();
+}
+
+function fromBaseUnit(n, exp) {
+  return ethers.BigNumber.from(n).mul(ethers.BigNumber.from(10).pow(exp));
 }

--- a/ui/DesignSystem/Component/Funding/Pool/TopUp.svelte
+++ b/ui/DesignSystem/Component/Funding/Pool/TopUp.svelte
@@ -8,15 +8,15 @@
   } from "../../../../src/funding/pool";
   import { ValidationStatus } from "../../../../src/validation";
 
-  import { BigNumber } from "ethers";
+  import Big from "big.js";
 
   export let amount = "";
   export let onBack: [string, () => void];
-  export let balance = "0";
+  export let balance: Big = Big(0);
   export let disabled = true;
 
   let validating = false;
-  $: validation = balanceValidationStore(BigNumber.from(balance));
+  $: validation = balanceValidationStore(balance);
   $: amountStore.set(amount);
   $: {
     if ($amountStore && $amountStore.length > 0) validating = true;
@@ -48,8 +48,8 @@
 <Emoji emoji="💸" size="huge" />
 <h1>Top up your account</h1>
 <p>
-  You can top up a couple of months worth of support or just enough for this
-  month.
+  You can top up a couple of weeks worth of support or just enough for this
+  week.
 </p>
 <Input.Text
   dataCy="modal-amount-input"

--- a/ui/DesignSystem/Component/Transaction/Center.svelte
+++ b/ui/DesignSystem/Component/Transaction/Center.svelte
@@ -30,7 +30,6 @@
       newTxs.forEach(tx => displayedTxs.add(tx.hash));
     }
   }
-
   $: negative = transactions.some(tx => tx.status === TxStatus.Rejected);
 </script>
 

--- a/ui/DesignSystem/Component/Transaction/Summary.svelte
+++ b/ui/DesignSystem/Component/Transaction/Summary.svelte
@@ -33,7 +33,7 @@
         <strong>{tx.topUp} DAI</strong>. You haven’t set any receivers. As soon
         as you do, money will begin streaming to them at a rate of
         <strong>{tx.budget} DAI</strong>
-        per month.
+        per week.
       </p>
     {:else}
       <p>
@@ -41,7 +41,7 @@
         <strong>{tx.topUp} DAI</strong>
         and stream
         <strong>{tx.budget} DAI</strong>
-        per month to these users:
+        per week to these users:
       </p>
       <Receivers
         receivers={new Map(tx.receivers)}
@@ -53,11 +53,11 @@
       <p>
         Stream
         <strong>{tx.amount} DAI</strong>
-        per month. You haven’t set any receivers. As soon as you do, money will
+        per week. You haven’t set any receivers. As soon as you do, money will
         begin streaming to them at this rate.
       </p>
     {:else}
-      <p>Stream <strong>{tx.amount} DAI</strong> per month to these users:</p>
+      <p>Stream <strong>{tx.amount} DAI</strong> per week to these users:</p>
       <Receivers
         receivers={new Map(tx.receivers)}
         style="margin-top: 1.2rem"

--- a/ui/DesignSystem/Component/Wallet/Panel.svelte
+++ b/ui/DesignSystem/Component/Wallet/Panel.svelte
@@ -10,7 +10,7 @@
   export let style = "";
 
   $: balanceFontSize = `min(36px, calc(20rem / ${Math.max(
-    account.balance.length,
+    account.balance.toString().length,
     1
   )}))`;
 
@@ -75,7 +75,7 @@
       color="var(--color-secondary)"
       size="h1"
       style={`font-size: ${balanceFontSize}`}>
-      {wallet.formattedBalance(parseInt(account.balance))}
+      {wallet.formattedBalance(account.balance.toNumber())}
     </Dai>
   </h1>
 

--- a/ui/DesignSystem/Component/Wallet/WrongNetwork.svelte
+++ b/ui/DesignSystem/Component/Wallet/WrongNetwork.svelte
@@ -1,0 +1,45 @@
+<script lang="typescript">
+  import { Emoji } from "../../Primitive";
+
+  export let expectedNetwork = "Mainnet";
+</script>
+
+<style>
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    align-items: center;
+
+    text-align: center;
+    padding: 10vh 0;
+
+    border: 1px solid var(--color-foreground-level-2);
+    box-sizing: border-box;
+    border-radius: 0.5rem;
+    width: 100%;
+  }
+
+  .inner {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    align-items: center;
+    gap: 1rem;
+
+    width: 23.75rem;
+    margin: 0 auto;
+  }
+</style>
+
+<div class="wrapper">
+  <div class="inner">
+    <Emoji emoji="👛" size="huge" />
+    <h2>Oops!</h2>
+    <p class="typo-text">
+      Your wallet is pointing to an unexpected network. Please, switch back to
+      <span class="typo-text-bold">{expectedNetwork}</span>
+      to keep using this feature.
+    </p>
+  </div>
+</div>

--- a/ui/Modal/Funding/LinkAddress.svelte
+++ b/ui/Modal/Funding/LinkAddress.svelte
@@ -1,11 +1,13 @@
 <script lang="typescript">
+  import * as svelteStore from "svelte/store";
+
   import EthToRadicle from "./Link/EthToRadicle.svelte";
   import EnterPassphrase from "./Link/EnterPassphrase.svelte";
   import SavedToRadicle from "./Link/SavedToRadicle.svelte";
   import RadicleToEth from "./Link/RadicleToEth.svelte";
   import { Remote } from "../../DesignSystem/Component";
 
-  import { wallet } from "../../src/wallet";
+  import { store as walletStore } from "../../src/wallet";
   import { session } from "../../src/session";
 
   import * as modal from "../../src/modal";
@@ -45,7 +47,7 @@
   // Values
   let passphrase: string = "";
 
-  $: address = wallet.account()?.address || "";
+  $: address = svelteStore.get(walletStore).account()?.address || "";
 </script>
 
 <style>

--- a/ui/Modal/Funding/Onboarding.svelte
+++ b/ui/Modal/Funding/Onboarding.svelte
@@ -12,7 +12,7 @@
   import { store } from "../../src/funding/pool";
   import type { Receivers } from "../../src/funding/pool";
 
-  import { BigNumber } from "ethers";
+  import Big from "big.js";
 
   enum Step {
     Erc20Allowance = "erc20",
@@ -85,7 +85,7 @@
   async function onConfirmed(): Promise<void> {
     return (
       $store
-        ?.onboard(BigNumber.from(topUp), BigNumber.from(budget), receivers)
+        ?.onboard(Big(topUp), Big(budget), receivers)
         .then(() => modal.hide()) ||
       Promise.reject("The pool is not instantiated")
     );

--- a/ui/Modal/Funding/Onboarding/Review.svelte
+++ b/ui/Modal/Funding/Onboarding/Review.svelte
@@ -45,13 +45,13 @@
     <strong>{topUp} DAI</strong>. You haven’t added any receivers yet, but as
     soon as you do, money will begin streaming to them at a rate of
     <strong>{budget} DAI</strong>
-    per month.
+    per week.
   {:else}
     Top up
     <strong>{topUp} DAI</strong>
     and stream
     <strong>{budget} DAI</strong>
-    per month to these users:
+    per week to these users:
   {/if}
 </p>
 <Receivers {receivers} style="margin-top: 1.5rem" />

--- a/ui/Modal/Funding/Onboarding/SetBudget.svelte
+++ b/ui/Modal/Funding/Onboarding/SetBudget.svelte
@@ -4,7 +4,7 @@
 
   import {
     budgetStore,
-    monthlyContributionValidationStore,
+    weeklyBudgetValidationStore,
   } from "../../../src/funding/pool";
   import { ValidationStatus } from "../../../src/validation";
 
@@ -13,7 +13,7 @@
   export let onContinue: () => void;
 
   let validating = false;
-  $: validation = monthlyContributionValidationStore();
+  $: validation = weeklyBudgetValidationStore();
   $: budgetStore.set(budget);
   $: {
     if ($budgetStore && $budgetStore.length > 0) validating = true;
@@ -52,9 +52,9 @@
 <svelte:window on:keydown={onKeydown} />
 
 <Emoji emoji="💸" size="huge" />
-<h1>Set a monthly budget</h1>
+<h1>Set a weekly budget</h1>
 <p>
-  Set your monthly budget for outgoing support. This amount will flow to your
+  Set your weekly budget for outgoing support. This amount will flow to your
   receivers in real time.
 </p>
 <Input.Text

--- a/ui/Modal/Funding/Onboarding/TopUp.svelte
+++ b/ui/Modal/Funding/Onboarding/TopUp.svelte
@@ -1,16 +1,21 @@
 <script lang="typescript">
+  import * as svelteStore from "svelte/store";
+
   import { Button } from "../../../DesignSystem/Primitive";
   import TopUp from "../../../DesignSystem/Component/Funding/Pool/TopUp.svelte";
 
-  import { wallet } from "../../../src/wallet";
+  import { store as walletStore } from "../../../src/wallet";
+
+  import Big from "big.js";
 
   export let amount = "";
   export let onBack: () => void;
   export let onContinue: () => void;
 
   let disabled = true;
-  let accountBalance = "";
-  $: accountBalance = wallet.account()?.balance || accountBalance;
+  let accountBalance = Big(0);
+  $: accountBalance =
+    svelteStore.get(walletStore).account()?.balance || accountBalance;
 
   const onKeydown = (event: KeyboardEvent) => {
     if (event.key === "Enter" && !disabled) {

--- a/ui/Modal/Funding/Pool/TopUp.svelte
+++ b/ui/Modal/Funding/Pool/TopUp.svelte
@@ -9,13 +9,13 @@
   import * as modal from "../../../src/modal";
   import { store } from "../../../src/funding/pool";
 
-  import { BigNumber } from "ethers";
+  import Big from "big.js";
 
   if ($store === null) pop();
 
   let amount = "";
   async function onConfirmed(): Promise<void> {
-    await get(store)?.topUp(BigNumber.from(amount));
+    await get(store)?.topUp(Big(amount));
     modal.hide();
     resolve();
   }
@@ -25,7 +25,7 @@
   }
 
   let disabled = true;
-  let balance = "";
+  let balance = Big(0);
   $: balance = $store?.getAccount()?.balance || balance;
 </script>
 

--- a/ui/Modal/Funding/Pool/Withdraw.svelte
+++ b/ui/Modal/Funding/Pool/Withdraw.svelte
@@ -14,17 +14,18 @@
   } from "../../../src/funding/pool";
   import { ValidationStatus } from "../../../src/validation";
 
-  import { BigNumber } from "ethers";
+  import Big from "big.js";
 
   if ($store === null) pop();
 
   // Validate the amount beign withdrawn
   let validatingAmount = false;
   let amount = "";
-  let validation = balanceValidationStore(0);
+  let balance = Big(0);
+  let validation = balanceValidationStore(balance);
 
   $: {
-    const balance = $store?.data.unwrap()?.balance || 0;
+    balance = $store?.data.unwrap()?.balance || balance;
     validation = balanceValidationStore(balance);
   }
 
@@ -45,7 +46,7 @@
     const pool = get(store);
     if (pool) {
       if (mode === Mode.SpecifyAmount) {
-        await pool.withdraw(BigNumber.from(amount));
+        await pool.withdraw(Big(amount));
       } else {
         await pool.withdrawAll();
       }

--- a/ui/Screen/Funding/Pool.svelte
+++ b/ui/Screen/Funding/Pool.svelte
@@ -8,7 +8,8 @@
   import * as fundingPool from "../../src/funding/pool";
   import type { Pool } from "../../src/funding/pool";
   import * as path from "../../src/path";
-  import * as transaction from "../../src/transaction";
+  import { TxKind, ongoing } from "../../src/transaction";
+  import { store as txs } from "../../src/transaction";
 
   export let pool: Pool;
 
@@ -18,9 +19,7 @@
   }
 
   let ongoingCollect = false;
-  transaction.store.subscribe(_ => {
-    ongoingCollect = transaction.ongoing(transaction.TxKind.CollectFunds);
-  });
+  $: ongoingCollect = $txs.some(ongoing(TxKind.CollectFunds));
 </script>
 
 <style>
@@ -31,7 +30,7 @@
 
 <div class="pool-container">
   <Remote store={pool.data} let:data={poolData}>
-    {#if poolData.collectableFunds > 0}
+    {#if poolData.collectableFunds.gt(0)}
       <Incoming
         amount={poolData.collectableFunds}
         {onCollect}

--- a/ui/Screen/Funding/Pool/Outgoing.svelte
+++ b/ui/Screen/Funding/Pool/Outgoing.svelte
@@ -5,14 +5,19 @@
   import Support from "./Outgoing/Support.svelte";
 
   import * as fundingPool from "../../../src/funding/pool";
+  import { TxKind, ongoing } from "../../../src/transaction";
+  import { store as txs } from "../../../src/transaction";
 
   export let pool: fundingPool.Pool;
+
+  let ongoingOnboardingTx = false;
+  $: ongoingOnboardingTx = $txs.some(ongoing(TxKind.SupportOnboarding));
 </script>
 
 <Remote store={pool.data} let:data={poolData}>
   {#if fundingPool.isOnboarded(poolData)}
     <Support bind:pool />
   {:else}
-    <GetStarted bind:pool />
+    <GetStarted ongoingTx={ongoingOnboardingTx} bind:pool />
   {/if}
 </Remote>

--- a/ui/Screen/Funding/Pool/Outgoing/GetStarted.svelte
+++ b/ui/Screen/Funding/Pool/Outgoing/GetStarted.svelte
@@ -6,6 +6,9 @@
   import * as fundingPool from "../../../../src/funding/pool";
 
   export let pool: fundingPool.Pool;
+  // Whether the onboarding tx is ongoing and this screen
+  // should, therefore, be disabled.
+  export let ongoingTx = false;
 
   function getStarted() {
     fundingPool.store.set(pool);
@@ -39,5 +42,5 @@
 <div class="wrapper">
   <Emoji emoji="💸" size="huge" />
   <p class="typo-text">Stream digital money to your favorite people.</p>
-  <Button on:click={getStarted}>Get started</Button>
+  <Button disabled={ongoingTx} on:click={getStarted}>Get started</Button>
 </div>

--- a/ui/Screen/Profile/Funding.svelte
+++ b/ui/Screen/Profile/Funding.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-  import { wallet, Status } from "../../src/wallet";
+  import {
+    selectedEnvironment as ethereumEnvironment,
+    supportedNetwork,
+  } from "../../src/ethereum";
+  import { store, Status } from "../../src/wallet";
   import * as pool from "../../src/funding/pool";
 
   import ConnectWallet from "../../DesignSystem/Component/Wallet/Connect.svelte";
   import WalletPanel from "../../DesignSystem/Component/Wallet/Panel.svelte";
+  import WrongNetwork from "../../DesignSystem/Component/Wallet/WrongNetwork.svelte";
 
   import Pool from "../Funding/Pool.svelte";
 
+  $: wallet = $store;
   // Hack to have Svelte working with checking the $wallet variant
   // and thus be able to access its appropriate fields.
   $: w = $wallet;
@@ -17,6 +23,7 @@
     min-width: var(--content-min-width);
     max-width: var(--content-max-width);
     padding: var(--content-padding);
+    padding-bottom: 9.375rem;
     margin: 0 auto;
 
     display: flex;
@@ -30,7 +37,11 @@
       onDisconnect={wallet.disconnect}
       account={w.connected.account}
       style={'margin-right: var(--content-padding)'} />
-    <Pool pool={pool.make(wallet)} />
+    {#if supportedNetwork($ethereumEnvironment) === w.connected.network}
+      <Pool pool={pool.make(wallet)} />
+    {:else}
+      <WrongNetwork expectedNetwork={supportedNetwork($ethereumEnvironment)} />
+    {/if}
   </div>
 {:else}
   <ConnectWallet

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -2,6 +2,8 @@
   import { getContext } from "svelte";
   import * as svelteStore from "svelte/store";
 
+  import { selectedEnvironment as ethereumEnvironment } from "../src/ethereum";
+  import * as ethereum from "../src/ethereum";
   import * as ipc from "../src/ipc";
   import {
     settings,
@@ -12,7 +14,11 @@
     updateFeatureFlags,
   } from "../src/session";
   import type { UnsealedSession } from "../src/session";
-  import { themeOptions, featureFlagOptions } from "../src/settings";
+  import {
+    themeOptions,
+    featureFlagOptions,
+    fundingEnvironmentOptions,
+  } from "../src/settings";
   import { updateChecker } from "../src/updateChecker";
   import * as path from "../src/path";
   import * as modal from "../src/modal";
@@ -31,6 +37,11 @@
 
   const updateFundingFeatureFlag = (event: CustomEvent) =>
     updateFeatureFlags({ ...$settings.featureFlags, funding: event.detail });
+
+  const updateEthereumEnvironment = (event: CustomEvent) => {
+    const environment = event.detail as ethereum.Environment;
+    ethereum.selectedEnvironment.set(environment);
+  };
 
   let seedInputValue = "";
 
@@ -285,6 +296,19 @@
                 on:select={updateFundingFeatureFlag} />
             </div>
           </div>
+          {#if $settings.featureFlags.funding}
+            <div class="section-item">
+              <div class="info">
+                <p class="typo-text-bold">Funding environment</p>
+              </div>
+              <div class="action">
+                <SegmentedControl
+                  active={$ethereumEnvironment}
+                  options={fundingEnvironmentOptions}
+                  on:select={updateEthereumEnvironment} />
+              </div>
+            </div>
+          {/if}
         </section>
       {/if}
 

--- a/ui/src/ethereum.ts
+++ b/ui/src/ethereum.ts
@@ -1,0 +1,73 @@
+import Big from "big.js";
+import * as ethers from "ethers";
+import persistentStore from "svelte-persistent-store/dist";
+
+// The Ethereum environments we support and may connect to.
+export enum Environment {
+  // A local node for testing and development. The test wallet we use
+  // for this environment may be in the 'Ropsten', 'Mainnet', or other
+  // network. However, those would not be the real 'Ropsten' and 'Mainnet'
+  // networks, respectively, but simply fake ones for testing purposes.
+  Local = "Local",
+  // The Ropsten testnet network
+  Ropsten = "Ropsten",
+  // N.B: We will support 'Mainnet' in the future
+}
+
+// The ethereum networks we may parse from a connected wallet across
+// all `Environment`s. See `supportedNetwork` to learn which networks
+// each Environment supports.
+export enum Network {
+  Ropsten = "Ropsten",
+  Mainnet = "Mainnet",
+  Other = "Other",
+}
+
+// Inform which `Network`s we support within the given environment.
+export function supportedNetwork(environment: Environment): Network {
+  switch (environment) {
+    case Environment.Local:
+      return Network.Mainnet;
+    case Environment.Ropsten:
+      return Network.Ropsten;
+  }
+}
+
+// Parse a `Network` value given a `chainId`.
+// For reference check https://chainid.network.
+export function networkFromChainId(chainId: number): Network {
+  switch (chainId) {
+    case 1:
+      return Network.Mainnet;
+    case 3:
+      return Network.Ropsten;
+    default:
+      return Network.Other;
+  }
+}
+
+// The store where the selected Ethereum environment is persisted.
+export const selectedEnvironment = persistentStore.local.writable<Environment>(
+  "ethereum-environment-v0",
+  Environment.Ropsten
+);
+
+// EIP-20 token decimals for the tokens we operate with across
+// the diferent environments. We hardcode this value since it
+// is well-settled and since we would need to request it from
+// the token contract for each number conversion otherwise.
+// We have, however, to keep in mind that new versions of the
+// token might change it.
+const TOKEN_DECIMALS = Big(10).pow(18);
+
+// Big.PE determines the exponent at which its `toString()` representation
+// starts being displayed in exponential notation. We never want to do that.
+Big.PE = Number.MAX_SAFE_INTEGER;
+
+export function toBaseUnit(n: ethers.BigNumber | Big): Big {
+  return Big(n.toString()).div(TOKEN_DECIMALS).round(2);
+}
+
+export function fromBaseUnit(n: Big): ethers.BigNumber {
+  return ethers.BigNumber.from(n.mul(TOKEN_DECIMALS).round().toString());
+}

--- a/ui/src/funding/contract.ts
+++ b/ui/src/funding/contract.ts
@@ -1,4 +1,7 @@
-import type { BigNumber, ContractTransaction, Signer } from "ethers";
+import type { ethers, BigNumber, ContractTransaction, Signer } from "ethers";
+
+import Big from "big.js";
+
 import {
   Erc20Pool,
   Erc20Pool__factory as PoolFactory,
@@ -6,20 +9,45 @@ import {
   ERC20__factory as Erc20Factory,
 } from "radicle-contracts/build/contract-bindings/ethers";
 
-// TODO(nuno): make the contract addresses configurable/env-dependant
+import * as ethereum from "../ethereum";
 
-export const POOL_ADDRESS: string =
-  "0x37c10d847bf9e708add451bf2f80c1297d7aa691";
+const addresses = {
+  pool: {
+    local: "0x37c10d847bf9e708add451bf2f80c1297d7aa691",
+    ropsten: "0xEc5bfca987C5FAA6d394044793f0aD6C9A85Da76",
+  },
+  dai: {
+    local: "0xf34a89802590f944e3de71b1f74d66ed1bafc9cd",
+    ropsten: "0xD069f9Cbe64979953357bCa3f21d902e775f1F48",
+  },
+};
 
-export function pool(signer: Signer): PoolContract {
-  return new PoolContract(signer, POOL_ADDRESS);
+// Get the address of the Pool Contract for the given environment
+export function poolAddress(environment: ethereum.Environment): string {
+  switch (environment) {
+    case ethereum.Environment.Local:
+      return addresses.pool.local;
+    case ethereum.Environment.Ropsten:
+      return addresses.pool.ropsten;
+  }
 }
 
-// Address of the DAI ERC20 token contract
-export const DAI_TOKEN_ADDRESS = "0xf34a89802590f944e3de71b1f74d66ed1bafc9cd";
+export function pool(signer: Signer, address: string): PoolContract {
+  return new PoolContract(signer, address);
+}
 
-export function daiToken(signer: Signer): ERC20 {
-  return Erc20Factory.connect(DAI_TOKEN_ADDRESS, signer);
+// Get the address of the Pool Contract for the given environment
+export function daiTokenAddress(environment: ethereum.Environment): string {
+  switch (environment) {
+    case ethereum.Environment.Local:
+      return addresses.dai.local;
+    case ethereum.Environment.Ropsten:
+      return addresses.dai.ropsten;
+  }
+}
+
+export function daiToken(signer: Signer, address: string): ERC20 {
+  return Erc20Factory.connect(address, signer);
 }
 
 // PoolContract is a wrapper type around the actual contract, `Erc20Pool`,
@@ -32,48 +60,78 @@ export class PoolContract {
   }
 
   async onboard(
-    topUp: BigNumber,
-    amountPerBlock: BigNumber,
+    topUp: Big,
+    weeklyBudget: Big,
     receivers: PoolReceiver[]
   ): Promise<ContractTransaction> {
-    return this.contract.updateSender(topUp, 0, amountPerBlock, receivers, []);
+    return this.contract.updateSender(
+      ethereum.fromBaseUnit(topUp),
+      0,
+      weeklyBudgetToAmountPerBlock(weeklyBudget),
+      receivers,
+      []
+    );
   }
 
   async updatePlan(
-    amountPerBlock: BigNumber,
+    weeklyBudget: Big,
     receivers: PoolReceiver[]
   ): Promise<ContractTransaction> {
-    return this.contract.updateSender(0, 0, amountPerBlock, receivers, []);
+    return this.contract.updateSender(
+      0,
+      0,
+      weeklyBudgetToAmountPerBlock(weeklyBudget),
+      receivers,
+      []
+    );
   }
 
-  async topUp(amount: BigNumber): Promise<ContractTransaction> {
+  async topUp(amount: Big): Promise<ContractTransaction> {
     const UNCHANGED = await this.contract.AMOUNT_PER_BLOCK_UNCHANGED();
-    return this.contract.updateSender(amount, 0, UNCHANGED, [], []);
+    return this.contract.updateSender(
+      ethereum.fromBaseUnit(amount),
+      0,
+      UNCHANGED,
+      [],
+      []
+    );
   }
 
-  async withdraw(amount: BigNumber): Promise<ContractTransaction> {
+  async withdraw(amount: Big): Promise<ContractTransaction> {
     const UNCHANGED = await this.contract.AMOUNT_PER_BLOCK_UNCHANGED();
-    return this.contract.updateSender(0, amount, UNCHANGED, [], []);
+    return this.contract.updateSender(
+      0,
+      ethereum.fromBaseUnit(amount),
+      UNCHANGED,
+      [],
+      []
+    );
+  }
+
+  async withdrawAll(): Promise<ContractTransaction> {
+    const UNCHANGED = await this.contract.AMOUNT_PER_BLOCK_UNCHANGED();
+    const ALL = await this.withdrawAllFlag();
+    return this.contract.updateSender(0, ALL, UNCHANGED, [], []);
   }
 
   async collect(): Promise<ContractTransaction> {
     return this.contract.collect();
   }
 
-  async withdrawAllFlag(): Promise<BigNumber> {
+  async withdrawAllFlag(): Promise<ethers.BigNumber> {
     return this.contract.WITHDRAW_ALL();
   }
 
-  async withdrawable(): Promise<BigNumber> {
-    return this.contract.withdrawable();
+  async withdrawable(): Promise<Big> {
+    return this.contract.withdrawable().then(ethereum.toBaseUnit);
   }
 
-  async collectable(): Promise<BigNumber> {
-    return this.contract.collectable();
+  async collectable(): Promise<Big> {
+    return this.contract.collectable().then(ethereum.toBaseUnit);
   }
 
-  async amountPerBlock(): Promise<BigNumber> {
-    return this.contract.getAmountPerBlock();
+  async weeklyBudget(): Promise<Big> {
+    return this.contract.getAmountPerBlock().then(amountPerBlockToWeeklyBudget);
   }
 
   async receivers(): Promise<PoolReceiver[]> {
@@ -88,3 +146,25 @@ export interface PoolReceiver {
   // The share the receiver gets within the pool they are a part of.
   weight: number;
 }
+
+// Convert the user-inputed `weeklyBudget` into how much it means per Ethereum block.
+function weeklyBudgetToAmountPerBlock(weeklyBudget: Big): BigNumber {
+  return ethereum.fromBaseUnit(weeklyBudget.div(ESTIMATED_BLOCKS_IN_WEEK));
+}
+
+// The inverse operation of `weeklyBudgetToAmountPerBlock`.
+function amountPerBlockToWeeklyBudget(amountPerBlock: BigNumber): Big {
+  return ethereum.toBaseUnit(
+    Big(amountPerBlock.toString()).mul(ESTIMATED_BLOCKS_IN_WEEK)
+  );
+}
+
+// The Ethereum network aims to mine a block at every 12.5 seconds.
+const AVG_ETHEREUM_BLOCK_TIME_SECONDS = 12.5;
+
+// The number of seconds in a week
+const AVG_SECONDS_IN_WEEK = 604800;
+
+// The estimated number of Ethereum blocks mined in a week
+const ESTIMATED_BLOCKS_IN_WEEK =
+  AVG_SECONDS_IN_WEEK / AVG_ETHEREUM_BLOCK_TIME_SECONDS;

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -1,7 +1,12 @@
 import { derived, get, writable } from "svelte/store";
 
+type OnHide = () => void;
+const doNothing = () => {
+  /**/
+};
+
 type ModalOverlay =
-  | { show: true; route: string }
+  | { show: true; route: string; onHide: OnHide }
   | { show: false; route: null };
 
 const overlayStore = writable<ModalOverlay>({
@@ -10,14 +15,21 @@ const overlayStore = writable<ModalOverlay>({
 });
 export const store = derived(overlayStore, $store => $store);
 
-export const hide = (): void => overlayStore.set({ show: false, route: null });
+export const hide = (): void => {
+  const modal = get(store);
+  if (modal.show) {
+    modal.onHide();
+  }
 
-export const toggle = (route: string): void => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (get(store).show && get(store).route === route) {
+  overlayStore.set({ show: false, route: null });
+};
+
+export const toggle = (route: string, onHide: OnHide = doNothing): void => {
+  const modal = get(store);
+  if (modal.show && modal.route === route) {
     hide();
     return;
   }
 
-  overlayStore.set({ show: true, route });
+  overlayStore.set({ show: true, route, onHide });
 };

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -1,3 +1,5 @@
+import * as ethereum from "./ethereum";
+
 // TYPES
 export interface Settings {
   appearance: Appearance;
@@ -64,6 +66,17 @@ export const featureFlagOptions: Option<boolean>[] = [
   {
     title: "Disabled",
     value: false,
+  },
+];
+
+export const fundingEnvironmentOptions: Option<ethereum.Environment>[] = [
+  {
+    title: ethereum.Environment.Local.toString(),
+    value: ethereum.Environment.Local,
+  },
+  {
+    title: ethereum.Environment.Ropsten.toString(),
+    value: ethereum.Environment.Ropsten,
   },
 ];
 

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -1,12 +1,12 @@
 import * as svelteStore from "svelte/store";
 import { writable as persistentStore } from "svelte-persistent-store/dist/local";
 
-import { BigNumber } from "ethers";
+import Big from "big.js";
 import type { ContractTransaction } from "ethers";
 import type { TransactionReceipt } from "@ethersproject/abstract-provider";
 
 import * as error from "./error";
-import { provider } from "./wallet";
+import { store as walletStore } from "./wallet";
 import type { Address, Receivers, ReceiverStatus } from "./funding/pool";
 
 // The store where all managed transactions are stored.
@@ -57,7 +57,7 @@ interface SupportOnboarding {
   kind: TxKind.SupportOnboarding;
   // The amount defined as the initial balance
   topUp: string;
-  // The amount to be disbursed monthly to the `receivers`.
+  // The amount to be disbursed weekly to the `receivers`.
   budget: string;
   // The receivers of this support.
   receivers: [Address, ReceiverStatus][];
@@ -80,7 +80,7 @@ interface CollectFunds {
 
 interface UpdateSupport {
   kind: TxKind.UpdateSupport;
-  // The amount to be disbursed monthly to the `receivers`.
+  // The amount to be disbursed weekly to the `receivers`.
   amount: string;
   // The changes made to the list of receivers.
   receivers: [Address, ReceiverStatus][];
@@ -112,8 +112,8 @@ export function erc20Allowance(txc: ContractTransaction): Tx {
 
 export function supportOnboarding(
   txc: ContractTransaction,
-  topUp: BigNumber,
-  budget: BigNumber,
+  topUp: Big,
+  budget: Big,
   receivers: Receivers
 ): Tx {
   const meta: SupportOnboarding = {
@@ -125,7 +125,7 @@ export function supportOnboarding(
   return { ...txData(txc), ...meta };
 }
 
-export function collect(txc: ContractTransaction, amount: BigNumber): Tx {
+export function collect(txc: ContractTransaction, amount: Big): Tx {
   const meta: CollectFunds = {
     kind: TxKind.CollectFunds,
     amount: amount.toString(),
@@ -133,19 +133,19 @@ export function collect(txc: ContractTransaction, amount: BigNumber): Tx {
   return { ...txData(txc), ...meta };
 }
 
-export function topUp(txc: ContractTransaction, amount: BigNumber): Tx {
+export function topUp(txc: ContractTransaction, amount: Big): Tx {
   const meta: TopUp = { kind: TxKind.TopUp, amount: amount.toString() };
   return { ...txData(txc), ...meta };
 }
 
-export function withdraw(txc: ContractTransaction, amount: BigNumber): Tx {
+export function withdraw(txc: ContractTransaction, amount: Big): Tx {
   const meta: Withdraw = { kind: TxKind.Withdraw, amount: amount.toString() };
   return { ...txData(txc), ...meta };
 }
 
 export function updateSupport(
   txc: ContractTransaction,
-  amount: BigNumber,
+  amount: Big,
   receivers: Receivers
 ): Tx {
   const meta: UpdateSupport = {
@@ -188,7 +188,9 @@ async function updateStatuses() {
       .filter((tx: Tx) => tx.status === TxStatus.AwaitingInclusion)
       .forEach(async (tx: Tx) => {
         try {
-          const receipt = await provider.getTransactionReceipt(tx.hash);
+          const receipt = await svelteStore
+            .get(walletStore)
+            .provider.getTransactionReceipt(tx.hash);
           tx.status = status(receipt);
         } catch (_error) {
           // We ignore network failures, therefore keeping the
@@ -211,12 +213,10 @@ function status(receipt: TransactionReceipt): TxStatus {
 
 /* UI helper functions */
 
-// Check if there is an ongoing transaction of a given kind.
-export function ongoing(txKind: TxKind): boolean {
-  const txs: Tx[] = svelteStore.get(store);
-  return txs.some(
-    tx => tx.status === TxStatus.AwaitingInclusion && tx.kind === txKind
-  );
+// Middleware criterion to check for an ongoing transaction of a given TxKind.
+export function ongoing(txKind: TxKind): (tx: Tx) => boolean {
+  return (tx: Tx) =>
+    tx.status === TxStatus.AwaitingInclusion && tx.kind === txKind;
 }
 
 export const colorForStatus = (status: TxStatus): string => {
@@ -330,14 +330,14 @@ export function isIncoming(tx: Tx): boolean {
 }
 
 // The amount the `tx` transfers. `undefined` when not applicable.
-export function transferAmount(tx: Tx): BigNumber | undefined {
+export function transferAmount(tx: Tx): Big | undefined {
   switch (tx.kind) {
     case TxKind.CollectFunds:
     case TxKind.Withdraw:
     case TxKind.TopUp:
-      return BigNumber.from(tx.amount);
+      return Big(tx.amount);
     case TxKind.SupportOnboarding:
-      return BigNumber.from(tx.topUp);
+      return Big(tx.topUp);
     default:
       return undefined;
   }

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -1,5 +1,7 @@
 import WalletConnect from "@walletconnect/client";
 import * as svelteStore from "svelte/store";
+
+import type { Big } from "big.js";
 import * as ethers from "ethers";
 import * as ethersBytes from "@ethersproject/bytes";
 import {
@@ -10,10 +12,12 @@ import {
 import type {
   Provider,
   TransactionRequest,
+  TransactionResponse,
 } from "@ethersproject/abstract-provider";
 
 import * as contract from "../src/funding/contract";
 import * as error from "../src/error";
+import * as ethereum from "../src/ethereum";
 import * as modal from "../src/modal";
 import * as path from "../src/path";
 
@@ -30,50 +34,75 @@ export type State =
 
 export interface Connected {
   account: Account;
+  network: ethereum.Network;
 }
 
 export interface Account {
   address: string;
-  balance: string;
+  balance: Big;
 }
 
 export interface Wallet extends svelteStore.Readable<State> {
+  environment: ethereum.Environment;
   connect(): Promise<void>;
   disconnect(): Promise<void>;
+  provider: ethers.providers.Provider;
   signer: ethers.Signer;
   account(): Account | undefined;
 }
 
-export const provider = new ethers.providers.JsonRpcProvider(
-  "http://localhost:8545"
-);
+function getProvider(
+  environment: ethereum.Environment
+): ethers.providers.Provider {
+  switch (environment) {
+    case ethereum.Environment.Local:
+      return new ethers.providers.JsonRpcProvider("http://localhost:8545");
+    case ethereum.Environment.Ropsten:
+      return new ethers.providers.InfuraProvider(
+        "ropsten",
+        "66fa0f92a54e4d8c9483ffdc6840d77b"
+      );
+  }
+}
 
-export function build(): Wallet {
+const qrCodeModal = {
+  open: (uri: string, _cb: unknown, _opts?: unknown) => {
+    uriStore.set(uri);
+    modal.toggle(path.walletQRCode());
+  },
+  close: () => {
+    // N.B: this is actually called when the connection is established,
+    // not when the modal is closed per se.
+    modal.hide();
+  },
+};
+
+function newWalletConnect(): WalletConnect {
+  return new WalletConnect({
+    bridge: "https://bridge.walletconnect.org",
+    qrcodeModal: qrCodeModal,
+  });
+}
+
+export function build(
+  environment: ethereum.Environment,
+  provider: ethers.providers.Provider
+): Wallet {
   const stateStore = svelteStore.writable<State>({
     status: Status.NotConnected,
   });
 
-  const qrCodeModal = {
-    open: (uri: string, _cb: unknown, _opts?: unknown) => {
-      uriStore.set(uri);
-      modal.toggle(path.walletQRCode());
-    },
-    close: async () => {
-      // N.B: this is actually called when the connection is established,
-      // not when the modal is closed per se.
-      modal.hide();
-    },
-  };
-
-  let walletConnect = new WalletConnect({
-    bridge: "https://bridge.walletconnect.org",
-    qrcodeModal: qrCodeModal,
-  });
-
-  const signer = new WalletConnectSigner(walletConnect, provider, disconnect);
-  const daiTokenContract = contract.daiToken(signer);
-
-  window.ethereumDebug = new EthereumDebug(provider);
+  let walletConnect = newWalletConnect();
+  const signer = new WalletConnectSigner(
+    walletConnect,
+    provider,
+    environment,
+    disconnect
+  );
+  const daiTokenContract = contract.daiToken(
+    signer,
+    contract.daiTokenAddress(environment)
+  );
 
   // Connect to a wallet using walletconnect
   async function connect() {
@@ -121,12 +150,17 @@ export function build(): Wallet {
   async function loadAccountData() {
     try {
       const accountAddress = await signer.getAddress();
-      const balance = await daiTokenContract.balanceOf(accountAddress);
+      const balance = await daiTokenContract
+        .balanceOf(accountAddress)
+        .then(ethereum.toBaseUnit);
+      const chainId = walletConnect.chainId;
+
       const connected = {
         account: {
           address: accountAddress,
-          balance: balance.toString(),
+          balance,
         },
+        network: ethereum.networkFromChainId(chainId),
       };
       stateStore.set({ status: Status.Connected, connected });
     } catch (error) {
@@ -156,9 +190,11 @@ export function build(): Wallet {
   }
 
   return {
+    environment,
     subscribe: stateStore.subscribe,
     connect,
     disconnect,
+    provider,
     signer,
     account,
   };
@@ -173,15 +209,18 @@ declare global {
 class WalletConnectSigner extends ethers.Signer {
   public walletConnect: WalletConnect;
   private _provider: ethers.providers.Provider;
+  private _environment: ethereum.Environment;
 
   constructor(
     walletConnect: WalletConnect,
     provider: Provider,
+    environment: ethereum.Environment,
     onDisconnect: () => void
   ) {
     super();
     defineReadOnly(this, "provider", provider);
     this._provider = provider;
+    this._environment = environment;
     this.walletConnect = walletConnect;
     this.walletConnect.on("disconnect", onDisconnect);
   }
@@ -200,12 +239,58 @@ class WalletConnectSigner extends ethers.Signer {
     throw new Error("not implemented");
   }
 
+  async sendTransaction(
+    transaction: Deferrable<TransactionRequest>
+  ): Promise<TransactionResponse> {
+    // When using a local Ethereum environment, we want our app to send
+    // the transaction to the local Ethereum node and have the external
+    // wallet just sign the transaction. In all other environments, we
+    // want the external wallet to submit the transaction to the network.
+    if (this._environment === ethereum.Environment.Local) {
+      return super.sendTransaction(transaction);
+    }
+
+    const tx = await resolveProperties(transaction);
+    const from = tx.from || (await this.getAddress());
+
+    const txHash = await this.walletConnect.sendTransaction({
+      from,
+      to: tx.to,
+      value: BigNumberToPrimitive(tx.value),
+      data: bytesLikeToString(tx.data),
+    });
+
+    return {
+      from,
+      value: ethers.BigNumber.from(tx.value || 0),
+      get chainId(): number {
+        throw new Error("this should never be called");
+      },
+      get nonce(): number {
+        throw new Error("this should never be called");
+      },
+      get gasLimit(): ethers.BigNumber {
+        throw new Error("this should never be called");
+      },
+      get gasPrice(): ethers.BigNumber {
+        throw new Error("this should never be called");
+      },
+      data: bytesLikeToString(tx.data) || "",
+      hash: txHash,
+      confirmations: 1,
+      wait: () => {
+        throw new Error("this should never be called");
+      },
+    };
+  }
+
   async signTransaction(
     transaction: Deferrable<TransactionRequest>
   ): Promise<string> {
     const tx = await resolveProperties(transaction);
     const from = tx.from || (await this.getAddress());
     const nonce = await this._provider.getTransactionCount(from);
+
     const signedTx = await this.walletConnect.signTransaction({
       from,
       to: tx.to,
@@ -272,5 +357,14 @@ export function formattedBalance(balance: number): string {
   return balance.toLocaleString("us-US");
 }
 
-// The wallet singleton
-export const wallet = build();
+export const store: svelteStore.Readable<Wallet> = svelteStore.derived(
+  ethereum.selectedEnvironment,
+  environment => {
+    const provider = getProvider(environment);
+    if (provider instanceof ethers.providers.JsonRpcProvider) {
+      window.ethereumDebug = new EthereumDebug(provider);
+    }
+
+    return build(environment, provider);
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,6 +392,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@ethersproject/abi@5.0.10", "@ethersproject/abi@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.10.tgz#c32baa919ad0e5cddabb2f3a8aed0eaeeed7fa4a"
+  integrity sha512-cfC3lGgotfxX3SMri4+CisOPwignoj/QGHW9J29spC4R4Qqcnk/SYuVkPFBMdLbvBp3f/pGiVqPNwont0TSXhg==
+  dependencies:
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+
 "@ethersproject/abi@5.0.9", "@ethersproject/abi@^5.0.5":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.9.tgz#738c1c557e56d8f395a5a27caef9b0449bc85a10"
@@ -420,6 +435,30 @@
     "@ethersproject/transactions" "^5.0.5"
     "@ethersproject/web" "^5.0.6"
 
+"@ethersproject/abstract-provider@5.0.8", "@ethersproject/abstract-provider@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz#880793c29bfed33dff4c2b2be7ecb9ba966d52c0"
+  integrity sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/networks" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/web" "^5.0.12"
+
+"@ethersproject/abstract-signer@5.0.11", "@ethersproject/abstract-signer@^5.0.10":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz#675da9ec168905c60ee79a6da95f7157ca956f46"
+  integrity sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+
 "@ethersproject/abstract-signer@5.0.9", "@ethersproject/abstract-signer@^5.0.4", "@ethersproject/abstract-signer@^5.0.6":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.9.tgz#238ddc06031aeb9dfceee2add965292d7dd1acbf"
@@ -442,6 +481,17 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/rlp" "^5.0.3"
 
+"@ethersproject/address@5.0.9", "@ethersproject/address@^5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.9.tgz#347ef30dc8243c682574a3f23ff63f73c8f8cbf1"
+  integrity sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/rlp" "^5.0.7"
+
 "@ethersproject/asm@^5.0.5":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/asm/-/asm-5.0.8.tgz#86f6e829ad3c166bc779b7864a0c12615fbb63e8"
@@ -456,6 +506,13 @@
   dependencies:
     "@ethersproject/bytes" "^5.0.4"
 
+"@ethersproject/base64@5.0.7", "@ethersproject/base64@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.7.tgz#d5da73699b4a33dc92bd8e5056ad1880b262057d"
+  integrity sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+
 "@ethersproject/basex@5.0.6", "@ethersproject/basex@^5.0.3":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.0.6.tgz#ab95c32e48288a3d868726463506641cb1e9fb6b"
@@ -463,6 +520,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/properties" "^5.0.3"
+
+"@ethersproject/basex@5.0.7", "@ethersproject/basex@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.0.7.tgz#2f7026b12c9dee6cdc7b7bf1805461836e635495"
+  integrity sha512-OsXnRsujGmYD9LYyJlX+cVe5KfwgLUbUJrJMWdzRWogrygXd5HvGd7ygX1AYjlu1z8W/+t2FoQnczDR/H2iBjA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/properties" "^5.0.7"
 
 "@ethersproject/bignumber@5.0.12", "@ethersproject/bignumber@^5.0.10", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.0.8":
   version "5.0.12"
@@ -473,12 +538,28 @@
     "@ethersproject/logger" "^5.0.5"
     bn.js "^4.4.0"
 
+"@ethersproject/bignumber@5.0.13", "@ethersproject/bignumber@^5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.13.tgz#a5466412b3b80104097b9c694f6ae827df4353fe"
+  integrity sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    bn.js "^4.4.0"
+
 "@ethersproject/bytes@5.0.8", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.0.8":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.8.tgz#cf1246a6a386086e590063a4602b1ffb6cc43db1"
   integrity sha512-O+sJNVGzzuy51g+EMK8BegomqNIg+C2RO6vOt0XP6ac4o4saiq69FnjlsrNslaiMFVO7qcEHBsWJ9hx1tj1lMw==
   dependencies:
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/bytes@5.0.9", "@ethersproject/bytes@^5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.9.tgz#2748247402ad20df69f3a3e935dc7b58c0d75c08"
+  integrity sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==
+  dependencies:
+    "@ethersproject/logger" "^5.0.8"
 
 "@ethersproject/cli@^5.0.7":
   version "5.0.7"
@@ -500,6 +581,13 @@
   dependencies:
     "@ethersproject/bignumber" "^5.0.7"
 
+"@ethersproject/constants@5.0.8", "@ethersproject/constants@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.0.8.tgz#50f2e23f48c0d1d0de3759ea79b68ec3e06435a1"
+  integrity sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+
 "@ethersproject/contracts@5.0.8":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.0.8.tgz#71d3ba16853a1555be2e161a6741df186f81c73b"
@@ -515,10 +603,39 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
 
-"@ethersproject/hash@5.0.8", "@ethersproject/hash@^5.0.4":
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.8.tgz#368a60addc3c5cd18e28f78c80dc94e1bacb82d8"
-  integrity sha512-Qay01tcFyFreYjSMt82rOQGMfQDmLm1sj3iNNO1BhrVf840xgBZuJ7gBATERzAjTuTCHUHw9BuGwxErJUS95yg==
+"@ethersproject/contracts@5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.0.9.tgz#6c67c0ebe20ee1af903f7f43568401023334a181"
+  integrity sha512-CCTxVeDh6sjdSEbjzONhtwPjECvaHE62oGkY8M7kP0CHmgLD2SEGel0HZib8e5oQKRKGly9AKcUFW4g3rQ0AQw==
+  dependencies:
+    "@ethersproject/abi" "^5.0.10"
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+
+"@ethersproject/hash@5.0.10", "@ethersproject/hash@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.10.tgz#41bf37428e8ddbc229ffd81c47af667174cb491a"
+  integrity sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+
+"@ethersproject/hash@5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.9.tgz#81252a848185b584aa600db4a1a68cad9229a4d4"
+  integrity sha512-e8/i2ZDeGSgCxXT0vocL54+pMbw5oX5fNjb2E3bAIvdkh5kH29M7zz1jHu1QDZnptIuvCZepIbhUH8lxKE2/SQ==
   dependencies:
     "@ethersproject/abstract-signer" "^5.0.6"
     "@ethersproject/address" "^5.0.5"
@@ -529,10 +646,10 @@
     "@ethersproject/properties" "^5.0.4"
     "@ethersproject/strings" "^5.0.4"
 
-"@ethersproject/hash@5.0.9":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.9.tgz#81252a848185b584aa600db4a1a68cad9229a4d4"
-  integrity sha512-e8/i2ZDeGSgCxXT0vocL54+pMbw5oX5fNjb2E3bAIvdkh5kH29M7zz1jHu1QDZnptIuvCZepIbhUH8lxKE2/SQ==
+"@ethersproject/hash@^5.0.4":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.8.tgz#368a60addc3c5cd18e28f78c80dc94e1bacb82d8"
+  integrity sha512-Qay01tcFyFreYjSMt82rOQGMfQDmLm1sj3iNNO1BhrVf840xgBZuJ7gBATERzAjTuTCHUHw9BuGwxErJUS95yg==
   dependencies:
     "@ethersproject/abstract-signer" "^5.0.6"
     "@ethersproject/address" "^5.0.5"
@@ -561,6 +678,43 @@
     "@ethersproject/transactions" "^5.0.5"
     "@ethersproject/wordlists" "^5.0.4"
 
+"@ethersproject/hdnode@5.0.8", "@ethersproject/hdnode@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.0.8.tgz#2b52ede921cfbce8de49da774ec5a74025fc2bb1"
+  integrity sha512-Mscpjd7BBjxYSWghaNMwV0xrBBkOoCq6YEPRm9MgE24CiBlzzbfEB5DGq6hiZqhQaxPkdCUtKKqZi3nt9hx43g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/basex" "^5.0.7"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/pbkdf2" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/sha2" "^5.0.7"
+    "@ethersproject/signing-key" "^5.0.8"
+    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/wordlists" "^5.0.8"
+
+"@ethersproject/json-wallets@5.0.10", "@ethersproject/json-wallets@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.0.10.tgz#cdc9c27cb486762a3313e25f6f2fef0eb890dbaf"
+  integrity sha512-Ux36u+d7Dm0M5AQ+mWuHdvfGPMN8K1aaLQgwzrsD4ELTWlwRuHuQbmn7/GqeOpbfaV6POLwdYcBk2TXjlGp/IQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/hdnode" "^5.0.8"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/pbkdf2" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/random" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/json-wallets@5.0.9", "@ethersproject/json-wallets@^5.0.6":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.0.9.tgz#2e1708c2854c4ab764e35920bd1f44c948b95434"
@@ -588,7 +742,15 @@
     "@ethersproject/bytes" "^5.0.4"
     js-sha3 "0.5.7"
 
-"@ethersproject/logger@5.0.8", "@ethersproject/logger@^5.0.5":
+"@ethersproject/keccak256@5.0.7", "@ethersproject/keccak256@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.7.tgz#2eedb5e4c160fcdf0079660f8ae362d7855ea943"
+  integrity sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    js-sha3 "0.5.7"
+
+"@ethersproject/logger@5.0.8", "@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.0.8":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.8.tgz#135c1903d35c878265f3cbf2b287042c4c20d5d4"
   integrity sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==
@@ -600,6 +762,13 @@
   dependencies:
     "@ethersproject/logger" "^5.0.5"
 
+"@ethersproject/networks@5.0.7", "@ethersproject/networks@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.0.7.tgz#8d06e41197b27c2404d89a29ca21f741a01acbfc"
+  integrity sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==
+  dependencies:
+    "@ethersproject/logger" "^5.0.8"
+
 "@ethersproject/pbkdf2@5.0.6", "@ethersproject/pbkdf2@^5.0.3":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.0.6.tgz#105dbfb08cd5fcf33869b42bfdc35a3ebd978cbd"
@@ -608,12 +777,27 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/sha2" "^5.0.3"
 
+"@ethersproject/pbkdf2@5.0.7", "@ethersproject/pbkdf2@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.0.7.tgz#a36fdb7327760ec0096857053e01c923a63417da"
+  integrity sha512-0SNLNixPMqnosH6pyc4yPiUu/C9/Jbu+f6I8GJW9U2qNpMBddmRJviwseoha5Zw1V+Aw0Z/yvYyzIIE8yPXqLA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/sha2" "^5.0.7"
+
 "@ethersproject/properties@5.0.6", "@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.0.4":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.6.tgz#44d82aaa294816fd63333e7def42426cf0e87b3b"
   integrity sha512-a9DUMizYhJ0TbtuDkO9iYlb2CDlpSKqGPDr+amvlZhRspQ6jbl5Eq8jfu4SCcGlcfaTbguJmqGnyOGn1EFt6xA==
   dependencies:
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/properties@5.0.7", "@ethersproject/properties@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.7.tgz#951d11ba592ff90bbe8ec34c5a03a5157e3b3360"
+  integrity sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==
+  dependencies:
+    "@ethersproject/logger" "^5.0.8"
 
 "@ethersproject/providers@5.0.17":
   version "5.0.17"
@@ -640,6 +824,31 @@
     bech32 "1.1.4"
     ws "7.2.3"
 
+"@ethersproject/providers@5.0.19":
+  version "5.0.19"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.0.19.tgz#94c8f1a86755ee4187911fc6250e94b1116c089a"
+  integrity sha512-G+flo1jK1y/rvQy6b71+Nu7qOlkOKz+XqpgqFMZslkCzGuzQRmk9Qp7Ln4soK8RSyP1e5TCujaRf1H+EZahoaw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/basex" "^5.0.7"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/networks" "^5.0.7"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/random" "^5.0.7"
+    "@ethersproject/rlp" "^5.0.7"
+    "@ethersproject/sha2" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/web" "^5.0.12"
+    bech32 "1.1.4"
+    ws "7.2.3"
+
 "@ethersproject/random@5.0.6", "@ethersproject/random@^5.0.3":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.0.6.tgz#9be80a1065f2b8e6f321dccb3ebeb4886cac9ea4"
@@ -648,6 +857,14 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
 
+"@ethersproject/random@5.0.7", "@ethersproject/random@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.0.7.tgz#e364268ce68bf6d300c36d654e622fd9d26b3a86"
+  integrity sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+
 "@ethersproject/rlp@5.0.6", "@ethersproject/rlp@^5.0.3":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.0.6.tgz#29f9097348a3c330811997433b7df89ab51cd644"
@@ -655,6 +872,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/rlp@5.0.7", "@ethersproject/rlp@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.0.7.tgz#cfa4fa6415960a435b7814e1a29bdfea657e2b6e"
+  integrity sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
 
 "@ethersproject/sha2@5.0.6", "@ethersproject/sha2@^5.0.3":
   version "5.0.6"
@@ -665,6 +890,15 @@
     "@ethersproject/logger" "^5.0.5"
     hash.js "1.1.3"
 
+"@ethersproject/sha2@5.0.7", "@ethersproject/sha2@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.0.7.tgz#ef9f18770c9f90a6cfd73840b0c3400910219099"
+  integrity sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    hash.js "1.1.3"
+
 "@ethersproject/signing-key@5.0.7", "@ethersproject/signing-key@^5.0.4":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.0.7.tgz#d03bfc5f565efb962bafebf8e6965e70d1c46d31"
@@ -673,6 +907,16 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
+    elliptic "6.5.3"
+
+"@ethersproject/signing-key@5.0.8", "@ethersproject/signing-key@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.0.8.tgz#156522e542916b9aa9135527b40c5b6f9235af02"
+  integrity sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
     elliptic "6.5.3"
 
 "@ethersproject/solidity@5.0.7":
@@ -686,6 +930,17 @@
     "@ethersproject/sha2" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/solidity@5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.0.8.tgz#a260116a794bc97558d89e98f59831ce8d25c733"
+  integrity sha512-OJkyBq9KaoGsi8E8mYn6LX+vKyCURvxSp0yuGBcOqEFM3vkn9PsCiXsHdOXdNBvlHG5evJXwAYC2UR0TzgJeKA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/sha2" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+
 "@ethersproject/strings@5.0.7", "@ethersproject/strings@^5.0.4":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.0.7.tgz#8dc68f794c9e2901f3b75e53b2afbcb6b6c15037"
@@ -694,6 +949,15 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/constants" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/strings@5.0.8", "@ethersproject/strings@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.0.8.tgz#11a1b0ed1e8417408693789839f0b5f4e323c0c9"
+  integrity sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/logger" "^5.0.8"
 
 "@ethersproject/transactions@5.0.8", "@ethersproject/transactions@^5.0.5":
   version "5.0.8"
@@ -710,6 +974,21 @@
     "@ethersproject/rlp" "^5.0.3"
     "@ethersproject/signing-key" "^5.0.4"
 
+"@ethersproject/transactions@5.0.9", "@ethersproject/transactions@^5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.0.9.tgz#ccfcc1d395b5e3ce7342545fa28bfe5541182fd6"
+  integrity sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==
+  dependencies:
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/rlp" "^5.0.7"
+    "@ethersproject/signing-key" "^5.0.8"
+
 "@ethersproject/units@5.0.8":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.0.8.tgz#563325b20fe1eceff7b61857711d5e2b3f38fd09"
@@ -718,6 +997,36 @@
     "@ethersproject/bignumber" "^5.0.7"
     "@ethersproject/constants" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/units@5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.0.9.tgz#f8dc406f593eadcba883d6e86cc077203b03e7da"
+  integrity sha512-4jIkcMVrJ3lCgXMO4M/2ww0/T/IN08vJTZld7FIAwa6aoBDTAy71+sby3sShl1SG3HEeKYbI3fBWauCUgPRUpQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/constants" "^5.0.8"
+    "@ethersproject/logger" "^5.0.8"
+
+"@ethersproject/wallet@5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.0.10.tgz#16ad0864d9e0e2b57fb32d768ea4161891d62727"
+  integrity sha512-5siYr38NhqZKH6DUr6u4PdhgOKur8Q6sw+JID2TitEUmW0tOl8f6rpxAe77tw6SJT60D2UcvgsyLtl32+Nl+ig==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.8"
+    "@ethersproject/abstract-signer" "^5.0.10"
+    "@ethersproject/address" "^5.0.9"
+    "@ethersproject/bignumber" "^5.0.13"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/hdnode" "^5.0.8"
+    "@ethersproject/json-wallets" "^5.0.10"
+    "@ethersproject/keccak256" "^5.0.7"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/random" "^5.0.7"
+    "@ethersproject/signing-key" "^5.0.8"
+    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/wordlists" "^5.0.8"
 
 "@ethersproject/wallet@5.0.9":
   version "5.0.9"
@@ -751,6 +1060,17 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/web@5.0.12", "@ethersproject/web@^5.0.12":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.0.12.tgz#f123397c107f863c31fce5f31a97c66ec155e755"
+  integrity sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==
+  dependencies:
+    "@ethersproject/base64" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
+
 "@ethersproject/wordlists@5.0.7", "@ethersproject/wordlists@^5.0.4":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.0.7.tgz#4e5ad38cfbef746b196a3290c0d41696eb7ab468"
@@ -761,6 +1081,17 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/wordlists@5.0.8", "@ethersproject/wordlists@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.0.8.tgz#593319b710a5a1f4e839b72641aa765b4f111137"
+  integrity sha512-px2mloc1wAcdTbzv0ZotTx+Uh/dfnDO22D9Rx8xr7+/PUwAhZQjoJ9t7Hn72nsaN83rWBXsLvFcIRZju4GIaEQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/hash" "^5.0.10"
+    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/strings" "^5.0.8"
 
 "@hapi/hoek@^9.0.0":
   version "9.1.1"
@@ -1157,6 +1488,11 @@
   integrity sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/big.js@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/big.js/-/big.js-6.0.2.tgz#a86938c1bb4511e69d91f69823cacc3f48ff1fa3"
+  integrity sha512-7NdmOT3zjtghMofDwP1nAJCJWVjc/96V5msXRAZ4lPrvpGlajA95VQec7OXwA2wQaVmhjt+F5ko8pjvQU1tTFA==
 
 "@types/bn.js@^4.11.3":
   version "4.11.6"
@@ -2015,6 +2351,11 @@ bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
+big.js@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.0.3.tgz#8b4d99ac7023668e0e465d3f78c23b8ac29ad381"
+  integrity sha512-n6yn1FyVL1EW2DBAr4jlU/kObhRzmr+NNRESl65VIOT8WBJj/Kezpx2zFdhJUqYI6qrtTW7moCStYL5VxeVdPA==
 
 binary-extensions@^2.0.0:
   version "2.1.0"
@@ -4012,41 +4353,41 @@ ethers@^5.0.13:
     "@ethersproject/web" "5.0.11"
     "@ethersproject/wordlists" "5.0.7"
 
-ethers@^5.0.23:
-  version "5.0.23"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.23.tgz#461a6e63c4906d5ea64126d53975ddf2ca81a979"
-  integrity sha512-f3pTcgYpMhtmMTMG9KO6pWHYjrCiGz7yVnvMsTQgAYfAVAeUxKy2H1cxQJyqyghRjtAvgVYJlnXQo8mMCD63BA==
+ethers@^5.0.24:
+  version "5.0.26"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.26.tgz#ef43c6b6aad71f10c1a184003f69b142d7d03bae"
+  integrity sha512-MqA8Fvutn3qEW0yBJOHeV6KZmRpF2rqlL2B5058AGkUFsuu6j5Ns/FRlMsbGeQwBz801IB23jQp7vjRfFsKSkg==
   dependencies:
-    "@ethersproject/abi" "5.0.9"
-    "@ethersproject/abstract-provider" "5.0.7"
-    "@ethersproject/abstract-signer" "5.0.9"
-    "@ethersproject/address" "5.0.8"
-    "@ethersproject/base64" "5.0.6"
-    "@ethersproject/basex" "5.0.6"
-    "@ethersproject/bignumber" "5.0.12"
-    "@ethersproject/bytes" "5.0.8"
-    "@ethersproject/constants" "5.0.7"
-    "@ethersproject/contracts" "5.0.8"
-    "@ethersproject/hash" "5.0.8"
-    "@ethersproject/hdnode" "5.0.7"
-    "@ethersproject/json-wallets" "5.0.9"
-    "@ethersproject/keccak256" "5.0.6"
+    "@ethersproject/abi" "5.0.10"
+    "@ethersproject/abstract-provider" "5.0.8"
+    "@ethersproject/abstract-signer" "5.0.11"
+    "@ethersproject/address" "5.0.9"
+    "@ethersproject/base64" "5.0.7"
+    "@ethersproject/basex" "5.0.7"
+    "@ethersproject/bignumber" "5.0.13"
+    "@ethersproject/bytes" "5.0.9"
+    "@ethersproject/constants" "5.0.8"
+    "@ethersproject/contracts" "5.0.9"
+    "@ethersproject/hash" "5.0.10"
+    "@ethersproject/hdnode" "5.0.8"
+    "@ethersproject/json-wallets" "5.0.10"
+    "@ethersproject/keccak256" "5.0.7"
     "@ethersproject/logger" "5.0.8"
-    "@ethersproject/networks" "5.0.6"
-    "@ethersproject/pbkdf2" "5.0.6"
-    "@ethersproject/properties" "5.0.6"
-    "@ethersproject/providers" "5.0.17"
-    "@ethersproject/random" "5.0.6"
-    "@ethersproject/rlp" "5.0.6"
-    "@ethersproject/sha2" "5.0.6"
-    "@ethersproject/signing-key" "5.0.7"
-    "@ethersproject/solidity" "5.0.7"
-    "@ethersproject/strings" "5.0.7"
-    "@ethersproject/transactions" "5.0.8"
-    "@ethersproject/units" "5.0.8"
-    "@ethersproject/wallet" "5.0.9"
-    "@ethersproject/web" "5.0.11"
-    "@ethersproject/wordlists" "5.0.7"
+    "@ethersproject/networks" "5.0.7"
+    "@ethersproject/pbkdf2" "5.0.7"
+    "@ethersproject/properties" "5.0.7"
+    "@ethersproject/providers" "5.0.19"
+    "@ethersproject/random" "5.0.7"
+    "@ethersproject/rlp" "5.0.7"
+    "@ethersproject/sha2" "5.0.7"
+    "@ethersproject/signing-key" "5.0.8"
+    "@ethersproject/solidity" "5.0.8"
+    "@ethersproject/strings" "5.0.8"
+    "@ethersproject/transactions" "5.0.9"
+    "@ethersproject/units" "5.0.9"
+    "@ethersproject/wallet" "5.0.10"
+    "@ethersproject/web" "5.0.12"
+    "@ethersproject/wordlists" "5.0.8"
 
 ethjs-unit@0.1.6:
   version "0.1.6"


### PR DESCRIPTION
Currently, if we click on "Connect your wallet", get the QR Code Modal, and dismiss that modal, the button won't work anymore.
The root caused was attempted to be fixed here but it seems that the issue persists.

Until WalletConnect addresses the issue, what we do is detecting when the modal was dismissed (i.e., the user closed it manually) and reinitialize the walletconnect instance when that happens.

Note that for that to be possible, we now allow an optional `onHide` parameter to be specified to a modal being shown.
This approach has no impact on the API of the modal module anywhere else and it offers a nice general-purpose capability, imo.

`Note`: This branch is based off #1582. Will change base when that PR is merged.