### PR TITLE
Add `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to this repository
+
+## Learn more about Upstream
+
+To familiarise yourself with the Upstream app and the Radicle ecosystem, have a
+look at the following resources:
+
+- [DEVELOPMENT.md][dmd]
+- [Discord][dc]
+- [radicle.xyz][ra]
+- [Radicle documentation][rd]
+
+## Your first bugfix
+
+If you have found a bug or see an [issue][oi] you'd like to fix, we are keen on
+receiving a contribution from you.
+
+We are currently accepting [PR's through GitHub][pr] while we make our own
+infrastructure more robust. If it's your first time using GitHub Pull Requests,
+learn more about it [here][ghf].
+
+We also accept contributions through [Upstream Patches][up] -- our first version
+of Pull Requests in Upstream. Learn more about the contribution flow
+[here][cbf]. For us to see you've contributed a Patch, we need to [add your
+Device ID as a remote][ar] to our repo. You can either add it to the [Remotes to
+track issue][rtr] or post it in [#upstream on Discord][dc-up].
+
+## Documentation
+
+We're writing documentation as we are developing new features. If you find
+something that is confusing or not covered at all, feel free to [open a bug][ob]
+or [contribute][cd]
+
+[gz]: https://github.com/geigerzaehler
+[ru]: https://github.com/rudolfs
+[bhl]: https://github.com/brandonhaslegs
+[jd]: https://github.com/juliendonck
+[dmd]: DEVELOPMENT.md
+[dc]: https://discord.gg/HRdnwAwGbG
+[dc-up]: https://discord.com/channels/841318878125490186/843873418205331506
+[ra]: https://radicle.xyz
+[rd]: https://docs.radicle.xyz
+[oi]: https://github.com/radicle-dev/radicle-docs/issues
+[pr]: https://github.com/radicle-dev/radicle-upstream/pulls
+[ghf]: https://guides.github.com/introduction/flow/
+[up]: http://docs.radicle.xyz/docs/using-radicle/creating-patches
+[cbf]: https://docs.radicle.xyz/docs/using-radicle/overview
+[ar]: http://docs.radicle.xyz/docs/using-radicle/tracking-and-viewing#adding-remotes
+[rtr]: https://github.com/radicle-dev/radicle-upstream/issues/1958
+[mt]: mailto:julien@monadic.xyz
+[ob]: https://github.com/radicle-dev/radicle-docs/issues/new/choose
+[cd]: https://github.com/radicle-dev/radicle-docs#readme

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ node [proxy][pr] logic is implemented in [Rust][ru].
 A good entry point for exploration is [`DEVELOPMENT.md`][de], where you'll find
 information on how to build Upstream from source.
 
+If you're looking to contribute, take a look at [`CONTRIBUTING.md`][co] to learn
+about the different ways that we accept contributions.
+
 If you have questions or would like to get in touch, check out
 [radicle.community][rc].
 
@@ -28,6 +31,7 @@ Upstream uses:
 
 [ba]: https://badge.buildkite.com/4fb43c6b471ab7cc26509eae235b0e4bbbaace11cc1848eae6.svg?branch=master
 [de]: DEVELOPMENT.md
+[co]: CONTRIBUTING.md
 [pr]: proxy
 [ra]: https://rsms.me/inter
 [rc]: https://radicle.community


### PR DESCRIPTION
Adding a basic contribution guide to point people to the fact that they'll be able to contribute code both through github PR's and radicle Patches.