### PR TITLE
ci: get notarization secrets from keychain

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -101,7 +101,19 @@ time FORCE_COLOR=1 ELECTRON_ENABLE_LOGGING=1 yarn test |
 log-group-end
 
 if [[ "${BUILDKITE_BRANCH:-}" == "master" || -n "${BUILDKITE_TAG:-}" ]]; then
-  log-group-start "Packaging and uploading app binaries"
-  time yarn dist
-  log-group-end
+  if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" == "macos" ]]; then
+    log-group-start "Packaging, notarizing and uploading app binaries"
+    (
+      export NOTARIZE=true
+      export APPLE_ID="rudolfs@monadic.xyz"
+      export APPLE_ID_PASSWORD="@keychain:AC_PASSWORD"
+      export CSC_NAME="Monadic GmbH (35C27H9VL2)"
+      time yarn dist
+    )
+    log-group-end
+  else
+    log-group-start "Packaging and uploading app binaries"
+    time yarn dist
+    log-group-end
+  fi
 fi


### PR DESCRIPTION
This PR moves notarization credentials from `/usr/local/etc/buildkite-agent/hooks` to the macOS keychain.

Refs https://github.com/radicle-dev/radicle-upstream/issues/1530.

A successful test build: https://buildkite.com/monadic/radicle-upstream/builds/8581#c39e7bdd-0260-4fdc-bce2-8b45c4fb5c99.