### PR TITLE
fix(dev): avoid yarn run to properly kill process

### DIFF
--- a/scripts/ethereum-dev-node.ts
+++ b/scripts/ethereum-dev-node.ts
@@ -24,10 +24,11 @@ async function main() {
   }
 
   const ganache = execa(
-    "yarn",
+    // We’re not using `yarn run` because it does not forward signals
+    // properly.
+    // https://github.com/yarnpkg/berry/issues/991
+    "./node_modules/.bin/ganache-cli",
     [
-      "run",
-      "ganache-cli",
       "--mnemonic",
       "image napkin cruise dentist name plunge crisp muscle nest floor vessel blush",
       "--defaultBalanceEther",


### PR DESCRIPTION
We avoid `yarn run` in the ethereum dev node script so that `ganache-cli` is properly killed when an error occurs.