### PR TITLE
chore(ui): fix typescript warning

### DIFF
--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -1,11 +1,8 @@
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import validatejs from "validate.js";
-  import {
-    ValidationStatus,
-    getValidationState,
-    ValidationState,
-  } from "../../src/validation";
+  import { ValidationStatus, getValidationState } from "../../src/validation";
+  import type { ValidationState } from "../../src/validation";
 
   import { Button, Input } from "../../DesignSystem/Primitive";
 


### PR DESCRIPTION
Possibly a regression from: https://github.com/radicle-dev/radicle-upstream/commit/c1f79c62d0059e10d26cf835d5c9bdb97c7cd0b2.

Fixes this:
```
  cached modules 7.13 MiB (javascript) 1.71 KiB (runtime) [cached] 1077 modules
  ./ui/Screen/Onboarding/EnterPassphrase.svelte 18.4 KiB [built]

  WARNING in ./ui/Screen/Onboarding/EnterPassphrase.svelte 516:2-17
  export 'ValidationState' (imported as 'ValidationState') was not found in '../../src/validation' (possible exports: ValidationStatus, createValidationStore, getValidationState)
   @ ./ui/Screen/Onboarding.svelte 35:0-66 126:23-38 566:2-17
   @ ./ui/App.svelte 49:0-52 370:17-27 413:2-12
   @ ./ui/index.ts 1:0-31 2:16-19
```