### PR TITLE
fix(ui): don't leak store subscriptions

### DIFF
--- a/ui/Screen/Funding/Pool/Outgoing/Support.svelte
+++ b/ui/Screen/Funding/Pool/Outgoing/Support.svelte
@@ -1,4 +1,5 @@
-<script lang="ts">
+<script lang="typescript">
+  import { onMount } from "svelte";
   import { Button, Icon, Input } from "../../../../DesignSystem/Primitive";
   import { Dai, Remote, TxButton } from "../../../../DesignSystem/Component";
 
@@ -55,16 +56,18 @@
   }
 
   let data: fundingPool.PoolData;
-  pool.data.subscribe(store => {
-    if (store.status === remote.Status.Success) {
-      data = store.data;
-      if (!editing) {
-        budget = data.weeklyBudget.toString();
-        receivers = new Map(data.receivers);
+  onMount(() =>
+    pool.data.subscribe(store => {
+      if (store.status === remote.Status.Success) {
+        data = store.data;
+        if (!editing) {
+          budget = data.weeklyBudget.toString();
+          receivers = new Map(data.receivers);
+        }
+        paused = data.balance.lte(data.weeklyBudget) || data.weeklyBudget.eq(0);
       }
-      paused = data.balance.lte(data.weeklyBudget) || data.weeklyBudget.eq(0);
-    }
-  });
+    })
+  );
 
   $: thereAreChanges =
     fundingPool.isValidBig(budget) &&

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-  import { getContext } from "svelte";
+  import { onMount, getContext } from "svelte";
   import { push } from "svelte-spa-router";
 
   import * as localPeer from "../src/localPeer";
@@ -44,14 +44,15 @@
     selectPeer(peer);
   };
 
-  localPeer.projectEvents.subscribe(event => {
-    if (!event) {
-      return;
-    }
-
-    if (event.urn === urn) {
-      refresh();
-    }
+  onMount(() => {
+    localPeer.projectEvents.subscribe(event => {
+      if (!event) {
+        return;
+      }
+      if (event.urn === urn) {
+        refresh();
+      }
+    });
   });
 
   // Initialise the screen by fetching the project and associated data.


### PR DESCRIPTION
Whenever we call `Store.subscribe` in a component we ensure that we unsubscribe when the component is destroyed. In `Screen/Project` this created particular issues where the current project page refreshed even if only a previously visited received an update.