### PR TITLE
chore(ci): clean up macOS build environment before each run

### DIFF
--- a/.buildkite/env.sh
+++ b/.buildkite/env.sh
@@ -2,6 +2,9 @@
 set -Eeou pipefail
 
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" == "macos" ]]; then
+  echo "--- Cleaning up macOS environment"
+  killall radicle-proxy
+
   echo "--- Setting up macOS environment"
 
   export HOME=/Users/buildkite


### PR DESCRIPTION
Since the macOS host doesn't have build process isolation like its Linux
counterpart, it can happen that leftovers from a previously cancelled
build are still hanging around. This makes sure that we stop any
lingering radicle-proxy processes before starting a new build.

This is a workaround, we should figure out how to do proper build
isolation on macOS in the future.

Affected builds:
https://buildkite.com/monadic/radicle-upstream/builds/7576#887aa993-12f0-475e-907c-a0e0c9ff515d
https://buildkite.com/monadic/radicle-upstream/builds/7576#3e0c96cc-065c-421e-a5f8-814a1acc8877