### PR TITLE
refactor(ui): download twemoji assets directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "_private:rollup:build": "rollup -c --failAfterWarnings",
     "_private:rollup:build:release": "ROLLUP_RELEASE=true rollup -c --failAfterWarnings",
     "_private:rollup:watch": "rollup -c -w",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package && scripts/install-twemoji-assets.sh"
   },
   "dependencies": {
     "@types/big.js": "^6.0.2",
@@ -175,8 +175,7 @@
     "semver": "^7.3.4",
     "svelte-persistent-store": "^0.1.6",
     "timeago.js": "^4.0.2",
-    "twemoji": "13.0.1",
-    "twemoji-svg-assets": "git+https://github.com/radicle-dev/twemoji-svg-assets.git#v13.0.1",
+    "twemoji": "13.0.2",
     "uuid": "^8.3.0",
     "validate.js": "^0.13.1"
   },

--- a/scripts/install-twemoji-assets.sh
+++ b/scripts/install-twemoji-assets.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Download the Twemoji SVGs and put them into public/twemoji
+
+set -Eeou pipefail
+
+version="$(yarn --silent info twemoji version)"
+
+echo "Installing Twemoji SVG assets v${version}"
+
+curl -sSL "https://github.com/twitter/twemoji/archive/refs/tags/v${version}.tar.gz" \
+  | tar -x -z -C public/twemoji/ --strip-components=3 "twemoji-${version}/assets/svg"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9152,14 +9152,10 @@ twemoji-parser@13.0.0:
   resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-13.0.0.tgz#bd9d1b98474f1651dc174696b45cabefdfa405af"
   integrity sha512-zMaGdskpH8yKjT2RSE/HwE340R4Fm+fbie4AaqjDa4H/l07YUmAvxkSfNl6awVWNRRQ0zdzLQ8SAJZuY5MgstQ==
 
-"twemoji-svg-assets@git+https://github.com/radicle-dev/twemoji-svg-assets.git#v13.0.1":
-  version "13.0.1"
-  resolved "git+https://github.com/radicle-dev/twemoji-svg-assets.git#d5118e43f8cf01de6db52448e2fba3d059979fc1"
-
-twemoji@13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-13.0.1.tgz#57ddc8bd86c8175c11376f5f9ab322a02e739c2d"
-  integrity sha512-mrTBq+XpCLM4zm76NJOjLHoQNV9mHdBt3Cba/T5lS1rxn8ArwpqE47mqTocupNlkvcLxoeZJjYSUW0DU5ZwqZg==
+twemoji@13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-13.0.2.tgz#e7ee8d26fd0ccc23a0afe68c7b7e61bd8d14ad24"
+  integrity sha512-R9tDS4pEVczjVYM5SvoAJ0AcZ4EgG1h3yw1oi1m/yrXOH17OOjaaRxZU4r5TIHEy3xYbuZQLB/tJZyC6rpQVmA==
   dependencies:
     fs-extra "^8.0.1"
     jsonfile "^5.0.0"


### PR DESCRIPTION
Instead of using our own `twemoji-svg-assets` package we download the assets directly as part of the `postinstall` scripts.

This has two advantages: First, we don’t need to maintain a separate package. Second, this removes a blocker of the [upgrade to Yarn v2][yv2]. Our `twemoji-svg-asstest` package copied the assets as part of *its* [post-install script][pis]. This only works under certain assumptions about the directory layout which don’t hold for Yarn v2.

[pis]: https://github.com/radicle-dev/twemoji-svg-assets/blob/master/package.json#L10
[yv2]: https://github.com/radicle-dev/radicle-upstream/issues/1687