### PR TITLE
chore: use Metadata as payload to create identity

### DIFF
--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -15,11 +15,13 @@ export interface Avatar {
   emoji: string;
 }
 
+export interface Metadata {
+  handle: string;
+}
+
 export interface Identity {
   avatarFallback: Avatar;
-  metadata: {
-    handle: string;
-  };
+  metadata: Metadata;
   peerId: PeerId;
   shareableEntityIdentifier: string;
   urn: Urn;
@@ -29,13 +31,8 @@ export interface Identity {
 const creationStore = remote.createStore<Identity>();
 export const store = creationStore.readable;
 
-interface CreateInput {
-  handle: string;
-  passphrase: string;
-}
-
-export const createIdentity = (input: CreateInput): Promise<Identity> => {
-  return api.post<CreateInput, Identity>("identities", input);
+export const createIdentity = (metadata: Metadata): Promise<Identity> => {
+  return api.post<Metadata, Identity>("identities", metadata);
 };
 
 export const fetch = (urn: string): Promise<Identity> => {


### PR DESCRIPTION
The REST endpoint that handles this request expects a `Metadata`, not a
type that contains a passphrase. Therefore, we drop `CreateInput` in
favour of a new `Metadata` struct.

Signed-off-by: Nuno Alexandre <hi@nunoalexandre.com>