### PR TITLE
style(ui): add basic padding to network diagnostic screen

### DIFF
--- a/ui/Screen/NetworkDiagnostics.svelte
+++ b/ui/Screen/NetworkDiagnostics.svelte
@@ -37,6 +37,12 @@
 </script>
 
 <style>
+  .container {
+    margin: 0 auto;
+    min-width: var(--content-min-width);
+    padding: 0 var(--content-padding);
+  }
+
   .title {
     display: flex;
     flex-direction: column;
@@ -50,12 +56,12 @@
       <h1>Status: {$store.type}</h1>
     </div>
   </Header>
-
   <ActionBar>
     <div slot="left">
       <HorizontalMenu items={topbarMenuItems} />
     </div>
   </ActionBar>
-
-  <Router routes={screenRoutes} />
+  <div class="container">
+    <Router routes={screenRoutes} />
+  </div>
 </SidebarLayout>

--- a/ui/Screen/NetworkDiagnostics/ConnectedPeers.svelte
+++ b/ui/Screen/NetworkDiagnostics/ConnectedPeers.svelte
@@ -14,7 +14,7 @@
     table-layout: fixed;
     width: 100%;
     border-collapse: collapse;
-    border: 3px solid purple;
+    margin-top: 1rem;
   }
 </style>
 

--- a/ui/Screen/NetworkDiagnostics/WaitingRoom.svelte
+++ b/ui/Screen/NetworkDiagnostics/WaitingRoom.svelte
@@ -10,7 +10,7 @@
     table-layout: fixed;
     width: 100%;
     border-collapse: collapse;
-    border: 3px solid purple;
+    margin-top: 1rem;
   }
 
   thead th:nth-child(1) {


### PR DESCRIPTION
Just added some basic padding to the screen, still left it full width.

@rudolfs is there a way to not show the shortcut?

Signed-off-by: Julien Donck <hello@juliendonck.com>