### PR TITLE
fix(api): only set eth claim extension when provided

### DIFF
--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -78,8 +78,10 @@ pub fn update_payload(
     payload.subject = Person {
         name: metadata.handle.into(),
     };
-    let ethereum_claim = metadata.ethereum.map(EthereumClaimExtV1::from);
-    payload.with_ext(ethereum_claim)
+    if let Some(ethereum) = metadata.ethereum {
+        payload.set_ext(EthereumClaimExtV1::from(ethereum))?;
+    }
+    Ok(payload)
 }
 
 impl TryFrom<Metadata> for PersonPayload {
@@ -90,8 +92,9 @@ impl TryFrom<Metadata> for PersonPayload {
             name: metadata.handle.into(),
         };
         let mut payload = Self::new(person);
-        let ethereum_claim = metadata.ethereum.map(EthereumClaimExtV1::from);
-        payload.set_ext(ethereum_claim)?;
+        if let Some(ethereum) = metadata.ethereum {
+            payload.set_ext(EthereumClaimExtV1::from(ethereum))?;
+        }
 
         Ok(payload)
     }

--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -80,6 +80,8 @@ pub fn update_payload(
     };
     if let Some(ethereum) = metadata.ethereum {
         payload.set_ext(EthereumClaimExtV1::from(ethereum))?;
+    } else {
+        payload.remove_ext::<EthereumClaimExtV1>()?;
     }
     Ok(payload)
 }


### PR DESCRIPTION
We only set the Ethereum claim extension when it is included in the metadata. Before we would call `payload.set_ext(None)` which would result in a `null` value in the identity document. This in turned failed to parse in `user.payload().get_ext::<EthereumClaimExtV1>()`.