### PR TITLE
fix(tests): wait for test project to be created

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -65,8 +65,8 @@ export const createProjectWithFixture = (
   defaultBranch = "master",
   fakePeers: string[] = []
 ): void => {
-  cy.then(() => {
-    proxyClient.control.projectCreate({
+  cy.then(async () => {
+    await proxyClient.control.projectCreate({
       name,
       description,
       defaultBranch,


### PR DESCRIPTION
We ensure that cypress waits for a test project to be created before it continues. Otherwise tests may fail.