### PR TITLE
refactor: remove tsconfig file for scripts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@ native/* @radicle-dev/upstream-ui
 *.js @radicle-dev/upstream-ui
 package.json @radicle-dev/upstream-ui
 cypress.json @radicle-dev/upstream-ui
-tsconfig.scripts.json @radicle-dev/upstream-ui
+tsconfig.json @radicle-dev/upstream-ui
 
 # All Proxy related code and files
 fixtures/* @radicle-dev/upstream-proxy

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx ts-node -P tsconfig.scripts.json
+#!/usr/bin/env -S npx ts-node
 
 import { execSync } from "child_process";
 import prompts from "prompts";

--- a/scripts/set-latest-release.ts
+++ b/scripts/set-latest-release.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx ts-node -P tsconfig.scripts.json
+#!/usr/bin/env -S npx ts-node
 
 // This script updates `releases.radicle.xyz/latest.json` with the
 // current.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,5 +97,10 @@
     // "experimentalDecorators": true,
     /* Enables experimental support for emitting type metadata for decorators. */
     // "emitDecoratorMetadata": true,
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
   }
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs"
-  }
-}


### PR DESCRIPTION
We remove the separate `tsconfig` file for scripts and add the configuration under the `ts-node` key to `tsconfig.json`.