### PR TITLE
chore: streamline release process

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -25,7 +25,7 @@ steps:
     agents:
       queue: agent-preview
   - label: "Test and package app on macOS"
-    if: build.branch == 'master'
+    if: build.branch == 'master' || build.tag != null
     command: ".buildkite/run.sh"
     agents:
       production: "false"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -435,8 +435,8 @@ environment. To do so, follow points 1 and 2 from the
 
 #### GitHub `hub` CLI tool
 
-Please install the [`hub`][hb] CLI tool, we use it in our release automation
-script to:
+Please install the [`hub`][hb] CLI tool (version >= **2.14**), we use it in our
+release automation script to:
 
   - create a pull-request off of a release branch;
   - to merge the release branch into master;

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -438,7 +438,7 @@ script to:
   - to close the pull-request.
 
 Then you'll have to create a _Personal access token_ for it in the
-[GitHub Developer settings][gs] page and authenticate the CLI tool once
+[GitHub Developer settings][gt] page and authenticate the CLI tool once
 by running any command that does a request to GitHub, like so: `hub api`.
 You'll be asked to provide your GitHub login and the access token.
 
@@ -480,6 +480,7 @@ instructions.
 [cs]: https://help.github.com/en/github/authenticating-to-github/signing-commits
 [eb]: https://github.com/electron-userland/electron-builder
 [el]: https://www.electronjs.org
+[es]: https://eslint.org
 [gc]: https://cloud.google.com/sdk/docs/quickstart-macos
 [gg]: https://cloud.google.com/storage/docs/gsutil_install
 [gp]: https://console.cloud.google.com/storage/browser/builds.radicle.xyz/releases/radicle-upstream

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -145,17 +145,24 @@ For this we need:
 Once you've created the _Developer ID Application_ certificate, download it
 locally and add it to your keychain by double clicking on the file.
 
-Before building a notarized DMG, make sure you're connected to the internet
-and then run:
+Before building a notarized DMG, make sure you're connected to the internet and
+then run:
 
 ```sh
 git checkout vX.X.X
-CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \\
-APPLE_ID="XXXXXXX@monadic.xyz" \\
-APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \\
-NOTARIZE=true \\
+CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \
+APPLE_ID="XXXXXXX@monadic.xyz" \
+APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \
+NOTARIZE=true \
 yarn dist
 ```
+
+Don't forget to replace the `X` in the template with the real values:
+  - `vX.X.X` is the version you'd like to build and notarize
+  - `CSC_NAME` is the "Developer ID Application" certificate ID
+  - `APPLE_ID` your Apple account ID
+  - `APPLE_ID_PASSWORD` your Apple account token that you generated in the
+    steps above
 
 
 ### Scripts

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -425,8 +425,13 @@ build times. If you need to update this image, proceed as follows:
    create a new branch and build the updated image.
 
 ## Releases
-
 ### Prerequisites
+#### Google Cloud CLI
+
+For uploading artifacts to releases.radicle.xyz, you'll need a working `gcloud`
+environment. To do so, follow points 1 and 2 from the
+[Docker image updates][do] section.
+
 
 #### GitHub `hub` CLI tool
 
@@ -441,6 +446,7 @@ Then you'll have to create a _Personal access token_ for it in the
 [GitHub Developer settings][gt] page and authenticate the CLI tool once
 by running any command that does a request to GitHub, like so: `hub api`.
 You'll be asked to provide your GitHub login and the access token.
+
 
 #### Apple notarization
 
@@ -478,6 +484,7 @@ instructions.
 [cl]: https://gist.github.com/Rich-Harris/0f910048478c2a6505d1c32185b61934
 [co]: https://github.com/rust-lang/cargo
 [cs]: https://help.github.com/en/github/authenticating-to-github/signing-commits
+[do]: #docker-image-updates
 [eb]: https://github.com/electron-userland/electron-builder
 [el]: https://www.electronjs.org
 [es]: https://eslint.org

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -454,6 +454,12 @@ To allow macOS Gatekeeper [to recognise][so] our Upstream packages as genuine,
 which allows the user to install and open Upstream without unnecessary
 [security warnings][sw], we have to [sign and notarize][sn] our macOS packages.
 
+NB: from now on this is done by our buildkite macOS build host and no local
+setup is necessary.
+
+If the build host is not available, it is possible to set up and perform
+notarization locally on Apple hardware.
+
 For this we need:
   - a paid Apple developer account registered to Monadic
   - an Apple ID token for allowing the notarization script to run on behalf of
@@ -465,6 +471,18 @@ For this we need:
 
 Once you've created the _Developer ID Application_ certificate, download it
 locally and add it to your keychain by double clicking on the file.
+
+Before building a notarized DMG, make sure you're connected to the internet
+and then run:
+
+```sh
+    git checkout vX.X.X
+    CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \\
+    APPLE_ID="XXXXXXX@monadic.xyz" \\
+    APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \\
+    NOTARIZE=true \\
+    yarn dist
+```
 
 
 ### Publishing a release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -476,12 +476,12 @@ Before building a notarized DMG, make sure you're connected to the internet
 and then run:
 
 ```sh
-    git checkout vX.X.X
-    CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \\
-    APPLE_ID="XXXXXXX@monadic.xyz" \\
-    APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \\
-    NOTARIZE=true \\
-    yarn dist
+git checkout vX.X.X
+CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \\
+APPLE_ID="XXXXXXX@monadic.xyz" \\
+APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \\
+NOTARIZE=true \\
+yarn dist
 ```
 
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -454,7 +454,7 @@ To allow macOS Gatekeeper [to recognise][so] our Upstream packages as genuine,
 which allows the user to install and open Upstream without unnecessary
 [security warnings][sw], we have to [sign and notarize][sn] our macOS packages.
 
-NB: from now on this is done by our buildkite macOS build host and no local
+This notarization step is automated using our custom macOS build host, no local
 setup is necessary.
 
 If the build host is not available, it is possible to set up and perform

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,6 +121,43 @@ You can build and package Upstream with: `yarn dist`. The generated package
 will be in: `dist/` as `radicle-upstream-X.X.X.{dmg|AppImage}`.
 
 
+#### Apple notarization
+
+To allow macOS Gatekeeper [to recognise][so] our Upstream packages as genuine,
+which allows users to install and open Upstream without unnecessary
+[security warnings][sw], we have to [sign and notarize][sn] our macOS packages.
+
+This notarization step is automated using our custom macOS build host for
+releases.
+
+However, if the build host is not available, it is possible to set up and
+perform notarization locally on Apple hardware.
+
+For this we need:
+  - a paid Apple developer account registered to Monadic
+  - an Apple ID token for allowing the notarization script to run on behalf of
+    our developer account
+    - [Account Manage][ma] -> APP-SPECIFIC PASSWORDS -> Generate password…
+  - a valid "Developer ID Application" certificate
+    - [Certificates Add][ca] -> Developer ID Application
+      **Note:** this can only be created via the company account holder
+
+Once you've created the _Developer ID Application_ certificate, download it
+locally and add it to your keychain by double clicking on the file.
+
+Before building a notarized DMG, make sure you're connected to the internet
+and then run:
+
+```sh
+git checkout vX.X.X
+CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \\
+APPLE_ID="XXXXXXX@monadic.xyz" \\
+APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \\
+NOTARIZE=true \\
+yarn dist
+```
+
+
 ### Scripts
 
 To get a list of all available script commands, run: `yarn run`.
@@ -446,43 +483,6 @@ Then you'll have to create a _Personal access token_ for it in the
 [GitHub Developer settings][gt] page and authenticate the CLI tool once
 by running any command that does a request to GitHub, like so: `hub api`.
 You'll be asked to provide your GitHub login and the access token.
-
-
-#### Apple notarization
-
-To allow macOS Gatekeeper [to recognise][so] our Upstream packages as genuine,
-which allows the user to install and open Upstream without unnecessary
-[security warnings][sw], we have to [sign and notarize][sn] our macOS packages.
-
-This notarization step is automated using our custom macOS build host, no local
-setup is necessary.
-
-If the build host is not available, it is possible to set up and perform
-notarization locally on Apple hardware.
-
-For this we need:
-  - a paid Apple developer account registered to Monadic
-  - an Apple ID token for allowing the notarization script to run on behalf of
-    our developer account
-    - [Account Manage][ma] -> APP-SPECIFIC PASSWORDS -> Generate password…
-  - a valid "Developer ID Application" certificate
-    - [Certificates Add][ca] -> Developer ID Application
-      **Note:** this can only be created via the company account holder
-
-Once you've created the _Developer ID Application_ certificate, download it
-locally and add it to your keychain by double clicking on the file.
-
-Before building a notarized DMG, make sure you're connected to the internet
-and then run:
-
-```sh
-git checkout vX.X.X
-CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \\
-APPLE_ID="XXXXXXX@monadic.xyz" \\
-APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \\
-NOTARIZE=true \\
-yarn dist
-```
 
 
 ### Publishing a release

--- a/QA.md
+++ b/QA.md
@@ -30,33 +30,17 @@
   - on Linux: run `PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage` by
     executing it from the terminal or clicking on it
   - on macOS: run `/Applications/Radicle Upstream.app` by double clicking it
-- [ ] Onboarding starts on the _Get started_ screen
-- [ ] Pressing <kbd>enter</kbd> leads to the next screen
-- [ ] Using `$$` as the _Display name_ shows a validation error
-- [ ] Entering two different passphrases shows a validation error
-- [ ] On the _All set!_ screen clicking the _Device ID_ copies it to the
-      clipboard
-- [ ] Clicking the _Go to my projects_ button leads to the _Profile_ screen
-- [ ] Hovering the network icon in the sidebar shows
-      _You're connected to 1 peer_
+- [ ] Complete all the onboarding steps until you land on the Profile screen
 
 
 ### Creating projects
 
-- [ ] Can create a new project with a new repository
-  - [ ] Using `%%` for the project name shows a validation error
-  - [ ] A placeholder is shown for the missing `README.md`
-- [ ] Can create a new project from a larger existing repository
+- [ ] Can create a new project from a larger existing repository (e.g. radicle-upstream)
   - [ ] UI interaction is blocked while project creation is in progress
   - [ ] `README.md` files are shown by default and markdown is rendered as HTML
     - [ ] Links to external resources open in external browser
     - [ ] Links to internal resources don't do anything
-  - [ ] Syntax highlighting works for source files (.toml, .sol, .ts, .svelte)
-  - [ ] Binary files show a placeholder
-  - [ ] It's possible to navigate to deeper hierarchies via the tree browser
-  - [ ] It's possible to select different branches
-  - [ ] Metadata and stats in UI reflect what is in the actual repository
-        [ℹ️](#04)
+  - [ ] Syntax highlighting works for source files (.toml, .ts, .svelte, etc.)
   - [ ] Commit tab shows a list of all the commits in the branch that was
         selected
   - [ ] Clicking on a commit shows the commit metadata as well as the diff
@@ -65,20 +49,18 @@
     - [ ] _Wallets_ tab on the User Profile screen
     - [ ] Tags are not visible in the revision selector on the _Project Source_
       screen
+    - [ ] _Design Sytem Guide_ is not listed in the shortcuts modal
+          <kbd>?</kbd> and the respective global hotkey is disabled
+          <kbd>⌘</kbd>+<kbd>d</kbd>
 
 
-### Settings
+### Settings & Misc
 
 - [ ] Links to external help resources open in an external browser
-- [ ] All documented shortcuts work. Press <kbd>?</kbd> to open the
-      _Keyboard shortcuts_ help screen.
-  - [ ] Only one modal is allowed at a time (no modal stacking possible)
-  - [ ] _Design Sytem Guide_ is not listed in the shortcuts modal
-        <kbd>?</kbd> and the respective global hotkey is disabled
-        <kbd>⌘</kbd>+<kbd>d</kbd>
 - [ ] The version number in the _Settings_ screen matches:
   - [ ] The version number in the package filename
   - [ ] The version number in the _About Radicle Upstream_ dialog
+- [ ] Only one modal is allowed at a time (no modal stacking possible)
 
 
 ### Replicating projects
@@ -104,23 +86,14 @@
     - [ ] The button is now called _Checkout_ instead of _Fork_
     - [ ] Create a commit and publish your chages via `git rad push`
       - [ ] The published commit appears in the _Commits_ tab of the project
-  - [ ] Add a remote that doesn't track the project, e.g.
-        `hync6jo9q9n4rfgag3o99gann391nsjhuq3oaemoe13oyn3gruwrgh`
-    - [ ] Shows the remote in the _Still looking…_ section
-  - [ ] Clicking the _Unfollow_ button removes the remote
 
 
 ### Lifecycle
 
 - [ ] Preferences are persisted across app reboots
-  - [ ] Color theme selection
-  - [ ] Network seed changes
   - [ ] Remote helper hint (in the Checkout and "New project" modals) is not
         shown after app restart once it is dismissed by clicking the `x` icon
         in the top right corner
-- [ ] Killing the proxy process while the app is running shows a blue error
-      screen with the proxy logs
-  - [ ] Clicking the button copies the logs to the clipboard
 
 
 ## Hints
@@ -164,26 +137,6 @@ in with a temporary user account).
 **On Linux (AppImage):**
 
   1. `chmod +x <PATH_TO_DOWNLOAD>/radicle-upstream-X.X.X.AppImage`
-
-
-### How to query repo stats from the CLI? <a href="#user-content-04" id="04">🔗</a>
-
-```
-  # local branch count
-  git branch | wc -l
-
-  # all unique contributors across all branches
-  git shortlog --summary --numbered --email --all
-
-  # all unique contributors in a specific branch
-  git shortlog --summary --numbered --email myfunkybranch
-
-  # unique commit count across all branches
-  git rev-list --all --count
-
-  # commit count in a specific branch
-  git rev-list --count myfunkybranch
-```
 
 
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -21,7 +21,7 @@ const verboseExec = (cmd: string) => {
 };
 
 const checkPrerequisites = () => {
-  const minHubVersion = "2.14.1";
+  const minHubVersion = "2.14.0";
   let result;
 
   try {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -43,7 +43,7 @@ const checkPrerequisites = () => {
     const version = semver.parse(match[1]);
 
     if (!version) {
-      throw new Error("Couldn't parse the version number");
+      throw new Error("Couldn't parse the version number of the hub CLI tool");
     }
 
     if (semver.lt(version, minHubVersion)) {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -40,13 +40,22 @@ const checkPrerequisites = () => {
   const match = result.match("hub version (.*)");
 
   if (match) {
-    const version = semver.parse(match[1]) || "0.0.0";
+    const version = semver.parse(match[1]);
+
+    if (!version) {
+      throw new Error("Couldn't parse the version number");
+    }
+
     if (semver.lt(version, minHubVersion)) {
       console.log(
         `\nPlease upgrade your hub CLI tool to the minimum required version of ${minHubVersion}.\n`
       );
       process.exit(1);
     }
+  } else {
+    throw new Error(
+      "Couldn't find version number in the `hub --version` output"
+    );
   }
 };
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -152,9 +152,9 @@ const printNextStepsMsg = (
 
             yarn release finalize ${version} ${pullRequestId}
 
-  - [ ] wait for the macOS and Linux packages to be built on master for the
-        release on our build servers
-  - [ ] upload macOS and Linux packages to https://releases.radicle.xyz
+  - [ ] wait for our build servers to build the macOS and Linux release
+        packages
+  - [ ] upload the macOS and Linux packages to https://releases.radicle.xyz
 
           gsutil cp \
             gs://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.AppImage \

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -130,21 +130,14 @@ const printNextStepsMsg = (
 
             yarn release finalize ${version} ${pullRequestId}
 
-  - [ ] build and notarize macOS package on your macOS machine:
+  - [ ] wait for the macOS and Linux packages to be built on master for the
+        release on our build servers
+  - [ ] upload macOS and Linux packages to https://releases.radicle.xyz
 
-          git checkout v${version}
-          CSC_NAME="Monadic GmbH (XXXXXXXXXX)" \\
-          APPLE_ID="XXXXXXX@monadic.xyz" \\
-          APPLE_ID_PASSWORD="XXXX-XXXX-XXXX-XXXX" \\
-          NOTARIZE=true \\
-          yarn dist
-
-  - [ ] wait for the Linux package to be built on master for the release on CI
-  - [ ] upload Linux and macOS packages to https://releases.radicle.xyz
-
-          (cd dist && curl -fLO "https://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.AppImage")
-          gsutil cp dist/radicle-upstream-${version}.AppImage gs://releases.radicle.xyz
-          gsutil cp dist/radicle-upstream-${version}.dmg gs://releases.radicle.xyz
+          curl -fLO "https://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.AppImage"
+          curl -fLO "https://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.dmg"
+          gsutil cp radicle-upstream-${version}.AppImage gs://releases.radicle.xyz
+          gsutil cp radicle-upstream-${version}.dmg gs://releases.radicle.xyz
 
   - [ ] create macOS and Linux QA issues in the Upstream repo
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -21,19 +21,32 @@ const verboseExec = (cmd: string) => {
 };
 
 const checkPrerequisites = () => {
+  const minHubVersion = "2.14.1";
+  let result;
+
   try {
-    execSync("git --version", {
-      stdio: "ignore",
-    });
-    execSync("hub --version", {
-      stdio: "ignore",
-    });
+    result = execSync("hub --version", {
+      stdio: "pipe",
+    }).toString("utf-8");
   } catch {
-    throw new Error(`
-  Please install missing dependencies:
-    - https://git-scm.com
-    - https://github.com/github/hub
-`);
+    console.log(
+      `\nCould not find the GitHub CLI tool >= ${minHubVersion}.\n` +
+        "You can get it here:\n\n" +
+        "  https://github.com/github/hub\n"
+    );
+    process.exit(1);
+  }
+
+  const match = result.match("hub version (.*)");
+
+  if (match) {
+    const version = semver.parse(match[1]) || "0.0.0";
+    if (semver.lt(version, minHubVersion)) {
+      console.log(
+        `\nPlease upgrade your hub CLI tool to the minimum required version of ${minHubVersion}.\n`
+      );
+      process.exit(1);
+    }
   }
 };
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -30,7 +30,7 @@ const checkPrerequisites = () => {
     }).toString("utf-8");
   } catch {
     console.log(
-      `\nCould not find the GitHub CLI tool >= ${minHubVersion}.\n` +
+      `\nCould not find the hub CLI tool >= ${minHubVersion}.\n` +
         "You can get it here:\n\n" +
         "  https://github.com/github/hub\n"
     );

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -134,10 +134,13 @@ const printNextStepsMsg = (
         release on our build servers
   - [ ] upload macOS and Linux packages to https://releases.radicle.xyz
 
-          curl -fLO "https://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.AppImage"
-          curl -fLO "https://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.dmg"
-          gsutil cp radicle-upstream-${version}.AppImage gs://releases.radicle.xyz
-          gsutil cp radicle-upstream-${version}.dmg gs://releases.radicle.xyz
+          gsutil cp \
+            gs://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.AppImage \
+            gs://releases.radicle.xyz
+
+          gsutil cp \
+            gs://builds.radicle.xyz/radicle-upstream/v${version}/dist/radicle-upstream-${version}.dmg \
+            gs://releases.radicle.xyz
 
   - [ ] create macOS and Linux QA issues in the Upstream repo
 


### PR DESCRIPTION
This removes the notarization step from the release process.

~~⚠️ Before we merge this, we have to adjust `mac-n-cheese` configuration, for the mac tag builds to work:
https://github.com/radicle-dev/infra/blob/master/ci/macos/usr/local/etc/buildkite-agent/hooks/environment#L12~~