### PR TITLE
refactor(ui): eliminate event indirection from session.ts

### DIFF
--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -2,7 +2,6 @@ import { Readable, derived, get } from "svelte/store";
 
 import * as proxy from "./proxy";
 import * as error from "./error";
-import * as event from "./event";
 import type * as identity from "./identity";
 import * as remote from "./remote";
 import {
@@ -87,28 +86,6 @@ export const settings: Readable<Settings> = derived(sessionStore, sess => {
   }
 });
 
-// EVENTS
-enum Kind {
-  ClearCache = "CLEAR_CACHE",
-  Fetch = "FETCH",
-  UpdateSettings = "UPDATE_SETTINGS",
-}
-
-interface ClearCache extends event.Event<Kind> {
-  kind: Kind.ClearCache;
-}
-
-interface Fetch extends event.Event<Kind> {
-  kind: Kind.Fetch;
-}
-
-interface UpdateSettings extends event.Event<Kind> {
-  kind: Kind.UpdateSettings;
-  settings: Settings;
-}
-
-type Msg = ClearCache | Fetch | UpdateSettings;
-
 const fetchSession = async (): Promise<void> => {
   try {
     const ses = await proxy.withRetry(() => proxy.client.sessionGet(), 100, 50);
@@ -158,7 +135,12 @@ export const createKeystore = (passphrase: string): Promise<void> => {
   return proxy.client.keyStoreCreate({ passphrase });
 };
 
-const updateSettings = async (settings: Settings): Promise<void> => {
+export const fetch = async (): Promise<void> => {
+  sessionStore.loading();
+  await fetchSession();
+};
+
+const setSettings = async (settings: Settings): Promise<void> => {
   try {
     await proxy.client.sessionSettingsSet(settings);
   } catch (err) {
@@ -173,55 +155,35 @@ const updateSettings = async (settings: Settings): Promise<void> => {
   await fetchSession();
 };
 
-const update = (msg: Msg): void => {
-  switch (msg.kind) {
-    case Kind.Fetch:
-      sessionStore.loading();
-      fetchSession();
-      break;
-
-    case Kind.UpdateSettings:
-      updateSettings(msg.settings);
-      break;
-  }
+const updateSettings = (f: (settings: Settings) => Settings): Promise<void> => {
+  return setSettings(f(get(settings)));
 };
 
-export const fetch = event.create<Kind, Msg>(Kind.Fetch, update);
-
-export const updateAppearance = (appearance: Appearance): void =>
-  event.create<Kind, Msg>(
-    Kind.UpdateSettings,
-    update
-  )({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    settings: { ...get(settings), appearance },
-  });
-
-export const updateFeatureFlags = (featureFlags: FeatureFlags): void =>
-  event.create<Kind, Msg>(
-    Kind.UpdateSettings,
-    update
-  )({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    settings: { ...get(settings), featureFlags },
-  });
-
-export const dismissRemoteHelperHint = (): void => {
-  updateAppearance({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    ...get(settings).appearance,
-    hints: { showRemoteHelper: false },
-  });
+export const updateAppearance = async (
+  appearance: Appearance
+): Promise<void> => {
+  await updateSettings(s => ({ ...s, appearance }));
 };
 
-export const updateCoCo = (coco: CoCo): void =>
-  event.create<Kind, Msg>(
-    Kind.UpdateSettings,
-    update
-  )({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    settings: { ...get(settings), coco },
-  });
+export const updateFeatureFlags = async (
+  featureFlags: FeatureFlags
+): Promise<void> => {
+  await updateSettings(s => ({ ...s, featureFlags }));
+};
+
+export const dismissRemoteHelperHint = async (): Promise<void> => {
+  await updateSettings(s => ({
+    ...s,
+    appearance: {
+      ...s.appearance,
+      hints: { showRemoteHelper: false },
+    },
+  }));
+};
+
+const updateCoCo = async (coco: CoCo): Promise<void> => {
+  await updateSettings(s => ({ ...s, coco }));
+};
 
 const VALID_SEED_MATCH = /^[\w\d]{54}@([\w\d-]+\.)*[\w\d-]+:[\d]{1,5}$/;
 


### PR DESCRIPTION
We eliminate the indirection created by events from `src/ui/session.ts` to streamline the code and make it more readable.