### PR TITLE
Reduce number of requests to an Ethereum client

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "mnemonist": "^0.38.3",
     "pure-svg-code": "^1.0.6",
     "qs": "^6.10.1",
-    "radicle-contracts": "github:radicle-dev/radicle-contracts#commit=f401f4f1222cbee48197c5268d81ee2cb92b6421",
+    "radicle-contracts": "github:radicle-dev/radicle-contracts#commit=752cf0767c6ba7428c626abf91ae1874de613f26",
     "semver": "^7.3.5",
     "stream-browserify": "^3.0.0",
     "svelte-persistent-store": "^0.1.6",

--- a/ui/src/attestation/contract.ts
+++ b/ui/src/attestation/contract.ts
@@ -56,10 +56,11 @@ export class ClaimsContract {
   ): Promise<() => void> {
     const filter = this.contract.filters.Claimed(address);
 
-    await this.contract.on(filter, async (_: unknown, event: ethers.Event) => {
+    const listener = async (_: unknown, event: ethers.Event) => {
       const claimed = await this.getClaimed(event.transactionHash, address);
       onClaimed(claimed);
-    });
+    };
+    await this.contract.on(filter, listener);
 
     const lastEvent = (await this.contract.queryFilter(filter)).pop();
     if (lastEvent !== undefined) {
@@ -72,7 +73,7 @@ export class ClaimsContract {
       onClaimed(undefined);
     }
     return () => {
-      this.contract.off(filter, onClaimed);
+      this.contract.off(filter, listener);
     };
   }
 

--- a/ui/src/funding/contract.ts
+++ b/ui/src/funding/contract.ts
@@ -1,48 +1,51 @@
-import type { BigNumber, ContractTransaction, Signer } from "ethers";
+import { BigNumber, ContractTransaction, Signer } from "ethers";
 
 import Big from "big.js";
 
 import {
   Erc20Pool,
   Erc20Pool__factory as PoolFactory,
-  ERC20,
-  ERC20__factory as Erc20Factory,
 } from "radicle-contracts/build/contract-bindings/ethers";
+
+import type { TypedEvent } from "radicle-contracts/build/contract-bindings/ethers/commons";
 
 import * as ethereum from "../ethereum";
 
 const addresses = {
-  pool: {
-    local: "0x56a32c0c857f1ae733562078a693ea845d9bb423",
-    ropsten: "0x336C7fE92c08A9e48738a48f846860C1fD35647C",
-  },
-  dai: {
-    local: "0xff1d4d289bf0aaaf918964c57ac30481a67728ef",
-    ropsten: "0x6e80bf4Fd0b102E6385C545375C8fF3B30D554eA",
-  },
+  local: "0x56a32c0c857f1ae733562078a693ea845d9bb423",
+  ropsten: "0x22B39d2F5768CE402077223b3f871d9b4393A5f2",
 };
 
-// Get the address of the Pool Contract for the given environment
-export function daiTokenAddress(environment: ethereum.Environment): string {
-  switch (environment) {
-    case ethereum.Environment.Local:
-      return addresses.dai.local;
-    case ethereum.Environment.Ropsten:
-      return addresses.dai.ropsten;
-  }
+interface SenderUpdatedArgs {
+  sender: string;
+  balance: BigNumber;
+  amtPerSec: BigNumber;
 }
+type SenderUpdatedEvent = TypedEvent<SenderUpdatedArgs & Array<unknown>>;
 
-export function daiToken(signer: Signer, address: string): ERC20 {
-  return Erc20Factory.connect(address, signer);
+interface CollectedArgs {
+  receiver: string;
+  amt: BigNumber;
 }
+type CollectedEvent = TypedEvent<CollectedArgs & Array<unknown>>;
+
+interface SenderToReceiverUpdatedArgs {
+  sender: string;
+  receiver: string;
+  amtPerSec: BigNumber;
+  endTime: BigNumber;
+}
+type SenderToReceiverUpdatedEvent = TypedEvent<
+  SenderToReceiverUpdatedArgs & Array<unknown>
+>;
 
 // Get the address of the Pool Contract for the given environment
 export function poolAddress(environment: ethereum.Environment): string {
   switch (environment) {
     case ethereum.Environment.Local:
-      return addresses.pool.local;
+      return addresses.local;
     case ethereum.Environment.Ropsten:
-      return addresses.pool.ropsten;
+      return addresses.ropsten;
   }
 }
 
@@ -54,9 +57,19 @@ export function pool(signer: Signer, address: string): PoolContract {
 // that offers a more ergonomic API around the contract.
 export class PoolContract {
   contract: Erc20Pool;
+  WITHDRAW_ALL = BigNumber.from(1).shl(128).sub(1);
+  AMT_PER_SEC_UNCHANGED = BigNumber.from(1).shl(128).sub(1);
 
   constructor(signer: Signer, address: string) {
     this.contract = PoolFactory.connect(address, signer);
+  }
+
+  contractAddr(): string {
+    return this.contract.address;
+  }
+
+  async signerAddr(): Promise<string> {
+    return this.contract.signer.getAddress();
   }
 
   async onboard(
@@ -87,64 +100,276 @@ export class PoolContract {
   }
 
   async topUp(amount: Big): Promise<ContractTransaction> {
-    const UNCHANGED = await this.contract.AMT_PER_SEC_UNCHANGED();
     return this.contract.updateSender(
       ethereum.fromBaseUnit(amount),
       0,
-      UNCHANGED,
+      this.AMT_PER_SEC_UNCHANGED,
       [],
       []
     );
   }
 
   async withdraw(amount: Big): Promise<ContractTransaction> {
-    const UNCHANGED = await this.contract.AMT_PER_SEC_UNCHANGED();
     return this.contract.updateSender(
       0,
       ethereum.fromBaseUnit(amount),
-      UNCHANGED,
+      this.AMT_PER_SEC_UNCHANGED,
       [],
       []
     );
   }
 
   async withdrawAll(): Promise<ContractTransaction> {
-    const UNCHANGED = await this.contract.AMT_PER_SEC_UNCHANGED();
-    const ALL = await this.withdrawAllFlag();
-    return this.contract.updateSender(0, ALL, UNCHANGED, [], []);
+    return this.contract.updateSender(
+      0,
+      this.WITHDRAW_ALL,
+      this.AMT_PER_SEC_UNCHANGED,
+      [],
+      []
+    );
   }
 
   async collect(): Promise<ContractTransaction> {
     return this.contract.collect();
   }
 
-  async withdrawAllFlag(): Promise<BigNumber> {
-    return this.contract.WITHDRAW_ALL();
+  // Start watching the state of a given pool sender.
+  // `onUpdated` is called immediately with the latest state.
+  // Returns a function, which unwatches the state when called.
+  async watchPoolSender(
+    sender: string,
+    onUpdated: (data: PoolSenderData) => void
+  ): Promise<() => void> {
+    const filter = this.contract.filters.SenderUpdated(sender);
+
+    const listener = async (
+      _sender: unknown,
+      _balance: unknown,
+      _amtPerSec: unknown,
+      event: SenderUpdatedEvent
+    ) => onUpdated(await getSenderData(event));
+    this.contract.on(filter, listener);
+
+    const lastEvents = await this.contract.queryFilter(filter);
+    const lastEvent = lastEvents.pop();
+    if (lastEvent) {
+      onUpdated(await getSenderData(lastEvent));
+    } else {
+      // Sender never configured
+      onUpdated({
+        getBalance: () => Big(0),
+        weeklyBudget: Big(0),
+        receivers: [],
+      });
+    }
+
+    return () => this.contract.off(filter, listener);
   }
 
-  async withdrawable(): Promise<Big> {
-    return this.contract.withdrawable().then(ethereum.toBaseUnit);
-  }
+  // Start watching the state of a given pool receiver.
+  // `onUpdated` is called immediately with the latest state.
+  // Returns a function, which unwatches the state when called.
+  async watchPoolReceiver(
+    receiver: string,
+    onUpdated: (getCollectable: (now: Date) => Big) => void
+  ): Promise<() => void> {
+    const cycleSecs = (await this.contract.cycleSecs()).toNumber();
+    const state = new ReceiverState(cycleSecs);
+    const getCollectable = (now: Date) => state.getCollectable(now);
 
-  async collectable(): Promise<Big> {
-    return this.contract.collectable().then(ethereum.toBaseUnit);
-  }
+    const filterStream = this.contract.filters.SenderToReceiverUpdated(
+      null,
+      receiver
+    );
 
-  async weeklyBudget(): Promise<Big> {
-    return this.contract.getAmtPerSec().then(amountPerSecToWeeklyBudget);
-  }
+    const streamListener = async (
+      _sender: unknown,
+      _receiver: unknown,
+      _amtPerSec: unknown,
+      _endTime: unknown,
+      event: SenderToReceiverUpdatedEvent
+    ) => {
+      await state.onStreamUpdated(event);
+      // For now it doesn't make sense to call `onUpdated` here,
+      // because `getCollectable` doesn't change.
+      // This is to keep the behavior of the `watchPoolReceiver`
+      // align with its documentation and leave room for addition of
+      // more watched parameters, e.g. the list of senders
+      onUpdated(getCollectable);
+    };
+    this.contract.on(filterStream, streamListener);
 
-  async receivers(): Promise<PoolReceiver[]> {
-    return this.contract.getAllReceivers();
+    const streamEvents = await this.contract.queryFilter(filterStream);
+    for (const event of streamEvents) {
+      await state.onStreamUpdated(event);
+    }
+
+    const filterCollected = this.contract.filters.Collected(receiver);
+
+    const collectedListener = async (
+      _receiver: unknown,
+      _amt: unknown,
+      event: CollectedEvent
+    ) => {
+      await state.onCollected(event);
+      // For now it doesn't make sense to call `onUpdated` here,
+      // because `getCollectable` doesn't change.
+      // This is to keep the behavior of the `watchPoolReceiver`
+      // align with its documentation and leave room for addition of
+      // more watched parameters, e.g. the last collection time
+      onUpdated(getCollectable);
+    };
+    this.contract.on(filterCollected, collectedListener);
+
+    const collectedEvents = await this.contract.queryFilter(filterCollected);
+    const lastCollectedEvent = collectedEvents.pop();
+    if (lastCollectedEvent) {
+      await state.onCollected(lastCollectedEvent);
+    }
+
+    onUpdated(getCollectable);
+
+    return () => {
+      this.contract.off(filterStream, streamListener);
+      this.contract.off(filterCollected, collectedListener);
+    };
   }
 }
 
 // The type used by the Radicle-Contracts library to express a Pool Receiver.
+export interface PoolSenderData {
+  getBalance: (now: Date) => Big;
+  weeklyBudget: Big;
+  receivers: string[];
+}
+
+async function getSenderData(
+  event: SenderUpdatedEvent
+): Promise<PoolSenderData> {
+  const int = new PoolFactory().interface;
+
+  const receipt = await event.getTransactionReceipt();
+  const eventFragment = int.getEvent("SenderToReceiverUpdated");
+  // The actual amount sent on every second,
+  // may be lower than the sender's configured amtPerSec or even 0
+  let totalAmtPerSec = BigNumber.from(0);
+  const receivers = [];
+  for (const log of receipt.logs) {
+    let eventLog;
+    try {
+      eventLog = int.decodeEventLog(eventFragment, log.data, log.topics);
+    } catch {
+      // Ignore unmatching events
+      continue;
+    }
+    const amtPerSec = eventLog.amtPerSec;
+    if (amtPerSec.isZero()) {
+      // Ignore events stopping sending
+      continue;
+    }
+    totalAmtPerSec = totalAmtPerSec.add(amtPerSec);
+    receivers.push(eventLog.receiver);
+  }
+
+  const balance = Big(event.args.balance.toString());
+  const timestamp = (await event.getBlock()).timestamp;
+  const amtPerSec = Big(totalAmtPerSec.toString());
+  const getBalance = (now: Date) => {
+    // The Ethereum timestamps are in seconds
+    const timestampNow = Math.floor(now.getTime() / 1000);
+    // Block timestamp in the future
+    if (timestampNow < timestamp) return balance;
+    const spent = amtPerSec.mul(timestampNow - timestamp);
+    // Spent everything, return the unspendable reminder
+    if (spent > balance) return balance.mod(amtPerSec);
+    return balance.minus(spent);
+  };
+
+  const weeklyBudget = amountPerSecToWeeklyBudget(event.args.amtPerSec);
+
+  return { getBalance, weeklyBudget, receivers };
+}
+
 export interface PoolReceiver {
   // The address of the receiver.
   receiver: string;
   // The share the receiver gets within the pool they are a part of.
   weight: number;
+}
+
+interface StreamFragment {
+  // Timestamp since which a stream sends funds (inclusive)
+  since: number;
+  // Timestamp to which a stream sends funds (exclusively)
+  to: number;
+  amtPerSec: BigNumber;
+}
+
+class ReceiverState {
+  // For each sender stores a list of non-overlapping stream fragments
+  // in chronological order
+  streams = new Map<string, StreamFragment[]>();
+  cycleSecs: number;
+  // Timestamp in seconds from which funds are collectable (inclusively).
+  collectableSince = 0;
+
+  constructor(cycleSecs: number) {
+    this.cycleSecs = cycleSecs;
+  }
+
+  getCollectable(now: Date): Big {
+    // The Ethereum timestamps are in seconds
+    const nowTimestamp = Math.floor(now.getTime() / 1000);
+    // timestamp to which a funds are collectable (exclusively)
+    const collectableTo = nowTimestamp - (nowTimestamp % this.cycleSecs);
+    let collectable = BigNumber.from(0);
+    for (const streamFragments of this.streams.values()) {
+      for (const fragment of streamFragments) {
+        if (
+          fragment.to <= this.collectableSince ||
+          fragment.since >= collectableTo
+        ) {
+          continue;
+        }
+        const since =
+          fragment.since >= this.collectableSince
+            ? fragment.since
+            : this.collectableSince;
+        const to = fragment.to <= collectableTo ? fragment.to : collectableTo;
+        const amt = fragment.amtPerSec.mul(to - since);
+        collectable = collectable.add(amt);
+      }
+    }
+    return Big(collectable.toString());
+  }
+
+  async onStreamUpdated(event: SenderToReceiverUpdatedEvent): Promise<void> {
+    const sender = event.args.sender;
+    const timestamp = (await event.getBlock()).timestamp;
+    let fragments = this.streams.get(sender);
+    if (!fragments) {
+      fragments = [];
+      this.streams.set(sender, fragments);
+    }
+
+    // Trim the last fragment if it overlaps with the new one
+    const lastFragment = fragments[fragments.length - 1];
+    if (lastFragment && lastFragment.to > timestamp) {
+      lastFragment.to = timestamp;
+    }
+
+    fragments.push({
+      since: timestamp,
+      to: event.args.endTime.toNumber(),
+      amtPerSec: event.args.amtPerSec,
+    });
+  }
+
+  async onCollected(event: CollectedEvent): Promise<void> {
+    const timestamp = (await event.getBlock()).timestamp;
+    const cycleStart = timestamp - (timestamp % this.cycleSecs);
+    this.collectableSince = cycleStart;
+  }
 }
 
 // Convert the user-inputed `weeklyBudget` into how much it means per Ethereum block.

--- a/ui/src/funding/daiToken.ts
+++ b/ui/src/funding/daiToken.ts
@@ -1,0 +1,52 @@
+import type { BigNumber, Signer } from "ethers";
+
+import Big from "big.js";
+
+import * as ethereum from "../ethereum";
+
+import {
+  ERC20,
+  ERC20__factory as Erc20Factory,
+} from "radicle-contracts/build/contract-bindings/ethers";
+
+export { ERC20 };
+
+const addresses = {
+  local: "0xff1d4d289bf0aaaf918964c57ac30481a67728ef",
+  ropsten: "0x31f42841c2db5173425b5223809cf3a38fede360",
+};
+
+// Get the address of the Pool Contract for the given environment
+export function daiTokenAddress(environment: ethereum.Environment): string {
+  switch (environment) {
+    case ethereum.Environment.Local:
+      return addresses.local;
+    case ethereum.Environment.Ropsten:
+      return addresses.ropsten;
+  }
+}
+
+export function connect(signer: Signer, address: string): ERC20 {
+  return Erc20Factory.connect(address, signer);
+}
+
+// Start watching an allowance on a given token.
+// `onUpdated` is called immediately with the latest allowance amount.
+// Returns a function, which unwatches the allowance when called.
+async function watchDaiTokenAllowance(
+  token: ERC20,
+  owner: string,
+  spender: string,
+  onUpdated: (allowance: Big) => void
+): Promise<() => void> {
+  // console.log("ERC20FILTERS " + JSON.stringify(token.eventstoken.events));
+  const filter = token.filters.Approval(owner, spender);
+  const listener = (_owner: unknown, _spender: unknown, allowance: BigNumber) =>
+    onUpdated(Big(allowance.toString()));
+  token.on(filter, listener);
+  const allowance = await token.allowance(owner, spender);
+  onUpdated(Big(allowance.toString()));
+  return () => token.off(filter, listener);
+}
+
+export { watchDaiTokenAllowance };

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -15,7 +15,7 @@ import type {
   TransactionResponse,
 } from "@ethersproject/abstract-provider";
 
-import * as contract from "../src/funding/contract";
+import * as daiToken from "../src/funding/daiToken";
 import * as error from "../src/error";
 import * as ethereum from "../src/ethereum";
 import * as modal from "../src/modal";
@@ -115,9 +115,9 @@ export function build(
     environment,
     disconnect
   );
-  const daiTokenContract = contract.daiToken(
+  const daiTokenContract = daiToken.connect(
     signer,
-    contract.daiTokenAddress(environment)
+    daiToken.daiTokenAddress(environment)
   );
 
   // Connect to a wallet using walletconnect

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,7 +532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/abi@npm:5.1.2, @ethersproject/abi@npm:^5.1.0":
+"@ethersproject/abi@npm:5.1.2, @ethersproject/abi@npm:^5.1.0, @ethersproject/abi@npm:^5.1.2":
   version: 5.1.2
   resolution: "@ethersproject/abi@npm:5.1.2"
   dependencies:
@@ -787,7 +787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@npm:5.1.2":
+"@ethersproject/providers@npm:5.1.2, @ethersproject/providers@npm:^5.1.2":
   version: 5.1.2
   resolution: "@ethersproject/providers@npm:5.1.2"
   dependencies:
@@ -10455,10 +10455,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"radicle-contracts@github:radicle-dev/radicle-contracts#commit=f401f4f1222cbee48197c5268d81ee2cb92b6421":
+"radicle-contracts@github:radicle-dev/radicle-contracts#commit=752cf0767c6ba7428c626abf91ae1874de613f26":
   version: 0.1.0
-  resolution: "radicle-contracts@https://github.com/radicle-dev/radicle-contracts.git#commit=f401f4f1222cbee48197c5268d81ee2cb92b6421"
-  checksum: 35874e6eeece3a2d94a4cbc1995b63159fad98a5e63a7b5b52048595a845af3d4a05237dfb687f6a84ea458ba640ee06fb7e7b73621dcad691759d465a6d41cb
+  resolution: "radicle-contracts@https://github.com/radicle-dev/radicle-contracts.git#commit=752cf0767c6ba7428c626abf91ae1874de613f26"
+  dependencies:
+    "@ethersproject/abi": ^5.1.2
+    "@ethersproject/bytes": ^5.1.0
+    "@ethersproject/providers": ^5.1.2
+    ethers: ^5.1.4
+  checksum: 4ac258434d0042bcbfec457301128b7a8f91006f0a42fb353463ceb395e42db808bb8e9da0e8c771f88646f96855d07b5b9bdc3062583645281e88ea6dc133d9
   languageName: node
   linkType: hard
 
@@ -10520,7 +10525,7 @@ __metadata:
     prompts: ^2.4.1
     pure-svg-code: ^1.0.6
     qs: ^6.10.1
-    radicle-contracts: "github:radicle-dev/radicle-contracts#commit=f401f4f1222cbee48197c5268d81ee2cb92b6421"
+    radicle-contracts: "github:radicle-dev/radicle-contracts#commit=752cf0767c6ba7428c626abf91ae1874de613f26"
     semver: ^7.3.5
     sinon: ^10.0.0
     standard-version: ^9.3.0


### PR DESCRIPTION
- Switch from polling for the pool state to listening to the pool events
- The same for Dai token
- Stop querying for contract constants, instead have them hardcoded
- Fix unwatching of the attestation contract