### PR TITLE
Igor/ethereum attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,11 @@ dependencies = [
  "argh",
  "async-stream",
  "bytes 1.0.1",
+ "chrono",
  "coco",
  "data-encoding",
  "directories 2.0.2",
+ "eip55",
  "futures 0.3.13",
  "http",
  "kv",
@@ -93,6 +95,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "url",
  "warp",
 ]
 
@@ -388,6 +391,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.43",
  "winapi",
 ]
@@ -420,6 +424,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -656,6 +661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "eip55"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fa92b223d7e4e6a45d35ed2a7a1d0329f2395eb3ab2547bd44b737a278f32f"
+dependencies = [
+ "rust-crypto",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +738,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -857,6 +877,12 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -2008,6 +2034,29 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2053,6 +2102,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -2094,6 +2158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2197,6 +2270,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-crypto"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+dependencies = [
+ "gcc",
+ "libc",
+ "rand 0.3.23",
+ "rustc-serialize",
+ "time 0.1.43",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2293,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"

--- a/docs/ethereum_attestation.md
+++ b/docs/ethereum_attestation.md
@@ -1,0 +1,137 @@
+# RFC: Ethereum attestation
+
+* Author: @CodeSandwich
+* Date: 2021-03-05
+* Status: draft
+* Community discussion: n/a
+
+## Motivation
+
+The attestation between Radicle Link and Ethereum is a valuable building block for a user identity.
+It brings the Radicle Link reputation coming from projects and contributions to the
+Ethereum world of DAOs and donations, where it's important to know who's behind an address.
+On the other hand, it lends Ethereum account reputation with its assets and undeniable history
+to Radicle Link to build user's trust in the identity.
+
+## Overview
+
+This RFC is built on top of the [identities spec][identities].
+It introduces support for Ethereum address claims on Radicle Link
+and a smart contract on Ethereum to make Radicle Link identity claims on Ethereum.
+
+## Radicle Link identity JSON extension
+
+The identity doc `payload` structure supports a new key: `https://radicle.xyz/ethereum/claim/v1`.
+It can be used only in person identities.
+Under this key, an Ethereum address claim is stored in this format:
+
+- `address` - the claimed Ethereum address, encoded according to [EIP-55][eip-55],
+e.g. using [ethers.js][ethers-addr]
+- `expiration` - the claim expiration timestamp, encoded as a [JavaScript Date][date].
+The claim is valid only before that timestamp.
+
+Example:
+```json
+{
+    "payload": {
+        "https://radicle.xyz/ethereum/claim/v1": {
+            "address": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+            "expiration": "2021-03-19T23:15:30.000Z"
+        }
+        ...
+    }
+    ...
+}
+```
+
+## Ethereum smart contract
+
+A new Ethereum smart contract is deployed to the network,
+which lets users claim their Radicle Link identities:
+
+```solidity
+contract Claims {
+    event Claimed(address indexed addr);
+    function claim(uint256 format, bytes calldata payload);
+}
+```
+
+To claim an identity, call `claim` using your Ethereum account
+and pass your Radicle Link identity root.
+It will emit an event `Claimed`, which later can be queried to discover your attestation.
+The claims have no expiration date and don't need to be renewed.
+
+Every new claim invalidates previous ones made with the same account.
+To revoke a claim without creating a new one, claim root hash `0`,
+which is guaranteed to not match any existing identity.
+
+Currently supported `format` values:
+- `1` - `payload` is exactly 20 bytes and contains an SHA-1 Radicle Identity root hash
+- `2` - `payload` is exactly 32 bytes and contains an SHA-256 Radicle Identity root hash
+
+We need to deploy an official instance of the `Claims` smart contract and
+it must be used by all the users.
+If anybody makes a claim using a different instance, it won't be recognized by others.
+
+## Creation of an attestation
+
+You need to perform 2 actions in any order:
+- Add or update an `https://radicle.xyz/ethereum/claim/v1` entry in your identity doc.
+The entry's `address` must be your Ethereum address.
+It's highly recommended to set a short expiration date as Ethereum claims don't expire.
+- Call `claim` in the `Claims` smart contract. The `root` must point to your link identity.
+
+## Discovery
+
+### From an Ethereum address
+
+When you know an Ethereum address, you can find the claimed link identity using an Ethereum client.
+The example calls are based on the standard [client JSON RPC API][rpc] and should be exposed
+by your favourite Ethereum client library.
+It's important that the client must be trusted not to hide the events.
+
+- Use [getLogs][rpc-logs] to get the newest `Claimed` event filtered for the given ethereum address
+- Get the event's `transactionHash` field and use it to fetch the transaction which emitted it with
+[getTransactionByHash][rpc-tx]
+- Validate that the transaction signature matches its data and the ethereum address.
+For reference the signature payload content is listed [here][rpc-sign].
+- Read the Radicle Link identity root hash from the transaction data
+- Verify that the Radicle Link identity doc claims back the Ethereum address,
+see [Discovery from a Radicle Link identity](#from-a-radicle-link-identity)
+
+### From a Radicle Link identity
+
+When you know a Radicle Link identity, you can find the claimed Ethereum address.
+Obtain the tip of its identity chain and read the Ethereum address from the identity doc
+`address` field in section `https://radicle.xyz/ethereum/claim/v1`, unless it's expired.
+You need to verify that the given Ethereum address claims back the Radicle Link identity root,
+see [Discovery from an Ethereum address](#from-an-ethereum-address).
+
+## Revocation of an attestation
+
+When your attestation for whatever reason is no longer valid,
+you should revoke it as soon as possible.
+Only one claim needs to be revoked to break the attestation,
+but to improve security you should revoke both sides if you can.
+
+To revoke a claim on Radicle Link, update the identity doc and publish it in a new revision.
+You can change the claimed Ethereum address or remove
+the `https://radicle.xyz/ethereum/claim/v1` section altogether.
+The other Radicle Link nodes will not notice this update until they fetch the new revision.
+
+To revoke a claim on Ethereum, call the `claim` function in `Claims` contract
+to can claim a different Radicle Link identity root
+or the `0` root to revoke any claim you may have.
+The other users will notice this update almost immediately if they
+are subscribed to the `Claimed` events for your Ethereum address in their Ethereum client.
+
+---
+
+[identities]: ../spec/sections/002-identities/index.md
+[eip-55]: https://eips.ethereum.org/EIPS/eip-55
+[date]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON
+[ethers-addr]: https://docs.ethers.io/v5/api/utils/address/
+[rpc]: https://eth.wiki/json-rpc/API
+[rpc-logs]: https://eth.wiki/json-rpc/API#eth_getlogs
+[rpc-tx]: https://eth.wiki/json-rpc/API#eth_gettransactionbyhash
+[rpc-sign]: https://eth.wiki/json-rpc/API#eth_signtransaction

--- a/proxy/api/Cargo.toml
+++ b/proxy/api/Cargo.toml
@@ -15,8 +15,10 @@ default-run = "radicle-proxy"
 anyhow = "1.0"
 argh = "0.1"
 async-stream = "0.3"
+chrono = { version = "0.4.19", features = [ "serde" ] }
 data-encoding = "2.3"
 directories = "2.0"
+eip55 = "0.1.1"
 futures = { version = "0.3", features = [ "compat" ] }
 lazy_static = "1.4"
 log = "0.4"
@@ -31,6 +33,7 @@ secstr = { version = "0.3.2", features = [ "serde" ] }
 tempfile = "3.1"
 thiserror = "1.0"
 tokio = { version = "1.2", features = [ "macros", "process", "signal", "time" ] }
+url = "2.1"
 warp = { version = "0.3", default-features = false }
 
 [dependencies.kv]

--- a/proxy/api/src/ethereum/address.rs
+++ b/proxy/api/src/ethereum/address.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    convert::{TryFrom, TryInto},
+    str::FromStr,
+};
+
+/// An [EIP-55](https://eips.ethereum.org/EIPS/eip-55) Ethereum address.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct Address(String);
+
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("invalid EIP-55 address")]
+pub struct InvalidEIP55AddressError;
+
+impl TryFrom<String> for Address {
+    type Error = InvalidEIP55AddressError;
+
+    fn try_from(address: String) -> Result<Self, Self::Error> {
+        if eip55::validate_address(&address) {
+            Ok(Self(address))
+        } else {
+            Err(InvalidEIP55AddressError)
+        }
+    }
+}
+
+impl FromStr for Address {
+    type Err = InvalidEIP55AddressError;
+
+    fn from_str(address: &str) -> Result<Self, Self::Err> {
+        address.to_string().try_into()
+    }
+}
+
+impl From<Address> for String {
+    fn from(address: Address) -> Self {
+        address.0
+    }
+}
+
+impl AsRef<str> for Address {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}

--- a/proxy/api/src/ethereum/claim_ext.rs
+++ b/proxy/api/src/ethereum/claim_ext.rs
@@ -1,0 +1,32 @@
+//! The user identity doc extension for Ethereum addresses attestation.
+//! See [the RFC](docs/ethereum_attestation.md).
+
+use crate::ethereum::address::Address;
+use chrono::{DateTime, Utc};
+use coco::identities::payload::HasNamespace;
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// The user identity doc extension for Ethereum addresses claims.
+/// Meaningful only if confirmed on Ethereum. See [the RFC](docs/ethereum_attestation.md).
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct V1 {
+    /// The Ethereum address claimed by the user.
+    pub address: Address,
+    /// The timestamp before which the address claim is valid
+    pub expiration: DateTime<Utc>,
+}
+
+lazy_static! {
+    static ref V1_NAMESPACE: Url = "https://radicle.xyz/ethereum/claim/v1"
+        .parse()
+        .expect("Static URL malformed");
+}
+
+impl HasNamespace for V1 {
+    fn namespace() -> &'static Url {
+        &V1_NAMESPACE
+    }
+}

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -1,6 +1,5 @@
 //! Manage the state and stateful interactions with the underlying peer API of librad.
 
-use serde::{Deserialize, Serialize};
 use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};
 
 use crate::{context, http};
@@ -54,7 +53,7 @@ mod handler {
     /// Create a new [`identity::Identity`].
     pub async fn create(
         ctx: context::Unsealed,
-        input: super::CreateInput,
+        metadata: identity::Metadata,
     ) -> Result<impl Reply, Rejection> {
         if let Some(session) = session::get_current(&ctx.store)? {
             return Err(Rejection::from(error::Error::SessionInUse(
@@ -62,7 +61,7 @@ mod handler {
             )));
         }
 
-        let id = identity::create(&ctx.peer, &input.handle).await?;
+        let id = identity::create(&ctx.peer, metadata).await?;
 
         session::initialize(&ctx.store, id.clone(), &ctx.default_seeds)?;
 
@@ -82,21 +81,12 @@ mod handler {
     }
 }
 
-// TODO(xla): Implement Deserialize on identity::Metadata and drop this type entirely, this will
-// help to avoid duplicate efforts for documentation.
-/// Bundled input data for identity creation.
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CreateInput {
-    /// Handle the user wants to go by.
-    handle: String,
-}
-
 #[allow(clippy::non_ascii_literal, clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
+    use std::convert::TryInto;
     use warp::{http::StatusCode, test::request};
 
     use radicle_avatar as avatar;
@@ -112,8 +102,15 @@ mod test {
         let res = request()
             .method("POST")
             .path("/")
-            .json(&super::CreateInput {
+            .json(&identity::Metadata {
                 handle: "cloudhead".into(),
+                ethereum: Some(identity::Ethereum {
+                    address: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                        .to_string()
+                        .try_into()
+                        .expect("Invalid address"),
+                    expiration: "2021-03-19T23:15:30.001Z".parse().expect("Invalid date"),
+                }),
             })
             .reply(&api)
             .await;
@@ -152,6 +149,10 @@ mod test {
                     "urn": urn,
                     "metadata": {
                         "handle": "cloudhead",
+                        "ethereum": {
+                            "address": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+                            "expiration": "2021-03-19T23:15:30.001Z",
+                        }
                     },
                     "shareableEntityIdentifier": &shareable_entity_identifier,
                 })
@@ -188,7 +189,10 @@ mod test {
                 peer_id,
                 urn: urn.clone(),
                 shareable_entity_identifier,
-                metadata: identity::Metadata { handle },
+                metadata: identity::Metadata {
+                    handle,
+                    ethereum: None
+                },
                 avatar_fallback: avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity),
             })
         );
@@ -206,7 +210,11 @@ mod test {
         let api = super::filters(ctx.clone().into());
 
         let fintohaps: identity::Identity = {
-            let id = identity::create(&ctx.peer, "cloudhead").await?;
+            let metadata = identity::Metadata {
+                handle: "cloudhead".to_string(),
+                ethereum: None,
+            };
+            let id = identity::create(&ctx.peer, metadata).await?;
 
             let owner = coco::state::get_user(&ctx.peer, id.urn.clone())
                 .await?

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -311,6 +311,7 @@ pub struct MetadataInput {
 #[allow(clippy::panic, clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
+    use coco::{identities::payload::Person, state::init_owner};
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
     use warp::{http::StatusCode, test::request};
@@ -329,7 +330,13 @@ mod test {
 
         let urn = {
             let handle = "cloudhead";
-            let owner = coco::state::init_owner(&ctx.peer, handle.to_string()).await?;
+            let owner = init_owner(
+                &ctx.peer,
+                Person {
+                    name: handle.into(),
+                },
+            )
+            .await?;
             session::initialize(
                 &ctx.store,
                 (ctx.peer.peer_id(), owner.clone().into_inner().into_inner()).into(),
@@ -410,8 +417,11 @@ mod test {
         let api = super::filters(ctx.clone().into());
 
         {
-            let handle = "cloudhead";
-            let id = identity::create(&ctx.peer, handle).await?;
+            let metadata = identity::Metadata {
+                handle: "cloudhead".to_string(),
+                ethereum: None,
+            };
+            let id = identity::create(&ctx.peer, metadata).await?;
 
             session::initialize(&ctx.store, id, &ctx.default_seeds)?;
         };
@@ -471,8 +481,11 @@ mod test {
         let api = super::filters(ctx.clone().into());
 
         {
-            let handle = "cloudhead";
-            let id = identity::create(&ctx.peer, handle).await?;
+            let metadata = identity::Metadata {
+                handle: "cloudhead".to_string(),
+                ethereum: None,
+            };
+            let id = identity::create(&ctx.peer, metadata).await?;
             session::initialize(&ctx.store, id, &ctx.default_seeds)?;
         };
 
@@ -546,7 +559,13 @@ mod test {
         let api = super::filters(ctx.clone().into());
 
         let urn = {
-            let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
+            let owner = init_owner(
+                &ctx.peer,
+                Person {
+                    name: "cloudhead".into(),
+                },
+            )
+            .await?;
             let platinum_project = coco::control::replicate_platinum(
                 &ctx.peer,
                 &owner,
@@ -582,7 +601,13 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
+        let owner = init_owner(
+            &ctx.peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
         coco::control::setup_fixtures(&ctx.peer, &owner).await?;
 
         let projects = project::Projects::list(&ctx.peer).await?;
@@ -613,7 +638,13 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
+        let owner = init_owner(
+            &ctx.peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
 
         coco::control::setup_fixtures(&ctx.peer, &owner).await?;
 
@@ -638,7 +669,13 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
+        let owner = init_owner(
+            &ctx.peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
         coco::control::setup_fixtures(&ctx.peer, &owner).await?;
         let projects = project::Projects::list(&ctx.peer).await?;
         let project = projects.contributed.first().expect("no projects setup");
@@ -666,7 +703,13 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
+        let owner = init_owner(
+            &ctx.peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
         coco::control::setup_fixtures(&ctx.peer, &owner).await?;
         let projects = project::Projects::list(&ctx.peer).await?;
         let project = projects.contributed.first().expect("no projects setup");
@@ -694,7 +737,13 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
+        let owner = init_owner(
+            &ctx.peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
         coco::control::setup_fixtures(&ctx.peer, &owner).await?;
         let projects = project::Projects::list(&ctx.peer).await?;
         let project = projects.contributed.first().expect("no projects setup");

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -761,7 +761,13 @@ mod test {
     }
 
     async fn replicate_platinum(ctx: &context::Unsealed) -> Result<coco::Urn, error::Error> {
-        let owner = coco::state::init_owner(&ctx.peer, "cloudhead".to_string()).await?;
+        let owner = coco::state::init_owner(
+            &ctx.peer,
+            coco::identities::payload::Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
         let platinum_project = coco::control::replicate_platinum(
             &ctx.peer,
             &owner,

--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -30,6 +30,10 @@ mod config;
 mod context;
 pub mod env;
 mod error;
+mod ethereum {
+    pub mod address;
+    pub mod claim_ext;
+}
 mod http;
 mod identity;
 mod notification;

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -95,9 +95,14 @@ pub fn set_settings(store: &kv::Store, settings: settings::Settings) -> Result<(
 /// Panics if anything goes wrong.
 #[cfg(test)]
 pub async fn initialize_test(ctx: &crate::context::Unsealed, owner_handle: &str) -> Session {
-    let owner = coco::state::init_owner(&ctx.peer, owner_handle.to_string())
-        .await
-        .expect("cannot init owner identity");
+    let owner = coco::state::init_owner(
+        &ctx.peer,
+        coco::identities::payload::Person {
+            name: owner_handle.into(),
+        },
+    )
+    .await
+    .expect("cannot init owner identity");
     let identity = (ctx.peer.peer_id(), owner.into_inner().into_inner()).into();
     initialize(&ctx.store, identity, &ctx.default_seeds).expect("failed to initialize session")
 }

--- a/proxy/coco/Cargo.toml
+++ b/proxy/coco/Cargo.toml
@@ -23,6 +23,7 @@ serde_millis = "0.1"
 syntect = "4.2"
 thiserror = "1.0"
 tokio = { version = "1.2", features = [ "macros", "net", "rt-multi-thread", "sync", "time" ] }
+url = "2.1"
 
 [dependencies.kv]
 git = "https://github.com/zshipko/rust-kv.git"

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -25,7 +25,7 @@
 
 pub use librad::{
     git::{self, identities::local::LocalIdentity, include, local::url::LocalUrl, Urn},
-    identities::{Person, Project},
+    identities::{self, Person, Project},
     keys,
     net::{self, discovery},
     paths::Paths,

--- a/proxy/coco/src/peer/announcement.rs
+++ b/proxy/coco/src/peer/announcement.rs
@@ -147,7 +147,7 @@ mod test {
     use librad::{git::Urn, keys::SecretKey, net};
     use radicle_git_ext::{oid, RefLike};
 
-    use crate::{config, signer, state};
+    use crate::{config, identities::payload::Person, signer};
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn announce() -> Result<(), Box<dyn std::error::Error>> {
@@ -159,7 +159,13 @@ mod test {
         let config = config::default(signer.clone(), tmp_dir.path())?;
         let peer = net::peer::Peer::new(config);
 
-        let _owner = state::init_owner(&peer, "cloudhead".to_string()).await?;
+        let _owner = crate::state::init_owner(
+            &peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
 
         // TODO(xla): Build up proper testnet to assert that haves are announced.
         let updates = super::build(&peer).await?;

--- a/proxy/coco/src/source.rs
+++ b/proxy/coco/src/source.rs
@@ -925,7 +925,7 @@ mod tests {
     use librad::{keys::SecretKey, net};
     use radicle_git_ext::Oid;
 
-    use crate::{config, control, signer, state};
+    use crate::{config, control, identities::payload::Person, signer, state};
 
     // TODO(xla): A wise man once said: This probably should be an integration test.
     #[tokio::test]
@@ -938,7 +938,13 @@ mod tests {
         let config = config::default(signer.clone(), tmp_dir.path())?;
         let peer = net::peer::Peer::new(config);
 
-        let owner = state::init_owner(&peer, "cloudhead".to_string()).await?;
+        let owner = crate::state::init_owner(
+            &peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
         let platinum_project = control::replicate_platinum(
             &peer,
             &owner,

--- a/proxy/coco/src/state/error.rs
+++ b/proxy/coco/src/state/error.rs
@@ -8,6 +8,7 @@ use librad::{
     net,
 };
 use radicle_surf::vcs::git::git2;
+use std::convert::Infallible;
 
 use crate::source;
 
@@ -113,6 +114,16 @@ pub enum Error {
         /// The reference that we looked for in the `Storage`.
         reference: Reference<One>,
     },
+
+    /// A document payload extension was malformed
+    #[error(transparent)]
+    MalformedPayloadExt(#[from] librad::identities::payload::ExtError),
+}
+
+impl From<Infallible> for Error {
+    fn from(infallible: Infallible) -> Self {
+        match infallible {}
+    }
 }
 
 /// Re-export the underlying [`storage::Error`] so that consumers don't need to add `librad` as a

--- a/proxy/coco/tests/gossip.rs
+++ b/proxy/coco/tests/gossip.rs
@@ -4,7 +4,13 @@ use assert_matches::assert_matches;
 use futures::{future, StreamExt as _};
 use tokio::time::timeout;
 
-use coco::{peer::run_config, seed::Seed, state, RunConfig};
+use coco::{
+    identities::payload::Person,
+    peer::run_config,
+    seed::Seed,
+    state::{self, init_owner},
+    RunConfig,
+};
 
 #[macro_use]
 mod common;
@@ -30,7 +36,13 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
     )
     .await?;
     let alice_peer_id = alice_peer.peer.peer_id();
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
@@ -64,7 +76,7 @@ async fn can_observe_announcement_from_connected_peer() -> Result<(), Box<dyn st
 
         peer
     };
-    let _bob = state::init_owner(&bob_peer, "bob".to_string()).await?;
+    let _bob = init_owner(&bob_peer, Person { name: "bob".into() }).await?;
     connected(bob_connected, 1).await?;
 
     let project =
@@ -94,7 +106,13 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     let alice_repo_path = alice_tmp_dir.path().join("radicle");
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
     let alice_peer_id = alice_peer.peer.peer_id();
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
     let mut alice_events = alice_peer.subscribe();
 
     let (alice_peer, alice_addrs) = {
@@ -120,7 +138,7 @@ async fn can_ask_and_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
     let bob_peer_id = bob_peer.peer.peer_id();
 
-    state::init_owner(&bob_peer.peer, "bob".to_string()).await?;
+    init_owner(&bob_peer.peer, Person { name: "bob".into() }).await?;
     let bob_events = bob_peer.subscribe();
     let mut bob_control = bob_peer.control();
     let clone_listener = bob_peer.subscribe();

--- a/proxy/coco/tests/replication.rs
+++ b/proxy/coco/tests/replication.rs
@@ -15,9 +15,12 @@ use librad::{
 use radicle_git_ext::RefLike;
 
 use coco::{
+    identities::payload::Person,
     project::{peer, Peer},
     seed::Seed,
-    state, RunConfig,
+    state,
+    state::init_owner,
+    RunConfig,
 };
 
 #[macro_use]
@@ -33,11 +36,17 @@ async fn can_clone_project() -> Result<(), Box<dyn std::error::Error>> {
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_repo_path = alice_tmp_dir.path().join("radicle");
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let bob_tmp_dir = tempfile::tempdir()?;
     let bob_peer = build_peer(&bob_tmp_dir, RunConfig::default()).await?;
-    let _bob = state::init_owner(&bob_peer.peer, "bob".to_string()).await?;
+    let _bob = init_owner(&bob_peer.peer, Person { name: "bob".into() }).await?;
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
@@ -109,7 +118,13 @@ async fn can_clone_user() -> Result<(), Box<dyn std::error::Error>> {
 
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let bob_tmp_dir = tempfile::tempdir()?;
     let bob_peer = build_peer(&bob_tmp_dir, RunConfig::default()).await?;
@@ -157,11 +172,17 @@ async fn can_fetch_project_changes() -> Result<(), Box<dyn std::error::Error>> {
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_repo_path = alice_tmp_dir.path().join("radicle");
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let bob_tmp_dir = tempfile::tempdir()?;
     let bob_peer = build_peer(&bob_tmp_dir, RunConfig::default()).await?;
-    let _bob = state::init_owner(&bob_peer.peer, "bob".to_string()).await?;
+    let _bob = init_owner(&bob_peer.peer, Person { name: "bob".into() }).await?;
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
@@ -331,8 +352,14 @@ async fn can_sync_on_startup() -> Result<(), Box<dyn std::error::Error>> {
     };
     let bob_peer_id = bob_peer.peer_id();
 
-    let alice = state::init_owner(&alice_peer, "alice".to_string()).await?;
-    let _bob = state::init_owner(&bob_peer, "bob".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
+    let _bob = init_owner(&bob_peer, Person { name: "bob".into() }).await?;
     state::init_project(
         &alice_peer,
         &alice,
@@ -357,17 +384,23 @@ async fn can_create_working_copy_of_peer() -> Result<(), Box<dyn std::error::Err
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_repo_path = alice_tmp_dir.path().join("radicle");
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let bob_tmp_dir = tempfile::tempdir()?;
     let bob_repo_path = bob_tmp_dir.path().join("radicle");
     let bob_peer = build_peer(&bob_tmp_dir, RunConfig::default()).await?;
-    let bob = state::init_owner(&bob_peer.peer, "bob".to_string()).await?;
+    let bob = init_owner(&bob_peer.peer, Person { name: "bob".into() }).await?;
 
     let eve_tmp_dir = tempfile::tempdir()?;
     let eve_repo_path = eve_tmp_dir.path().join("radicle");
     let eve_peer = build_peer(&eve_tmp_dir, RunConfig::default()).await?;
-    let _eve = state::init_owner(&eve_peer.peer, "eve".to_string()).await?;
+    let _eve = init_owner(&eve_peer.peer, Person { name: "eve".into() }).await?;
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();
@@ -497,7 +530,13 @@ async fn track_peer() -> Result<(), Box<dyn std::error::Error>> {
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_repo_path = alice_tmp_dir.path().join("radicle");
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
     let mut alice_events = alice_peer.subscribe();
 
     let (alice_peer, alice_addrs) = {
@@ -521,7 +560,7 @@ async fn track_peer() -> Result<(), Box<dyn std::error::Error>> {
         RunConfig::default(),
     )
     .await?;
-    let _bob = state::init_owner(&bob_peer.peer, "bob".to_string()).await?;
+    let _bob = init_owner(&bob_peer.peer, Person { name: "bob".into() }).await?;
 
     let bob_peer = {
         let peer = bob_peer.peer.clone();

--- a/proxy/coco/tests/source.rs
+++ b/proxy/coco/tests/source.rs
@@ -1,7 +1,11 @@
 use nonempty::NonEmpty;
 use pretty_assertions::assert_eq;
 
-use coco::{state, RunConfig};
+use coco::{
+    identities::payload::Person,
+    state::{self, init_owner},
+    RunConfig,
+};
 
 mod common;
 use common::{build_peer, init_logging, shia_le_pathbuf, started};
@@ -14,11 +18,17 @@ async fn can_browse_peers_branch() -> Result<(), Box<dyn std::error::Error + 'st
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_repo_path = alice_tmp_dir.path().join("radicle");
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let bob_tmp_dir = tempfile::tempdir()?;
     let bob_peer = build_peer(&bob_tmp_dir, RunConfig::default()).await?;
-    let _bob = state::init_owner(&bob_peer.peer, "bob".to_string()).await?;
+    let _bob = init_owner(&bob_peer.peer, Person { name: "bob".into() }).await?;
 
     let (alice_peer, alice_addrs) = {
         let peer = alice_peer.peer.clone();

--- a/proxy/coco/tests/working_copy.rs
+++ b/proxy/coco/tests/working_copy.rs
@@ -1,4 +1,9 @@
-use coco::{project::checkout, state, RunConfig};
+use coco::{
+    identities::payload::Person,
+    project::checkout,
+    state::{self, init_owner},
+    RunConfig,
+};
 
 use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
@@ -13,7 +18,13 @@ async fn upstream_for_default() -> Result<(), Box<dyn std::error::Error>> {
 
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let alice_peer = {
         let peer = alice_peer.peer.clone();
@@ -43,7 +54,13 @@ async fn checkout_twice_fails() -> Result<(), Box<dyn std::error::Error>> {
 
     let alice_tmp_dir = tempfile::tempdir()?;
     let alice_peer = build_peer(&alice_tmp_dir, RunConfig::default()).await?;
-    let alice = state::init_owner(&alice_peer.peer, "alice".to_string()).await?;
+    let alice = init_owner(
+        &alice_peer.peer,
+        Person {
+            name: "alice".into(),
+        },
+    )
+    .await?;
 
     let alice_peer = {
         let peer = alice_peer.peer.clone();


### PR DESCRIPTION
The first step of adding Ethereum attestations to the backend. Allows setting a claim when creating a new identity and returns it when queried. There's no update feature yet, that's to be built on top of this PR when it's ok.

The RFC has been reviewed before, so it should be fine as it is, it's only updated for the updated `Claims` contract. Putting it here feels right, 98% of its implementation resides here, but I'm fine with moving it somewhere else.