### PR TITLE
fix: remote status indicator vanishing

### DIFF
--- a/ui/DesignSystem/Component/ConnectionStatusIndicator.svelte
+++ b/ui/DesignSystem/Component/ConnectionStatusIndicator.svelte
@@ -1,14 +1,13 @@
-<script>
-  import { status as store, StatusType } from "../../src/localPeer.ts";
+<script lang="typescript">
+  import { status, StatusType } from "ui/src/localPeer";
 
-  import Remote from "../Component/Remote.svelte";
   import { Icon } from "../Primitive";
   import Tooltip from "./Tooltip.svelte";
 
   import Syncing from "./ConnectionStatusIndicator/Syncing.svelte";
   import Offline from "./ConnectionStatusIndicator/Offline.svelte";
 
-  const peerCount = count => {
+  const peerCount = (count: number) => {
     if (count === 1) {
       return "1 peer";
     } else {
@@ -30,35 +29,33 @@
   }
 </style>
 
-<Remote {store} let:data={status}>
-  <div>
-    {#if status.type === StatusType.Online}
-      <Tooltip value={`You’re connected to ${peerCount(status.connected)}`}>
-        <div class="item indicator" data-cy="connection-status-online">
-          <Icon.Network />
-        </div>
-      </Tooltip>
-    {:else if status.type === StatusType.Syncing}
-      <Tooltip
-        value={`Syncing with ${peerCount(
-          status.syncs
-        )} to get new content from your network`}>
-        <div class="item indicator" data-cy="connection-status-syncing">
-          <Syncing />
-        </div>
-      </Tooltip>
-    {:else if status.type === StatusType.Offline || status.type === StatusType.Started}
-      <Tooltip value="You’re not connected to any peers">
-        <div class="item indicator" data-cy="connection-status-offline">
-          <Offline />
-        </div>
-      </Tooltip>
-    {:else if status.type === StatusType.Stopped}
-      <Tooltip value="The app couldn't start your peer">
-        <div class="item indicator" data-cy="connection-status-stopped">
-          <Offline style="fill: var(--color-negative);" />
-        </div>
-      </Tooltip>
-    {/if}
-  </div>
-</Remote>
+<div>
+  {#if $status.type === StatusType.Online}
+    <Tooltip value={`You’re connected to ${peerCount($status.connected)}`}>
+      <div class="item indicator" data-cy="connection-status-online">
+        <Icon.Network />
+      </div>
+    </Tooltip>
+  {:else if $status.type === StatusType.Syncing}
+    <Tooltip
+      value={`Syncing with ${peerCount(
+        $status.syncs
+      )} to get new content from your network`}>
+      <div class="item indicator" data-cy="connection-status-syncing">
+        <Syncing />
+      </div>
+    </Tooltip>
+  {:else if $status.type === StatusType.Offline || $status.type === StatusType.Started}
+    <Tooltip value="You’re not connected to any peers">
+      <div class="item indicator" data-cy="connection-status-offline">
+        <Offline />
+      </div>
+    </Tooltip>
+  {:else if $status.type === StatusType.Stopped}
+    <Tooltip value="The app couldn't start your peer">
+      <div class="item indicator" data-cy="connection-status-stopped">
+        <Offline style="fill: var(--color-negative);" />
+      </div>
+    </Tooltip>
+  {/if}
+</div>

--- a/ui/src/localPeer.ts
+++ b/ui/src/localPeer.ts
@@ -1,5 +1,6 @@
 import { push } from "svelte-spa-router";
 import * as zod from "zod";
+import * as svelteStore from "svelte/store";
 
 import type * as identity from "./identity";
 import * as config from "./config";
@@ -223,10 +224,12 @@ export const requestEvents: bacon.EventStream<RequestEvent> = bacon.filterMap(
   }
 );
 
-export const status = remote.createStore<Status>();
+export const status = svelteStore.writable<Status>({
+  type: StatusType.Offline,
+});
 
 eventBus.onValue(event => {
   if (event.type === EventType.StatusChanged) {
-    status.success(event.new);
+    status.set(event.new);
   }
 });


### PR DESCRIPTION
We fix an issue where the remote status indicator vanished when the user navigated to the settings page.

The issue was caused by the `remote` store used to hold the status resetting it’s internal state when the sidebar was re-rendered.

Instead of relying on the remote store with this side-effect we use a simple writable svelte store.