### PR TITLE
chore(ui): show version and latest commit sha in dev mode

### DIFF
--- a/native/index.ts
+++ b/native/index.ts
@@ -173,7 +173,19 @@ installMainProcessHandler({
     clipboard.writeText(text);
   },
   async getVersion(): Promise<string> {
-    return app.getVersion();
+    if (isDev) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const version = require("../package.json")["version"];
+      const { stdout, stderr } = await execAsync("git rev-parse HEAD");
+
+      if (!version || stderr) {
+        return "0.0.0";
+      } else {
+        return `${version}-${stdout.trim()}`;
+      }
+    } else {
+      return app.getVersion();
+    }
   },
   async openPath(path: string): Promise<void> {
     shell.openPath(path);


### PR DESCRIPTION
Unfortunately [`app.getVersion()`](app.getVersion()
) only returns the app's version when it is bundled and run in production. In dev mode it returns Electron's version.

|before|after|
|------|-----|
| <img width="1552" alt="Screenshot 2021-04-14 at 17 39 13" src="https://user-images.githubusercontent.com/158411/114739147-ea5b7300-9d48-11eb-9f11-13b75cee6852.png"> | <img width="1552" alt="Screenshot 2021-04-14 at 17 39 39" src="https://user-images.githubusercontent.com/158411/114739185-f34c4480-9d48-11eb-84c6-42525803e089.png"> |
