### PR TITLE
chore: put the peer in a loop

### DIFF
--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -198,7 +198,7 @@ impl Unsealed {
     /// * coco key creation fails
     /// * creation of the [`kv::Store`] fails
     #[cfg(test)]
-    pub async fn tmp(
+    pub fn tmp(
         tmp_dir: &tempfile::TempDir,
     ) -> Result<(Self, impl std::future::Future<Output = ()>), crate::error::Error> {
         let store = kv::Store::new(kv::Config::new(tmp_dir.path().join("store")))?;
@@ -207,10 +207,9 @@ impl Unsealed {
         let signer = signer::BoxedSigner::from(signer::SomeSigner { signer: key });
 
         let (peer_control, peer, run_handle) = {
-            let config = coco::config::default(signer.clone(), tmp_dir.path())?;
+            let config = coco::config::default(signer, tmp_dir.path())?;
             let disco = coco::config::static_seed_discovery(&[]);
-            let coco_peer =
-                coco::bootstrap(config, disco, store.clone(), RunConfig::default()).await?;
+            let coco_peer = coco::Peer::new(config, disco, store.clone(), RunConfig::default());
             let peer = coco_peer.peer.clone();
 
             let peer_control = coco_peer.control();

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -106,7 +106,7 @@ mod test {
     #[tokio::test]
     async fn create() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let res = request()
@@ -164,7 +164,7 @@ mod test {
     #[tokio::test]
     async fn get() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let user = coco::state::init_user(&ctx.peer, "cloudhead".to_string()).await?;
@@ -202,7 +202,7 @@ mod test {
     #[tokio::test]
     async fn list() -> Result<(), error::Error> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let fintohaps: identity::Identity = {

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -324,7 +324,7 @@ mod test {
         let tmp_dir = tempfile::tempdir()?;
         let repos_dir = tempfile::tempdir_in(tmp_dir.path())?;
         let dir = tempfile::tempdir_in(repos_dir.path())?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let urn = {
@@ -406,7 +406,7 @@ mod test {
         let tmp_dir = tempfile::tempdir()?;
         let repos_dir = tempfile::tempdir_in(tmp_dir.path())?;
         let dir = tempfile::tempdir_in(repos_dir.path())?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         {
@@ -467,7 +467,7 @@ mod test {
         let repos_dir = tempfile::tempdir_in(tmp_dir.path())?;
         let dir = tempfile::tempdir_in(repos_dir.path())?;
         let repo_path = dir.path().join("Upstream");
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         {
@@ -542,7 +542,7 @@ mod test {
     #[tokio::test]
     async fn get() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let urn = {
@@ -579,7 +579,7 @@ mod test {
     #[tokio::test]
     async fn list_for_user() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
@@ -610,7 +610,7 @@ mod test {
     #[tokio::test]
     async fn list_contributed() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
@@ -635,7 +635,7 @@ mod test {
     #[tokio::test]
     async fn track() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
@@ -663,7 +663,7 @@ mod test {
     #[tokio::test]
     async fn untrack() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
@@ -691,7 +691,7 @@ mod test {
     #[tokio::test]
     async fn untrack_after_track() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;

--- a/proxy/api/src/http/project/request.rs
+++ b/proxy/api/src/http/project/request.rs
@@ -102,7 +102,7 @@ mod test {
     #[tokio::test]
     async fn cancel() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (mut ctx, run) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (mut ctx, run) = context::Unsealed::tmp(&tmp_dir)?;
         let handle = tokio::spawn(run);
         let api = super::filters(ctx.clone().into());
 
@@ -129,7 +129,7 @@ mod test {
     #[tokio::test]
     async fn create() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (mut ctx, run) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (mut ctx, run) = context::Unsealed::tmp(&tmp_dir)?;
         let handle = tokio::spawn(run);
         let api = super::filters(ctx.clone().into());
 
@@ -155,7 +155,7 @@ mod test {
     #[tokio::test]
     async fn list() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (mut ctx, run) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (mut ctx, run) = context::Unsealed::tmp(&tmp_dir)?;
         let handle = tokio::spawn(run);
         let api = super::filters(ctx.clone().into());
 

--- a/proxy/api/src/http/session.rs
+++ b/proxy/api/src/http/session.rs
@@ -70,7 +70,7 @@ mod test {
     #[tokio::test]
     async fn get() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
         let session = session::initialize_test(&ctx, "xla").await;
 
@@ -87,7 +87,7 @@ mod test {
     #[tokio::test]
     async fn update_settings() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
         session::initialize_test(&ctx, "cloudhead").await;
 

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -319,7 +319,7 @@ mod test {
     #[tokio::test]
     async fn blob() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let urn = replicate_platinum(&ctx).await?;
@@ -439,7 +439,7 @@ mod test {
     #[tokio::test]
     async fn blob_dev_branch() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let urn = replicate_platinum(&ctx).await?;
@@ -483,7 +483,7 @@ mod test {
     #[tokio::test]
     async fn branches() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
         let urn = replicate_platinum(&ctx).await?;
 
@@ -511,7 +511,7 @@ mod test {
     #[allow(clippy::indexing_slicing)]
     async fn commit() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let urn = replicate_platinum(&ctx).await?;
@@ -556,7 +556,7 @@ mod test {
     #[tokio::test]
     async fn commits() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let urn = replicate_platinum(&ctx).await?;
@@ -595,7 +595,7 @@ mod test {
     #[tokio::test]
     async fn local_state() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let mut path = env::current_dir()?;
@@ -628,7 +628,7 @@ mod test {
     #[tokio::test]
     async fn tags() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
         let urn = replicate_platinum(&ctx).await?;
@@ -658,7 +658,7 @@ mod test {
     #[tokio::test]
     async fn tree() -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
         let urn = replicate_platinum(&ctx).await?;
 
@@ -727,7 +727,7 @@ mod test {
             .add(b'=');
 
         let tmp_dir = tempfile::tempdir()?;
-        let (ctx, _) = context::Unsealed::tmp(&tmp_dir).await?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
         let urn = replicate_platinum(&ctx).await?;
 

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -242,7 +242,7 @@ async fn rig(
         );
         let disco = coco::config::StreamDiscovery::new(seeds_receiver);
 
-        let peer = coco::bootstrap(config, disco, store.clone(), coco_run_config()).await?;
+        let peer = coco::Peer::new(config, disco, store.clone(), coco_run_config());
 
         let peer_control = peer.control();
         let ctx = context::Context::Unsealed(context::Unsealed {

--- a/proxy/coco/src/config.rs
+++ b/proxy/coco/src/config.rs
@@ -82,6 +82,7 @@ pub fn static_seed_discovery(seeds: &[seed::Seed]) -> discovery::Static {
 }
 
 /// Stream based discovery based on a watch.
+#[derive(Clone)]
 pub struct StreamDiscovery {
     /// Stream of new sets of seeds coming from configuration changes.
     seeds_receiver: watch::Receiver<Vec<seed::Seed>>,

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -50,9 +50,7 @@ mod identifier;
 pub use identifier::Identifier;
 pub mod keystore;
 pub mod peer;
-pub use peer::{
-    bootstrap, Control as PeerControl, Event as PeerEvent, Peer, RunConfig, Status as PeerStatus,
-};
+pub use peer::{Control as PeerControl, Event as PeerEvent, Peer, RunConfig, Status as PeerStatus};
 pub mod project;
 pub mod request;
 pub mod state;

--- a/proxy/coco/src/peer/run_state/input.rs
+++ b/proxy/coco/src/peer/run_state/input.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{net::SocketAddr, time::SystemTime};
 
 use tokio::sync::oneshot;
 
@@ -17,6 +17,7 @@ pub enum Input {
     Announce(Announce),
     /// Peer state change events.
     Control(Control),
+    ListenAddrs(Vec<SocketAddr>),
     /// Inputs from the underlying coco protocol.
     Protocol(ProtocolEvent),
     /// Lifecycle events during peer sync operations.
@@ -40,6 +41,7 @@ pub enum Announce {
 /// Requests from the peer control.
 #[derive(Debug)]
 pub enum Control {
+    ListenAddrs(oneshot::Sender<Vec<SocketAddr>>),
     /// New status.
     Status(oneshot::Sender<super::Status>),
 

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -10,7 +10,7 @@ use coco::{peer::run_config, seed::Seed, state, RunConfig};
 mod common;
 use common::{
     assert_cloned, build_peer, build_peer_with_seeds, connected, init_logging, radicle_project,
-    requested, shia_le_pathbuf,
+    requested, shia_le_pathbuf, started,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -34,8 +34,12 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
 
@@ -54,7 +58,10 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
 
     let bob_peer = {
         let peer = bob_peer.peer.clone();
+        let events = bob_peer.subscribe();
         tokio::task::spawn(bob_peer.into_running());
+        started(events).await?;
+
         peer
     };
     let _bob = state::init_owner(&bob_peer, "bob".to_string()).await?;
@@ -92,8 +99,12 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
 
@@ -117,7 +128,10 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
 
     let bob_peer = {
         let peer = bob_peer.peer.clone();
+        let events = bob_peer.subscribe();
         tokio::task::spawn(bob_peer.into_running());
+        started(events).await?;
+
         peer
     };
 

--- a/proxy/coco/tests/replication.rs
+++ b/proxy/coco/tests/replication.rs
@@ -22,7 +22,9 @@ use coco::{
 
 #[macro_use]
 mod common;
-use common::{build_peer, build_peer_with_seeds, connected, init_logging, shia_le_pathbuf};
+use common::{
+    build_peer, build_peer_with_seeds, connected, init_logging, shia_le_pathbuf, started,
+};
 
 #[tokio::test]
 async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
@@ -39,13 +41,20 @@ async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
     let bob_peer = {
         let peer = bob_peer.peer.clone();
+        let events = bob_peer.subscribe();
         tokio::task::spawn(bob_peer.into_running());
+        started(events).await?;
+
         peer
     };
 
@@ -107,13 +116,20 @@ async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
     let bob_peer = {
         let peer = bob_peer.peer.clone();
+        let events = bob_peer.subscribe();
         tokio::task::spawn(bob_peer.into_running());
+        started(events).await?;
+
         peer
     };
 
@@ -149,13 +165,20 @@ async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
     let bob_peer = {
         let peer = bob_peer.peer.clone();
+        let events = bob_peer.subscribe();
         tokio::task::spawn(bob_peer.into_running());
+        started(events).await?;
+
         peer
     };
 
@@ -274,8 +297,12 @@ async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
     let mut alice_events = alice_peer.subscribe();
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
     let alice_peer_id = alice_peer.peer_id();
@@ -338,19 +365,29 @@ async fn can_create_working_copy_of_peer() -> Result<(), Box<dyn std::error::Err
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
     let (bob_peer, bob_addrs) = {
         let peer = bob_peer.peer.clone();
-        let listen_addrs = bob_peer.listen_addrs.clone();
+        let events = bob_peer.subscribe();
+        let mut peer_control = bob_peer.control();
         tokio::task::spawn(bob_peer.into_running());
-        (peer, listen_addrs)
+        started(events).await?;
+
+        (peer, peer_control.listen_addrs().await)
     };
     let eve_peer = {
         let peer = eve_peer.peer.clone();
+        let events = eve_peer.subscribe();
         tokio::task::spawn(eve_peer.into_running());
+        started(events).await?;
+
         peer
     };
 
@@ -459,8 +496,12 @@ async fn track_peer() -> Result<(), Box<dyn std::error::Error>> {
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
-        let listen_addrs = alice_peer.listen_addrs.clone();
+        let events = alice_peer.subscribe();
+        let mut peer_control = alice_peer.control();
         tokio::task::spawn(alice_peer.into_running());
+        started(events).await?;
+
+        let listen_addrs = peer_control.listen_addrs().await;
         (peer, listen_addrs)
     };
 
@@ -478,7 +519,10 @@ async fn track_peer() -> Result<(), Box<dyn std::error::Error>> {
 
     let bob_peer = {
         let peer = bob_peer.peer.clone();
+        let events = bob_peer.subscribe();
         tokio::task::spawn(bob_peer.into_running());
+        started(events).await?;
+
         peer
     };
 


### PR DESCRIPTION
To not implode the entire networking machinery on an accept error, we
follow suit with the example of the link seed code and put the bind and
accept in a loop. Only when an error on bind is encountered it's
terminate.

Signed-off-by: Alexander Simmerl <a.simmerl@gmail.com>