### PR TITLE
feat(ui): improve error handling

### DIFF
--- a/ui/DesignSystem/Component/Remote.svelte
+++ b/ui/DesignSystem/Component/Remote.svelte
@@ -24,11 +24,7 @@
     !!noErrorSlotProvided &&
     !disableErrorLogging
   ) {
-    error.show({
-      code: error.Code.RemoteStoreError,
-      message: storeValue.error.message,
-      source: storeValue.error,
-    });
+    error.show(storeValue.error);
   }
 
   $: data =

--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -82,11 +82,13 @@
       });
     } catch (err) {
       push(path.profileProjects());
-      error.show({
-        code: error.Code.ProjectCreationFailure,
-        message: `Could not create project: ${err.message}`,
-        source: err,
-      });
+      error.show(
+        new error.Error({
+          code: error.Code.ProjectCreationFailure,
+          message: `Could not create project: ${err.message}`,
+          source: err,
+        })
+      );
     } finally {
       dispatch("hide");
       loading = false;

--- a/ui/Screen/Onboarding.svelte
+++ b/ui/Screen/Onboarding.svelte
@@ -48,14 +48,16 @@
     } catch (err) {
       animateBackward();
       state = State.EnterName;
-      error.show({
-        code: "create-identity-failed",
-        message: `Could not create identity`,
-        details: {
-          handle,
-        },
-        source: error.fromException(err),
-      });
+      error.show(
+        new error.Error({
+          code: "create-identity-failed",
+          message: `Could not create identity`,
+          details: {
+            handle,
+          },
+          source: err,
+        })
+      );
     } finally {
       screen.unlock();
       createIdentityInProgress = false;

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -65,11 +65,13 @@
         ],
       });
     } catch (err) {
-      error.show({
-        code: error.Code.ProjectCheckoutFailure,
-        message: `Checkout failed: ${err.message}`,
-        source: err,
-      });
+      error.show(
+        new error.Error({
+          code: error.Code.ProjectCheckoutFailure,
+          message: `Checkout failed: ${err.message}`,
+          source: err,
+        })
+      );
     } finally {
       screen.unlock();
     }

--- a/ui/src/customProtocolHandler.ts
+++ b/ui/src/customProtocolHandler.ts
@@ -18,11 +18,13 @@ const handleMessage = (message: ipc.CustomProtocolInvocation): void => {
   );
 
   if (!match) {
-    error.show({
-      code: error.Code.CustomProtocolParseError,
-      message: "Could not parse the provided URL",
-      details: { url: message.url },
-    });
+    error.show(
+      new error.Error({
+        code: error.Code.CustomProtocolParseError,
+        message: "Could not parse the provided URL",
+        details: { url: message.url },
+      })
+    );
 
     return;
   }
@@ -30,31 +32,37 @@ const handleMessage = (message: ipc.CustomProtocolInvocation): void => {
   const [namespace, version, urn] = match.slice(1);
 
   if (namespace !== "link") {
-    error.show({
-      code: error.Code.CustomProtocolUnsupportedNamespace,
-      message: `The custom protocol namespace "${namespace}" is not supported`,
-      details: { url: message.url },
-    });
+    error.show(
+      new error.Error({
+        code: error.Code.CustomProtocolUnsupportedNamespace,
+        message: `The custom protocol namespace "${namespace}" is not supported`,
+        details: { url: message.url },
+      })
+    );
 
     return;
   }
 
   if (Number(version) !== 0) {
-    error.show({
-      code: error.Code.CustomProtocolUnsupportedVersion,
-      message: `The custom protocol version v${version} is not supported`,
-      details: { url: message.url },
-    });
+    error.show(
+      new error.Error({
+        code: error.Code.CustomProtocolUnsupportedVersion,
+        message: `The custom protocol version v${version} is not supported`,
+        details: { url: message.url },
+      })
+    );
 
     return;
   }
 
   if (!urn) {
-    error.show({
-      code: error.Code.CustomProtocolParseError,
-      message: "The provided URL does not contain a Radicle ID",
-      details: { url: message.url },
-    });
+    error.show(
+      new error.Error({
+        code: error.Code.CustomProtocolParseError,
+        message: "The provided URL does not contain a Radicle ID",
+        details: { url: message.url },
+      })
+    );
 
     return;
   }

--- a/ui/src/error.test.ts
+++ b/ui/src/error.test.ts
@@ -1,0 +1,36 @@
+import { Error, fromUnknown, Code } from "./error";
+
+describe("fromUnknown", () => {
+  test("returns Error as-is", () => {
+    const error = new Error({
+      code: Code.UnknownException,
+      message: "foo",
+    });
+    const wrappedError = fromUnknown(error);
+    expect(wrappedError).toBe(error);
+  });
+
+  test("wraps built-in error with custom props", () => {
+    const error = new globalThis.Error("MESSAGE");
+    const details = {
+      name: "MyError",
+      foo: "bar",
+      qux: true,
+    };
+    Object.assign(error, details);
+    const wrappedError = fromUnknown(error, Code.BackendTerminated);
+    expect(wrappedError.code).toBe(Code.BackendTerminated);
+    expect(wrappedError.message).toBe(error.message);
+    expect(wrappedError.stack).toBe(error.stack);
+    expect(wrappedError.details).toEqual(details);
+  });
+
+  test("wraps some arbitrary data", () => {
+    const reason = { foo: "bar", qux: true };
+    const wrappedError = fromUnknown(reason, Code.BackendTerminated, "MESSAGE");
+    expect(wrappedError.code).toBe(Code.BackendTerminated);
+    expect(wrappedError.message).toBe("MESSAGE");
+    expect(wrappedError.stack).toBeDefined();
+    expect(wrappedError.details).toEqual(reason);
+  });
+});

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -80,10 +80,12 @@ export const fetchFollowing = (): void => {
 export const showNotificationsForFailedProjects = async (): Promise<void> => {
   const failedProjects = await project.fetchFailed();
   failedProjects.forEach(failedProject => {
-    error.show({
-      code: error.Code.ProjectRequestFailure,
-      message: `The project ${failedProject.metadata.name} could not be loaded`,
-      details: failedProject,
-    });
+    error.show(
+      new error.Error({
+        code: error.Code.ProjectRequestFailure,
+        message: `The project ${failedProject.metadata.name} could not be loaded`,
+        details: failedProject,
+      })
+    );
   });
 };

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -173,7 +173,7 @@ const update = (msg: Msg): void => {
       api
         .post<CreateInput, Project>(`projects`, msg.input)
         .then(creationStore.success)
-        .catch((err: Error) => creationStore.error(error.fromException(err)));
+        .catch(err => creationStore.error(error.fromUnknown(err)));
 
       break;
 
@@ -183,7 +183,7 @@ const update = (msg: Msg): void => {
       api
         .get<Projects>("projects/contributed")
         .then(projectsStore.success)
-        .catch((err: Error) => projectsStore.error(error.fromException(err)));
+        .catch(err => projectsStore.error(error.fromUnknown(err)));
 
       break;
 
@@ -192,7 +192,7 @@ const update = (msg: Msg): void => {
       source
         .getLocalState(msg.path)
         .then(localStateStore.success)
-        .catch((err: Error) => localStateStore.error(error.fromException(err)));
+        .catch(err => localStateStore.error(error.fromUnknown(err)));
       break;
   }
 };
@@ -315,11 +315,13 @@ const fetchBranches = async (path: string) => {
   try {
     state = await source.getLocalState(path);
   } catch (err) {
-    error.log({
-      code: error.Code.LocalStateFetchFailure,
-      message: err.message,
-      source: err,
-    });
+    error.log(
+      new error.Error({
+        code: error.Code.LocalStateFetchFailure,
+        message: err.message,
+        source: err,
+      })
+    );
     localStateError.set(err.message);
     return;
   }

--- a/ui/src/remote.ts
+++ b/ui/src/remote.ts
@@ -165,5 +165,5 @@ export const fetch = <T>(
       return filter ? filter(val) : val;
     })
     .then(store.success)
-    .catch((err: globalThis.Error) => store.error(error.fromException(err)));
+    .catch(err => store.error(error.fromUnknown(err)));
 };

--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -41,7 +41,7 @@ export const fetch = (projectUrn: Urn): void => {
         selectedPeer: peerSelection[0],
       });
     })
-    .catch(err => screenStore.error(error.fromException(err)));
+    .catch(err => screenStore.error(error.fromUnknown(err)));
 };
 
 export const fetchPeers = (): void => {
@@ -73,7 +73,7 @@ export const fetchPeers = (): void => {
           requestInProgress: null,
         });
       })
-      .catch(err => screenStore.error(error.fromException(err)));
+      .catch(err => screenStore.error(error.fromUnknown(err)));
   }
 };
 
@@ -109,7 +109,7 @@ export const refresh = (): void => {
           requestInProgress: null,
         });
       })
-      .catch(err => screenStore.error(error.fromException(err)));
+      .catch(err => screenStore.error(error.fromUnknown(err)));
   }
 };
 
@@ -151,14 +151,14 @@ export const trackPeer = (projectUrn: Urn, peerId: PeerId): void => {
   project
     .trackPeer(projectUrn, peerId)
     .then(() => fetchPeers())
-    .catch(err => screenStore.error(error.fromException(err)));
+    .catch(err => screenStore.error(error.fromUnknown(err)));
 };
 
 export const untrackPeer = (projectUrn: Urn, peerId: PeerId): void => {
   project
     .untrackPeer(projectUrn, peerId)
     .then(() => fetchPeers())
-    .catch(err => screenStore.error(error.fromException(err)));
+    .catch(err => screenStore.error(error.fromUnknown(err)));
 };
 
 export const VALID_PEER_MATCH = /[1-9A-HJ-NP-Za-km-z]{54}/;

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -108,7 +108,7 @@ export const fetch = async (project: Project, peer: User): Promise<void> => {
       tree: writable<source.Tree>(tree),
     });
   } catch (err) {
-    screenStore.error(error.fromException(err));
+    screenStore.error(error.fromUnknown(err));
   }
 };
 
@@ -201,7 +201,7 @@ export const selectRevision = async (
         },
       });
     } catch (err) {
-      screenStore.error(error.fromException(err));
+      screenStore.error(error.fromUnknown(err));
     }
   }
 };
@@ -220,12 +220,14 @@ export const fetchCommit = async (sha1: string): Promise<void> => {
     try {
       commitStore.success(await source.fetchCommit(project.urn, sha1));
     } catch (err) {
-      commitStore.error(error.fromException(err));
-      error.show({
-        code: error.Code.CommitFetchFailure,
-        message: "Could not fetch commit",
-        source: err,
-      });
+      commitStore.error(error.fromUnknown(err));
+      error.show(
+        new error.Error({
+          code: error.Code.CommitFetchFailure,
+          message: "Could not fetch commit",
+          source: err,
+        })
+      );
     }
   }
 };

--- a/ui/src/search.ts
+++ b/ui/src/search.ts
@@ -31,7 +31,7 @@ export const requestProject = async (urn: string): Promise<void> => {
     );
     projectRequestStore.success(projectRequest);
   } catch (err) {
-    projectRequestStore.error(error.fromException(err));
+    projectRequestStore.error(error.fromUnknown(err));
   }
 };
 
@@ -41,6 +41,6 @@ export const searchProject = async (urn: string): Promise<void> => {
     const project = await api.get<project.Project>(`projects/${urn}`);
     projectSearchStore.success(project);
   } catch (err) {
-    projectSearchStore.error(error.fromException(err));
+    projectSearchStore.error(error.fromUnknown(err));
   }
 };

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -101,11 +101,13 @@ const fetchSession = async (): Promise<void> => {
       }
     }
 
-    sessionStore.error({
-      code: error.Code.SessionFetchFailure,
-      message: "Failed to load the session",
-      source: error.fromException(err),
-    });
+    sessionStore.error(
+      new error.Error({
+        code: error.Code.SessionFetchFailure,
+        message: "Failed to load the session",
+        source: error.fromJsError(err),
+      })
+    );
   }
 };
 
@@ -118,11 +120,13 @@ export const unseal = async (passphrase: string): Promise<boolean> => {
   try {
     await proxy.client.keyStoreUnseal({ passphrase });
   } catch (err) {
-    error.show({
-      code: error.Code.KeyStoreUnsealFailure,
-      message: `Could not unlock the session: ${err.message}`,
-      source: err,
-    });
+    error.show(
+      new error.Error({
+        code: error.Code.KeyStoreUnsealFailure,
+        message: `Could not unlock the session: ${err.message}`,
+        source: err,
+      })
+    );
 
     return false;
   }
@@ -144,11 +148,13 @@ const setSettings = async (settings: Settings): Promise<void> => {
   try {
     await proxy.client.sessionSettingsSet(settings);
   } catch (err) {
-    error.show({
-      code: error.Code.SessionSettingsUpdateFailure,
-      message: `Failed to update settings: ${err.message}`,
-      source: error.fromException(err),
-    });
+    error.show(
+      new error.Error({
+        code: error.Code.SessionSettingsUpdateFailure,
+        message: `Failed to update settings: ${err.message}`,
+        source: error.fromJsError(err),
+      })
+    );
     return;
   }
 

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -398,9 +398,9 @@ export function convertError(e: globalThis.Error, label: string): error.Error {
     message = "an unkown transaction error occurred";
   }
 
-  return {
+  return new error.Error({
     code,
     message: `${label}: ${message}`,
-    stack: e.message,
-  };
+    source: error.fromJsError(e),
+  });
 }

--- a/ui/src/userProfile.ts
+++ b/ui/src/userProfile.ts
@@ -13,12 +13,12 @@ export const fetchProjects = (urn: string): void => {
   project
     .fetchUserList(urn)
     .then(projectsStore.success)
-    .catch((err: Error) => projectsStore.error(error.fromException(err)));
+    .catch(err => projectsStore.error(error.fromUnknown(err)));
 };
 
 export const fetchUser = (urn: string): void => {
   identity
     .fetch(urn)
     .then(userStore.success)
-    .catch((err: Error) => userStore.error(error.fromException(err)));
+    .catch(err => userStore.error(error.fromUnknown(err)));
 };

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -129,12 +129,15 @@ export function build(
       await walletConnect.connect();
     } catch (e) {
       stateStore.set({ status: Status.NotConnected, error: e });
-      error.show({
-        code: error.Code.WalletConnectionFailure,
-        message: `Failed to connect wallet: ${e
-          .toString()
-          .replace("Error: ", "")}`,
-      });
+      error.show(
+        new error.Error({
+          code: error.Code.WalletConnectionFailure,
+          message: `Failed to connect wallet: ${e
+            .toString()
+            .replace("Error: ", "")}`,
+          source: error.fromJsError(e),
+        })
+      );
     }
     await initialize();
   }


### PR DESCRIPTION
* Make `Error` a class instead of an interface. This means that we get stack traces whenever an error is created. This allows us to trace the sources of errors more easily. Since `Error` is also a subclass of the built-in JS `Error` we can also `throw` instances of `Error` now.

* Introduce `error.fromUnknown` as a replacement for `fromException`. `fromException` was used `try/catch` blocks to turn a built-in JS Error into our error. It is not guaranteed though that the error from a catch block is an instance of the built-in Error so we also need to cover that case.

* We call `event.preventDefault()` on the global handlers to avoid reporting errors to the console twice.

* We log error details and source to the console along with the stack trace.