### PR TITLE
feat(proxy): add PUT identity metadata endpoint

### DIFF
--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -8,6 +8,7 @@ use crate::{context, http};
 pub fn filters(ctx: context::Context) -> BoxedFilter<(impl Reply,)> {
     get_filter(ctx.clone())
         .or(create_filter(ctx.clone()))
+        .or(update_filter(ctx.clone()))
         .or(list_filter(ctx))
         .boxed()
 }
@@ -21,6 +22,17 @@ fn create_filter(
         .and(http::with_context_unsealed(ctx))
         .and(warp::body::json())
         .and_then(handler::create)
+}
+
+/// `PUT /`
+fn update_filter(
+    ctx: context::Context,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path::end()
+        .and(warp::put())
+        .and(http::with_context_unsealed(ctx))
+        .and(warp::body::json())
+        .and_then(handler::update)
 }
 
 /// `GET /<id>`
@@ -48,7 +60,7 @@ fn list_filter(
 mod handler {
     use warp::{http::StatusCode, reply, Rejection, Reply};
 
-    use crate::{context, error, identity, session};
+    use crate::{context, error, http, identity, session};
 
     /// Create a new [`identity::Identity`].
     pub async fn create(
@@ -66,6 +78,18 @@ mod handler {
         session::initialize(&ctx.store, id.clone(), &ctx.default_seeds)?;
 
         Ok(reply::with_status(reply::json(&id), StatusCode::CREATED))
+    }
+
+    /// Update the [`identity::Identity`] metadata.
+    pub async fn update(
+        ctx: context::Unsealed,
+        metadata: identity::Metadata,
+    ) -> Result<impl Reply, Rejection> {
+        session::get_current(&ctx.store)?.ok_or(http::error::Routing::NoSession)?;
+        let id = identity::update(&ctx.peer, metadata).await?;
+        session::update_identity(&ctx.store, id.clone())?;
+
+        Ok(reply::with_status(reply::json(&id), StatusCode::OK))
     }
 
     /// Get the [`identity::Identity`] for the given `id`.
@@ -153,6 +177,163 @@ mod test {
                             "address": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
                             "expiration": "2021-03-19T23:15:30.001Z",
                         }
+                    },
+                    "shareableEntityIdentifier": &shareable_entity_identifier,
+                })
+            );
+        });
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update() -> Result<(), error::Error> {
+        let tmp_dir = tempfile::tempdir()?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
+        let api = super::filters(ctx.clone().into());
+
+        let res = request()
+            .method("POST")
+            .path("/")
+            .json(&identity::Metadata {
+                handle: "cloudhead".into(),
+                ethereum: None,
+            })
+            .reply(&api)
+            .await;
+        http::test::assert_response(&res, StatusCode::CREATED, |_| ());
+
+        let res = request()
+            .method("PUT")
+            .path("/")
+            .json(&identity::Metadata {
+                handle: "cloudhead_next".into(),
+                ethereum: Some(identity::Ethereum {
+                    address: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                        .to_string()
+                        .try_into()
+                        .expect("Invalid address"),
+                    expiration: "2021-03-19T23:15:30.001Z".parse().expect("Invalid date"),
+                }),
+            })
+            .reply(&api)
+            .await;
+
+        let urn = {
+            let session = session::get_current(&ctx.store)?.expect("no session exists");
+            session.identity.urn
+        };
+
+        let peer_id = ctx.peer.peer_id();
+
+        // Assert that we set the default owner and it's the same one as the session
+        {
+            assert_eq!(
+                coco::state::default_owner(&ctx.peer)
+                    .await?
+                    .unwrap()
+                    .into_inner()
+                    .into_inner(),
+                coco::state::get_user(&ctx.peer, urn.clone())
+                    .await?
+                    .unwrap()
+                    .into_inner()
+                    .into_inner()
+            );
+        }
+
+        http::test::assert_response(&res, StatusCode::OK, |have| {
+            let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
+            let shareable_entity_identifier = format!("cloudhead_next@{}", peer_id);
+            assert_eq!(
+                have,
+                json!({
+                    "peerId": peer_id,
+                    "avatarFallback": avatar,
+                    "urn": urn,
+                    "metadata": {
+                        "handle": "cloudhead_next",
+                        "ethereum": {
+                            "address": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+                            "expiration": "2021-03-19T23:15:30.001Z",
+                        }
+                    },
+                    "shareableEntityIdentifier": &shareable_entity_identifier,
+                })
+            );
+        });
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_remove_ethereum_claim() -> Result<(), error::Error> {
+        let tmp_dir = tempfile::tempdir()?;
+        let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
+        let api = super::filters(ctx.clone().into());
+
+        let res = request()
+            .method("POST")
+            .path("/")
+            .json(&identity::Metadata {
+                handle: "cloudhead".into(),
+                ethereum: Some(identity::Ethereum {
+                    address: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                        .to_string()
+                        .try_into()
+                        .expect("Invalid address"),
+                    expiration: "2021-03-19T23:15:30.001Z".parse().expect("Invalid date"),
+                }),
+            })
+            .reply(&api)
+            .await;
+        http::test::assert_response(&res, StatusCode::CREATED, |_| ());
+
+        let res = request()
+            .method("PUT")
+            .path("/")
+            .json(&identity::Metadata {
+                handle: "cloudhead".into(),
+                ethereum: None,
+            })
+            .reply(&api)
+            .await;
+
+        let urn = {
+            let session = session::get_current(&ctx.store)?.expect("no session exists");
+            session.identity.urn
+        };
+
+        let peer_id = ctx.peer.peer_id();
+
+        // Assert that we set the default owner and it's the same one as the session
+        {
+            assert_eq!(
+                coco::state::default_owner(&ctx.peer)
+                    .await?
+                    .unwrap()
+                    .into_inner()
+                    .into_inner(),
+                coco::state::get_user(&ctx.peer, urn.clone())
+                    .await?
+                    .unwrap()
+                    .into_inner()
+                    .into_inner()
+            );
+        }
+
+        http::test::assert_response(&res, StatusCode::OK, |have| {
+            let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
+            let shareable_entity_identifier = format!("cloudhead@{}", peer_id);
+            assert_eq!(
+                have,
+                json!({
+                    "peerId": peer_id,
+                    "avatarFallback": avatar,
+                    "urn": urn,
+                    "metadata": {
+                        "handle": "cloudhead",
+                        "ethereum": null
                     },
                     "shareableEntityIdentifier": &shareable_entity_identifier,
                 })

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -74,6 +74,23 @@ pub fn initialize(
     Ok(session)
 }
 
+/// Update the current session with the given identity.
+/// Does nothing if there is no session yet.
+///
+/// # Errors
+///
+/// * Errors when we cannot write to the store.
+pub fn update_identity(
+    store: &kv::Store,
+    identity: identity::Identity,
+) -> Result<(), error::Error> {
+    if let Some(mut session) = get_current(store)? {
+        session.identity = identity;
+        set_current(store, session)?
+    }
+    Ok(())
+}
+
 /// Update the session settings. Does nothing if there is no session yet.
 ///
 /// # Errors

--- a/proxy/coco/src/state.rs
+++ b/proxy/coco/src/state.rs
@@ -66,13 +66,7 @@ where
 ///   * Loading the `LocalIdentity` failed
 pub async fn default_owner(peer: &Peer<BoxedSigner>) -> Result<Option<LocalIdentity>, Error> {
     Ok(peer
-        .using_storage(move |store| {
-            if let Some(urn) = store.config()?.user()? {
-                return local::load(store, urn).map_err(Error::from);
-            }
-
-            Ok::<_, Error>(None)
-        })
+        .using_storage(move |store| local::default(store))
         .await??)
 }
 
@@ -103,40 +97,46 @@ where
     P: TryInto<PersonPayload> + Send,
     Error: From<P::Error>,
 {
-    match peer
-        .using_storage(move |store| local::default(store))
-        .await??
-    {
-        Some(owner) => Ok(owner),
-        None => {
-            let pk = keys::PublicKey::from(peer.signer().public_key());
-            let payload = payload.try_into()?;
-            let person = peer
-                .using_storage(move |store| {
-                    person::create(store, payload, Some(pk).into_iter().collect())
-                })
-                .await??;
-
-            let urn = person.urn();
-            let owner = peer
-                .using_storage(move |store| local::load(store, urn))
-                .await??
-                .ok_or_else(|| Error::PersonNotFound(person.urn()))?;
-
-            {
-                let owner = owner.clone();
-                peer.using_storage(move |store| {
-                    let mut config = store.config()?;
-                    config.set_user(owner)?;
-
-                    Ok::<_, Error>(())
-                })
-                .await??;
-            }
-
-            Ok(owner)
-        },
+    if let Some(owner) = default_owner(peer).await? {
+        return Ok(owner);
     }
+
+    let payload = payload.try_into()?;
+    let pk = keys::PublicKey::from(peer.signer().public_key());
+    let delegations = Some(pk).into_iter().collect();
+    let person = peer
+        .using_storage(move |store| person::create(store, payload, delegations))
+        .await??;
+
+    let urn = person.urn();
+    let owner = peer
+        .using_storage(move |store| local::load(store, urn))
+        .await??
+        .ok_or_else(|| Error::PersonNotFound(person.urn()))?;
+
+    set_default_owner(peer, owner.clone()).await?;
+
+    Ok(owner)
+}
+
+/// Sets a new person payload for the default owner of this [`Peer`].
+///
+/// # Errors
+///
+///   * Fails to load the default owner
+///   * Fails to verify `User`.
+///   * Fails to set the default `rad/self` for this `PeerApi`.
+#[allow(clippy::single_match_else)]
+pub async fn update_owner_payload<P>(peer: &Peer<BoxedSigner>, payload: P) -> Result<(), Error>
+where
+    P: TryInto<PersonPayload> + Send,
+    Error: From<P::Error>,
+{
+    let urn = default_owner(peer).await?.ok_or(Error::MissingOwner)?.urn();
+    let payload = payload.try_into()?;
+    peer.using_storage(move |store| person::update(store, &urn, None, payload, None))
+        .await??;
+    Ok(())
 }
 
 /// Given some hints as to where you might find it, get the urn of the project found at `url`.
@@ -880,11 +880,27 @@ fn role(
 #[allow(clippy::panic, clippy::unwrap_used)]
 #[cfg(test)]
 pub mod test {
-    use std::{env, path::PathBuf};
-
+    use crate::{config, identities::payload::HasNamespace, project, signer};
+    use lazy_static::lazy_static;
     use librad::{git_ext::OneLevel, identities::payload::Person, keys::SecretKey, net, reflike};
+    use serde::{Deserialize, Serialize};
+    use std::{env, path::PathBuf};
+    use url::Url;
 
-    use crate::{config, project, signer};
+    #[derive(Deserialize, Serialize)]
+    struct TestExt(String);
+
+    lazy_static! {
+        static ref NAMESPACE: Url = "https://radicle.xyz/test"
+            .parse()
+            .expect("Static URL malformed");
+    }
+
+    impl HasNamespace for TestExt {
+        fn namespace() -> &'static Url {
+            &NAMESPACE
+        }
+    }
 
     fn fakie_project(path: PathBuf) -> project::Create {
         project::Create {
@@ -957,6 +973,66 @@ pub mod test {
         let annie = super::init_user(&peer, "annie_are_you_ok?".to_string()).await;
         assert!(annie.is_ok());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_init_owner() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = signer::BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config);
+        let payload = super::PersonPayload::new(Person {
+            name: "cloudhead".into(),
+        })
+        .with_ext(TestExt("test".to_string()))?;
+
+        super::init_owner(&peer, payload).await?;
+
+        peer.using_storage(|storage| {
+            assert_eq!(
+                storage.config()?.user_name()?,
+                "cloudhead",
+                "Invalid config user name"
+            );
+            Ok::<_, super::Error>(())
+        })
+        .await??;
+        let owner = super::default_owner(&peer).await?.expect("No owner set");
+        assert_eq!(*owner.subject().name, "cloudhead", "Invalid owner name");
+        let ext: TestExt = owner.payload().get_ext()?.expect("No owner extension");
+        assert_eq!(ext.0, "test", "Invalid owner extension");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_update_owner_payload() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = signer::BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config);
+        let payload = super::PersonPayload::new(Person {
+            name: "cloudhead".into(),
+        })
+        .with_ext(TestExt("test".to_string()))?;
+        super::init_owner(&peer, payload).await?;
+        let new_payload = super::PersonPayload::new(Person {
+            name: "cloudhead_next".into(),
+        })
+        .with_ext(TestExt("test_next".to_string()))?;
+
+        super::update_owner_payload(&peer, new_payload).await?;
+
+        let owner = super::default_owner(&peer).await?.expect("No owner set");
+        assert_eq!(
+            *owner.subject().name,
+            "cloudhead_next",
+            "Invalid owner name"
+        );
+        let ext: TestExt = owner.payload().get_ext()?.expect("No owner extension");
+        assert_eq!(ext.0, "test_next", "Invalid owner extension");
         Ok(())
     }
 


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-upstream/issues/965. Adds an API endpoint for updating the user payload. This allows updating the ethereum claims and as a byproduct also changing the user handle.