### PR TITLE
chore(build): fix build prerequisites

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@
     platform: "linux"
   timeout_in_minutes: 60
   env:
-    DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.9.0"
+    DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.10.0"
     SHARED_MASTER_CACHE: true
   artifact_paths:
     - "dist/*.AppImage"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,32 +40,16 @@ linting and formatting are enforced locally on a pre-commit basis with
 Additionally we run the same checks as separate build steps on our CI, just to
 make sure only properly formatted and lint-free code lands into master.
 
+## Development prerequisites
+
+* [NodeJS](https://nodejs.org/en/)
+* [Yarn](https://yarnpkg.com/getting-started/install)
+* [Rustup](https://github.com/rust-lang/rustup)
+* Dependencies of [Cypress](https://docs.cypress.io/guides/getting-started/installing-cypress#System-requirements)
 
 ### Running Upstream
 
-You'll have to install some external dependencies to be able to compile the
-proxy as well as the UI.
-
-On macOS:
-```
-xcode-select --install
-sudo xcodebuild -license
-brew install yarn pkgconfig nettle
-```
-
-On Linux:
-  - [Autoconf](https://www.gnu.org/software/autoconf)
-  - [Clang](https://clang.llvm.org)
-  - [Git](https://git-scm.com)
-  - [GMP](https://gmplib.org)
-  - [GNU M4](https://www.gnu.org/software/m4)
-  - [Nettle](http://www.lysator.liu.se/~nisse/nettle)
-  - [OpenSSL](https://www.openssl.org)
-  - [Yarn](https://yarnpkg.com)
-
-1. Get Upstream: `git clone git@github.com:radicle-dev/radicle-upstream.git`.
-2. Install dependencies: `cd radicle-upstream && yarn install`.
-3. Start Upstream in development mode: `yarn start`.
+To start Upstream run `yarn start`.
 
 Running upstream will create new directories in `XDG_DATA_HOME` &
 `XDG_CONFIG_HOME` (or `HOME` respectiveley). To overwrite the locations, you

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,18 +4,36 @@ FROM debian:buster-slim
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    clang \
-    curl \
-    git \
-    jq \
-    libssl-dev \
-    pkg-config \
-    procps
-
-# install cypress deps
-RUN apt-get -y install --no-install-recommends autoconf git nettle-dev m4 gnupg xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      procps \
+      # Cypress deps
+      # See https://github.com/cypress-io/cypress-docker-images/blob/422d5f00ca2bfcaa3b31b347f536817809500f96/base/14.16.0/Dockerfile#L10
+      libgtk2.0-0 \
+      libgtk-3-0 \
+      libnotify-dev \
+      libgconf-2-4 \
+      libgbm-dev \
+      libnss3 \
+      libxss1 \
+      libasound2 \
+      libxtst6 \
+      xauth \
+      xvfb \
+      fonts-noto-color-emoji \
+      fonts-arphic-bkai00mp \
+      fonts-arphic-bsmi00lp \
+      fonts-arphic-gbsn00lp \
+      fonts-arphic-gkai00mp \
+      fonts-arphic-ukai \
+      fonts-arphic-uming \
+      ttf-wqy-zenhei \
+      ttf-wqy-microhei \
+      xfonts-wqy; \
+  rm -rf /var/lib/apt/lists/*;
 
 # install node and yarn
 RUN set -eux; \

--- a/package.json
+++ b/package.json
@@ -51,16 +51,6 @@
     "linux": {
       "target": [
         "Appimage"
-      ],
-      "extraFiles": [
-        {
-          "from": "/usr/lib/x86_64-linux-gnu/libhogweed.so.4",
-          "to": "usr/lib/libhogweed.so.4"
-        },
-        {
-          "from": "/usr/lib/x86_64-linux-gnu/libnettle.so.6",
-          "to": "usr/lib/libnettle.so.6"
-        }
       ]
     },
     "mac": {


### PR DESCRIPTION
* Remove references to unused build prerequisites (libnettle, libssl, clang)
* Simplify section in `DEVELOPMENT.md`. We only link to prerequisites and don’t provide detailed instructions for the different platforms. We can assume that the links provide enough documentation.