### PR TITLE
refactor(ui): better type checking of node manager task api

### DIFF
--- a/cypress/plugins/nodeManager/shared.ts
+++ b/cypress/plugins/nodeManager/shared.ts
@@ -12,10 +12,36 @@ export interface NodeSession {
   httpPort: number;
 }
 
-export enum Commands {
-  StartNode = "startNode",
-  OnboardNode = "onboardNode",
-  StopAllNodes = "stopAllNodes",
-  GetOnboardedNodes = "getOnboardedNodes",
-  ConnectNodes = "connectNodes",
+export type NodeId = number;
+
+export interface StartNodeOptions {
+  id: NodeId;
 }
+
+export interface OnboardNodeOptions {
+  id: NodeId;
+  handle: string;
+  passphrase: string;
+}
+
+export interface ConnectNodeOptions {
+  nodeIds: NodeId[];
+}
+
+// We us `Promise<null>` because Cypress complains if we use
+// `Promise<void>` or `Promise<undefined>`.
+//
+// See https://docs.cypress.io/api/commands/task.html#Usage
+export interface NodeManagerPlugin {
+  startNode: () => Promise<number>;
+  onboardNode: (options: OnboardNodeOptions) => Promise<NodeSession>;
+  connectNodes: (options: ConnectNodeOptions) => Promise<null>;
+  stopAllNodes: () => Promise<null>;
+}
+
+export const pluginMethods: Array<keyof NodeManagerPlugin> = [
+  "startNode",
+  "onboardNode",
+  "stopAllNodes",
+  "connectNodes",
+];

--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -1,10 +1,28 @@
 import type { NodeSession } from "../plugins/nodeManager/shared";
-import { Commands } from "../plugins/nodeManager/shared";
+import {
+  pluginMethods,
+  NodeManagerPlugin,
+} from "../plugins/nodeManager/shared";
+
+const nodeManagerPlugin = createNodeManagerPlugin();
+
+const startAndOnboardNode = (
+  handle: string
+): Cypress.Chainable<NodeSession> => {
+  return nodeManagerPlugin.startNode().then(id => {
+    cy.log(`Started node ${id}`);
+    return nodeManagerPlugin.onboardNode({
+      id,
+      handle,
+      passphrase: "radicle-upstream",
+    });
+  });
+};
 
 const withNodeManager = (callback: () => void): void => {
-  cy.task(Commands.StopAllNodes, {}, { log: false });
+  nodeManagerPlugin.stopAllNodes();
   callback();
-  cy.task(Commands.StopAllNodes, {}, { log: false });
+  nodeManagerPlugin.stopAllNodes();
 };
 
 interface WithTwoOnboardedNodesOptions {
@@ -17,11 +35,7 @@ export const connectTwoNodes = (
   node2: NodeSession
 ): void => {
   cy.log(`adding node ${node2.id} as seed to node ${node1.id}`);
-  cy.task(
-    Commands.ConnectNodes,
-    { nodeIds: [node1.id, node2.id] },
-    { log: false }
-  );
+  nodeManagerPlugin.connectNodes({ nodeIds: [node1.id, node2.id] });
 };
 
 export const withTwoOnboardedNodes = (
@@ -29,32 +43,13 @@ export const withTwoOnboardedNodes = (
   callback: (node1: NodeSession, node2: NodeSession) => void
 ): void => {
   withNodeManager(() => {
-    const NODE1_ID = 17000;
-    const NODE2_ID = 18000;
-
-    cy.log(`starting and onboarding node ${NODE1_ID}`);
-
-    cy.task(Commands.StartNode, { id: NODE1_ID }, { log: false });
-    cy.task(
-      Commands.OnboardNode,
-      { id: NODE1_ID, handle: options.node1Handle },
-      { log: false }
-    );
-
-    cy.log(`starting and onboarding node ${NODE2_ID}`);
-
-    cy.task(Commands.StartNode, { id: NODE2_ID }, { log: false });
-    cy.task(
-      Commands.OnboardNode,
-      { id: NODE2_ID, handle: options.node2Handle },
-      { log: false }
-    );
-
-    cy.task<NodeSession[]>(Commands.GetOnboardedNodes, {}, { log: false }).then(
-      nodes => {
-        callback(nodes[0], nodes[1]);
-      }
-    );
+    startAndOnboardNode(options.node1Handle || "secretariat-1").then(node0 => {
+      startAndOnboardNode(options.node2Handle || "secretariat-2").then(
+        node1 => {
+          callback(node0, node1);
+        }
+      );
+    });
   });
 };
 
@@ -67,3 +62,43 @@ export const asNode = (node: NodeSession): void => {
   // `localhost`, the app loads with a auth-cookie mismatch error.
   cy.visit(`./public/index.html?backend=localhost:${node.httpPort}`);
 };
+
+// Replaces the return type `Promise<S>` of the function type `T` with
+// `Cypress.Chainable<S>`.
+//
+// For example, if
+//
+//    T ≡ (foo: number) => Promise<string>
+//
+// then
+//
+//    ChainableReturn<T> ≡ (foo: number) => Cypress.Chainable<string>
+//
+type ChainableReturn<T> = T extends (...params: infer P) => Promise<infer R>
+  ? (...params: P) => Cypress.Chainable<R>
+  : never;
+
+// Replaces the return type `Promise<S>` of the all the properties in
+// the API object `R` with `Cypress.Chainable<S>`.
+//
+// For example, if
+//
+//    R ≡ { bar: (foo: number) => Promise<string> }
+//
+// then
+//
+//    ChainableApi<R> ≡ { bar: (foo: number) => Cypress.Chainable<string> }
+//
+type ChainableApi<R> = {
+  [K in keyof R]: ChainableReturn<R[K]>;
+};
+
+function createNodeManagerPlugin(): ChainableApi<NodeManagerPlugin> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nodeManagerPlugin: any = {};
+  pluginMethods.forEach(task => {
+    nodeManagerPlugin[task] = (arg: unknown) =>
+      cy.task(task, arg, { log: false });
+  });
+  return nodeManagerPlugin;
+}


### PR DESCRIPTION
*Happy to delay this until more tests have been merged if that reduces overhead*

We improve the node manager plugin API to achieve the following

* Introduce a common interface for the plugin API that can be used in the test runner and the background process.
* Eliminate manual calls to `cy.task()`. Instead we have a generic `nodeManagerPlugin` object with the correct types.
* We can now expose the `NodeManager` instance directly through the plugin API.
* The plugin API now returns values from `startNode()` and other calls. This eliminates the need for bookkeeping and ensuring that the implemenations match.