### PR TITLE
style(ui): disable contextual alternatives by default

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -10,7 +10,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scrollbar-width: none;
-  font-feature-settings: "ss01", "ss02", "cv01";
+  font-feature-settings: "ss01", "ss02", "cv01", "calt" 0;
 }
 
 ::-webkit-scrollbar {

--- a/public/typography.css
+++ b/public/typography.css
@@ -145,7 +145,7 @@ p,
   letter-spacing: 0.05rem;
 }
 
-/* Disables contextual alternates */
-.typo-disable-calt {
-  font-feature-settings: "calt" 0;
+/* Enable contextual alternates */
+.typo-enable-calt {
+  font-feature-settings: "calt";
 }

--- a/ui/DesignSystem/Component/SegmentedControl.svelte
+++ b/ui/DesignSystem/Component/SegmentedControl.svelte
@@ -61,7 +61,7 @@
 <div class="segmented-control">
   {#each options as option}
     <button
-      class="typo-semi-bold typo-disable-calt"
+      class="typo-semi-bold"
       class:active={option.value === currentlyActive}
       value={option.value}
       on:click={() => onClick(option)}>

--- a/ui/DesignSystem/Component/Wallet/Panel.svelte
+++ b/ui/DesignSystem/Component/Wallet/Panel.svelte
@@ -79,7 +79,7 @@
     </Dai>
   </h1>
 
-  <div class="address-box typo-text typo-disable-calt">
+  <div class="address-box typo-text">
     <Copyable
       showIcon={false}
       styleContent={false}

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -225,8 +225,8 @@
         <p class="typo-all-caps">Radicle Upstream</p>
       </TypographySwatch>
 
-      <TypographySwatch title={`<p class="typo-disable-calt">`}>
-        <p class="typo-disable-calt">0x0Baf8f...fe71F471</p>
+      <TypographySwatch title={`<p class="typo-enable-calt">`}>
+        <p class="typo-enable-calt">100x20</p>
       </TypographySwatch>
     </Section>
 


### PR DESCRIPTION
In most places we don't want to have contextual alternates enabled.
This way we can selectively enable them where necessary and avoid
missing some spots where they should have been disabled.