### PR TITLE
fix(test): isolate git config in cypress tests

### DIFF
--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -66,6 +66,7 @@ git commit --allow-empty -m "${options.subject}"
 git -c credential.helper=${credentialsHelper(options.passphrase)} push rad`,
     {
       env: {
+        HOME: options.radHome,
         RAD_HOME: options.radHome,
         GIT_AUTHOR_NAME: options.name || "John McPipefail",
         GIT_AUTHOR_EMAIL: options.email || "john@mcpipefail.com",


### PR DESCRIPTION
We provide better isolation for git commands run in tests. This fixes the tests for developers who have GPG configured. Backports #1631