### PR TITLE
refactor(ui): introduce proxy api client

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,8 @@
     "timeago.js": "^4.0.2",
     "twemoji": "13.0.2",
     "uuid": "^8.3.2",
-    "validate.js": "^0.13.1"
+    "validate.js": "^0.13.1",
+    "zod": "^1.11.13"
   },
   "husky": {
     "hooks": {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -16,7 +16,7 @@ interface Init extends Options {
 }
 
 export class ResponseError extends Error {
-  public response;
+  public response: Response;
   constructor(response: Response, body_: unknown) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const body: any = body_;

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -1,42 +1,23 @@
-import * as api from "./api";
 import * as remote from "./remote";
-import type { Urn } from "./urn";
+import * as proxy from "./proxy";
+import type { Identity } from "./proxy/identity";
 
-// TYPES
+export type { Identity };
+
 // FIXME(xla): Improve type safety of it, this is a placeholder to avoid using strings everywhere.
 export type PeerId = string;
 
-export interface Avatar {
-  background: {
-    r: number;
-    g: number;
-    b: number;
-  };
-  emoji: string;
-}
-
-export interface Metadata {
-  handle: string;
-}
-
-export interface Identity {
-  avatarFallback: Avatar;
-  metadata: Metadata;
-  peerId: PeerId;
-  shareableEntityIdentifier: string;
-  urn: Urn;
-}
-
-// STATE
 const creationStore = remote.createStore<Identity>();
 export const store = creationStore.readable;
 
-export const createIdentity = (metadata: Metadata): Promise<Identity> => {
-  return api.post<Metadata, Identity>("identities", metadata);
+export const createIdentity = (
+  params: proxy.IdentityCreateParams
+): Promise<Identity> => {
+  return proxy.client.identityCreate(params);
 };
 
 export const fetch = (urn: string): Promise<Identity> => {
-  return api.get<Identity>(`identities/${urn}`);
+  return proxy.client.identityGet(urn);
 };
 
 // MOCK

--- a/ui/src/proxy/control.ts
+++ b/ui/src/proxy/control.ts
@@ -1,0 +1,44 @@
+import type { Fetcher, RequestOptions } from "./fetcher";
+
+interface ProjectCreateParams {
+  name: string;
+  description: string;
+  defaultBranch: string;
+  fakePeers: string[];
+}
+
+export class Control {
+  private fetcher: Fetcher;
+
+  constructor(fetcher: Fetcher) {
+    this.fetcher = fetcher;
+  }
+
+  async reset(options?: RequestOptions): Promise<void> {
+    return this.fetcher.fetchOkNoContent({
+      method: "GET",
+      path: "control/reset",
+      options,
+    });
+  }
+
+  async seal(options?: RequestOptions): Promise<void> {
+    return this.fetcher.fetchOkNoContent({
+      method: "GET",
+      path: "control/seal",
+      options,
+    });
+  }
+
+  async projectCreate(
+    params: ProjectCreateParams,
+    options?: RequestOptions
+  ): Promise<void> {
+    return this.fetcher.fetchOkNoContent({
+      method: "POST",
+      path: "control/create-project",
+      body: params,
+      options,
+    });
+  }
+}

--- a/ui/src/proxy/fetcher.ts
+++ b/ui/src/proxy/fetcher.ts
@@ -1,0 +1,101 @@
+import type * as zod from "zod";
+
+// This module provides low-level capabilities to interact with a typed
+// JSON HTTP API.
+
+// Error that is thrown by `Fetcher` methods.
+export class ResponseError extends Error {
+  public response: Response;
+  public body: unknown;
+  constructor(response: Response, body_: unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const body: any = body_;
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      typeof body.message === "string"
+    ) {
+      super(body.message);
+    } else {
+      super("Response error");
+    }
+
+    this.body = body_;
+    this.response = response;
+  }
+}
+
+export interface RequestOptions {
+  abort?: AbortSignal;
+}
+
+export interface FetchParams {
+  method: Method;
+  // Path to append to the `Fetcher`s base URL to get the final uRL
+  path: string;
+  // Object that is serialized into JSON and sent as the data
+  body?: unknown;
+  options?: RequestOptions;
+}
+
+type Method = "GET" | "POST" | "PUT" | "DELETE";
+
+export class Fetcher {
+  private baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  // Execute a fetch and parse the result with the provided schema.
+  // Return the parsed payload.
+  //
+  // Throws `ResponseError` if the response status code is not `200`.
+  async fetchOk<T>(params: FetchParams, schema: zod.Schema<T>): Promise<T> {
+    const response = await this.fetch(params);
+
+    const responseBody = await response.json();
+
+    if (!response.ok) {
+      throw new ResponseError(response, responseBody);
+    }
+
+    return schema.parse(responseBody);
+  }
+
+  // Execute a fetch and ignore the response body.
+  //
+  // Throws `ResponseError` if the response status code is not `200`.
+  async fetchOkNoContent(params: FetchParams): Promise<void> {
+    const response = await this.fetch(params);
+
+    if (!response.ok) {
+      let responseBody = await response.text();
+      try {
+        responseBody = JSON.parse(responseBody);
+      } catch (_e) {
+        // We keep the original text response body
+      }
+      throw new ResponseError(response, responseBody);
+    }
+  }
+
+  private async fetch({
+    method,
+    path,
+    body,
+    options = {},
+  }: FetchParams): Promise<Response> {
+    const headers: Record<string, string> = {};
+    if (body !== undefined) {
+      headers["content-type"] = "application/json";
+    }
+    return fetch(`${this.baseUrl}/v1/${path}`, {
+      method,
+      headers,
+      body: body === undefined ? null : JSON.stringify(body),
+      credentials: "include",
+      ...options,
+    });
+  }
+}

--- a/ui/src/proxy/identity.ts
+++ b/ui/src/proxy/identity.ts
@@ -1,0 +1,39 @@
+import * as zod from "zod";
+
+export interface Avatar {
+  background: {
+    r: number;
+    g: number;
+    b: number;
+  };
+  emoji: string;
+}
+
+const avatarSchema: zod.ZodSchema<Avatar> = zod.object({
+  background: zod.object({
+    r: zod.number(),
+    g: zod.number(),
+    b: zod.number(),
+  }),
+  emoji: zod.string(),
+});
+
+export interface Identity {
+  avatarFallback: Avatar;
+  metadata: {
+    handle: string;
+  };
+  peerId: string;
+  shareableEntityIdentifier: string;
+  urn: string;
+}
+
+export const identitySchema: zod.ZodSchema<Identity> = zod.object({
+  avatarFallback: avatarSchema,
+  metadata: zod.object({
+    handle: zod.string(),
+  }),
+  peerId: zod.string(),
+  shareableEntityIdentifier: zod.string(),
+  urn: zod.string(),
+});

--- a/ui/src/proxy/index.ts
+++ b/ui/src/proxy/index.ts
@@ -1,0 +1,143 @@
+import * as zod from "zod";
+import * as config from "../config";
+
+import * as settings from "./settings";
+import * as identity from "./identity";
+import * as control from "./control";
+import { Fetcher, ResponseError, RequestOptions } from "./fetcher";
+
+export { ResponseError };
+
+export interface Session {
+  identity: identity.Identity;
+  settings: settings.Settings;
+}
+
+export const sessionSchema: zod.ZodSchema<Session> = zod.object({
+  identity: identity.identitySchema,
+  settings: settings.settingsSchema,
+});
+
+export interface IdentityCreateParams {
+  handle: string;
+}
+
+interface KeyStoreUnsealParams {
+  passphrase: string;
+}
+
+interface KeyStoreCreateParams {
+  passphrase: string;
+}
+
+export class Client {
+  private fetcher: Fetcher;
+
+  public control: control.Control;
+
+  constructor(baseUrl: string) {
+    this.fetcher = new Fetcher(baseUrl);
+    this.control = new control.Control(this.fetcher);
+  }
+
+  async sessionGet(options?: RequestOptions): Promise<Session> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: "session",
+        options,
+      },
+      sessionSchema
+    );
+  }
+
+  async sessionSettingsSet(
+    settings: settings.Settings,
+    options?: RequestOptions
+  ): Promise<void> {
+    return this.fetcher.fetchOkNoContent({
+      method: "POST",
+      path: "session/settings",
+      body: settings,
+      options,
+    });
+  }
+
+  async identityCreate(
+    params: IdentityCreateParams,
+    options?: RequestOptions
+  ): Promise<identity.Identity> {
+    return this.fetcher.fetchOk(
+      {
+        method: "POST",
+        path: "identities",
+        body: params,
+        options,
+      },
+      identity.identitySchema
+    );
+  }
+
+  async identityGet(
+    urn: string,
+    options?: RequestOptions
+  ): Promise<identity.Identity> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: `identities/${urn}`,
+        options,
+      },
+      identity.identitySchema
+    );
+  }
+
+  async keyStoreUnseal(
+    params: KeyStoreUnsealParams,
+    options?: RequestOptions
+  ): Promise<void> {
+    await this.fetcher.fetchOkNoContent({
+      method: "POST",
+      path: "keystore/unseal",
+      body: params,
+      options,
+    });
+  }
+
+  async keyStoreCreate(
+    params: KeyStoreCreateParams,
+    options?: RequestOptions
+  ): Promise<void> {
+    return this.fetcher.fetchOkNoContent({
+      method: "POST",
+      path: "keystore",
+      body: params,
+      options,
+    });
+  }
+}
+
+export const client = new Client(`http://${config.proxyAddress}`);
+
+export const withRetry = async <T>(
+  request: () => Promise<T>,
+  delayTime: number,
+  retries: number
+): Promise<T> => {
+  for (; ; retries--) {
+    try {
+      return await request();
+    } catch (error) {
+      if (error.message !== "Failed to fetch" || retries < 0) {
+        throw error;
+      }
+    }
+    await sleep(delayTime);
+  }
+};
+
+const sleep = (delay: number) => {
+  return new Promise((resolve, _reject) => {
+    setTimeout(resolve, delay);
+  });
+};

--- a/ui/src/proxy/settings.ts
+++ b/ui/src/proxy/settings.ts
@@ -1,0 +1,43 @@
+import * as zod from "zod";
+
+export interface Settings {
+  appearance: Appearance;
+  coco: CoCo;
+  featureFlags: FeatureFlags;
+}
+
+export interface FeatureFlags {
+  funding: boolean;
+}
+
+export interface Appearance {
+  theme: Theme;
+  hints: {
+    showRemoteHelper: boolean;
+  };
+}
+
+export interface CoCo {
+  seeds: string[];
+}
+
+export enum Theme {
+  Dark = "dark",
+  Light = "light",
+  H4x0r = "h4x0r",
+}
+
+export const settingsSchema: zod.ZodSchema<Settings> = zod.object({
+  appearance: zod.object({
+    hints: zod.object({
+      showRemoteHelper: zod.boolean(),
+    }),
+    theme: zod.enum([Theme.Dark, Theme.Light, Theme.H4x0r]),
+  }),
+  coco: zod.object({
+    seeds: zod.array(zod.string()),
+  }),
+  featureFlags: zod.object({
+    funding: zod.boolean(),
+  }),
+});

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -1,11 +1,15 @@
 import * as ethereum from "./ethereum";
 
-// TYPES
-export interface Settings {
-  appearance: Appearance;
-  coco: CoCo;
-  featureFlags: FeatureFlags;
-}
+import {
+  Settings,
+  Theme,
+  Appearance,
+  CoCo,
+  FeatureFlags,
+} from "./proxy/settings";
+
+export type { Settings, Appearance, CoCo, FeatureFlags };
+export { Theme };
 
 export const defaultSetttings = (): Settings => ({
   appearance: {
@@ -21,23 +25,6 @@ export const defaultSetttings = (): Settings => ({
     funding: false,
   },
 });
-
-export interface Appearance {
-  theme: Theme;
-  hints: {
-    showRemoteHelper: boolean;
-  };
-}
-
-export enum Theme {
-  Dark = "dark",
-  Light = "light",
-  H4x0r = "h4x0r",
-}
-
-export interface CoCo {
-  seeds: string[];
-}
 
 interface Option<T> {
   value: T;
@@ -58,10 +45,6 @@ export const themeOptions: Option<string>[] = [
     value: Theme.H4x0r,
   },
 ];
-
-export interface FeatureFlags {
-  funding: boolean;
-}
 
 export const featureFlagOptions: Option<boolean>[] = [
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10811,6 +10811,7 @@ __metadata:
     wait-on: ^5.3.0
     webpack: ^5.30.0
     webpack-cli: ^4.6.0
+    zod: ^1.11.13
   languageName: unknown
   linkType: soft
 
@@ -14181,5 +14182,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 096c3b40beb2804659539be1605a35c58eb0c85285f94b77b3e924f42ee265c1a40bf9f4153770039517146b469a964d51742395f35ca8135fc9f7e4982b785d
+  languageName: node
+  linkType: hard
+
+"zod@npm:^1.11.13":
+  version: 1.11.13
+  resolution: "zod@npm:1.11.13"
+  checksum: 23b86e185a66b9703d656fe8fa78c3e559676cb993cb2c06d7190ab0b22a528033c74ff62591c1be7c551d947c403b4e46f4c6f7b62cd4b32497e54ec406d706
   languageName: node
   linkType: hard


### PR DESCRIPTION
We introduce the `ui/src/proxy` module that provides checked, reusable access to the proxy HTTP. It’s intended to supersede `ui/src/api` in the future.

We gain the following advantages
* We separate stateful code from the stateless proxy API code (e.g. in `ui/src/session`)
* Response payloads are validated against TypeScript types with `zod`.
* We can reuse the proxy client in the cypress test commands.
* Provide an foundation to extend the proxy client with more APIs.