### PR TITLE
refactor(ui): explicit grouping of commits

### DIFF
--- a/ui/DesignSystem/Component/SourceBrowser/History.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/History.svelte
@@ -1,11 +1,14 @@
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 
-  import type { CommitHeader, CommitsHistory } from "../../../src/source";
+  import type {
+    CommitHeader,
+    GroupedCommitsHistory,
+  } from "../../../src/source";
 
   import CommitTeaser from "./CommitTeaser.svelte";
 
-  export let history: CommitsHistory;
+  export let history: GroupedCommitsHistory;
 
   const dispatch = createEventDispatcher();
   const onSelect = (commit: CommitHeader) => {
@@ -45,21 +48,23 @@
   }
 </style>
 
-{#each history.history as group (group.time)}
-  <div class="commit-group">
-    <header>
-      <p>{group.time}</p>
-    </header>
-    <ul>
-      {#each group.commits as commit (commit.sha1)}
-        <li class="commit" on:click={() => onSelect(commit)}>
-          <CommitTeaser
-            {commit}
-            style="background: none; --commit-message-color:
+<div data-cy="history">
+  {#each history.history as group (group.time)}
+    <div class="commit-group" data-cy="commit-group">
+      <header>
+        <p>{group.time}</p>
+      </header>
+      <ul>
+        {#each group.commits as commit (commit.sha1)}
+          <li class="commit" data-cy="commit" on:click={() => onSelect(commit)}>
+            <CommitTeaser
+              {commit}
+              style="background: none; --commit-message-color:
             var(--color-foreground-level-6); --commit-sha-color:
             var(--color-foreground)" />
-        </li>
-      {/each}
-    </ul>
-  </div>
-{/each}
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/each}
+</div>

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -49,7 +49,7 @@ export interface Code {
 
 interface Screen {
   code: Writable<Code>;
-  history: source.CommitsHistory;
+  history: source.GroupedCommitsHistory;
   menuItems: HorizontalItem[];
   peer: User;
   project: Project;
@@ -92,11 +92,12 @@ export const fetch = async (project: Project, peer: User): Promise<void> => {
       source.fetchCommits(project.urn, peer.peerId, selectedRevision),
       fetchTreeRoot(selectedRevision),
     ]);
+    const groupedHistory = source.groupCommitHistory(history);
 
     screenStore.success({
       code: writable<Code>(root),
-      history,
-      menuItems: menuItems(project, history),
+      history: groupedHistory,
+      menuItems: menuItems(project, groupedHistory),
       peer,
       project,
       revisions: mapRevisions(revisions),
@@ -188,13 +189,14 @@ export const selectRevision = async (
         source.fetchCommits(project.urn, peer.peerId, revision),
         fetchTreeCode(),
       ]);
+      const groupedHistory = source.groupCommitHistory(history);
       code.set(newCode);
       tree.set(newTree);
 
       screenStore.success({
         ...screen.data,
-        history,
-        menuItems: menuItems(project, history),
+        history: groupedHistory,
+        menuItems: menuItems(project, groupedHistory),
         selectedRevision: {
           request: null,
           selected: revision,
@@ -366,7 +368,7 @@ const mapRevisions = (
 
 const menuItems = (
   project: Project,
-  history: source.CommitsHistory
+  history: source.GroupedCommitsHistory
 ): HorizontalItem[] => {
   return [
     {


### PR DESCRIPTION
In preparation for patches we move the grouping of commits out of `source.fetchCommits` and closer to the UI. This allows us to also obtain ungrouped commits from `fetchCommits` which is needed for patches.