### PR TITLE
fix(build): fix macOS notarization bundle identifier

### DIFF
--- a/builder/notarize.js
+++ b/builder/notarize.js
@@ -1,4 +1,5 @@
 const { notarize } = require("electron-notarize");
+const appId = require("../package.json").build.appId;
 
 exports.default = async function notarizeApp(context) {
   if (process.env.NOTARIZE !== "true") {
@@ -21,8 +22,12 @@ exports.default = async function notarizeApp(context) {
     );
   }
 
+  if (!(typeof appId === "string" && appId.length > 0)) {
+    throw new Error("build.appId must be set in package.json!");
+  }
+
   return await notarize({
-    appBundleId: process.env.npm_package_build_appId,
+    appBundleId: appId,
     appPath: `${context.appOutDir}/${context.packager.appInfo.productFilename}.app`,
     appleId: process.env.APPLE_ID,
     appleIdPassword: process.env.APPLE_ID_PASSWORD,


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/radicle-dev/radicle-upstream/commit/4ab47ce13bde63c3d6fb7122936002a93d045253.

| Before | After |
|--------|------|
| <img width="661" alt="Screenshot 2021-03-30 at 10 59 12" src="https://user-images.githubusercontent.com/158411/112968137-49679800-914c-11eb-8c06-56c9ed31232f.png"> | <img width="619" alt="Screenshot 2021-03-30 at 10 59 17" src="https://user-images.githubusercontent.com/158411/112968140-4a98c500-914c-11eb-9f6a-9b1c410e52d5.png"> |
