### PR TITLE
chore: fix failing builds on mac-n-cheese

### DIFF
--- a/.buildkite/env.sh
+++ b/.buildkite/env.sh
@@ -2,9 +2,6 @@
 set -Eeou pipefail
 
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" == "macos" ]]; then
-  echo "--- Cleaning up macOS environment"
-  killall radicle-proxy
-
   echo "--- Setting up macOS environment"
 
   export HOME=/Users/buildkite

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -94,7 +94,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
         // Give `coco::SpawnAbortable` some time to release all the resources.
         // See https://github.com/radicle-dev/radicle-upstream/issues/1163
-        tokio::time::delay_for(Duration::from_millis(50)).await
+        tokio::time::delay_for(Duration::from_millis(200)).await
     }
 }
 


### PR DESCRIPTION
After a macOS upgrade the mac-n-cheese machine is slightly slower consistently triggering a pre-existing race condition. Increasing the timeout seems to work around the problem for now.

Undoing the previous attempt to fix this from: https://github.com/radicle-dev/radicle-upstream/commit/848cbb413502979dd2b77a4541d580cdb524da8b.

This happens when we do a seal request to the http control api.
```
WARN  api::http::control::handler > keystore seal requested
--
  | INFO  proxy::http                 > "GET /v1/control/seal HTTP/1.1" 200 358.586µs
  | Error: Sled(Io(Custom { kind: Other, error: "could not acquire lock on \"/var/folders/tq/s3zmlwns0g1b2t5tw3mwkhgm0000gn/T/.tmpFfqVXU/store/db\": Os { code: 35, kind: WouldBlock, message: \"Resource temporarily unavailable\" }" }))
  | error Command failed with exit code 1.
```

https://buildkite.com/monadic/radicle-upstream/builds/7576#f09055af-ccc9-48f3-a017-122c797866d8