### PR TITLE
fix(ui): search enter key follow only when fetched

### DIFF
--- a/cypress/integration/search.spec.ts
+++ b/cypress/integration/search.spec.ts
@@ -27,6 +27,7 @@ context("search", () => {
     it("follows the project by pressing the [enter] hotkey", () => {
       commands.pick("sidebar", "search").click();
       commands.pasteInto(["search-input"], `rad:git:${projectId}`);
+      commands.pick("search-modal", "follow-toggle").should("exist");
       cy.get("body").type("{enter}");
       commands
         .pickWithContent(["undiscovered-project"], projectId)
@@ -92,6 +93,9 @@ context("search", () => {
 
         commands.pick("sidebar", "search").click();
         commands.pick("search-input").type(urn);
+        commands
+          .pick("search-modal", "project-name")
+          .should("contain", "platinum");
         cy.get("body").type("{enter}");
 
         commands.pick("project-screen").should("exist");

--- a/ui/Modal/Search.svelte
+++ b/ui/Modal/Search.svelte
@@ -25,6 +25,7 @@
 
   let value: string;
   $: value = $inputStore.trim();
+  $: storeValue = $store;
 
   const urnValidation = urnValidationStore();
 
@@ -40,13 +41,9 @@
   const onKeydown = (event: KeyboardEvent) => {
     switch (event.code) {
       case "Enter":
-        // Navigate to project directly if present.
-        if ($store.status === remote.Status.Success) {
-          // FIXME(xla): Once remote/Remote offer stronger type guarantees this needs to go.
-          navigateToProject(
-            ($store as { status: remote.Status.Success; data: Project }).data
-          );
-        } else {
+        if (storeValue.status === remote.Status.Success) {
+          navigateToProject(storeValue.data);
+        } else if (storeValue.status === remote.Status.Error) {
           follow();
         }
         break;


### PR DESCRIPTION
Hitting “enter” in the search dialog only triggers a follow if we know whether the project has been found or not. It doesn’t trigger when we’re still fetching the search result.

We also adapt the tests so that we wait for the search result to be present.