### PR TITLE
refactor(ui): tsconfig path mapping for absolute imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "ts-jest": "^26.5.4",
     "ts-loader": "^8.1.0",
     "ts-node": "^9.1.1",
+    "tsconfig-paths-webpack-plugin": "^3.5.1",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4",
     "util": "^0.12.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,9 +68,11 @@
     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "moduleResolution": "node",
     /* Base directory to resolve non-absolute module names. */
-    // "baseUrl": "./",
+    "baseUrl": "./",
     /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "paths": {},
+    "paths": {
+      "ui/*": ["ui/*"]
+    },
     /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "rootDirs": [],
     /* List of folders to include type definitions from. */

--- a/ui/DesignSystem/Component/SourceBrowser/FileView/Blob.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/FileView/Blob.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-  import type { Blob } from "../../../../src/screen/project/source";
+  import type { Blob } from "ui/src/screen/project/source";
 
   import FileSource from "../FileSource.svelte";
 

--- a/ui/DesignSystem/Component/SourceBrowser/FileView/Root.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/FileView/Root.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
-  import type { CommitHeader } from "../../../../src/source";
-  import type { Root } from "../../../../src/screen/project/source";
+  import type { CommitHeader } from "ui/src/source";
+  import type { Root } from "ui/src/screen/project/source";
 
   import EmptyState from "../../EmptyState.svelte";
   import Readme from "../Readme.svelte";

--- a/ui/DesignSystem/Component/SourceBrowser/RevisionSelector/Entry.svelte
+++ b/ui/DesignSystem/Component/SourceBrowser/RevisionSelector/Entry.svelte
@@ -1,12 +1,12 @@
 <script lang="typescript">
-  import { RevisionType } from "../../../../src/source";
-  import { BadgeType } from "../../../../src/badge";
-  import type { Branch, Tag } from "../../../../src/source";
+  import { RevisionType } from "ui/src/source";
+  import { BadgeType } from "ui/src/badge";
+  import type { Branch, Tag } from "ui/src/source";
 
-  import IconBranch from "../../../Primitive/Icon/Branch.svelte";
-  import IconLabel from "../../../Primitive/Icon/Label.svelte";
-  import Spinner from "../../../Component/Spinner.svelte";
-  import Badge from "../../../Component/Badge.svelte";
+  import IconBranch from "ui/DesignSystem/Primitive/Icon/Branch.svelte";
+  import IconLabel from "ui/DesignSystem/Primitive/Icon/Label.svelte";
+  import Spinner from "ui/DesignSystem/Component/Spinner.svelte";
+  import Badge from "ui/DesignSystem/Component/Badge.svelte";
 
   export let loading: boolean = false;
   export let defaultBranch: boolean = false;

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -2,16 +2,16 @@ import { derived, get, writable } from "svelte/store";
 import type { Readable, Writable } from "svelte/store";
 import { push } from "svelte-spa-router";
 
-import * as error from "../../error";
-import * as config from "../../config";
-import type { HorizontalItem } from "../../menu";
-import * as path from "../../path";
-import type { Project, User } from "../../project";
-import * as remote from "../../remote";
-import * as source from "../../source";
+import * as error from "ui/src/error";
+import * as config from "ui/src/config";
+import type { HorizontalItem } from "ui/src/menu";
+import * as path from "ui/src/path";
+import type { Project, User } from "ui/src/project";
+import * as remote from "ui/src/remote";
+import * as source from "ui/src/source";
 
-import IconCommit from "../../../DesignSystem/Primitive/Icon/Commit.svelte";
-import IconFile from "../../../DesignSystem/Primitive/Icon/File.svelte";
+import IconCommit from "ui/DesignSystem/Primitive/Icon/Commit.svelte";
+import IconFile from "ui/DesignSystem/Primitive/Icon/File.svelte";
 
 export enum ViewKind {
   Aborted = "ABORTED",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -2,6 +2,7 @@ import path from "path";
 import sveltePreprocess from "svelte-preprocess";
 import webpack from "webpack";
 import HtmlWebpackPlugin from "html-webpack-plugin";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 interface Argv {
   mode?: "production" | "development";
@@ -85,6 +86,11 @@ function ui(_env: unknown, argv: Argv): webpack.Configuration {
         stream: require.resolve("stream-browserify"),
       },
       extensions: [".svelte", ".ts", ".js"],
+      plugins: [
+        new TsconfigPathsPlugin({
+          extensions: [".svelte", ".ts", ".js"],
+        }),
+      ],
     },
     output: {
       filename: "bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json5@npm:^0.0.29":
+  version: 0.0.29
+  resolution: "@types/json5@npm:0.0.29"
+  checksum: 66e9ac0143ec521522c7bb670301e9836ee886207eeed1aab6d4854a1b19b404ab3a54cd8d449f9b1f13acc357f540be96f8ac2d1e86e301eab52ae0f9a4066f
+  languageName: node
+  linkType: hard
+
 "@types/keyv@npm:^3.1.1":
   version: 3.1.1
   resolution: "@types/keyv@npm:3.1.1"
@@ -8422,6 +8429,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json5@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json5@npm:1.0.1"
+  dependencies:
+    minimist: ^1.2.0
+  bin:
+    json5: lib/cli.js
+  checksum: df41624f9f40bfacc546f779eef6d161a3312fbb6ec1dbd69f8c4388e9807af653b753371ab19b6d2bab22af2ca7dde62fe03c791596acf76915e1fc4ee6fd88
+  languageName: node
+  linkType: hard
+
 "jsonfile@npm:^2.1.0":
   version: 2.4.0
   resolution: "jsonfile@npm:2.4.0"
@@ -10780,6 +10798,7 @@ __metadata:
     ts-jest: ^26.5.4
     ts-loader: ^8.1.0
     ts-node: ^9.1.1
+    tsconfig-paths-webpack-plugin: ^3.5.1
     tslib: ^2.2.0
     twemoji: 13.0.2
     typescript: ^4.2.4
@@ -12989,6 +13008,29 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: a90db4a342872cd0e7a80babdfcb15d2f7c06e700d735003098f7cc79db575c3380580c58a19ae0d0eaab553af083651d4237060c92170e6f8ac4e64693113ea
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths-webpack-plugin@npm:^3.5.1":
+  version: 3.5.1
+  resolution: "tsconfig-paths-webpack-plugin@npm:3.5.1"
+  dependencies:
+    chalk: ^4.1.0
+    enhanced-resolve: ^5.7.0
+    tsconfig-paths: ^3.9.0
+  checksum: 522a48d26112f94850c1d71694bd59a768337df86af5e7b7304debf7b3f825b9a3351484185b3d928de59c882296c6f95bc6167e68c71c60224aa4238b5680b4
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "tsconfig-paths@npm:3.9.0"
+  dependencies:
+    "@types/json5": ^0.0.29
+    json5: ^1.0.1
+    minimist: ^1.2.0
+    strip-bom: ^3.0.0
+  checksum: 5383ba626b3ac70e08094b9dfd1e30ce82878407b6c8db8cd84279cc7c7340d5f53f67dbeb8174a233c082a068322a6b00ec8514b96d9a80a453e0476dc116d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We use TypeScript path mapping to allow absolute imports of the `ui`
folder. I’ve converted some files to the new style to showcase this.

Fixes #734