### PR TITLE
fix(ui): more permissive seed validation

### DIFF
--- a/ui/src/session.test.ts
+++ b/ui/src/session.test.ts
@@ -1,0 +1,31 @@
+import { __test__ as session } from "./session";
+
+describe("VALID_SEED_MATCH", () => {
+  const peer_id = new Array(54).fill("a").join("");
+
+  it("matches valid values", () => {
+    const values = [
+      `${peer_id}@radicle.xyz:1`,
+      `${peer_id}@radicle.xyz:12345`,
+      `${peer_id}@localhost:12345`,
+      `${new Array(54).fill("1").join("")}@123.or:12345`,
+      `${peer_id}@foo-bar.example.org:12345`,
+    ];
+
+    for (const value of values) {
+      expect(value).toMatch(session.VALID_SEED_MATCH);
+    }
+  });
+
+  it("does not match invalid values", () => {
+    const values = [
+      `radicle.xyz:12345`,
+      `${peer_id}@radicle.xyz`,
+      `${peer_id}@radicle?xyz:12345`,
+    ];
+
+    for (const value of values) {
+      expect(value).not.toMatch(session.VALID_SEED_MATCH);
+    }
+  });
+});

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -215,7 +215,7 @@ export const updateCoCo = (coco: CoCo): void =>
     settings: { ...get(settings), coco },
   });
 
-const VALID_SEED_MATCH = /^[\w\d]{54}@[\w\d.]*:[\d]{1,5}$/;
+const VALID_SEED_MATCH = /^[\w\d]{54}@([\w\d-]+\.)*[\w\d-]+:[\d]{1,5}$/;
 
 const checkSeedUniqueness = (seed: string): Promise<boolean> => {
   return Promise.resolve(!get(settings).coco.seeds.includes(seed));
@@ -253,4 +253,8 @@ export const removeSeed = (seed: string): void => {
     seeds: get(settings).coco.seeds.filter((x: string) => x !== seed),
   });
   seedValidation.reset();
+};
+
+export const __test__ = {
+  VALID_SEED_MATCH,
 };


### PR DESCRIPTION
We allow all valid DNS names in the seed node address validation.

Note that the validation is in-fact too permissive since it allows `-`, `-.-`, `123` and other invalid names. Take all edge cases into account would increase the complexit of the regexp though.

Fixes #1618.