### PR TITLE
refactor(ui): add project proxy client

### DIFF
--- a/ui/DesignSystem/Component/ProjectList.svelte
+++ b/ui/DesignSystem/Component/ProjectList.svelte
@@ -11,7 +11,7 @@
 
   const projectCardProps = (project: Project) => ({
     title: project.metadata.name,
-    description: project.metadata.description,
+    description: project.metadata.description || "",
     showMaintainerBadge: isMaintainer(userUrn, project),
   });
 </script>

--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -10,7 +10,6 @@
   import * as remote from "../src/remote";
   import {
     clearLocalState,
-    create,
     defaultBranch,
     defaultBranchForNewRepository,
     localState,
@@ -19,8 +18,8 @@
     formatNameInput,
     extractName,
     repositoryPathValidationStore,
-    RepoType,
   } from "../src/project";
+  import * as proxy from "../src/proxy";
   import { ValidationStatus } from "../src/validation";
   import * as screen from "../src/screen";
   import type { Settings } from "../src/settings";
@@ -36,13 +35,15 @@
   } from "../DesignSystem/Component";
   import { CSSPosition } from "../src/style";
 
+  type RepoType = "new" | "existing";
+
   let currentSelection: RepoType;
   let nameInput: HTMLInputElement;
 
   let startValidations = false;
 
-  $: isNew = currentSelection === RepoType.New;
-  $: isExisting = currentSelection === RepoType.Existing;
+  $: isNew = currentSelection === "new";
+  $: isExisting = currentSelection === "existing";
 
   let name = "";
   let description = "";
@@ -66,14 +67,14 @@
       loading = true;
       screen.lock();
 
-      const response = await create({
+      const response = await proxy.client.project.create({
         description,
         defaultBranch: isNew
           ? await defaultBranchForNewRepository()
           : $defaultBranch,
         repo: isNew
-          ? { type: RepoType.New, name, path: newRepositoryPath }
-          : { type: RepoType.Existing, path: existingRepositoryPath },
+          ? { type: "new", name, path: newRepositoryPath }
+          : { type: "existing", path: existingRepositoryPath },
       });
 
       push(path.project(response.urn));
@@ -197,7 +198,7 @@
         active={isNew}
         on:click={ev => {
           ev.stopPropagation();
-          setCurrentSelection(RepoType.New);
+          setCurrentSelection('new');
         }}
         dataCy="new-project">
         <div slot="option-body">
@@ -220,7 +221,7 @@
         active={isExisting}
         on:click={ev => {
           ev.stopPropagation();
-          setCurrentSelection(RepoType.Existing);
+          setCurrentSelection('existing');
         }}
         dataCy="existing-project">
         <div slot="option-body">

--- a/ui/Screen/Profile/Following.svelte
+++ b/ui/Screen/Profile/Following.svelte
@@ -9,7 +9,7 @@
   import * as modal from "../../src/modal";
   import * as path from "../../src/path";
   import { following as store, fetchFollowing } from "../../src/profile";
-  import { cancelRequest } from "../../src/project";
+  import * as proxy from "../../src/proxy";
   import type { Project } from "../../src/project";
   import type { UnsealedSession } from "../../src/session";
   import type { Urn } from "../../src/urn";
@@ -27,7 +27,7 @@
 
   const session: UnsealedSession = getContext("session");
   const onCancel = (urn: Urn): void => {
-    cancelRequest(urn).then(fetchFollowing);
+    proxy.client.project.requestCancel(urn).then(fetchFollowing);
   };
   const onSelect = ({ detail: project }: { detail: Project }) => {
     push(path.project(project.urn));

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -7,7 +7,7 @@
   import type { HorizontalItem } from "../../src/menu";
   import * as notification from "../../src/notification";
   import * as path from "../../src/path";
-  import { checkout } from "../../src/project";
+  import * as proxy from "../../src/proxy";
   import type { Project, User } from "../../src/project";
   import {
     fetch,
@@ -46,11 +46,10 @@
   ) => {
     try {
       screen.lock();
-      const path = await checkout(
-        project.urn,
-        checkoutPath,
-        peer.identity.peerId
-      );
+      const path = await proxy.client.project.checkout(project.urn, {
+        path: checkoutPath,
+        peerId: peer.identity.peerId,
+      });
 
       notification.info({
         message: `${project.metadata.name} checked out to ${path}`,

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -5,6 +5,7 @@ import * as localPeer from "./localPeer";
 import * as project from "./project";
 import * as remote from "./remote";
 import * as waitingRoom from "./waitingRoom";
+import * as proxy from "./proxy";
 
 // TYPES
 interface Following {
@@ -71,14 +72,14 @@ export const following: Readable<remote.Data<Following | null>> = derived(
 
 // ACTIONS
 export const fetchFollowing = (): void => {
-  remote.fetch(followingProjectsStore, project.fetchTracking());
+  remote.fetch(followingProjectsStore, proxy.client.project.listTracked());
   remote.fetch(requestedProjectsStore, project.fetchSearching(), reqs => {
     return reqs.filter(req => req.type !== waitingRoom.Status.Cloned);
   });
 };
 
 export const showNotificationsForFailedProjects = async (): Promise<void> => {
-  const failedProjects = await project.fetchFailed();
+  const failedProjects = await proxy.client.project.listFailed();
   failedProjects.forEach(failedProject => {
     error.show(
       new error.Error({

--- a/ui/src/project.test.ts
+++ b/ui/src/project.test.ts
@@ -1,6 +1,5 @@
 import { get } from "svelte/store";
 
-import * as api from "./api";
 import * as project from "./project";
 import * as remote from "./remote";
 import { UPSTREAM_DEFAULT_BRANCH } from "./config";
@@ -60,32 +59,6 @@ describe("creating a project", () => {
       process.nextTick(() => {
         expect(get(project.defaultBranch)).toEqual(UPSTREAM_DEFAULT_BRANCH);
       });
-    });
-  });
-
-  it("sends a correctly-formatted POST request to api", () => {
-    project
-      .create({
-        defaultBranch: "trunk",
-        description: "surfing",
-        repo: {
-          type: project.RepoType.New,
-          name: "radicle-surf",
-          path: "somewhere/in/the/machine",
-        },
-      })
-      .catch(reason => {
-        console.error("Project creation failed: ", reason);
-      });
-
-    expect(api.post).toHaveBeenCalledWith("projects", {
-      defaultBranch: "trunk",
-      description: "surfing",
-      repo: {
-        type: project.RepoType.New,
-        name: "radicle-surf",
-        path: "somewhere/in/the/machine",
-      },
     });
   });
 });

--- a/ui/src/proxy/index.ts
+++ b/ui/src/proxy/index.ts
@@ -4,6 +4,7 @@ import * as config from "../config";
 import * as settings from "./settings";
 import * as identity from "./identity";
 import * as control from "./control";
+import * as project from "./project";
 import { Fetcher, ResponseError, RequestOptions } from "./fetcher";
 
 export { ResponseError };
@@ -34,10 +35,12 @@ export class Client {
   private fetcher: Fetcher;
 
   public control: control.Control;
+  public project: project.Client;
 
   constructor(baseUrl: string) {
     this.fetcher = new Fetcher(baseUrl);
     this.control = new control.Control(this.fetcher);
+    this.project = new project.Client(this.fetcher);
   }
 
   async sessionGet(options?: RequestOptions): Promise<Session> {

--- a/ui/src/proxy/project.ts
+++ b/ui/src/proxy/project.ts
@@ -1,0 +1,167 @@
+import * as zod from "zod";
+import type { Fetcher } from "./fetcher";
+
+export interface Project {
+  urn: string;
+  shareableEntityIdentifier: string;
+  metadata: Metadata;
+  stats: Stats;
+}
+
+const projectSchema: zod.Schema<Project> = zod.object({
+  urn: zod.string(),
+  shareableEntityIdentifier: zod.string(),
+  metadata: zod.object({
+    name: zod.string(),
+    defaultBranch: zod.string(),
+    description: zod.string().nullable(),
+    maintainers: zod.array(zod.string()),
+  }),
+  stats: zod.object({
+    branches: zod.number(),
+    commits: zod.number(),
+    contributors: zod.number(),
+  }),
+});
+
+export interface Stats {
+  branches: number;
+  commits: number;
+  contributors: number;
+}
+
+export interface Metadata {
+  name: string;
+  defaultBranch: string;
+  description: string | null;
+  maintainers: string[];
+}
+
+export interface CreateParams {
+  repo: NewRepo | ExistingRepo;
+  description?: string;
+  defaultBranch: string;
+}
+
+interface NewRepo {
+  type: "new";
+  path: string;
+  name: string;
+}
+
+interface ExistingRepo {
+  type: "existing";
+  path: string;
+}
+
+export interface CheckoutParams {
+  peerId?: string;
+  path: string;
+}
+
+export class Client {
+  private fetcher: Fetcher;
+
+  constructor(fetcher: Fetcher) {
+    this.fetcher = fetcher;
+  }
+
+  async create(params: CreateParams): Promise<Project> {
+    return this.fetcher.fetchOk(
+      {
+        method: "POST",
+        path: "projects",
+        body: params,
+      },
+      projectSchema
+    );
+  }
+
+  async get(urn: string): Promise<Project> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: `projects/${urn}`,
+      },
+      projectSchema
+    );
+  }
+
+  async listFailed(): Promise<Project[]> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: "projects/failed",
+      },
+      zod.array(projectSchema)
+    );
+  }
+
+  async listTracked(): Promise<Project[]> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: "projects/tracked",
+      },
+      zod.array(projectSchema)
+    );
+  }
+
+  async listContributed(): Promise<Project[]> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: "projects/contributed",
+      },
+      zod.array(projectSchema)
+    );
+  }
+
+  async listForUser(userUrn: string): Promise<Project[]> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: `projects/user/${userUrn}`,
+      },
+      zod.array(projectSchema)
+    );
+  }
+
+  async requestCancel(urn: string): Promise<void> {
+    return this.fetcher.fetchOkNoContent({
+      method: "DELETE",
+      path: `projects/requests/${urn}`,
+    });
+  }
+
+  async peerTrack(urn: string, peerId: string): Promise<boolean> {
+    return this.fetcher.fetchOk(
+      {
+        method: "PUT",
+        path: `projects/${urn}/track/${peerId}`,
+      },
+      zod.boolean()
+    );
+  }
+
+  async peerUntrack(urn: string, peerId: string): Promise<boolean> {
+    return this.fetcher.fetchOk(
+      {
+        method: "PUT",
+        path: `projects/${urn}/untrack/${peerId}`,
+      },
+      zod.boolean()
+    );
+  }
+
+  async checkout(urn: string, params: CheckoutParams): Promise<string> {
+    return this.fetcher.fetchOk(
+      {
+        method: "POST",
+        path: `projects/${urn}/checkout`,
+        body: params,
+      },
+      zod.string()
+    );
+  }
+}

--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -6,6 +6,7 @@ import * as project from "../project";
 import * as remote from "../remote";
 import type { Urn } from "../urn";
 import * as validation from "../validation";
+import * as proxy from "../proxy";
 
 interface Screen {
   peers: project.Peer[];
@@ -23,8 +24,8 @@ export const fetch = (projectUrn: Urn): void => {
 
   let current: project.Project;
 
-  project
-    .fetch(projectUrn)
+  proxy.client.project
+    .get(projectUrn)
     .then(p => {
       current = p;
 
@@ -148,15 +149,15 @@ export const pendingPeers: Readable<
 );
 
 export const trackPeer = (projectUrn: Urn, peerId: PeerId): void => {
-  project
-    .trackPeer(projectUrn, peerId)
+  proxy.client.project
+    .peerTrack(projectUrn, peerId)
     .then(() => fetchPeers())
     .catch(err => screenStore.error(error.fromUnknown(err)));
 };
 
 export const untrackPeer = (projectUrn: Urn, peerId: PeerId): void => {
-  project
-    .untrackPeer(projectUrn, peerId)
+  proxy.client.project
+    .peerUntrack(projectUrn, peerId)
     .then(() => fetchPeers())
     .catch(err => screenStore.error(error.fromUnknown(err)));
 };

--- a/ui/src/userProfile.ts
+++ b/ui/src/userProfile.ts
@@ -1,17 +1,18 @@
 import * as identity from "./identity";
-import * as project from "./project";
 import * as remote from "./remote";
 import * as error from "./error";
+import * as proxy from "./proxy";
+import type { Project } from "./proxy/project";
 
-const projectsStore = remote.createStore<project.Project[]>();
+const projectsStore = remote.createStore<Project[]>();
 export const projects = projectsStore.readable;
 
 const userStore = remote.createStore<identity.Identity>();
 export const user = userStore.readable;
 
 export const fetchProjects = (urn: string): void => {
-  project
-    .fetchUserList(urn)
+  proxy.client.project
+    .listForUser(urn)
     .then(projectsStore.success)
     .catch(err => projectsStore.error(error.fromUnknown(err)));
 };


### PR DESCRIPTION
We add an `Client` to interact with the project API of the proxy and use this throughout the codebase.