### PR TITLE
feat(test): store test node logs in file

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -11,6 +11,8 @@
   artifact_paths:
     - "dist/*.AppImage"
     - "cypress/screenshots/**/*.png"
+    - "cypress/workspace/test-tmp/*/node-*/*.log"
+    - "cypress/workspace/test-tmp/*/combined-node.log"
 
 steps:
   - branches: master
@@ -35,3 +37,5 @@ steps:
     artifact_paths:
       - "dist/*.dmg"
       - "cypress/screenshots/**/*.png"
+      - "cypress/workspace/test-tmp/*/node-*/*.log"
+      - "cypress/workspace/test-tmp/*/combined-node.log"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,3 +30,11 @@ jobs:
             ~/cache/proxy-target
           key: build-${{ runner.os }}-rust-v1-${{ hashFiles('Cargo.lock') }}
       - run: ci/run.sh
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-artifacts
+          path: |
+            cypress/screenshots/**/*.png
+            cypress/workspace/test-tmp/*/node-*/*.log
+            cypress/workspace/test-tmp/*/combined-node.log

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -96,8 +96,6 @@ time FORCE_COLOR=1 ELECTRON_ENABLE_LOGGING=1 yarn test |
     s/^\\s*Running:/$(log-group-end)\n$(log-group-start)Running:/
     s/^.*Run Finished.*/$(log-group-end)\n$(log-group-start)Run Finished/
   "
-
-
 log-group-end
 
 if [[ "${BUILDKITE_BRANCH:-}" == "master" || -n "${BUILDKITE_TAG:-}" ]]; then

--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -139,7 +139,7 @@ context("p2p networking", () => {
             "Commit replication from maintainer to contributor";
 
           nodeManager.exec(
-            `cd ${projectPath}
+            `cd "${projectPath}"
             git commit --allow-empty -m "${maintainerCommitSubject}"
             git push rad`,
             maintainerNode
@@ -196,7 +196,7 @@ context("p2p networking", () => {
           );
 
           nodeManager.exec(
-            `cd ${forkedProjectPath}
+            `cd "${forkedProjectPath}"
             git commit --allow-empty -m "${contributorCommitSubject}"
             git push rad`,
             contributorNode


### PR DESCRIPTION
We store the output of nodes in tests in files instead of printing it to stdout. This declutters the test output and makes it easier to inspect the logs, especially on CI. On CI we upload the logs as artifacts.

To make it easy to find the logs we adjust the function that creates temporary directories so that it uses the test name instead of a UUID.

You can see this in action on [buildkite](https://buildkite.com/monadic/radicle-upstream/builds/8607#d7f9ce8d-b212-4eca-ab09-d44a2860c705) and [Github Actions](https://github.com/radicle-dev/radicle-upstream/actions/runs/755714868).

**Open Question**: Should we also send the logs to stdout when developing locally with `yarn test:integration:debug`?