### PR TITLE
fix: don’t destroy wallet when all views unsubscribe

### DIFF
--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -392,3 +392,9 @@ export const store: svelteStore.Readable<Wallet> = svelteStore.derived(
     return () => wallet.destroy();
   }
 );
+
+// Activate the store so that the wallet is never destroyed when all views
+// unsubscribe.
+//
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+store.subscribe(() => {});


### PR DESCRIPTION
Before, on every page navigation all views would unsubscribe from the wallet store and then subscribe again when the new page was rendered. This resulted in the wallet reconnecting and loading all its data.