### PR TITLE
move identifier

### DIFF
--- a/proxy/api/src/identifier.rs
+++ b/proxy/api/src/identifier.rs
@@ -1,18 +1,18 @@
-//! An `Identifier` is the combination of a user handle and the [`librad::git::Urn`] that
+//! An `Identifier` is the combination of a user handle and the [`coco::PeerId`] that
 //! identifies the user.
 
 use std::{fmt, str::FromStr};
 
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-use librad::{identities::Person, peer};
+use coco::{identities::Person, PeerId};
 
 /// Errors captured when parsing a shareable identifier of the form `<handle>@<urn>`.
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
     /// Could not parse the URN portion of the identifier.
     #[error(transparent)]
-    Peer(#[from] peer::conversion::Error),
+    Peer(#[from] coco::conversion::Error),
     /// The identifier contained more than one '@' symbol.
     #[error("shared identifier contains more than one '@' symbol")]
     AtSplitError,
@@ -30,11 +30,11 @@ pub struct Identifier {
     /// The user's chosen handle.
     pub handle: String,
     /// The unique identifier of the user.
-    pub peer_id: peer::PeerId,
+    pub peer_id: PeerId,
 }
 
-impl From<(peer::PeerId, Person)> for Identifier {
-    fn from((peer_id, user): (peer::PeerId, Person)) -> Self {
+impl From<(PeerId, Person)> for Identifier {
+    fn from((peer_id, user): (PeerId, Person)) -> Self {
         Self {
             handle: user.subject().name.to_string(),
             peer_id,

--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -14,6 +14,7 @@ use coco::{
 use crate::{
     error,
     ethereum::{address::Address, claim_ext::V1 as EthereumClaimExtV1},
+    identifier::Identifier,
 };
 
 use std::convert::TryFrom;
@@ -27,7 +28,7 @@ pub struct Identity {
     /// The coco URN.
     pub urn: coco::Urn,
     /// Unambiguous identifier pointing at this identity.
-    pub shareable_entity_identifier: coco::Identifier,
+    pub shareable_entity_identifier: Identifier,
     /// Bundle of user provided data.
     pub metadata: Metadata,
     /// Generated fallback avatar to be used if actual avatar url is missing or can't be loaded.
@@ -49,7 +50,7 @@ impl From<(coco::PeerId, coco::Person)> for Identity {
         Self {
             peer_id,
             urn: urn.clone(),
-            shareable_entity_identifier: coco::Identifier {
+            shareable_entity_identifier: Identifier {
                 handle: handle.clone(),
                 peer_id,
             },

--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -35,6 +35,7 @@ mod ethereum {
     pub mod claim_ext;
 }
 mod http;
+mod identifier;
 mod identity;
 mod notification;
 mod process;

--- a/proxy/coco/src/lib.rs
+++ b/proxy/coco/src/lib.rs
@@ -29,7 +29,7 @@ pub use librad::{
     keys,
     net::{self, discovery},
     paths::Paths,
-    peer::PeerId,
+    peer::{conversion, PeerId},
     profile, signer,
 };
 
@@ -46,8 +46,6 @@ pub mod config;
 pub mod control;
 pub mod convert;
 pub mod git_helper;
-mod identifier;
-pub use identifier::Identifier;
 pub mod keystore;
 pub mod peer;
 pub use peer::{Control as PeerControl, Event as PeerEvent, Peer, RunConfig, Status as PeerStatus};


### PR DESCRIPTION
I found the identifier module lying around in coco. I don't think it
needs to be there so I'm moving to api for now.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>