### PR TITLE
refactor(proxy): avoid spawning tasks when running a peer

### DIFF
--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -214,7 +214,7 @@ impl Unsealed {
 
             let peer_control = coco_peer.control();
             let run_handle = async move {
-                if let Err(err) = coco_peer.into_running().await {
+                if let Err(err) = coco_peer.run().await {
                     log::error!("peer run error: {:?}", err);
                 }
             };

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -202,7 +202,7 @@ async fn run_rigging(
 
         let peer = async move {
             log::info!("starting peer");
-            peer.into_running().await
+            peer.run().await
         };
 
         tasks.push(peer.map_err(RunError::from).boxed());

--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -3,7 +3,10 @@
 
 use std::{io, net::SocketAddr, vec};
 
-use futures::prelude::*;
+use futures::{
+    future::{FutureExt as _, TryFutureExt as _},
+    stream::StreamExt as _,
+};
 use tokio::{
     sync::{broadcast, mpsc, watch},
     task::JoinError,

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -36,7 +36,7 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -59,7 +59,7 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
     let bob_peer = {
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         peer
@@ -101,7 +101,7 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -129,7 +129,7 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     let bob_peer = {
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         peer

--- a/proxy/coco/tests/internal.rs
+++ b/proxy/coco/tests/internal.rs
@@ -18,7 +18,7 @@ async fn can_observe_timers() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut alice_events = alice_peer.subscribe();
 
-    tokio::spawn(alice_peer.into_running());
+    tokio::spawn(alice_peer.run());
 
     let ticked = async_stream::stream! {
         loop { yield alice_events.recv().await }

--- a/proxy/coco/tests/replication.rs
+++ b/proxy/coco/tests/replication.rs
@@ -43,7 +43,7 @@ async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -52,7 +52,7 @@ async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     let bob_peer = {
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         peer
@@ -118,7 +118,7 @@ async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -127,7 +127,7 @@ async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
     let bob_peer = {
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         peer
@@ -167,7 +167,7 @@ async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -176,7 +176,7 @@ async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
     let bob_peer = {
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         peer
@@ -299,7 +299,7 @@ async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -320,7 +320,7 @@ async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
         let bob_events = peer.subscribe();
         let bob_peer = peer.peer.clone();
-        tokio::task::spawn(peer.into_running());
+        tokio::task::spawn(peer.run());
         (bob_peer, bob_events)
     };
     let bob_peer_id = bob_peer.peer_id();
@@ -367,7 +367,7 @@ async fn can_create_working_copy_of_peer() -> Result<(), Box<dyn std::error::Err
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -377,7 +377,7 @@ async fn can_create_working_copy_of_peer() -> Result<(), Box<dyn std::error::Err
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
         let mut peer_control = bob_peer.control();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         (peer, peer_control.listen_addrs().await)
@@ -385,7 +385,7 @@ async fn can_create_working_copy_of_peer() -> Result<(), Box<dyn std::error::Err
     let eve_peer = {
         let peer = eve_peer.peer.clone();
         let events = eve_peer.subscribe();
-        tokio::task::spawn(eve_peer.into_running());
+        tokio::task::spawn(eve_peer.run());
         started(events).await?;
 
         peer
@@ -498,7 +498,7 @@ async fn track_peer() -> Result<(), Box<dyn std::error::Error>> {
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -520,7 +520,7 @@ async fn track_peer() -> Result<(), Box<dyn std::error::Error>> {
     let bob_peer = {
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         peer

--- a/proxy/coco/tests/source.rs
+++ b/proxy/coco/tests/source.rs
@@ -24,7 +24,7 @@ async fn can_browse_peers_branch() -> Result<(), Box<dyn std::error::Error + 'st
         let peer = alice_peer.peer.clone();
         let events = alice_peer.subscribe();
         let mut peer_control = alice_peer.control();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         started(events).await?;
 
         let listen_addrs = peer_control.listen_addrs().await;
@@ -34,7 +34,7 @@ async fn can_browse_peers_branch() -> Result<(), Box<dyn std::error::Error + 'st
     let bob_peer = {
         let peer = bob_peer.peer.clone();
         let events = bob_peer.subscribe();
-        tokio::task::spawn(bob_peer.into_running());
+        tokio::task::spawn(bob_peer.run());
         started(events).await?;
 
         peer

--- a/proxy/coco/tests/working_copy.rs
+++ b/proxy/coco/tests/working_copy.rs
@@ -17,7 +17,7 @@ async fn upstream_for_default() -> Result<(), Box<dyn std::error::Error>> {
 
     let alice_peer = {
         let peer = alice_peer.peer.clone();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         peer
     };
 
@@ -47,7 +47,7 @@ async fn checkout_twice_fails() -> Result<(), Box<dyn std::error::Error>> {
 
     let alice_peer = {
         let peer = alice_peer.peer.clone();
-        tokio::task::spawn(alice_peer.into_running());
+        tokio::task::spawn(alice_peer.run());
         peer
     };
 


### PR DESCRIPTION
Instead of spawning tasks when `peer.into_running()` is called we construct a future. This simplifies the code while retaining the behavior that when the returned object is dropped we stop polling the protocol and subroutines.

We also replace the custom `futures::select` implementation.