### PR TITLE
feat(ui): open upstream via a custom protocol

### DIFF
--- a/cypress/integration/deep_linking.spec.ts
+++ b/cypress/integration/deep_linking.spec.ts
@@ -1,0 +1,91 @@
+import * as commands from "../support/commands";
+import * as ipcStub from "../support/ipc-stub";
+import * as ipcTypes from "../../native/ipc-types";
+
+context("deep linking", () => {
+  beforeEach(() => {
+    commands.resetProxyState();
+    commands.onboardUser();
+    cy.visit("./public/index.html");
+  });
+
+  context("when passing in a valid URL", () => {
+    it("opens the search modal and pre-fills the input field with the Radicle ID", () => {
+      ipcStub.getStubs().then(stubs => {
+        stubs.sendMessage({
+          kind: ipcTypes.MainMessageKind.CUSTOM_PROTOCOL_INVOCATION,
+          data: {
+            url:
+              "radicle://link/v0/rad:git:hnrkjm5z3rwae9g3n6jhyo6kzh9eup5ku5odo",
+          },
+        });
+      });
+
+      commands
+        .pick("search-modal", "search-input")
+        .should("have.value", "rad:git:hnrkjm5z3rwae9g3n6jhyo6kzh9eup5ku5odo");
+      commands
+        .pick("search-modal", "follow-toggle")
+        .should("contain", "Follow");
+    });
+  });
+
+  context("when passing in an invalid URL", () => {
+    it("shows an error notification", () => {
+      ipcStub.getStubs().then(stubs => {
+        stubs.sendMessage({
+          kind: ipcTypes.MainMessageKind.CUSTOM_PROTOCOL_INVOCATION,
+          data: {
+            url: "radicle://THIS_IS_NOT_A_VALID_URN",
+          },
+        });
+      });
+
+      commands
+        .pick("notification")
+        .should("contain", "Could not parse the provided URL");
+
+      ipcStub.getStubs().then(stubs => {
+        stubs.sendMessage({
+          kind: ipcTypes.MainMessageKind.CUSTOM_PROTOCOL_INVOCATION,
+          data: {
+            url: "radicle://ethereum/v0/",
+          },
+        });
+      });
+
+      commands
+        .pick("notification")
+        .should(
+          "contain",
+          `The custom protocol namespace "ethereum" is not supported`
+        );
+
+      ipcStub.getStubs().then(stubs => {
+        stubs.sendMessage({
+          kind: ipcTypes.MainMessageKind.CUSTOM_PROTOCOL_INVOCATION,
+          data: {
+            url: "radicle://link/v1/",
+          },
+        });
+      });
+
+      commands
+        .pick("notification")
+        .should("contain", "The custom protocol version v1 is not supported");
+
+      ipcStub.getStubs().then(stubs => {
+        stubs.sendMessage({
+          kind: ipcTypes.MainMessageKind.CUSTOM_PROTOCOL_INVOCATION,
+          data: {
+            url: "radicle://link/v0/",
+          },
+        });
+      });
+
+      commands
+        .pick("notification")
+        .should("contain", "The provided URL does not contain a Radicle ID");
+    });
+  });
+});

--- a/native/ipc-types.ts
+++ b/native/ipc-types.ts
@@ -1,11 +1,17 @@
 // Messages sent from the main process to the renderer
-export type MainMessage = {
-  kind: MainMessageKind.PROXY_ERROR;
-  data: ProxyError;
-};
+export type MainMessage =
+  | {
+      kind: MainMessageKind.PROXY_ERROR;
+      data: ProxyError;
+    }
+  | {
+      kind: MainMessageKind.CUSTOM_PROTOCOL_INVOCATION;
+      data: CustomProtocolInvocation;
+    };
 
 export enum MainMessageKind {
   PROXY_ERROR = "PROXY_ERROR",
+  CUSTOM_PROTOCOL_INVOCATION = "CUSTOM_PROTOCOL_INVOCATION",
 }
 
 // Payload for the ProxyError `MainMessage`.
@@ -13,6 +19,11 @@ export interface ProxyError {
   status: number | null;
   signal: NodeJS.Signals | null;
   output: string;
+}
+
+// Payload for the CustomProtocolInvocation `MainMessage`
+export interface CustomProtocolInvocation {
+  url: string;
 }
 
 // RPC interface exposed by the main process to the renderer.

--- a/native/nativeCustomProtocolHandler.test.ts
+++ b/native/nativeCustomProtocolHandler.test.ts
@@ -1,0 +1,51 @@
+import * as sinon from "sinon";
+import { handleCustomProtocolInvocation } from "./nativeCustomProtocolHandler";
+
+jest.useFakeTimers("modern");
+
+beforeEach(() => {
+  jest.runAllTimers();
+});
+
+describe("handleCustomProtocolInvocation", () => {
+  it("passes valid URLs", () => {
+    const callback = sinon.stub();
+    handleCustomProtocolInvocation(
+      `radicle://link/v1/rad:git:hnrkj7qjesxx4omprbj5c6apd97ebc9e5izoo`,
+      callback
+    );
+    expect(callback.callCount).toEqual(1);
+  });
+
+  it("rejects empty strings", () => {
+    const callback = sinon.stub();
+    handleCustomProtocolInvocation("", callback);
+    expect(callback.callCount).toEqual(0);
+  });
+
+  it("passes URLs that are exactly 1024 bytes long", () => {
+    const callback = sinon.stub();
+    handleCustomProtocolInvocation(`radicle://${"x".repeat(1014)}`, callback);
+    expect(callback.callCount).toEqual(1);
+  });
+
+  it("rejects handling URLs longer than 1024 bytes", () => {
+    const callback = sinon.stub();
+    handleCustomProtocolInvocation(`radicle://${"x".repeat(1015)}`, callback);
+    expect(callback.callCount).toEqual(0);
+  });
+
+  it("rejects URLs that are not prefixed with radicle://", () => {
+    const callback = sinon.stub();
+    handleCustomProtocolInvocation("upstream://", callback);
+    expect(callback.callCount).toEqual(0);
+  });
+
+  it("throttles incomming requests", () => {
+    const callback = sinon.stub();
+    handleCustomProtocolInvocation("radicle://", callback);
+    handleCustomProtocolInvocation("radicle://", callback);
+    handleCustomProtocolInvocation("radicle://", callback);
+    expect(callback.callCount).toEqual(1);
+  });
+});

--- a/native/nativeCustomProtocolHandler.ts
+++ b/native/nativeCustomProtocolHandler.ts
@@ -1,0 +1,23 @@
+import lodash from "lodash";
+
+const THROTTLE_TIMEOUT = 1000; // 1 second
+
+export const handleCustomProtocolInvocation: (
+  url: string,
+  callback: (url: string) => void
+) => void = lodash.throttle(
+  (url, callback) => {
+    if (
+      typeof url !== "string" ||
+      url.length === 0 ||
+      Buffer.byteLength(url, "utf8") > 1024 ||
+      !url.toLowerCase().match(/^radicle:\/\//)
+    ) {
+      return;
+    }
+
+    callback(url);
+  },
+  THROTTLE_TIMEOUT,
+  { trailing: false }
+);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,14 @@
         "to": "assets"
       }
     ],
+    "protocols": [
+      {
+        "name": "radicle",
+        "schemes": [
+          "radicle"
+        ]
+      }
+    ],
     "linux": {
       "target": [
         "Appimage"

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -7,6 +7,7 @@
   import * as path from "./src/path.ts";
   import * as remote from "./src/remote.ts";
   import * as error from "./src/error.ts";
+  import * as customProtocolHandler from "./src/customProtocolHandler.ts";
   import { fetch, session as store, Status } from "./src/session.ts";
 
   import {
@@ -103,6 +104,8 @@
   $: sessionIsUnsealed =
     $store.status === remote.Status.Success &&
     $store.data.status === Status.UnsealedSession;
+
+  customProtocolHandler.register();
 </script>
 
 <style>

--- a/ui/Modal/Search.svelte
+++ b/ui/Modal/Search.svelte
@@ -7,6 +7,7 @@
   import type { Project } from "../src/project";
   import * as remote from "../src/remote";
   import {
+    inputStore,
     projectRequest as request,
     projectSearch as store,
     reset,
@@ -20,10 +21,9 @@
   import { FollowToggle, Remote } from "../DesignSystem/Component";
 
   let id: string;
-  let input: string = "";
 
   let value: string;
-  $: value = input.trim();
+  $: value = $inputStore.trim();
 
   const dispatch = createEventDispatcher();
   const urnValidation = urnValidationStore();
@@ -133,7 +133,7 @@
   <div class="search-bar">
     <Input.Text
       autofocus
-      bind:value={input}
+      bind:value={$inputStore}
       dataCy="search-input"
       inputStyle="height: 3rem; color: var(--color-foreground-level-6); border-radius: 0.5rem; border: 0; box-shadow: var(--color-shadows);"
       on:keydown={onKeydown}

--- a/ui/src/customProtocolHandler.ts
+++ b/ui/src/customProtocolHandler.ts
@@ -1,0 +1,64 @@
+import * as ipc from "./ipc";
+import * as session from "./session";
+import * as modal from "./modal";
+import * as path from "./path";
+import * as error from "./error";
+import { inputStore } from "./search";
+
+export const register = (): void => {
+  ipc.listenCustomProtocolInvocation(async message => {
+    await session.waitUnsealed();
+    handleMessage(message);
+  });
+};
+
+const handleMessage = (message: ipc.CustomProtocolInvocation): void => {
+  const match = message.url.match(
+    /^radicle:\/\/(\w+)\/v([\d+])\/?(rad:git:[1-9A-HJ-NP-Za-km-z]{37})?/
+  );
+
+  if (!match) {
+    error.show({
+      code: error.Code.CustomProtocolParseError,
+      message: "Could not parse the provided URL",
+      details: { url: message.url },
+    });
+
+    return;
+  }
+
+  const [namespace, version, urn] = match.slice(1);
+
+  if (namespace !== "link") {
+    error.show({
+      code: error.Code.CustomProtocolUnsupportedNamespace,
+      message: `The custom protocol namespace "${namespace}" is not supported`,
+      details: { url: message.url },
+    });
+
+    return;
+  }
+
+  if (Number(version) !== 0) {
+    error.show({
+      code: error.Code.CustomProtocolUnsupportedVersion,
+      message: `The custom protocol version v${version} is not supported`,
+      details: { url: message.url },
+    });
+
+    return;
+  }
+
+  if (!urn) {
+    error.show({
+      code: error.Code.CustomProtocolParseError,
+      message: "The provided URL does not contain a Radicle ID",
+      details: { url: message.url },
+    });
+
+    return;
+  }
+
+  inputStore.set(urn);
+  modal.show(path.search());
+};

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -36,6 +36,11 @@ export enum Code {
   FailedOrRejectedTransaction = "FailedOrRejectedTransaction",
   UnkownTransactionFailure = "UnkownTransactionFailure",
   InsufficientGas = "InsufficientGas",
+
+  // Custom protocol error codes
+  CustomProtocolUnsupportedVersion = "CustomProtocolUnsupportedVersion",
+  CustomProtocolUnsupportedNamespace = "CustomProtocolUnsupportedNamespace",
+  CustomProtocolParseError = "CustomProtocolParseError",
 }
 
 // Turn a Javascript `Error` into our `Error`.

--- a/ui/src/ipc.ts
+++ b/ui/src/ipc.ts
@@ -2,7 +2,10 @@ import type {} from "../../native/preload";
 import * as ipcTypes from "../../native/ipc-types";
 import * as config from "./config";
 
-export type { ProxyError } from "../../native/ipc-types";
+export type {
+  ProxyError,
+  CustomProtocolInvocation,
+} from "../../native/ipc-types";
 
 function makeMainProcessClient(): ipcTypes.MainProcess {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,6 +43,26 @@ export function listenProxyError(
     "message",
     (_event: unknown, message: ipcTypes.MainMessage) => {
       if (message.kind === ipcTypes.MainMessageKind.PROXY_ERROR) {
+        f(message.data);
+      }
+    }
+  );
+}
+
+// Register a listener for the `ipcTypes.CustomProtocolInvocation` message.
+export function listenCustomProtocolInvocation(
+  f: (customProtocolInvocation: ipcTypes.CustomProtocolInvocation) => void
+): void {
+  if (config.isNodeTestEnv || config.isCypressTestEnv) {
+    return;
+  }
+
+  window.electron.ipcRenderer.on(
+    "message",
+    (_event: unknown, message: ipcTypes.MainMessage) => {
+      if (
+        message.kind === ipcTypes.MainMessageKind.CUSTOM_PROTOCOL_INVOCATION
+      ) {
         f(message.data);
       }
     }

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -1,9 +1,8 @@
 import { derived, get, writable } from "svelte/store";
 
 type OnHide = () => void;
-const doNothing = () => {
-  /**/
-};
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const doNothing = () => {};
 
 type ModalOverlay =
   | { show: true; route: string; onHide: OnHide }
@@ -23,6 +22,10 @@ export const hide = (): void => {
   overlayStore.set({ show: false });
 };
 
+export const show = (route: string, onHide: OnHide = doNothing): void => {
+  overlayStore.set({ show: true, route, onHide });
+};
+
 export const toggle = (route: string, onHide: OnHide = doNothing): void => {
   const modal = get(store);
   if (modal.show && modal.route === route) {
@@ -30,5 +33,5 @@ export const toggle = (route: string, onHide: OnHide = doNothing): void => {
     return;
   }
 
-  overlayStore.set({ show: true, route, onHide });
+  show(route, onHide);
 };

--- a/ui/src/search.ts
+++ b/ui/src/search.ts
@@ -1,3 +1,5 @@
+import { writable, Writable } from "svelte/store";
+
 import * as api from "./api";
 import * as error from "./error";
 import type * as project from "./project";
@@ -5,6 +7,8 @@ import * as remote from "./remote";
 import type * as waitingRoom from "./waitingRoom";
 
 // STATE
+export const inputStore: Writable<string> = writable("");
+
 const projectSearchStore = remote.createStore<project.Project>();
 export const projectSearch = projectSearchStore.readable;
 


### PR DESCRIPTION
This PR implements the simplest possible deep-linking support. It's based on this [community discussion](https://radicle.community/t/opening-upstream-via-links-on-the-web/1856). Implementing a parser/router for the [proposed URL scheme](https://github.com/radicle-dev/radicle-decisions/pull/10) is left as a follow-up for when we all agree on the scheme. For now the parser just looks for the first `Radicle ID` in the URI and shows the search screen with the input field pre-filled with that URI.

Refs https://github.com/radicle-dev/radicle-upstream/issues/1512
Refs https://github.com/radicle-dev/radicle-decisions/pull/10
Refs https://github.com/radicle-dev/radicle-docs/pull/126

- [x] make it work on macOS
- [x] make it work on Linux
- [x] add section in docs.radicle.xyz about how to set up a `.desktop` file by hand for Linux users: https://github.com/radicle-dev/radicle-docs/pull/126
- [x] tests
- [x] implement parser/handler according to spec


Test this from a browser:
```html
<a href="radicle://link/v0/rad:git:hnrkjm5z3rwae9g3n6jhyo6kzh9eup5ku5odo">radicle://link/v0/rad:git:hnrkjm5z3rwae9g3n6jhyo6kzh9eup5ku5odo</a>
```

Or from the terminal:
```sh
// Linux
xdg-open "radicle://link/v0/rad:git:hnrkjm5z3rwae9g3n6jhyo6kzh9eup5ku5odo"

// macOS
open "radicle://link/v0/rad:git:hnrkjm5z3rwae9g3n6jhyo6kzh9eup5ku5odo"
```