### PR TITLE
feat(ui): add selectedNetwork to wallet tooltip

### DIFF
--- a/ui/DesignSystem/Component/WalletStatusIndicator.svelte
+++ b/ui/DesignSystem/Component/WalletStatusIndicator.svelte
@@ -32,7 +32,7 @@
         </SidebarItem>
       </Tooltip>
     {:else}
-      <Tooltip value="Wallet · Connected">
+      <Tooltip value={`Wallet · Connected to ${wallet.environment}`}>
         <SidebarItem
           dataCy="wallet"
           indicator


### PR DESCRIPTION
Hi folks,

This PR adds the functionality requested in #1945.
It uses the `environment` property created by `wallet.ts`
https://github.com/radicle-dev/radicle-upstream/blob/eef980fe3976fa28c98517b6c9a61d7e5fb84d8a/ui/src/wallet.ts#L390

Let me know what you think.
Cheers!