### PR TITLE
fix: make reset script backwards compatible

### DIFF
--- a/scripts/reset-state.sh
+++ b/scripts/reset-state.sh
@@ -7,6 +7,7 @@ if [ "$platform" == "Darwin" ]; then
     dirs=(
         "$HOME/.radicle"
         "$HOME/Library/Application Support/Radicle Upstream"
+        "$HOME/Library/Application Support/xyz.radicle.radicle"
         "$HOME/Library/Application Support/xyz.radicle.radicle-link"
         "$HOME/Library/Application Support/xyz.radicle.radicle-upstream"
         "$HOME/Library/Preferences/xyz.radicle.radicle-upstream.plist"
@@ -18,8 +19,10 @@ elif [ "$platform" == "Linux" ]; then
 
     dirs=(
         "$HOME/.radicle"
+        "$config_home/radicle"
         "$config_home/radicle-link"
         "$config_home/Radicle Upstream"
+        "$data_home/radicle"
         "$data_home/radicle-link"
         "$data_home/radicle-upstream"
     );


### PR DESCRIPTION
Before Upstream 0.2.0 radicle-link used a different location to store its data,
since all our documentation links to the `reset.sh` script on the `master`
branch of this repository, the script wouldn't reset all the state leading to
the following error:

```
{
  "code": "create-identity-failed",
  "message": "Could not create identity",
  "details": {
    "handle": "rudolfs"
  },
  "source": {
    "code": "UnknownException",
    "message": "A key already exists",
    "details": {
      "message": "A key already exists",
      "variant": "KEY_EXISTS"
    }
  }
}
```

With this fix we allow users to reset any Upstream version.

Signed-off-by: Rūdolfs Ošiņš <rudolfs@osins.org>