### PR TITLE
Reactive patches list

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -90,7 +90,7 @@ export const createEmptyProject = (
   name: string = "new-project",
   path: string,
   port: number = 17246
-): Cypress.Chainable<void> =>
+): Cypress.Chainable<string> =>
   requestOk({
     url: `http://localhost:${port}/v1/projects`,
     method: "POST",
@@ -106,7 +106,7 @@ export const createEmptyProject = (
       description: "This is the description.",
       defaultBranch: "main",
     }),
-  });
+  }).then(response => response.urn as string);
 
 export const followProject = (
   urn: string,
@@ -169,13 +169,12 @@ export const metaKey = (): string => {
  */
 function requestOk(
   opts: Partial<Cypress.RequestOptions> & { url: string }
-): Cypress.Chainable<void> {
-  return cy
-    .request(opts)
-    .then(response => {
-      expect(response.status).to.be.within(200, 299, "Failed response");
-    })
-    .wrap(undefined);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Cypress.Chainable<any> {
+  return cy.request(opts).then(response => {
+    expect(response.status).to.be.within(200, 299, "Failed response");
+    return response.body;
+  });
 }
 
 function getCurrentTestName() {

--- a/ui/DesignSystem/Component/SegmentedControl.svelte
+++ b/ui/DesignSystem/Component/SegmentedControl.svelte
@@ -63,6 +63,7 @@
     <button
       class="typo-semi-bold"
       class:active={option.value === currentlyActive}
+      data-cy="segmented-control-option"
       value={option.value}
       on:click={() => onClick(option)}>
       {option.title}

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -1,4 +1,5 @@
 <script lang="typescript">
+  import { onDestroy } from "svelte";
   import Router, { location } from "svelte-spa-router";
   import * as router from "svelte-spa-router/wrap";
 
@@ -11,6 +12,7 @@
   import type { Project, User } from "../../src/project";
   import {
     fetch,
+    watchPatchUpdates,
     selectPath,
     selectRevision,
     store,
@@ -100,6 +102,8 @@
     selectRevision(revision);
   };
 
+  const unwatchPatchUpdates = watchPatchUpdates();
+  onDestroy(unwatchPatchUpdates);
   $: fetch(project, selectedPeer);
 </script>
 

--- a/ui/Screen/Project/Source/PatchList.svelte
+++ b/ui/Screen/Project/Source/PatchList.svelte
@@ -74,7 +74,7 @@
 </style>
 
 <div class="container">
-  <div class="filters">
+  <div class="filters" data-cy="patch-filter-tabs">
     <SegmentedControl
       active={filter}
       options={filterOptions}


### PR DESCRIPTION
We subscribe to the `ProjectUpdated` events to show new patches in the list view without reloading the page. The patches counter in the horizontal menu bar is also updated. Note that the event is currently only triggered for changes coming from other remotes, so updating the list when the user is pushing a patch themselves has to be done in a separate PR.

The following is an example of a `ProjectUpdated` event triggered by a remote pushing a new patch `feature-1`
```
{
    provider: "hyys5xxamaizo7nxbhrxsjkpwh385mabea8uxy3zn1kzmks5jqemj4" 
    type: "projectUpdated" 
    urn: "rad:git:hnrkbpzranjs7kbn45zxfyborhibcugrbyeio/tags/radicle-patch/feature-1"
}
```