### PR TITLE
refactor(test): extract empty project creation for networking tests

### DIFF
--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -57,9 +57,7 @@ context("p2p networking", () => {
           cy.log("Create a project via API");
           commands.createEmptyProject(
             projectName,
-            "description...",
             maintainerProjectsDir,
-            "main",
             maintainerNode.httpPort
           );
 

--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -53,21 +53,20 @@ context("p2p networking", () => {
           );
           cy.exec(`mkdir -p "${maintainerProjectsDir}"`);
 
-          ipcStub.getStubs().then(stubs => {
-            stubs.selectDirectory.returns(maintainerProjectsDir);
-          });
           const projectName = "new-fancy-project.xyz";
+          cy.log("Create a project via API");
+          commands.createEmptyProject(
+            projectName,
+            "description...",
+            maintainerProjectsDir,
+            "main",
+            maintainerNode.httpPort
+          );
 
-          commands.pick("new-project-button").click();
-          commands.pasteInto(["name"], projectName);
-
-          commands.pick("new-project").click();
-          commands.pick("new-project", "choose-path-button").click();
-          // Make sure UI has time to update path value from stub,
-          // this prevents this spec from failing on CI.
-          cy.wait(500);
-
-          commands.pick("create-project-button").click();
+          cy.log("refresh the UI for the project to show up");
+          commands.pick("sidebar", "settings").click();
+          commands.pick("sidebar", "profile").click();
+          commands.pick("project-list-entry-new-fancy-project.xyz").click();
 
           commands
             .pickWithContent(["project-screen", "header"], "new-fancy-project")

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -79,9 +79,7 @@ export const createProjectWithFixture = (
 
 export const createEmptyProject = (
   name: string = "new-project",
-  description: string,
   path: string,
-  defaultBranch: string = "trunk",
   localhost: number = 17246
 ): Cypress.Chainable<void> =>
   requestOk({
@@ -96,8 +94,8 @@ export const createEmptyProject = (
         path,
         name,
       },
-      description,
-      defaultBranch,
+      description: "This is the description.",
+      defaultBranch: "main",
     }),
   });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -77,6 +77,30 @@ export const createProjectWithFixture = (
   });
 };
 
+export const createEmptyProject = (
+  name: string = "new-project",
+  description: string,
+  path: string,
+  defaultBranch: string = "trunk",
+  localhost: number = 17246
+): Cypress.Chainable<void> =>
+  requestOk({
+    url: `http://localhost:${localhost}/v1/projects`,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      repo: {
+        type: "new",
+        path,
+        name,
+      },
+      description,
+      defaultBranch,
+    }),
+  });
+
 export const onboardUser = (
   handle = "secretariat"
 ): Cypress.Chainable<void> => {
@@ -89,3 +113,17 @@ export const onboardUser = (
 export const metaKey = (): string => {
   return navigator.platform.includes("Mac") ? "meta" : "ctrl";
 };
+
+/**
+ * Invokes `cy.request` and assert that the response status code is 2xx.
+ */
+function requestOk(
+  opts: Partial<Cypress.RequestOptions> & { url: string }
+): Cypress.Chainable<void> {
+  return cy
+    .request(opts)
+    .then(response => {
+      expect(response.status).to.be.within(200, 299, "Failed response");
+    })
+    .wrap(undefined);
+}


### PR DESCRIPTION
In order to speed up the networking tests and limit the ui interactions to the ones we actually want to test, a new empty project creation command is implemented. This will become useful as well when we extend replication tests to other areas of the app, eg #1682 