### PR TITLE
fix(ui): more robust session context

### DIFF
--- a/ui/DesignSystem/Component/SidebarLayout.svelte
+++ b/ui/DesignSystem/Component/SidebarLayout.svelte
@@ -1,14 +1,12 @@
 <script lang="typescript">
-  import { getContext } from "svelte";
-
-  import type { UnsealedSession } from "../../src/session";
+  import * as sess from "../../src/session";
 
   import Sidebar from "./Sidebar.svelte";
 
   export let dataCy: string = "";
   export let style: string = "";
 
-  const session: UnsealedSession = getContext("session");
+  const session = sess.getUnsealedFromContext();
 </script>
 
 <style>

--- a/ui/Screen/Profile.svelte
+++ b/ui/Screen/Profile.svelte
@@ -1,11 +1,10 @@
 <script lang="typescript">
-  import { getContext } from "svelte";
   import Router from "svelte-spa-router";
 
   import { isExperimental } from "../src/config";
   import * as modal from "../src/modal";
   import * as path from "../src/path";
-  import type { UnsealedSession } from "../src/session";
+  import * as sess from "../src/session";
   import { settings } from "../src/session";
 
   import { Button, Icon } from "../DesignSystem/Primitive";
@@ -51,7 +50,7 @@
     });
   }
 
-  const session: UnsealedSession = getContext("session");
+  const session = sess.getUnsealedFromContext();
 </script>
 
 <SidebarLayout style="margin-top: 0;" dataCy="profile-screen">

--- a/ui/Screen/Profile/Following.svelte
+++ b/ui/Screen/Profile/Following.svelte
@@ -1,5 +1,4 @@
 <script lang="typescript">
-  import { getContext } from "svelte";
   import { fade } from "svelte/transition";
   import { push } from "svelte-spa-router";
 
@@ -11,7 +10,7 @@
   import { following as store, fetchFollowing } from "../../src/profile";
   import * as proxy from "../../src/proxy";
   import type { Project } from "../../src/project";
-  import type { UnsealedSession } from "../../src/session";
+  import * as sess from "../../src/session";
   import type { Urn } from "../../src/urn";
 
   import {
@@ -25,7 +24,7 @@
   } from "../../DesignSystem/Component";
   import { Button, Icon } from "../../DesignSystem/Primitive";
 
-  const session: UnsealedSession = getContext("session");
+  const session = sess.getUnsealedFromContext();
   const onCancel = (urn: Urn): void => {
     proxy.client.project.requestCancel(urn).then(fetchFollowing);
   };

--- a/ui/Screen/Profile/Projects.svelte
+++ b/ui/Screen/Profile/Projects.svelte
@@ -1,5 +1,4 @@
 <script lang="typescript">
-  import { getContext } from "svelte";
   import { push } from "svelte-spa-router";
 
   import ModalNewProject from "../../Modal/NewProject.svelte";
@@ -9,7 +8,7 @@
   import { fetchList, projects as store } from "../../src/project";
   import type { Project } from "../../src/project";
   import { showNotificationsForFailedProjects } from "../../src/profile";
-  import type { UnsealedSession } from "../../src/session";
+  import * as sess from "../../src/session";
 
   import {
     EmptyState,
@@ -18,7 +17,7 @@
     Remote,
   } from "../../DesignSystem/Component";
 
-  const session: UnsealedSession = getContext("session");
+  const session = sess.getUnsealedFromContext();
 
   const create = () => {
     modal.toggle(ModalNewProject);

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-  import { onMount, getContext } from "svelte";
+  import { onMount } from "svelte";
   import { push } from "svelte-spa-router";
 
   import * as localPeer from "../src/localPeer";
@@ -8,7 +8,7 @@
   import { isMaintainer, isContributor } from "../src/project";
   import type { User } from "../src/project";
   import { fetch, selectPeer, refresh, store } from "../src/screen/project";
-  import type { UnsealedSession } from "../src/session";
+  import * as sess from "../src/session";
   import { CSSPosition } from "../src/style";
   import type { Urn } from "../src/urn";
 
@@ -28,7 +28,7 @@
   export let params: { urn: Urn };
 
   const { urn } = params;
-  const session: UnsealedSession = getContext("session");
+  const session = sess.getUnsealedFromContext();
   const trackTooltipMaintainer = "You can't unfollow your own project";
   const trackTooltip = "Unfollowing is not yet supported";
 

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -1,5 +1,4 @@
 <script lang="typescript">
-  import { getContext } from "svelte";
   import * as svelteStore from "svelte/store";
 
   import { selectedEnvironment as ethereumEnvironment } from "../src/ethereum";
@@ -14,7 +13,7 @@
     updateAppearance,
     updateFeatureFlags,
   } from "../src/session";
-  import type { UnsealedSession } from "../src/session";
+  import * as sess from "../src/session";
   import {
     themeOptions,
     uiFontOptions,
@@ -95,7 +94,7 @@
     { value: "off", title: "Turn off" },
   ];
 
-  const session = getContext("session") as UnsealedSession;
+  const session = sess.getUnsealedFromContext();
 </script>
 
 <style>

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -60,6 +60,7 @@ export enum Code {
   UnhandledError = "UnhandledError",
   UnhandledRejection = "UnhandledRejection",
   UnknownException = "UnknownException",
+  UnsealedSessionExpected = "UnsealedSessionExpected",
 
   // Funding related error codes
   WalletConnectionFailure = "WalletConnectionFailure",

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -1,3 +1,4 @@
+import * as svelte from "svelte";
 import { Readable, derived, get } from "svelte/store";
 
 import * as proxy from "./proxy";
@@ -85,6 +86,26 @@ export const settings: Readable<Settings> = derived(sessionStore, sess => {
     return defaultSetttings();
   }
 });
+
+// Get the unsealed session from the Svelte context. Throws if the
+// session is not unsealed.
+//
+// The function uses `svelte.getContext` and must be called from a
+// component.
+export const getUnsealedFromContext = (): UnsealedSession => {
+  const session = svelte.getContext("session") as Session;
+  if (session.status === Status.UnsealedSession) {
+    return session;
+  } else {
+    throw new error.Error({
+      code: error.Code.UnsealedSessionExpected,
+      message: "session is not unsealed",
+      details: {
+        status: session.status,
+      },
+    });
+  }
+};
 
 const fetchSession = async (): Promise<void> => {
   try {


### PR DESCRIPTION
We make acquiring the unsealed session from the context more robust. This was inspired by [comments on #1828][1].

* We stop hardcoding the `session` string into the context
* Instead of using type assertion which don’t fail at runtime we throw an error. If a session is not unsealed this will make it easier to locate the cause.

[1]: https://github.com/radicle-dev/radicle-upstream/pull/1828#discussion_r620346071