### PR TITLE
dev: isolate development environment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -51,10 +51,20 @@ make sure only properly formatted and lint-free code lands into master.
 
 To start Upstream run `yarn start`.
 
-Running upstream will create new directories in `XDG_DATA_HOME` &
-`XDG_CONFIG_HOME` (or `HOME` respectiveley). To overwrite the locations, you
-can set `RAD_HOME` to your desired directory. Note that you will also have to
-set it for using git remote helper functionality outside of upstream.
+Running upstream with `yarn start` will use `<repo_root>/sandbox/rad_home` as
+the default `RAD_HOME` value to isolate you development state.
+
+### Using the Git remote
+
+Upstream provides the `git-remote-rad` binary to fetch and push Git
+repositories. If you want to use the rad remote in development you need to set
+the environment in your terminal
+
+```bash
+source ./scripts/env
+```
+
+Make sure to source the script from the repository root.
 
 
 ### Feature flagging

--- a/cypress/plugins/nodeManager/plugin.ts
+++ b/cypress/plugins/nodeManager/plugin.ts
@@ -137,6 +137,7 @@ class Node {
         `${HOST}:${this.httpPort}`,
         "--peer-listen",
         `${HOST}:${this.peerPort}`,
+        "--skip-remote-helper-install",
       ],
       { env: { ...global.process.env, RAD_HOME: this.radHome } }
     );

--- a/native/index.ts
+++ b/native/index.ts
@@ -40,6 +40,7 @@ if (isDev) {
   proxyArgs.push(
     "hybz9gfgtd9d4pd14a6r66j5hz6f77fed4jdu7pana4fxaxbt369kg@setzling.radicle.xyz:12345"
   );
+  proxyArgs.push("--skip-remote-helper-install");
 } else {
   // Packaged app, i.e. production.
   proxyPath = path.join(__dirname, "../../radicle-proxy");
@@ -47,6 +48,10 @@ if (isDev) {
     "--default-seed",
     "hynkyndc6w3p8urucakobzna7sxwgcqny7xxtw88dtx3pkf7m3nrzc@sprout.radicle.xyz:12345",
   ];
+}
+
+if (isDev && !process.env.RAD_HOME) {
+  process.env.RAD_HOME = path.resolve(__dirname, "..", "sandbox", "rad_home");
 }
 
 if (process.env.RAD_HOME) {

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -36,6 +36,9 @@ pub struct Args {
     /// add one or more default seed addresses to initialise the settings store (default: none)
     #[argh(option, long = "default-seed")]
     pub default_seeds: Vec<String>,
+    /// don’t install the git-remote-rad binary
+    #[argh(switch)]
+    pub skip_remote_helper_install: bool,
 }
 
 /// Data required to run the peer and the API
@@ -56,7 +59,9 @@ struct Rigging {
 pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let proxy_path = config::proxy_path()?;
     let bin_dir = config::bin_dir()?;
-    git_helper::setup(&proxy_path, &bin_dir)?;
+    if !args.skip_remote_helper_install {
+        git_helper::setup(&proxy_path, &bin_dir)?;
+    }
 
     let mut service_manager = service::Manager::new(args.test)?;
     let mut sighup = signal(SignalKind::hangup())?;

--- a/scripts/env
+++ b/scripts/env
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+export RAD_HOME="$(realpath ./sandbox/rad_home)"
+export PATH="$(realpath ./target/release):$PATH"


### PR DESCRIPTION
* Running Uptream in development mode uses `sandbox/rad_home` from the repo as `RAD_HOME`.
* We don’t install `git-remote-rad` in development mode anymore
* We provide a script that makes `git-remote-rad` available in dev mode and sets `RAD_HOME`