### PR TITLE
Move network diagnostics shortcut to ⌘ + 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,6 @@
     "radicle-contracts": "github:radicle-dev/radicle-contracts#commit=752cf0767c6ba7428c626abf91ae1874de613f26",
     "semver": "^7.3.5",
     "stream-browserify": "^3.0.0",
-    "svelte-json-tree": "^0.1.0",
     "svelte-persistent-store": "^0.1.6",
     "timeago.js": "^4.0.2",
     "twemoji": "13.0.2",

--- a/typings/svelte-json-tree/index.d.ts
+++ b/typings/svelte-json-tree/index.d.ts
@@ -1,8 +1,0 @@
-declare module "svelte-json-tree" {
-  import type { SvelteComponentTyped } from "svelte";
-  interface Props {
-    key?: string;
-    value: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  }
-  export default class JSONTree extends SvelteComponentTyped<Props> {}
-}

--- a/ui/Screen/NetworkDiagnostics/WaitingRoom.svelte
+++ b/ui/Screen/NetworkDiagnostics/WaitingRoom.svelte
@@ -1,7 +1,5 @@
 <script lang="typescript">
-  import JSONTree from "svelte-json-tree";
-
-  import StateTable from "./StateTable.svelte";
+  import StateTable from "ui/Screen/NetworkDiagnostics/StateTable.svelte";
   import { waitingRoomEventLog, waitingRoomState } from "ui/src/localPeer";
 </script>
 
@@ -19,6 +17,10 @@
 
   thead th:nth-child(2) {
     width: 10%;
+  }
+
+  pre {
+    overflow: scroll;
   }
 </style>
 
@@ -42,7 +44,10 @@
       {#each $waitingRoomEventLog as transition}
         <tr>
           <td>
-            <JSONTree value={transition.event} />
+            <pre
+              class="typo-text-small">
+              {JSON.stringify(transition.event, null, 2)}
+            </pre>
           </td>
           <td>{new Date(transition.timestamp).toISOString()}</td>
           <td>

--- a/ui/src/hotkeys.ts
+++ b/ui/src/hotkeys.ts
@@ -23,7 +23,7 @@ export enum ShortcutKey {
   NewProjects = "n",
   Search = "p",
   Settings = ",",
-  NetworkDiagnostics = "y",
+  NetworkDiagnostics = "1",
 }
 
 export interface KeyboardShortcut {

--- a/ui/src/hotkeys.ts
+++ b/ui/src/hotkeys.ts
@@ -23,7 +23,7 @@ export enum ShortcutKey {
   NewProjects = "n",
   Search = "p",
   Settings = ",",
-  NetworkDiagnostics = "i",
+  NetworkDiagnostics = "y",
 }
 
 export interface KeyboardShortcut {
@@ -42,17 +42,17 @@ export const shortcuts: KeyboardShortcut[] = [
   },
   { description: "Search", key: ShortcutKey.Search, modifierKey: true },
   { description: "Settings", key: ShortcutKey.Settings, modifierKey: true },
+  {
+    description: "Network diagnostics",
+    key: ShortcutKey.NetworkDiagnostics,
+    modifierKey: true,
+  },
 ];
 
 export const devShortcuts: KeyboardShortcut[] = [
   {
     description: "Design system",
     key: ShortcutKey.DesignSystem,
-    modifierKey: true,
-  },
-  {
-    description: "Network diagnostics",
-    key: ShortcutKey.NetworkDiagnostics,
     modifierKey: true,
   },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -10532,7 +10532,6 @@ __metadata:
     stream-browserify: ^3.0.0
     svelte: ^3.38.2
     svelte-check: ^1.5.2
-    svelte-json-tree: ^0.1.0
     svelte-loader: ^3.1.1
     svelte-persistent-store: ^0.1.6
     svelte-preprocess: ^4.7.3
@@ -12193,13 +12192,6 @@ __metadata:
   peerDependencies:
     svelte: ">=3.19.0"
   checksum: 1b7e145c3fdbaa216887d9ed000e564a63f6c73f85239e1d57460518d4a37ab454aa8af9234d6be162bf674c53bef08890436eeeffa7a1c308d1957a313b502d
-  languageName: node
-  linkType: hard
-
-"svelte-json-tree@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "svelte-json-tree@npm:0.1.0"
-  checksum: 7bdf3f097be4f68285deea0dc62cef71ac42ff48afe9e1623289b91402686c6d1e20e30af2f31721752c58105ebfbcf769246262c1d00d8841ae0398cef11def
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
~~Moving from `⌘ + i` to `⌘ + y`, because `⌘ + i` clashes with the dev tools shortcut `option + ⌘ + i` on mac.~~

`⌘ + 1` it is.

And make it available in the production build, because we want users to be able to access the diagnostics to troubleshoot problems on live systems.

Signed-off-by: Rūdolfs Ošiņš <rudolfs@osins.org>