### PR TITLE
feat(ui): improve error reporting for parse failures

### DIFF
--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -35,8 +35,14 @@ export class Error extends globalThis.Error {
 
   constructor(params: ErrorParams) {
     super(params.message);
-    this.message = params.message;
+    Object.defineProperty(this, "stack", {
+      enumerable: true,
+    });
     this.code = params.code;
+    this.message = params.message;
+    Object.defineProperty(this, "message", {
+      enumerable: true,
+    });
     this.details = params.details;
     if (params.source) {
       this.source = fromUnknown(params.source);
@@ -48,6 +54,7 @@ export enum Code {
   BackendTerminated = "BackendTerminated",
   CommitFetchFailure = "CommitFetchFailure",
   IdentityCreationFailure = "IdentityCreationFailure",
+  ProxyEventParseFailure = "ProxyEventParseFailure",
   KeyStoreUnsealFailure = "KeyStoreUnsealFailure",
   LocalStateFetchFailure = "LocalStateFetchFailure",
   ProjectCheckoutFailure = "ProjectCheckoutFailure",

--- a/ui/src/localPeer.ts
+++ b/ui/src/localPeer.ts
@@ -9,6 +9,7 @@ import * as path from "./path";
 import * as remote from "./remote";
 import * as session from "./session";
 import type * as urn from "./urn";
+import * as error from "./error";
 
 // TYPES
 export enum StatusType {
@@ -154,8 +155,20 @@ session.session.subscribe(sess => {
       );
       eventSource.addEventListener("message", msg => {
         const data = JSON.parse(msg.data);
-        const event = eventSchema.parse(data);
-        eventStore.set(event);
+        const result = eventSchema.safeParse(data);
+        if (result.success) {
+          eventStore.set(result.data);
+        } else {
+          error.show(
+            new error.Error({
+              code: error.Code.ProxyEventParseFailure,
+              message: "Failed to parse proxy event",
+              details: {
+                errors: result.error.errors,
+              },
+            })
+          );
+        }
       });
     }
   }


### PR DESCRIPTION
We improve the reporting of errors when parsing the proxy response fails.

* We make the `message` and `stack` properties of `Error` enumberable so that they are part of the error payload that is copied to the clipboard.
* We wrap `zod.Schema.parse` so that we can attach information about the requests to the error that is thrown.