### PR TITLE
feat(test): reusable `nodeManager.exec` command

### DIFF
--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -29,12 +29,10 @@ context("p2p networking", () => {
   it("replicates a project from one node to another", () => {
     const maintainer = {
       handle: "rudolfs",
-      fullName: "Rūdolfs Ošiņš",
       passphrase: "1111",
     };
     const contributor = {
       handle: "abbey",
-      fullName: "Abbey Titcomb",
       passphrase: "2222",
     };
 
@@ -139,17 +137,16 @@ context("p2p networking", () => {
           cy.log("test commit replication from maintainer to contributor");
 
           cy.log("add a new commit to the maintainer's project working dir");
-          const projctPath = path.join(maintainerProjectsDir, projectName);
+          const projectPath = path.join(maintainerProjectsDir, projectName);
           const maintainerCommitSubject =
             "Commit replication from maintainer to contributor";
 
-          nodeManager.createCommit({
-            repositoryPath: projctPath,
-            radHome: maintainerNode.radHome,
-            subject: maintainerCommitSubject,
-            passphrase: maintainer.passphrase,
-            name: maintainer.fullName,
-          });
+          nodeManager.exec(
+            `cd ${projectPath}
+            git commit --allow-empty -m "${maintainerCommitSubject}"
+            git push rad`,
+            maintainerNode
+          );
 
           cy.log("refresh the UI for the new commit to show up");
           cy.get("body").type("{esc}");
@@ -201,13 +198,12 @@ context("p2p networking", () => {
             projectName
           );
 
-          nodeManager.createCommit({
-            repositoryPath: forkedProjectPath,
-            radHome: contributorNode.radHome,
-            subject: contributorCommitSubject,
-            passphrase: contributor.passphrase,
-            name: contributor.fullName,
-          });
+          nodeManager.exec(
+            `cd ${forkedProjectPath}
+            git commit --allow-empty -m "${contributorCommitSubject}"
+            git push rad`,
+            contributorNode
+          );
 
           cy.log("refresh the UI for the new commit to show up");
           cy.get("body").type("{esc}");

--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -45,33 +45,18 @@ export const connectTwoNodes = (
   nodeManagerPlugin.connectNodes({ nodeIds: [node1.id, node2.id] });
 };
 
-interface createCommitOptions {
-  repositoryPath: string;
-  radHome: string;
-  subject: string;
-  passphrase: string;
-  name?: string;
-  email?: string;
-}
-
-const credentialsHelper = (passphrase: string) =>
-  `'!f() { test "$1" = get && echo "password=${passphrase}"; }; f'`;
-
-export const createCommit = (options: createCommitOptions): void => {
+// Executes a shell command in the context of a node session.
+//
+// In particular, `.gitconfig` is properly set for the node.
+export const exec = (cmd: string, session: NodeSession): void => {
   cy.exec(
     `set -euo pipefail
-export PATH=$PWD/target/release:$PATH
-cd ${options.repositoryPath}
-git commit --allow-empty -m "${options.subject}"
-git -c credential.helper=${credentialsHelper(options.passphrase)} push rad`,
+export PATH="$PWD/target/release:$PATH"
+${cmd}`,
     {
       env: {
-        HOME: options.radHome,
-        RAD_HOME: options.radHome,
-        GIT_AUTHOR_NAME: options.name || "John McPipefail",
-        GIT_AUTHOR_EMAIL: options.email || "john@mcpipefail.com",
-        GIT_COMMITTER_NAME: options.name || "John McPipefail",
-        GIT_COMMITTER_EMAIL: options.email || "john@mcpipefail.com",
+        HOME: session.radHome,
+        RAD_HOME: session.radHome,
       },
     }
   );

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "browserify": "^17.0.0",
     "crypto-browserify": "^3.12.0",
     "ethers": "^5.1.0",
+    "execa": "^5.0.0",
     "marked": "^2.0.1",
     "mnemonist": "^0.38.3",
     "pure-svg-code": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10768,6 +10768,7 @@ __metadata:
     eslint-plugin-svelte3: =3.0.0
     eslint-svelte3-preprocess: =0.0.4
     ethers: ^5.1.0
+    execa: ^5.0.0
     exit-hook: ^2.2.1
     ganache-cli: ^6.12.2
     html-webpack-plugin: ^5.3.1


### PR DESCRIPTION
We generalize the `nodeManager.createCommit` command to `nodeManager.exec` to support other commands in the merge request tests.

This change required us to persist the credential helper setting. We accomplish this by writing the setting to `.gitconfig` in the node’s home directory. We use the same mechanism to write user data got `.gitconfig` which eliminates the need to specify those explicitly every time.