### PR TITLE
refactor(test): make node data directories discoverable

### DIFF
--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -9,17 +9,19 @@ context("p2p networking", () => {
       "reacts to network state changes",
       { defaultCommandTimeout: 8000 },
       () => {
-        nodeManager.withTwoOnboardedNodes(
-          { node1User: {}, node2User: {} },
-          (node1, node2) => {
-            nodeManager.asNode(node1);
-            commands.pick("connection-status-offline").should("exist");
-            nodeManager.connectTwoNodes(node1, node2);
-            commands.pick("connection-status-online").should("exist");
-            nodeManager.asNode(node2);
-            commands.pick("connection-status-online").should("exist");
-          }
-        );
+        commands.withTempDir(tempDirPath => {
+          nodeManager.withTwoOnboardedNodes(
+            { dataDir: tempDirPath, node1User: {}, node2User: {} },
+            (node1, node2) => {
+              nodeManager.asNode(node1);
+              commands.pick("connection-status-offline").should("exist");
+              nodeManager.connectTwoNodes(node1, node2);
+              commands.pick("connection-status-online").should("exist");
+              nodeManager.asNode(node2);
+              commands.pick("connection-status-online").should("exist");
+            }
+          );
+        });
       }
     );
   });
@@ -39,6 +41,7 @@ context("p2p networking", () => {
     commands.withTempDir(tempDirPath => {
       nodeManager.withTwoOnboardedNodes(
         {
+          dataDir: tempDirPath,
           node1User: maintainer,
           node2User: contributor,
         },
@@ -46,14 +49,14 @@ context("p2p networking", () => {
           nodeManager.connectTwoNodes(maintainerNode, contributorNode);
           nodeManager.asNode(maintainerNode);
 
-          const maintainerNodeWorkingDir = path.join(
+          const maintainerProjectsDir = path.join(
             tempDirPath,
-            "maintainerNode"
+            "maintainer-projects"
           );
-          cy.exec(`mkdir -p ${maintainerNodeWorkingDir}`);
+          cy.exec(`mkdir -p "${maintainerProjectsDir}"`);
 
           ipcStub.getStubs().then(stubs => {
-            stubs.selectDirectory.returns(maintainerNodeWorkingDir);
+            stubs.selectDirectory.returns(maintainerProjectsDir);
           });
           const projectName = "new-fancy-project.xyz";
 
@@ -136,7 +139,7 @@ context("p2p networking", () => {
           cy.log("test commit replication from maintainer to contributor");
 
           cy.log("add a new commit to the maintainer's project working dir");
-          const projctPath = path.join(maintainerNodeWorkingDir, projectName);
+          const projctPath = path.join(maintainerProjectsDir, projectName);
           const maintainerCommitSubject =
             "Commit replication from maintainer to contributor";
 
@@ -171,15 +174,15 @@ context("p2p networking", () => {
 
           cy.log("test commit replication from contributor to maintainer");
 
-          const contributorNodeWorkingDir = path.join(
+          const contributorProjectsPath = path.join(
             tempDirPath,
-            "contributorNode"
+            "contributor-projects"
           );
 
-          cy.exec(`mkdir -p ${contributorNodeWorkingDir}`);
+          cy.exec(`mkdir -p "${contributorProjectsPath}"`);
 
           ipcStub.getStubs().then(stubs => {
-            stubs.selectDirectory.returns(contributorNodeWorkingDir);
+            stubs.selectDirectory.returns(contributorProjectsPath);
           });
           commands.pick("checkout-modal-toggle").click();
           commands.pick("choose-path-button").click();
@@ -194,7 +197,7 @@ context("p2p networking", () => {
           const contributorCommitSubject =
             "Commit replication from contributor to maintainer";
           const forkedProjectPath = path.join(
-            contributorNodeWorkingDir,
+            contributorProjectsPath,
             projectName
           );
 

--- a/cypress/plugins/nodeManager/shared.ts
+++ b/cypress/plugins/nodeManager/shared.ts
@@ -4,8 +4,6 @@
 // don't have access to those, so indlucing `plugin.ts` inside `commands.ts`
 // leads to errors.
 
-import * as path from "path";
-
 export type PeerId = string;
 
 export interface NodeSession {
@@ -28,19 +26,17 @@ export interface ConnectNodeOptions {
   nodeIds: NodeId[];
 }
 
-// A directory that can be used for temporary test data.
-//
-// It is located within this repository so that there is no extra setup
-// necessary when using it locally or on CI. To avoid committing any left-over
-// temp data this directory ignored via .gitignore.
-export const CYPRESS_WORKSPACE_PATH = path.join(__dirname, "../../workspace");
-
 // We us `Promise<null>` because Cypress complains if we use
 // `Promise<void>` or `Promise<undefined>`.
 //
 // See https://docs.cypress.io/api/commands/task.html#Usage
 export interface NodeManagerPlugin {
-  startNode: () => Promise<number>;
+  // Start a node and return the node’s ID which is also the port it
+  // the API is listening on.
+  //
+  // The directory `${dataDir}/node-${id}` will be used to store node
+  // related data.
+  startNode: (dataDir: string) => Promise<number>;
   onboardNode: (options: OnboardNodeOptions) => Promise<NodeSession>;
   connectNodes: (options: ConnectNodeOptions) => Promise<null>;
   stopAllNodes: () => Promise<null>;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,6 +1,5 @@
 import * as uuid from "uuid";
 import * as path from "path";
-import { CYPRESS_WORKSPACE_PATH } from "../plugins/nodeManager/shared";
 
 export const resetProxyState = (): Cypress.Chainable<void> =>
   requestOk({ url: "http://localhost:17246/v1/control/reset" });
@@ -19,6 +18,13 @@ export const pick = (...ids: string[]): Cypress.Chainable<JQuery> => {
   const selectorString = ids.map(id => `[data-cy="${id}"]`).join(" ");
   return cy.get(selectorString);
 };
+
+// A directory that can be used for temporary test data.
+//
+// It is located within this repository so that there is no extra setup
+// necessary when using it locally or on CI. To avoid committing any left-over
+// temp data this directory ignored via .gitignore.
+const CYPRESS_WORKSPACE_PATH = path.join(__dirname, "../workspace");
 
 export const withTempDir = (callback: (tempDirPath: string) => void): void => {
   const tempDirPath = path.join(CYPRESS_WORKSPACE_PATH, uuid.v4());

--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -7,9 +7,10 @@ import {
 const nodeManagerPlugin = createNodeManagerPlugin();
 
 const startAndOnboardNode = (
+  dataDir: string,
   onboardedUser: OnboardedUser
 ): Cypress.Chainable<NodeSession> => {
-  return nodeManagerPlugin.startNode().then(id => {
+  return nodeManagerPlugin.startNode(dataDir).then(id => {
     cy.log(`Started node ${id}`);
     return nodeManagerPlugin.onboardNode({
       id,
@@ -31,6 +32,7 @@ interface OnboardedUser {
 }
 
 interface WithTwoOnboardedNodesOptions {
+  dataDir: string;
   node1User: OnboardedUser;
   node2User: OnboardedUser;
 }
@@ -79,8 +81,8 @@ export const withTwoOnboardedNodes = (
   callback: (node1: NodeSession, node2: NodeSession) => void
 ): void => {
   withNodeManager(() => {
-    startAndOnboardNode(options.node1User).then(node0 => {
-      startAndOnboardNode(options.node2User).then(node1 => {
+    startAndOnboardNode(options.dataDir, options.node1User).then(node0 => {
+      startAndOnboardNode(options.dataDir, options.node2User).then(node1 => {
         callback(node0, node1);
       });
     });


### PR DESCRIPTION
Before, each node had its own temporary directory `cypress/workspace/<uuid>` where `uuid` was different for each node. This made debugging the node state (in particular their monorepos) difficult.

With this change node data is located in the per-test temporary directory created by `withTempDir`.