### PR TITLE
fix: local networking test timeout

### DIFF
--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -50,6 +50,7 @@ git commit --allow-empty -m "${options.subject}"
 git -c credential.helper=${credentialsHelper(options.passphrase)} push rad`,
     {
       env: {
+        HOME: options.radHome,
         RAD_HOME: options.radHome,
         GIT_AUTHOR_NAME: options.name || "John McPipefail",
         GIT_AUTHOR_EMAIL: options.email || "john@mcpipefail.com",


### PR DESCRIPTION
When running the `networking.spec.ts` tests locally, the test timeouts on executing `createCommit`. This fixes the problem.

Thanks to @geigerzaehler for the suggestion!

Signed-off-by: Merle Breitkreuz <merle@monadic.xyz>