### PR TITLE
fix(ci): run-p --race kills process

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -4,33 +4,27 @@ FROM debian:buster-slim
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+    build-essential \
     ca-certificates \
     clang \
     curl \
-    gcc \
     git \
     jq \
-    libc6-dev \
     libssl-dev \
-    make \
-    pkg-config
+    pkg-config \
+    procps
 
 # install cypress deps
 RUN apt-get -y install --no-install-recommends autoconf git nettle-dev m4 gnupg xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 
-# install npm
-RUN curl -sfLS https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get -y update
-RUN apt-get -y --no-install-recommends install build-essential nodejs
-
-# install yarn
-RUN curl -sfLS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get -y update
-RUN apt-get -y --no-install-recommends install yarn
-
-RUN apt-get autoremove; \
-    rm -rf /var/lib/apt/lists/*
+# install node and yarn
+RUN set -eux; \
+  curl -sfLS https://deb.nodesource.com/setup_14.x | bash -; \
+  apt-get -y update; \
+  apt-get -y --no-install-recommends install nodejs; \
+  apt-get autoremove; \
+  rm -rf /var/lib/apt/lists/*; \
+  npm install --global yarn;
 
 # Rust toolchain
 # Make sure this is in sync with rust-toolchain!

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@
     platform: "linux"
   timeout_in_minutes: 60
   env:
-    DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.6.0"
+    DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.7.0"
     SHARED_MASTER_CACHE: true
   artifact_paths:
     - "dist/*.AppImage"

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "reset:state": "scripts/reset-state.sh",
     "_private:start": "yarn _private:proxy:build:release && yarn run-p --race _private:rollup:watch _private:electron:start",
     "_private:start:dev": "yarn _private:proxy:build && yarn run-p --race _private:rollup:watch _private:electron:start",
-    "_private:test:integration": "wait-on tcp:17246 && yarn _private:rollup:build && yarn run cypress run; status=$?; [ \"$CI\" = true ] && kill `pidof radicle-proxy`; exit $status",
+    "_private:test:integration": "wait-on tcp:17246 && yarn _private:rollup:build && yarn run cypress run",
     "_private:test:integration:debug": "wait-on ./public/bundle.js tcp:17246 && yarn run cypress open",
     "_private:electron:start": "wait-on ./public/bundle.js ./native/main.comp.js && NODE_ENV=development electron .",
     "_private:dist:clean": "rm -rf ./dist && mkdir ./dist",


### PR DESCRIPTION
Before `run-p --race` did not kill processes on CI and we had to to this manually. The reason for this behavior was that the `ps` binary was not installed. We fix that by installing the `procps` package. Having `ps` in the image is also useful for debugging.

We also take the opportunity to clean up the Dockerfile a bit.
* We move the `build-essential` package to the top and stop listing its dependencies (like gcc) explicitly.
* We install `yarn` via `npm` instead of a debian package