### PR TITLE
fix(ci): use new ci script on mac os agent

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -27,7 +27,7 @@ steps:
       queue: agent-preview
   - label: "Test and package app on macOS"
     if: build.branch == 'master' || build.tag != null
-    command: ".buildkite/run.sh"
+    command: "ci/run.sh"
     agents:
       production: "false"
       platform: "macos"


### PR DESCRIPTION
Use the new ci script `ci/run.sh` also on the MacOS buildkite agent