### PR TITLE
refactor(proxy): fair select on subroutines

### DIFF
--- a/proxy/coco/src/peer.rs
+++ b/proxy/coco/src/peer.rs
@@ -151,7 +151,7 @@ where
         let (addrs_tx, addrs_rx) = watch::channel(vec![]);
 
         let protocol_events = peer.subscribe().boxed();
-        let mut subroutines = Subroutines::new(
+        let subroutines = Subroutines::new(
             peer.clone(),
             addrs_rx,
             store,
@@ -160,6 +160,8 @@ where
             subscriber,
             control_receiver,
         )
+        .run()
+        .fuse()
         .map_err(Error::Join);
 
         let protocol = async move {
@@ -188,6 +190,8 @@ where
             }
         }
         .fuse();
+
+        futures::pin_mut!(subroutines);
         futures::pin_mut!(protocol);
 
         futures::select! {


### PR DESCRIPTION
We replace the custom `Future` implementation for `Subroutines` with a simple `run()` function that uses `futures::select`. One important consequence is that now `Subroutines::inputs` and `Subroutines::pending_tasks` are polled fairly. Before `Spending_tasks` was preferred and we tried to drain it which could lead to a delay in the handling of `inputs`. (This could be the cause for #1378.)