### PR TITLE
fix(dev): allow empty function lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,18 +18,6 @@ module.exports = {
       processor: "svelte3/svelte3",
     },
     {
-      files: ["*.ts", "*.json"],
-      extends: ["plugin:@typescript-eslint/recommended"],
-      rules: {
-        // TODO(sos): typescript rule changes are ignored unless explicitly associated with the override.
-        //
-        // We need to turn this one off because svelte-check needs explicit type annotations for boolean
-        // props with default values.
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md
-        "@typescript-eslint/no-inferrable-types": "off",
-      },
-    },
-    {
       files: ["scripts/*.ts"],
       rules: {
         // Script files are not bundled so we can’t use module imports.

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -2,7 +2,6 @@ import { derived, get, writable } from "svelte/store";
 import type { SvelteComponent } from "svelte";
 
 type OnHide = () => void;
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 const doNothing = () => {};
 
 type ModalOverlay = {

--- a/ui/src/notification.ts
+++ b/ui/src/notification.ts
@@ -52,7 +52,6 @@ export const store: Readable<Notification[]> = derived(
 
 const closeAction: Action = {
   label: "Close",
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   handler: () => {},
 };
 

--- a/ui/src/updateChecker.ts
+++ b/ui/src/updateChecker.ts
@@ -93,7 +93,6 @@ class UpdateChecker {
           },
           {
             label: "Dismiss",
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
             handler: () => {},
           },
         ],
@@ -194,7 +193,6 @@ class UpdateChecker {
           },
           {
             label: "Dismiss",
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
             handler: () => {},
           },
         ],

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -395,6 +395,4 @@ export const store: svelteStore.Readable<Wallet> = svelteStore.derived(
 
 // Activate the store so that the wallet is never destroyed when all views
 // unsubscribe.
-//
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 store.subscribe(() => {});


### PR DESCRIPTION
We disable the lint that complains about empty functions.

This is achieved by removing the override for typescript files so that extending the override configuration with the rules from `@typescript-eslint/recommended` doesn’t override the top-level rules that already allow empty functions.