### PR TITLE
Log timestamps

### DIFF
--- a/proxy/api/src/bin/radicle-proxy.rs
+++ b/proxy/api/src/bin/radicle-proxy.rs
@@ -2,7 +2,7 @@
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     api::env::set_if_unset("RUST_BACKTRACE", "full");
     api::env::set_if_unset("RUST_LOG", "info,quinn=warn");
-    pretty_env_logger::init();
+    pretty_env_logger::init_timed();
 
     api::run(argh::from_env()).await
 }


### PR DESCRIPTION
This makes debugging easier. With timestamps we can correlate upstream
and seed logs.

Signed-off-by: Stanisław Pitucha <viraptor@gmail.com>