### PR TITLE
Load merge request details

### DIFF
--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -42,7 +42,7 @@
     "/projects/:urn/source/commit/:hash": Commit,
     "/projects/:urn/source/commits": Commits,
     "/projects/:urn/source/merge_requests": MergeRequests,
-    "/projects/:urn/source/merge_request": router.wrap({
+    "/projects/:urn/source/merge_request/:peerId/:id": router.wrap({
       component: MergeRequest,
       props: {
         project,

--- a/ui/Screen/Project/Source/MergeRequest.svelte
+++ b/ui/Screen/Project/Source/MergeRequest.svelte
@@ -1,136 +1,38 @@
 <script lang="typescript">
-  import qs from "qs";
-  import { pop, querystring } from "svelte-spa-router";
   import { getContext } from "svelte";
+  import * as remote from "../../../src/remote";
+  import MergeRequestLoaded from "./MergeRequestLoaded.svelte";
 
-  import { isMaintainer } from "../../../src/project";
   import type { Project } from "../../../src/project";
   import type { UnsealedSession } from "../../../src/session";
-  import {
-    mergeRequestCommits as store,
-    fetchMergeRequestCommits,
-    selectCommit,
-  } from "../../../src/screen/project/source";
-  import type { CommitHeader } from "../../../src/source";
-  import type { MergeRequest } from "../../../src/project/mergeRequest";
+  import type { MergeRequestDetails } from "../../../src/project/mergeRequest";
+  import * as mergeRequest from "../../../src/project/mergeRequest";
 
-  import { Avatar, Icon, Markdown } from "../../../DesignSystem/Primitive";
-  import {
-    CompareBranches,
-    Header,
-    Remote,
-  } from "../../../DesignSystem/Component";
-  import History from "../../../DesignSystem/Component/SourceBrowser/History.svelte";
-  import CheckoutMergeRequestButton from "./CheckoutMergeRequestButton.svelte";
-  import AcceptMergeRequestButton from "./AcceptMergeRequestButton.svelte";
+  import { Remote } from "../../../DesignSystem/Component";
 
   export let project: Project;
-
-  const onSelect = ({ detail: commit }: { detail: CommitHeader }) => {
-    selectCommit(commit);
+  export let params: {
+    urn: string;
+    peerId: string;
+    id: string;
   };
 
   const session = getContext("session") as UnsealedSession;
 
-  const parsed = qs.parse($querystring || "");
-  const defaultBranch = (parsed.defaultBranch as unknown) as string;
-  const mergeRequest = (parsed.mergeRequest as unknown) as MergeRequest;
-
-  const mergeInfo = mergeRequest && mergeRequest.merged ? "Closed" : "Opened";
-  const iconColor =
-    mergeRequest && mergeRequest.merged
-      ? "var(--color-negative);"
-      : "var(--color-positive);";
-
-  fetchMergeRequestCommits(mergeRequest);
+  const mergeRequestRemote = remote.createStore<MergeRequestDetails>();
+  $: {
+    remote.fetch(
+      mergeRequestRemote,
+      mergeRequest.getDetails(
+        session.identity.peerId,
+        project,
+        params.peerId,
+        params.id
+      )
+    );
+  }
 </script>
 
-<style>
-  .merge-request-page {
-    max-width: var(--content-max-width);
-    margin: 0 auto;
-    padding: 0 var(--content-padding);
-    min-width: var(--content-min-width);
-  }
-
-  .title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin: -0.1875rem 0 0.5rem;
-  }
-
-  .metadata {
-    display: flex;
-    align-items: center;
-    color: var(--color-foreground-level-5);
-  }
-
-  .desc {
-    border-top: 1px solid var(--color-foreground-level-3);
-    padding: 1.5rem;
-  }
-
-  .action-box {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    background: var(--color-foreground-level-1);
-    border-radius: 0.5rem;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .action-box .buttons {
-    display: flex;
-    gap: 1rem;
-  }
-</style>
-
-<div class="merge-request-page" data-cy="merge-request-page">
-  <Header.Back style="padding: 1rem; z-index: 0;" on:arrowClick={() => pop()}>
-    <div>
-      <div class="title">
-        <Icon.Revision style={`fill: ${iconColor};`} />
-        {#if mergeRequest.title}
-          <h2>{mergeRequest.title}</h2>
-        {/if}
-      </div>
-    </div>
-    <div class="metadata">
-      <span> {mergeInfo} by </span>
-      {#if mergeRequest.identity}
-        <Avatar
-          avatarFallback={mergeRequest.identity.avatarFallback}
-          size="small"
-          style="display: flex; justify-content: flex-start; margin-left: 0.5rem;"
-          title={mergeRequest.identity.metadata.handle}
-          variant="circle" />
-      {:else}
-        <p style="margin-left: 0.5rem;">{mergeRequest.peerId}</p>
-      {/if}
-    </div>
-  </Header.Back>
-  {#if mergeRequest.description}
-    <div class="desc">
-      <Markdown content={mergeRequest.description} />
-    </div>
-  {/if}
-  <div class="action-box">
-    <CompareBranches
-      baseBranch={defaultBranch}
-      compareBranch={mergeRequest.id} />
-    <div class="buttons">
-      <CheckoutMergeRequestButton
-        id={mergeRequest.id}
-        peerId={mergeRequest.peerId} />
-      {#if isMaintainer(session.identity.urn, project)}
-        <AcceptMergeRequestButton id={mergeRequest.id} />
-      {/if}
-    </div>
-  </div>
-  <Remote {store} let:data={history}>
-    <History {history} on:select={onSelect} />
-  </Remote>
-</div>
+<Remote store={mergeRequestRemote} let:data={{ mergeRequest, commits }}>
+  <MergeRequestLoaded {session} {project} {mergeRequest} {commits} />
+</Remote>

--- a/ui/Screen/Project/Source/MergeRequestList.svelte
+++ b/ui/Screen/Project/Source/MergeRequestList.svelte
@@ -23,8 +23,8 @@
     router.push(
       path.projectSourceMergeRequest(
         project.urn,
-        mergeRequest,
-        project.metadata.defaultBranch
+        mergeRequest.peerId,
+        mergeRequest.id
       )
     );
   };

--- a/ui/Screen/Project/Source/MergeRequestLoaded.svelte
+++ b/ui/Screen/Project/Source/MergeRequestLoaded.svelte
@@ -19,11 +19,10 @@
   export let commits: GrouppedCommitsHistory;
   export let session: UnsealedSession;
 
-  const mergeInfo = mergeRequest && mergeRequest.merged ? "Closed" : "Opened";
-  const iconColor =
-    mergeRequest && mergeRequest.merged
-      ? "var(--color-negative);"
-      : "var(--color-positive);";
+  const mergeInfo = mergeRequest.merged ? "Closed" : "Opened";
+  const iconColor = mergeRequest.merged
+    ? "var(--color-negative);"
+    : "var(--color-positive);";
 </script>
 
 <style>

--- a/ui/Screen/Project/Source/MergeRequestLoaded.svelte
+++ b/ui/Screen/Project/Source/MergeRequestLoaded.svelte
@@ -1,0 +1,115 @@
+<script lang="typescript">
+  import { pop } from "svelte-spa-router";
+
+  import { isMaintainer } from "../../../src/project";
+  import type { Project } from "../../../src/project";
+  import type { UnsealedSession } from "../../../src/session";
+  import { selectCommit } from "../../../src/screen/project/source";
+  import type { GrouppedCommitsHistory } from "../../../src/source";
+  import type { MergeRequest } from "../../../src/project/mergeRequest";
+
+  import { Avatar, Icon, Markdown } from "../../../DesignSystem/Primitive";
+  import { CompareBranches, Header } from "../../../DesignSystem/Component";
+  import History from "../../../DesignSystem/Component/SourceBrowser/History.svelte";
+  import CheckoutMergeRequestButton from "./CheckoutMergeRequestButton.svelte";
+  import AcceptMergeRequestButton from "./AcceptMergeRequestButton.svelte";
+
+  export let project: Project;
+  export let mergeRequest: MergeRequest;
+  export let commits: GrouppedCommitsHistory;
+  export let session: UnsealedSession;
+
+  const mergeInfo = mergeRequest && mergeRequest.merged ? "Closed" : "Opened";
+  const iconColor =
+    mergeRequest && mergeRequest.merged
+      ? "var(--color-negative);"
+      : "var(--color-positive);";
+</script>
+
+<style>
+  .merge-request-page {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    padding: 0 var(--content-padding);
+    min-width: var(--content-min-width);
+  }
+
+  .title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: -0.1875rem 0 0.5rem;
+  }
+
+  .metadata {
+    display: flex;
+    align-items: center;
+    color: var(--color-foreground-level-5);
+  }
+
+  .desc {
+    border-top: 1px solid var(--color-foreground-level-3);
+    padding: 1.5rem;
+  }
+
+  .action-box {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    background: var(--color-foreground-level-1);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .action-box .buttons {
+    display: flex;
+    gap: 1rem;
+  }
+</style>
+
+<div class="merge-request-page" data-cy="merge-request-page">
+  <Header.Back style="padding: 1rem; z-index: 0;" on:arrowClick={() => pop()}>
+    <div>
+      <div class="title">
+        <Icon.Revision style={`fill: ${iconColor};`} />
+        {#if mergeRequest.title}
+          <h2>{mergeRequest.title}</h2>
+        {/if}
+      </div>
+    </div>
+    <div class="metadata">
+      <span> {mergeInfo} by </span>
+      {#if mergeRequest.identity}
+        <Avatar
+          avatarFallback={mergeRequest.identity.avatarFallback}
+          size="small"
+          style="display: flex; justify-content: flex-start; margin-left: 0.5rem;"
+          title={mergeRequest.identity.metadata.handle}
+          variant="circle" />
+      {:else}
+        <p style="margin-left: 0.5rem;">{mergeRequest.peerId}</p>
+      {/if}
+    </div>
+  </Header.Back>
+  {#if mergeRequest.description}
+    <div class="desc">
+      <Markdown content={mergeRequest.description} />
+    </div>
+  {/if}
+  <div class="action-box">
+    <CompareBranches
+      baseBranch={project.metadata.defaultBranch}
+      compareBranch={mergeRequest.id} />
+    <div class="buttons">
+      <CheckoutMergeRequestButton
+        id={mergeRequest.id}
+        peerId={mergeRequest.peerId} />
+      {#if isMaintainer(session.identity.urn, project)}
+        <AcceptMergeRequestButton id={mergeRequest.id} />
+      {/if}
+    </div>
+  </div>
+  <History history={commits} on:select={event => selectCommit(event.detail)} />
+</div>

--- a/ui/src/path.ts
+++ b/ui/src/path.ts
@@ -1,8 +1,6 @@
-import qs from "qs";
 import regexparam from "regexparam";
 
 import type { Urn } from "./urn";
-import type { MergeRequest } from "./project/mergeRequest";
 
 export const blank = (): string => "/";
 export const settings = (): string => "/settings";
@@ -29,14 +27,10 @@ export const projectSourceCommits = (urn: Urn): string =>
 export const projectSourceMergeRequests = (urn: Urn): string =>
   `/projects/${urn}/source/merge_requests`;
 export const projectSourceMergeRequest = (
-  urn: Urn,
-  mergeRequest: MergeRequest,
-  defaultBranch: string
-): string =>
-  `/projects/${urn}/source/merge_request?${qs.stringify({
-    defaultBranch,
-    mergeRequest,
-  })}`;
+  projectUrn: Urn,
+  peerId: string,
+  id: string
+): string => `/projects/${projectUrn}/source/merge_request/${peerId}/${id}`;
 export const project = projectSourceFiles;
 
 export const designSystemGuide = (): string => "/design-system-guide";

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -373,34 +373,6 @@ const mapRevisions = (
   return branches;
 };
 
-const mergeRequestCommitsStore = remote.createStore<source.GrouppedCommitsHistory>();
-export const mergeRequestCommits = mergeRequestCommitsStore.readable;
-
-export const fetchMergeRequestCommits = async (
-  mr: mergeRequest.MergeRequest
-): Promise<void> => {
-  const screen = get(screenStore);
-
-  if (screen.status === remote.Status.Success) {
-    const {
-      data: { peer, project },
-    } = screen;
-
-    try {
-      const history = await mergeRequest.getCommits(peer.peerId, project, mr);
-
-      mergeRequestCommitsStore.success(source.groupCommitHistory(history));
-    } catch (err) {
-      mergeRequestCommitsStore.error(error.fromException(err));
-      error.show({
-        code: error.Code.CommitFetchFailure,
-        message: "Could not fetch merge request commits",
-        source: err,
-      });
-    }
-  }
-};
-
 const menuItems = (
   project: Project,
   history: source.GrouppedCommitsHistory,


### PR DESCRIPTION
Explicitly load the merge request details instead of partially getting them from the query string and partially through `fetchMergeRequestCommits`.