### PR TITLE
fix(build): don't crash app on typescript error

### DIFF
--- a/rollup.app.js
+++ b/rollup.app.js
@@ -64,10 +64,7 @@ export default {
       },
     },
 
-    typescript({
-      // See https://github.com/rollup/plugins/issues/272
-      noEmitOnError: watch,
-    }),
+    typescript(),
 
     // Watch the `public` directory and refresh the
     // browser on changes when not in production

--- a/rollup.electron.js
+++ b/rollup.electron.js
@@ -2,8 +2,6 @@ import commonjs from "@rollup/plugin-commonjs";
 import externals from "rollup-plugin-node-externals";
 import typescript from "@rollup/plugin-typescript";
 
-const production = !process.env.ROLLUP_WATCH;
-
 export default {
   input: "native/main.ts",
   output: {
@@ -14,11 +12,7 @@ export default {
   plugins: [
     commonjs(),
 
-    typescript({
-      // See https://github.com/rollup/plugins/issues/272
-      noEmitOnError: production,
-      module: "es6",
-    }),
+    typescript(),
 
     // This avoids the following warning:
     //


### PR DESCRIPTION
Before, the `noEmitOnError` option for the rollup typescript plugin was inadvertently set to `true` in development mode. This lead to the watcher exiting when a type error was encountered and this tore down the whole app. We always fallback to the default `false` now.