### PR TITLE
fix: add 'Buffer' to webpack.ProvidePlugin list

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -92,6 +92,7 @@ function ui(_env: unknown, argv: Argv): webpack.Configuration {
     },
     plugins: [
       new webpack.ProvidePlugin({
+        Buffer: ["buffer", "Buffer"],
         process: "process",
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
Running the funding feature now using webpack crashes the app due to
Buffer not being available.

Solution found in https://github.com/webpack/changelog-v5/issues/10#issuecomment-615877593.

Signed-off-by: Nuno Alexandre <hi@nunoalexandre.com>