### PR TITLE
fix(ui): parse ethereum field of identity in ui

### DIFF
--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -32,6 +32,7 @@ export const fallback: Identity = {
   },
   metadata: {
     handle: "cloudhead",
+    ethereum: null,
   },
   peerId: "hwd1yreyza9z77xzp1rwyxw9uk4kdrrzag5uybd7w1ihke18xxhxn6qu4oy",
   shareableEntityIdentifier:

--- a/ui/src/proxy/identity.ts
+++ b/ui/src/proxy/identity.ts
@@ -22,6 +22,10 @@ export interface Identity {
   avatarFallback: Avatar;
   metadata: {
     handle: string;
+    ethereum: {
+      address: string;
+      expiration: string;
+    } | null;
   };
   peerId: string;
   shareableEntityIdentifier: string;
@@ -32,6 +36,12 @@ export const identitySchema: zod.ZodSchema<Identity> = zod.object({
   avatarFallback: avatarSchema,
   metadata: zod.object({
     handle: zod.string(),
+    ethereum: zod
+      .object({
+        address: zod.string(),
+        expiration: zod.string(),
+      })
+      .nullable(),
   }),
   peerId: zod.string(),
   shareableEntityIdentifier: zod.string(),


### PR DESCRIPTION
We fix a conflict between #1756 and #1712 and add the `ethereum` field for identities to the UI types and parse it properly.