### PR TITLE
fix(ui): avoid tx center from overlapping support elements

### DIFF
--- a/ui/Screen/Profile/Funding.svelte
+++ b/ui/Screen/Profile/Funding.svelte
@@ -22,6 +22,7 @@
     min-width: var(--content-min-width);
     max-width: var(--content-max-width);
     padding: var(--content-padding);
+    padding-bottom: 9.375rem;
     margin: 0 auto;
 
     display: flex;


### PR DESCRIPTION
Currently, when on a reduced vertical viewport, the transaction center overlaps elements of the Support page:
![b](https://user-images.githubusercontent.com/7075260/107378956-c7b0a200-6aec-11eb-9a2e-7e6a6a3310d6.png)

We fix that by adding an appropriate `padding-bottom` that grants enough scrolling space at all times:

![editing](https://user-images.githubusercontent.com/7075260/107379216-ff1f4e80-6aec-11eb-972e-9bb1a0c9ae0a.png)
![beforez](https://user-images.githubusercontent.com/7075260/107379219-ffb7e500-6aec-11eb-8efc-ea2ddaf1c3ff.png)

