### PR TITLE
chore(ci): get rid of warnings about fonts

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -7,36 +7,47 @@
     <title>Radicle Upstream</title>
 
     <!-- Prevents font load related flickering on boot -->
-    <link rel="preload" href="fonts/Inter-Bold.otf" as="font" type="font/otf" />
+    <link
+      rel="preload"
+      href="fonts/Inter-Bold.otf"
+      as="font"
+      type="font/otf"
+      crossorigin
+    />
     <link
       rel="preload"
       href="fonts/Inter-SemiBold.otf"
       as="font"
       type="font/otf"
+      crossorigin
     />
     <link
       rel="preload"
       href="fonts/Inter-Regular.otf"
       as="font"
       type="font/otf"
+      crossorigin
     />
     <link
       rel="preload"
       href="fonts/SourceCodePro-Bold.otf"
       as="font"
       type="font/otf"
+      crossorigin
     />
     <link
       rel="preload"
       href="fonts/SourceCodePro-Semibold.otf"
       as="font"
       type="font/otf"
+      crossorigin
     />
     <link
       rel="preload"
       href="fonts/SourceCodePro-Regular.otf"
       as="font"
       type="font/otf"
+      crossorigin
     />
 
     <style>


### PR DESCRIPTION
Removes the following warnings from the CI console output:
```
[4936:0422/071855.175313:INFO:CONSOLE(0)] "A preload for 'http://localhost:44433/public/fonts/Inter-Bold.otf' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.", source: http://localhost:44433/public/index.html (0)
```

<img width="1091" alt="Screenshot 2021-04-22 at 09 52 09" src="https://user-images.githubusercontent.com/158411/115677084-7294d600-a350-11eb-86bd-ac747a0f2c12.png">
