### PR TITLE
Change "display name" error to "project name"

### DIFF
--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -136,7 +136,7 @@ const validateNewRepository = async (path: string): Promise<boolean> => {
 
 const projectNameConstraints = {
   presence: {
-    message: "You must provide a display name",
+    message: "You must provide a project name",
     allowEmpty: false,
   },
   firstHandleChar: {


### PR DESCRIPTION
error for empty project name field should say "project name" instead of "display name" #1959

Signed-off-by: Rohitanshu Kumar <iamrohitanshu@gmail.com>