### PR TITLE
test: commit replication (#1589)

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -63,31 +63,6 @@
 - [ ] Only one modal is allowed at a time (no modal stacking possible)
 
 
-### Replicating projects
-
-- [ ] Replicate a project from seedling.radicle.xyz
-  - [ ] Pick a project from seedling.radicle.xyz and search for it by pasting
-        the `Radicle ID` of the project into the search bar by pressing
-        <kbd>⌘</kbd>+<kbd>p</kbd>, then click the _Follow_ button
-    - [ ] The project shows up in the _Following_ tab of the profile screen in
-          the waiting area
-    - [ ] After a while the project is replicated and moves out of the waiting
-          area
-    - [ ] When going to the Project source screen, the maintainer is selected
-          in the peer selector
-      - [ ] Your identity does not show up in the peer selector
-  - [ ] Set up the remote helper according to the instructions in the _Fork_
-        modal hint
-  - [ ] Fork the replicated project to a local directory
-    - [ ] The forked project should now appear in the _Projects_ tab of the
-          profile screen
-    - [ ] Your identity shows up in the peer selector and is selected by
-          default instead of the maintainer's identity
-    - [ ] The button is now called _Checkout_ instead of _Fork_
-    - [ ] Create a commit and publish your chages via `git rad push`
-      - [ ] The published commit appears in the _Commits_ tab of the project
-
-
 ### Lifecycle
 
 - [ ] Preferences are persisted across app reboots

--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -9,37 +9,56 @@ context("p2p networking", () => {
       "reacts to network state changes",
       { defaultCommandTimeout: 8000 },
       () => {
-        nodeManager.withTwoOnboardedNodes({}, (node1, node2) => {
-          nodeManager.asNode(node1);
-          commands.pick("connection-status-offline").should("exist");
-          nodeManager.connectTwoNodes(node1, node2);
-          commands.pick("connection-status-online").should("exist");
-          nodeManager.asNode(node2);
-          commands.pick("connection-status-online").should("exist");
-        });
+        nodeManager.withTwoOnboardedNodes(
+          { node1User: {}, node2User: {} },
+          (node1, node2) => {
+            nodeManager.asNode(node1);
+            commands.pick("connection-status-offline").should("exist");
+            nodeManager.connectTwoNodes(node1, node2);
+            commands.pick("connection-status-online").should("exist");
+            nodeManager.asNode(node2);
+            commands.pick("connection-status-online").should("exist");
+          }
+        );
       }
     );
   });
 
   it("replicates a project from one node to another", () => {
+    const maintainer = {
+      handle: "rudolfs",
+      fullName: "Rūdolfs Ošiņš",
+      passphrase: "1111",
+    };
+    const contributor = {
+      handle: "abbey",
+      fullName: "Abbey Titcomb",
+      passphrase: "2222",
+    };
+
     commands.withTempDir(tempDirPath => {
       nodeManager.withTwoOnboardedNodes(
-        { node1Handle: "rudolfs", node2Handle: "abbey" },
+        {
+          node1User: maintainer,
+          node2User: contributor,
+        },
         (maintainerNode, contributorNode) => {
           nodeManager.connectTwoNodes(maintainerNode, contributorNode);
           nodeManager.asNode(maintainerNode);
-          const newProjectPath = path.join(
-            tempDirPath,
-            "maintainerNode/new-project"
-          );
 
-          cy.exec(`mkdir -p ${newProjectPath}`);
+          const maintainerNodeWorkingDir = path.join(
+            tempDirPath,
+            "maintainerNode"
+          );
+          cy.exec(`mkdir -p ${maintainerNodeWorkingDir}`);
 
           ipcStub.getStubs().then(stubs => {
-            stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(newProjectPath);
+            stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(maintainerNodeWorkingDir);
           });
+          const projectName = "new-fancy-project.xyz";
+
           commands.pick("new-project-button").click();
-          commands.pick("name").type("new-fancy-project.xyz");
+          commands.pasteInto(["name"], projectName);
 
           commands.pick("new-project").click();
           commands.pick("new-project", "choose-path-button").click();
@@ -60,10 +79,11 @@ context("p2p networking", () => {
             }
 
             nodeManager.asNode(contributorNode);
+
             cy.log("navigate to the 'Following' tab");
             commands.pick("following-tab").click();
             commands.pick("sidebar", "search").click();
-            commands.pick("search-input").type(urn);
+            commands.pasteInto(["search-input"], urn);
             commands.pick("follow-toggle").click();
           });
 
@@ -75,7 +95,7 @@ context("p2p networking", () => {
             )
             .click();
 
-          cy.log("the maintainer shows up in the peer selector");
+          cy.log("maintainer shows up in the peer selector");
           commands
             .pickWithContent(["peer-selector"], "rudolfs")
             .should("exist");
@@ -84,24 +104,24 @@ context("p2p networking", () => {
             .should("exist");
           commands.pick("peer-selector").click();
 
-          cy.log("the current user does not show up in the peer selector");
+          cy.log("current user does not show up in the peer selector");
           commands
             .pickWithContent(["peer-dropdown-container"], "abbey")
             .should("not.exist");
 
           cy.log("add contributor remote on maintainer's node");
           nodeManager.asNode(maintainerNode);
+
           commands.pick("project-list-entry-new-fancy-project.xyz").click();
 
           commands.pick("peer-selector").click();
           commands.pick("manage-remotes").click();
-
           commands.pick("followed-peers", "peer-abbey").should("not.exist");
 
-          commands.pick("peer-input").type(contributorNode.peerId);
+          commands.pasteInto(["peer-input"], contributorNode.peerId);
           commands.pick("follow-button").click();
 
-          cy.log("the remote shows up in the waiting area");
+          cy.log("remote shows up in the waiting area");
           const shortenedPeerId = contributorNode.peerId.slice(0, 7);
           commands
             .pickWithContent(["followed-peers", "peer-abbey"], shortenedPeerId)
@@ -111,6 +131,111 @@ context("p2p networking", () => {
               ["followed-peers", "peer-abbey", "follow-toggle"],
               "Following"
             )
+            .should("exist");
+
+          cy.log("test commit replication from maintainer to contributor");
+
+          cy.log("add a new commit to the maintainer's project working dir");
+          const projctPath = path.join(maintainerNodeWorkingDir, projectName);
+          const maintainerCommitSubject =
+            "Commit replication from maintainer to contributor";
+
+          nodeManager.createCommit({
+            repositoryPath: projctPath,
+            radHome: maintainerNode.radHome,
+            subject: maintainerCommitSubject,
+            passphrase: maintainer.passphrase,
+            name: maintainer.fullName,
+          });
+
+          cy.log("refresh the UI for the new commit to show up");
+          cy.get("body").type("{esc}");
+          commands.pick("sidebar", "profile").click();
+
+          cy.log("make sure new commit shows up in the maintainer's UI");
+          commands.pick("project-list-entry-new-fancy-project.xyz").click();
+          commands.pick("commits-tab").click();
+          commands
+            .pickWithContent(["commits-page"], maintainerCommitSubject)
+            .should("exist");
+
+          cy.log("check that the commit shows up in the contributor's UI");
+          nodeManager.asNode(contributorNode);
+
+          commands.pick("following-tab").click();
+          commands.pick("project-list-entry-new-fancy-project.xyz").click();
+          commands.pick("commits-tab").click();
+          commands
+            .pickWithContent(["commits-page"], maintainerCommitSubject)
+            .should("exist");
+
+          cy.log("test commit replication from contributor to maintainer");
+
+          const contributorNodeWorkingDir = path.join(
+            tempDirPath,
+            "contributorNode"
+          );
+
+          cy.exec(`mkdir -p ${contributorNodeWorkingDir}`);
+
+          ipcStub.getStubs().then(stubs => {
+            stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(contributorNodeWorkingDir);
+          });
+          commands.pick("checkout-modal-toggle").click();
+          commands.pick("choose-path-button").click();
+          commands.pick("checkout-button").click();
+
+          cy.log("make sure checkout finishes writing to disk");
+          commands
+            .pickWithContent(["notification"], `${projectName} checked out to`)
+            .should("exist");
+
+          cy.log("add a new commit to the project from contributor's node");
+          const contributorCommitSubject =
+            "Commit replication from contributor to maintainer";
+          const forkedProjectPath = path.join(
+            contributorNodeWorkingDir,
+            projectName
+          );
+
+          nodeManager.createCommit({
+            repositoryPath: forkedProjectPath,
+            radHome: contributorNode.radHome,
+            subject: contributorCommitSubject,
+            passphrase: contributor.passphrase,
+            name: contributor.fullName,
+          });
+
+          cy.log("refresh the UI for the new commit to show up");
+          cy.get("body").type("{esc}");
+          commands.pick("sidebar", "profile").click();
+
+          cy.log('project moved to the "Projects" tab');
+          commands.pick("project-list-entry-new-fancy-project.xyz").click();
+
+          cy.log('"Fork" button now is called "Checkout"');
+          commands
+            .pickWithContent(["checkout-modal-toggle"], "Checkout")
+            .should("exist");
+
+          cy.log("contributor is pre-selected in the peer selector");
+          commands.pickWithContent(["peer-selector"], "abbey").should("exist");
+          commands.pickWithContent(["peer-selector"], "you").should("exist");
+          commands.pick("commits-tab").click();
+          commands
+            .pickWithContent(["commits-page"], contributorCommitSubject)
+            .should("exist");
+
+          cy.log("maintainer received the contributor's commit");
+          nodeManager.asNode(maintainerNode);
+          commands.pick("project-list-entry-new-fancy-project.xyz").click();
+          commands.pick("peer-selector").click();
+          commands
+            .pickWithContent(["peer-dropdown-container"], "abbey")
+            .click();
+          commands.pick("commits-tab").click();
+          commands
+            .pickWithContent(["commits-page"], contributorCommitSubject)
             .should("exist");
         }
       );

--- a/cypress/plugins/nodeManager/shared.ts
+++ b/cypress/plugins/nodeManager/shared.ts
@@ -1,7 +1,10 @@
-// Types shared between `plugin.ts` and `commands.ts`. These types can't be in
-// `plugin.ts`, because Cypress plugins run in a separate Nodejs environment
-// and can directly use Nodejs libraries, the Cypress tests don't have access
-// to those, so indlucing `plugin.ts` inside `commands.ts` leads to errors.
+// Types and constants shared between `plugin.ts` and `commands.ts`. These
+// types can't be in `plugin.ts`, because Cypress plugins run in a separate
+// Nodejs environment and can directly use Nodejs libraries, the Cypress tests
+// don't have access to those, so indlucing `plugin.ts` inside `commands.ts`
+// leads to errors.
+
+import * as path from "path";
 
 export type PeerId = string;
 
@@ -10,6 +13,7 @@ export interface NodeSession {
   peerId: PeerId;
   authToken: string;
   httpPort: number;
+  radHome: string;
 }
 
 export enum Commands {
@@ -19,3 +23,10 @@ export enum Commands {
   GetOnboardedNodes = "getOnboardedNodes",
   ConnectNodes = "connectNodes",
 }
+
+// A directory that can be used for temporary test data.
+//
+// It is located within this repository so that there is no extra setup
+// necessary when using it locally or on CI. To avoid committing any left-over
+// temp data this directory ignored via .gitignore.
+export const CYPRESS_WORKSPACE_PATH = path.join(__dirname, "../../workspace");

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,12 +1,6 @@
 import * as uuid from "uuid";
 import * as path from "path";
-
-// A directory that can be used for temporary test data.
-//
-// It is located within this repository so that there is no extra setup necessary
-// when using it locally or on CI. To avoid committing any left-over temp data
-// this directory ignored via .gitignore.
-const CYPRESS_WORKSPACE_PATH = path.join(__dirname, "../../cypress/workspace");
+import { CYPRESS_WORKSPACE_PATH } from "../plugins/nodeManager/shared";
 
 export const resetProxyState = (): Cypress.Chainable<void> =>
   requestOk({ url: "http://localhost:17246/v1/control/reset" });

--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -7,9 +7,14 @@ const withNodeManager = (callback: () => void): void => {
   cy.task(Commands.StopAllNodes, {}, { log: false });
 };
 
+interface OnboardedUser {
+  handle?: string;
+  passphrase?: string;
+}
+
 interface WithTwoOnboardedNodesOptions {
-  node1Handle?: string;
-  node2Handle?: string;
+  node1User: OnboardedUser;
+  node2User: OnboardedUser;
 }
 
 export const connectTwoNodes = (
@@ -21,6 +26,37 @@ export const connectTwoNodes = (
     Commands.ConnectNodes,
     { nodeIds: [node1.id, node2.id] },
     { log: false }
+  );
+};
+
+interface createCommitOptions {
+  repositoryPath: string;
+  radHome: string;
+  subject: string;
+  passphrase: string;
+  name?: string;
+  email?: string;
+}
+
+const credentialsHelper = (passphrase: string) =>
+  `'!f() { test "$1" = get && echo "password=${passphrase}"; }; f'`;
+
+export const createCommit = (options: createCommitOptions): void => {
+  cy.exec(
+    `set -euo pipefail
+export PATH=$PWD/target/release:$PATH
+cd ${options.repositoryPath}
+git commit --allow-empty -m "${options.subject}"
+git -c credential.helper=${credentialsHelper(options.passphrase)} push rad`,
+    {
+      env: {
+        RAD_HOME: options.radHome,
+        GIT_AUTHOR_NAME: options.name || "John McPipefail",
+        GIT_AUTHOR_EMAIL: options.email || "john@mcpipefail.com",
+        GIT_COMMITTER_NAME: options.name || "John McPipefail",
+        GIT_COMMITTER_EMAIL: options.email || "john@mcpipefail.com",
+      },
+    }
   );
 };
 
@@ -37,7 +73,11 @@ export const withTwoOnboardedNodes = (
     cy.task(Commands.StartNode, { id: NODE1_ID }, { log: false });
     cy.task(
       Commands.OnboardNode,
-      { id: NODE1_ID, handle: options.node1Handle },
+      {
+        id: NODE1_ID,
+        handle: options.node1User.handle,
+        passphrase: options.node1User.passphrase,
+      },
       { log: false }
     );
 
@@ -46,7 +86,11 @@ export const withTwoOnboardedNodes = (
     cy.task(Commands.StartNode, { id: NODE2_ID }, { log: false });
     cy.task(
       Commands.OnboardNode,
-      { id: NODE2_ID, handle: options.node2Handle },
+      {
+        id: NODE2_ID,
+        handle: options.node2User.handle,
+        passphrase: options.node2User.passphrase,
+      },
       { log: false }
     );
 

--- a/package.json
+++ b/package.json
@@ -154,8 +154,8 @@
     "_private:proxy:build": "cargo build --all-features --all-targets",
     "_private:proxy:build:release": "cargo build --release",
     "_private:proxy:clean": "cargo clean",
-    "_private:proxy:start:test": "cargo build --bin git-remote-rad && cargo run -- --test",
-    "_private:proxy:start:test:watch": "cargo build --bin git-remote-rad && cargo watch -x 'run -- --test'",
+    "_private:proxy:start:test": "cargo build --release --bin git-remote-rad && cargo run --release -- --test",
+    "_private:proxy:start:test:watch": "cargo build --release --bin git-remote-rad && cargo watch -x 'run --release -- --test'",
     "_private:rollup:build": "yarn _private:rollup:clean && rollup -c --failAfterWarnings",
     "_private:rollup:watch": "yarn _private:rollup:clean && rollup -c -w",
     "postinstall": "patch-package"


### PR DESCRIPTION
Backport of https://github.com/radicle-dev/radicle-upstream/pull/1589 to `master`.

Original description

---

* Automate remaining networking QA steps
* Use pasteInto to speed up specs
* Run integration tests in --release mode to speed them up
* Rename storagePath to radHome
* Don't block the plugin thread
* Fix race condition in remote management modal

The remote list in the modal sometimes wouldn't update correctly showing
a newly added remote in a "still looking" state forever. This happened
consistently on CI because of subtle timing differences.

The cause of this bug was that clicking the "Add" remote button would
trigger a backend request to get the updated list, at this moment the
list would still contain the remote in a "still looking" state. Meanwhile
the backend would find the remote and fire a refresh event that the UI
would pick up and update the store to show the found remote, this all
happens before the first request completes. At this moment the remote
list shows the correct state, but now the first request finishes and
re-updates the list with the old value showing the remote again in a
"still looking" state.

To prevent the race condition we additionally add the locking mechanism
to the fetchPeers function.

Closes #1529