### PR TITLE
refactor(ui): electron start path improvements

### DIFF
--- a/native/main.ts
+++ b/native/main.ts
@@ -19,7 +19,7 @@ let proxyArgs: string[] = [];
 
 if (isDev) {
   if (process.env.RADICLE_UPSTREAM_PROXY_PATH) {
-    proxyPath = path.join(__dirname, process.env.RADICLE_UPSTREAM_PROXY_PATH);
+    proxyPath = path.resolve(process.env.RADICLE_UPSTREAM_PROXY_PATH);
   } else {
     throw new Error(
       "RADICLE_UPSTREAM_PROXY_PATH must be set when running in dev mode!"
@@ -41,8 +41,8 @@ if (isDev) {
 }
 
 if (process.env.RAD_HOME) {
-  const electronPath = `${process.env.RAD_HOME}/electron`;
-  if (!fs.existsSync(electronPath)) fs.mkdirSync(electronPath);
+  const electronPath = path.resolve(process.env.RAD_HOME, "electron");
+  fs.mkdirSync(electronPath, { recursive: true });
   app.setPath("userData", electronPath);
   app.setPath("appData", electronPath);
 }

--- a/package.json
+++ b/package.json
@@ -127,9 +127,9 @@
     "wait-on": "^5.2.1"
   },
   "scripts": {
-    "start": "RADICLE_UPSTREAM_PROXY_PATH=../target/release/radicle-proxy RADICLE_UPSTREAM_PROXY_ARGS='--default-seed hynewpywqj6x4mxgj7sojhue3erucyexiyhobxx4du9w66hxhbfqbw@seedling.radicle.xyz:12345' yarn _private:start",
-    "start:dev": "RADICLE_UPSTREAM_PROXY_PATH=../target/debug/radicle-proxy RADICLE_UPSTREAM_PROXY_ARGS='--default-seed hynewpywqj6x4mxgj7sojhue3erucyexiyhobxx4du9w66hxhbfqbw@seedling.radicle.xyz:12345' yarn _private:start:dev",
-    "start:test": "RADICLE_UPSTREAM_PROXY_PATH=../target/release/radicle-proxy RADICLE_UPSTREAM_PROXY_ARGS='--test' yarn _private:start",
+    "start": "RADICLE_UPSTREAM_PROXY_PATH=./target/release/radicle-proxy RADICLE_UPSTREAM_PROXY_ARGS='--default-seed hynewpywqj6x4mxgj7sojhue3erucyexiyhobxx4du9w66hxhbfqbw@seedling.radicle.xyz:12345' yarn _private:start",
+    "start:dev": "RADICLE_UPSTREAM_PROXY_PATH=./target/debug/radicle-proxy RADICLE_UPSTREAM_PROXY_ARGS='--default-seed hynewpywqj6x4mxgj7sojhue3erucyexiyhobxx4du9w66hxhbfqbw@seedling.radicle.xyz:12345' yarn _private:start:dev",
+    "start:test": "RADICLE_UPSTREAM_PROXY_PATH=./target/release/radicle-proxy RADICLE_UPSTREAM_PROXY_ARGS='--test' yarn _private:start",
     "ethereum:start": "./scripts/ethereum-dev-node.sh",
     "test": "TZ='UTC' yarn test:unit && TZ='UTC' yarn test:integration",
     "test:integration": "TZ='UTC' run-p --race _private:proxy:start:test _private:test:integration",


### PR DESCRIPTION
A two changes that improve the path handling when the app starts

* `RADICLE_UPSTREAM_PROXY_PATH` is now relative to the working directory instead of the source file. Now the user can set this properly without knowing the location of the file.
* We create the electron storage directory recursively so that it works even if `RAD_HOME` does not exist yet.