### PR TITLE
feat(ui): handle "enter" hotkey in search modal

### DIFF
--- a/cypress/integration/project/follow.spec.ts
+++ b/cypress/integration/project/follow.spec.ts
@@ -6,10 +6,11 @@ context("project following", () => {
   beforeEach(() => {
     commands.resetProxyState();
     commands.onboardUser("cloudhead");
+    commands.createProjectWithFixture();
     cy.visit("./public/index.html");
   });
 
-  it("follows and unfollows", () => {
+  it("follows and unfollows with mouse click", () => {
     commands.pick("following-tab").click();
     commands.pick("primary-action").contains("Look for a project").click();
     // The extra whitespace is intentional to check that the input is
@@ -30,5 +31,36 @@ context("project following", () => {
       });
 
     commands.pick("empty-state").should("exist");
+  });
+
+  context("when the project is not yet followed", () => {
+    it("follows the project when the [enter] hotkey is pressed", () => {
+      commands.pick("sidebar", "search").click();
+      commands.pasteInto(["search-input"], `rad:git:${projectId}`);
+      cy.get("body").type("{enter}");
+      commands
+        .pickWithContent(["undiscovered-project"], projectId)
+        .should("exist");
+    });
+  });
+
+  context("when the project is already followed", () => {
+    it("opens the project when the [enter] hotkey is pressed", () => {
+      commands.pick("project-list-entry-platinum").click();
+      commands.pick("project-screen", "header", "urn").then(el => {
+        const urn = el.attr("title");
+        if (!urn) {
+          throw new Error("Could not find URN");
+        }
+        commands.pick("sidebar", "profile").click();
+        commands.pick("profile-screen").should("exist");
+
+        commands.pick("sidebar", "search").click();
+        commands.pick("search-input").type(urn);
+        cy.get("body").type("{enter}");
+
+        commands.pick("project-screen").should("exist");
+      });
+    });
   });
 });

--- a/ui/Modal/Search.svelte
+++ b/ui/Modal/Search.svelte
@@ -42,6 +42,8 @@
           navigateToProject(
             ($store as { status: remote.Status.Success; data: Project }).data
           );
+        } else {
+          follow();
         }
         break;
       case "Escape":


### PR DESCRIPTION
Pressing the "enter" key after pasting a Radicle ID into the search
input will, depending on whether the project is already followed or not,
either open the project screen or follow the project.

Signed-off-by: Rūdolfs Ošiņš <rudolfs@osins.org>


https://user-images.githubusercontent.com/158411/114216463-3bddb980-9967-11eb-9a9c-e586d6c5f447.mov

