### PR TITLE
fix(ui): replace `path.active`

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
     "pure-svg-code": "^1.0.6",
     "qs": "^6.10.1",
     "radicle-contracts": "github:radicle-dev/radicle-contracts#commit=9fb23ac74a403b167a22513fc666779d871d292e",
-    "regexparam": "^1.3.0",
     "semver": "^7.3.5",
     "stream-browserify": "^3.0.0",
     "svelte-persistent-store": "^0.1.6",

--- a/ui/DesignSystem/Component/HorizontalMenu.svelte
+++ b/ui/DesignSystem/Component/HorizontalMenu.svelte
@@ -3,7 +3,6 @@
   import { location } from "svelte-spa-router";
 
   import type { HorizontalItem } from "../../src/menu";
-  import * as path from "../../src/path";
 
   import MenuItem from "./HorizontalMenu/MenuItem.svelte";
 
@@ -51,7 +50,7 @@
           dataCy={`${item.title.toLowerCase()}-tab`}
           counter={item.counter}
           href={item.href}
-          active={path.active(item.href, $location, item.looseActiveStateMatching)} />
+          active={$location.startsWith(item.href)} />
       </li>
     {/each}
   </ul>

--- a/ui/DesignSystem/Component/Sidebar.svelte
+++ b/ui/DesignSystem/Component/Sidebar.svelte
@@ -104,7 +104,7 @@
       <div
         class="item indicator"
         data-cy="profile"
-        class:active={path.active(path.profile(), $location, true)}
+        class:active={$location.startsWith(path.profile())}
         on:click|stopPropagation={() => push(path.profileProjects())}>
         <Avatar
           size="regular"
@@ -127,7 +127,7 @@
       <div
         class="item indicator"
         data-cy="settings"
-        class:active={path.active(path.settings(), $location)}
+        class:active={$location.startsWith(path.settings())}
         on:click|stopPropagation={() => push(path.settings())}>
         <Icon.Settings />
       </div>

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -9,7 +9,7 @@
   import { isDev } from "./src/config";
 
   const toggle = (destination: string) => {
-    if (path.active(destination, $location)) {
+    if (destination === $location) {
       pop();
     }
     push(destination);
@@ -17,7 +17,7 @@
   };
 
   const toggleModal = (destination: string) => {
-    if (path.active(path.designSystemGuide(), $location)) {
+    if (path.designSystemGuide() === $location) {
       pop();
     }
     modal.toggle(destination);

--- a/ui/Screen/Profile.svelte
+++ b/ui/Screen/Profile.svelte
@@ -39,13 +39,11 @@
       icon: Icon.ChevronLeftRight,
       title: "Projects",
       href: path.profileProjects(),
-      looseActiveStateMatching: true,
     },
     {
       icon: Icon.Network,
       title: "Following",
       href: path.profileFollowing(),
-      looseActiveStateMatching: false,
     },
   ];
 
@@ -54,7 +52,6 @@
       icon: Icon.Wallet,
       title: "Funding",
       href: path.profileFunding(),
-      looseActiveStateMatching: false,
     });
   }
 

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -77,7 +77,7 @@
   const onMenuSelect = ({ detail: item }: { detail: HorizontalItem }) => {
     if (
       item.title === "Files" &&
-      path.active(path.projectSourceFiles(project.urn), get(location), true)
+      get(location).startsWith(path.projectSourceFiles(project.urn))
     ) {
       selectPath("");
     }

--- a/ui/src/menu.ts
+++ b/ui/src/menu.ts
@@ -4,6 +4,5 @@ export interface HorizontalItem {
   icon: typeof SvelteComponent;
   title: string;
   href: string;
-  looseActiveStateMatching: boolean;
   counter?: number;
 }

--- a/ui/src/path.ts
+++ b/ui/src/path.ts
@@ -1,5 +1,3 @@
-import regexparam from "regexparam";
-
 import type { Urn } from "./urn";
 
 export const blank = (): string => "/";
@@ -40,11 +38,3 @@ export const poolTopUp = (): string => "/funding/pool/top-up";
 export const poolWithdraw = (): string => "/funding/pool/withdraw";
 export const collectFunds = (): string => "/funding/pool/collect";
 export const transaction = (): string => "/transaction";
-
-export const active = (
-  path: string,
-  location: string,
-  loose = false
-): boolean => {
-  return regexparam(path, loose).pattern.test(location);
-};

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -371,14 +371,12 @@ const menuItems = (
       icon: IconFile,
       title: "Files",
       href: path.projectSourceFiles(project.urn),
-      looseActiveStateMatching: true,
     },
     {
       icon: IconCommit,
       title: "Commits",
       counter: history.stats.commits,
       href: path.projectSourceCommits(project.urn),
-      looseActiveStateMatching: true,
     },
   ];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10780,7 +10780,6 @@ __metadata:
     pure-svg-code: ^1.0.6
     qs: ^6.10.1
     radicle-contracts: "github:radicle-dev/radicle-contracts#commit=9fb23ac74a403b167a22513fc666779d871d292e"
-    regexparam: ^1.3.0
     semver: ^7.3.5
     sinon: ^10.0.0
     standard-version: ^9.2.0
@@ -11025,7 +11024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexparam@npm:1.3.0, regexparam@npm:^1.3.0":
+"regexparam@npm:1.3.0":
   version: 1.3.0
   resolution: "regexparam@npm:1.3.0"
   checksum: 3be8055bc697d720647e2b2a781e8a784013e80d51724dce833524c8f1a9fbfa7efd3dac90572ce64191b82e908c8e70c6ff40b8da3ff0b3fb4199af73d4a8b5


### PR DESCRIPTION
We replace the incorrectly used `patch.active` function. Whenever this function was used it was called with a _rendered_ path like `/projects/rad:git:123` instead of a pattern. The implementation however interpreted that path as a pattern and passed it to `regexparam`.

This approach worked as long as no `?` was contained in the path passed to `path.active`. In my case I added a horizontal menu item where the `href` field looked like `/foo/bar?filter=true`. This `href` field is used as the `path` argument and the `?` is treated as a special character. This resulted in `path.active(href, href)` returning false.

The purpose of detecting whether a certain path is active can be more easily achieved by comparing the rendered path with `$location`. For the “loose” match mode supported by `path.active` we use `$location.startsWith`.