### PR TITLE
feat(ci): collapse cypress tests in CI logs

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -89,7 +89,15 @@ time yarn run webpack --config-name main
 log-group-end
 
 log-group-start "Starting proxy daemon and runing app tests"
-time ELECTRON_ENABLE_LOGGING=1 yarn test
+# We modify the output of the tests to add log groups to the cypress
+# tests.
+time FORCE_COLOR=1 ELECTRON_ENABLE_LOGGING=1 yarn test |
+  sed "
+    s/^\\s*Running:/$(log-group-end)\n$(log-group-start)Running:/
+    s/^.*Run Finished.*/$(log-group-end)\n$(log-group-start)Run Finished/
+  "
+
+
 log-group-end
 
 if [[ "${BUILDKITE_BRANCH:-}" == "master" || -n "${BUILDKITE_TAG:-}" ]]; then

--- a/ci/setup-buildkite.sh
+++ b/ci/setup-buildkite.sh
@@ -21,7 +21,7 @@ else
 fi
 
 function log-group-start () {
-  echo "--- $1"
+  echo "--- ${1:-}"
 }
 
 function log-group-end () {

--- a/ci/setup-github-actions.sh
+++ b/ci/setup-github-actions.sh
@@ -4,7 +4,7 @@ set -Eeou pipefail
 export CACHE_FOLDER="$HOME/cache"
 
 function log-group-start () {
-  echo "::group::$1"
+  echo "::group::${1:-}"
 }
 
 function log-group-end () {


### PR DESCRIPTION
We collapse the cypress tests in the CI logs to aid readability.

[Example](https://buildkite.com/monadic/radicle-upstream/builds/8584#416f1ce9-1d25-4525-be02-2ea0fbd03856/367)