### PR TITLE
hotfix: show wallet only in dev mode when pressing the enter key

### DIFF
--- a/ui/Screen/Onboarding/Success.svelte
+++ b/ui/Screen/Onboarding/Success.svelte
@@ -11,7 +11,11 @@
 
   const onKeydown = (event: KeyboardEvent) => {
     if (event.key === "Enter") {
-      wallet();
+      if (isDev) {
+        wallet();
+      } else {
+        profile();
+      }
     }
   };
 


### PR DESCRIPTION
Fixes a regression discovered during [0.2.6 QA](https://github.com/radicle-dev/radicle-upstream/issues/1950).