### PR TITLE
fix(ui): display branch a commit belongs to

### DIFF
--- a/cypress/integration/project/source_browsing.spec.ts
+++ b/cypress/integration/project/source_browsing.spec.ts
@@ -49,6 +49,7 @@ context("project source browsing", () => {
           .pick("commit-header")
           .contains("Commit 223aaf87d6ea62eef0014857640fd7c8dd0f80b5")
           .should("exist");
+        commands.pick("commit-branch").should("contain", "master");
       });
 
       it("shows the commit history for another branch", () => {
@@ -76,6 +77,8 @@ context("project source browsing", () => {
             "Commit 27acd68c7504755aa11023300890bb85bbd69d45"
           )
           .should("exist");
+
+        commands.pick("commit-branch").should("contain", "dev");
       });
     });
   });

--- a/ui/src/source.ts
+++ b/ui/src/source.ts
@@ -31,6 +31,7 @@ export interface CommitStats {
 }
 
 export interface Commit {
+  branches: string[];
   diff: diff.Diff;
   header: CommitHeader;
   stats: CommitStats;


### PR DESCRIPTION
The API now provides the branch a commit belongs to. This partially reverts #1717.

The issue was not discovered because of disabled type checking due to #1798. We address this by not using the `Remote` component

The motivation for #1717 was to gracefully handle commits without branches and not panic. We accomplish this by returning the (possibly empty) list of all branches and only showing the first branch (if present) in the UI.

Fixes #1793