### PR TITLE
refactor(ui): make ipc interface generic and type-safe

### DIFF
--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -53,7 +53,7 @@ context("p2p networking", () => {
           cy.exec(`mkdir -p ${maintainerNodeWorkingDir}`);
 
           ipcStub.getStubs().then(stubs => {
-            stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(maintainerNodeWorkingDir);
+            stubs.selectDirectory.returns(maintainerNodeWorkingDir);
           });
           const projectName = "new-fancy-project.xyz";
 
@@ -179,7 +179,7 @@ context("p2p networking", () => {
           cy.exec(`mkdir -p ${contributorNodeWorkingDir}`);
 
           ipcStub.getStubs().then(stubs => {
-            stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(contributorNodeWorkingDir);
+            stubs.selectDirectory.returns(contributorNodeWorkingDir);
           });
           commands.pick("checkout-modal-toggle").click();
           commands.pick("choose-path-button").click();

--- a/cypress/integration/project/checkout.spec.ts
+++ b/cypress/integration/project/checkout.spec.ts
@@ -12,8 +12,8 @@ context("project checkout", () => {
       cy.exec(`mkdir -p ${checkoutPath}`);
 
       ipcStub.getStubs().then(stubs => {
-        stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(checkoutPath);
-        stubs.IPC_OPEN_PATH.returns("");
+        stubs.selectDirectory.returns(checkoutPath);
+        stubs.openPath.returns("");
       });
 
       callback(checkoutPath);
@@ -72,7 +72,7 @@ context("project checkout", () => {
 
           // Make sure mock is set up correctly.
           ipcStub.getStubs().then(stubs => {
-            expect(stubs.IPC_OPEN_PATH.called).to.be.false;
+            expect(stubs.openPath.called).to.be.false;
           });
 
           // Perform the checkout.
@@ -93,7 +93,7 @@ context("project checkout", () => {
           // Make sure we do the electron call for opening the folder in the OS
           // file browser.
           ipcStub.getStubs().then(stubs => {
-            expect(stubs.IPC_OPEN_PATH.called).to.be.true;
+            expect(stubs.openPath.called).to.be.true;
           });
 
           // Make sure the notification gets closed after we open the folder in

--- a/cypress/integration/project/creation.spec.ts
+++ b/cypress/integration/project/creation.spec.ts
@@ -12,7 +12,7 @@ context("project creation", () => {
       cy.exec(`mkdir -p ${emptyDirectoryPath}`);
 
       ipcStub.getStubs().then(stubs => {
-        stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(emptyDirectoryPath);
+        stubs.selectDirectory.returns(emptyDirectoryPath);
       });
 
       callback();
@@ -33,7 +33,7 @@ context("project creation", () => {
 
       // stub native call and return the directory path to the UI
       ipcStub.getStubs().then(stubs => {
-        stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(noCommitsRepoPath);
+        stubs.selectDirectory.returns(noCommitsRepoPath);
       });
 
       callback();
@@ -68,7 +68,7 @@ context("project creation", () => {
 
       // stub native call and return the directory path to the UI
       ipcStub.getStubs().then(stubs => {
-        stubs.IPC_DIALOG_SHOWOPENDIALOG.returns(platinumPath);
+        stubs.selectDirectory.returns(platinumPath);
       });
 
       callback(repoName);
@@ -334,7 +334,7 @@ context("project creation", () => {
 
         it("picks the Upstream default git branch when it can not obtain the git global config one", () => {
           ipcStub.getStubs().then(stubs => {
-            stubs.GET_GIT_GLOBAL_DEFAULT_BRANCH.returns(undefined);
+            stubs.getGitGlobalDefaultBranch.returns(undefined);
           });
           go(config.UPSTREAM_DEFAULT_BRANCH);
         });

--- a/cypress/integration/settings.spec.ts
+++ b/cypress/integration/settings.spec.ts
@@ -170,7 +170,7 @@ context("settings", () => {
         .click();
 
       ipcStub.getStubs().then(stubs => {
-        assert.deepEqual(stubs.IPC_OPEN_URL.args, [["ANNOUNCEMENT_URL"]]);
+        assert.deepEqual(stubs.openUrl.args, [["ANNOUNCEMENT_URL"]]);
       });
 
       commands
@@ -213,7 +213,7 @@ context("settings", () => {
       commands.pick("checkout-new-version").click();
 
       ipcStub.getStubs().then(stubs => {
-        assert.deepEqual(stubs.IPC_OPEN_URL.args, [["ANNOUNCEMENT_URL"]]);
+        assert.deepEqual(stubs.openUrl.args, [["ANNOUNCEMENT_URL"]]);
       });
     });
 

--- a/native/ipc-types.ts
+++ b/native/ipc-types.ts
@@ -15,12 +15,24 @@ export interface ProxyError {
   output: string;
 }
 
-// Message kinds sent from the renderer to the main process.
-export enum RendererMessage {
-  CLIPBOARD_WRITETEXT = "IPC_CLIPBOARD_WRITETEXT",
-  DIALOG_SHOWOPENDIALOG = "IPC_DIALOG_SHOWOPENDIALOG",
-  GET_VERSION = "GET_VERSION",
-  OPEN_PATH = "IPC_OPEN_PATH",
-  OPEN_URL = "IPC_OPEN_URL",
-  GET_GIT_GLOBAL_DEFAULT_BRANCH = "GET_GIT_GLOBAL_DEFAULT_BRANCH",
+// RPC interface exposed by the main process to the renderer.
+export interface MainProcess {
+  clipboardWriteText(text: string): Promise<void>;
+  getVersion(): Promise<string>;
+  openPath(path: string): Promise<void>;
+  openUrl(path: string): Promise<void>;
+  // Open a system dialog to select a directory and returns the
+  // selected directory.
+  selectDirectory(): Promise<string>;
+  // Get the git global default branch, which can be customized by the user.
+  getGitGlobalDefaultBranch(): Promise<string | undefined>;
 }
+
+export const mainProcessMethods: Array<keyof MainProcess> = [
+  "clipboardWriteText",
+  "getVersion",
+  "openPath",
+  "openUrl",
+  "selectDirectory",
+  "getGitGlobalDefaultBranch",
+];

--- a/native/preload.d.ts
+++ b/native/preload.d.ts
@@ -1,11 +1,11 @@
-import type { MainMessage, RendererMessage } from "./ipc-types";
+import type { MainMessage } from "./ipc-types";
 
 declare global {
   interface Window {
     electron: {
       ipcRenderer: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        invoke: (cmd: RendererMessage, args?: unknown) => Promise<any>;
+        invoke: (cmd: unknown, args?: unknown) => Promise<any>;
         on: (
           event: "message",
           handle: (event: unknown, message: MainMessage) => void


### PR DESCRIPTION
We make the IPC interface between the electron main process and the renderer generic and type-safe. This reduces boilerplate and increases robustness.