### PR TITLE
fix(tests): unload app when test is successful

### DIFF
--- a/cypress/integration/shortcuts.spec.ts
+++ b/cypress/integration/shortcuts.spec.ts
@@ -2,7 +2,7 @@ import * as commands from "../support/commands";
 const metaKey = commands.metaKey();
 
 context("documented shortcuts", () => {
-  before(() => {
+  beforeEach(() => {
     commands.resetProxyState();
     commands.onboardUser("cloudhead");
     cy.visit("./public/index.html");

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -3,8 +3,6 @@ import * as proxy from "../../ui/src/proxy";
 const proxyClient = new proxy.Client("http://localhost:17246");
 
 export const resetProxyState = (): void => {
-  // We unload the app so that resetting does not mess with it
-  cy.visit("./cypress/empty.html");
   cy.then(() => proxyClient.control.reset());
 };
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -10,6 +10,16 @@ Cypress.on("window:before:load", appWindow => {
   ipcStub.setup(appWindow);
 });
 
+// If a test was successful we unload the app so it stops running. If the test
+// was failed we want to keep the app around so we can inspect it.
+//
+// This is to workaround https://github.com/cypress-io/cypress/issues/15247
+afterEach(function () {
+  if (this.currentTest && this.currentTest.state !== "failed") {
+    cy.visit("./cypress/empty.html");
+  }
+});
+
 // Common setup for all tests.
 beforeEach(() => {
   cy.window().then(win => {


### PR DESCRIPTION
We’re running into a [cypress issue][1] where the app from a previous tests still runs while a second test is started. When the cookies are cleared to prepare the second test the app from the first test may error because the authentication token is invalid.

To work around this problem we unload the app after a successful test run.

[1]: https://github.com/cypress-io/cypress/issues/15247