### PR TITLE
fix: prevent lock race condition

### DIFF
--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -62,42 +62,42 @@
   };
 
   const createProject = async () => {
-    try {
-      loading = true;
-      screen.lock();
+    screen.withLock(async () => {
+      try {
+        loading = true;
 
-      const response = await proxy.client.project.create({
-        description,
-        defaultBranch: isNew
-          ? await defaultBranchForNewRepository()
-          : $defaultBranch,
-        repo: isNew
-          ? { type: "new", name, path: newRepositoryPath }
-          : { type: "existing", path: existingRepositoryPath },
-      });
+        const response = await proxy.client.project.create({
+          description,
+          defaultBranch: isNew
+            ? await defaultBranchForNewRepository()
+            : $defaultBranch,
+          repo: isNew
+            ? { type: "new", name, path: newRepositoryPath }
+            : { type: "existing", path: existingRepositoryPath },
+        });
 
-      router.push({
-        type: "project",
-        urn: response.urn,
-        activeView: { type: "files" },
-      });
-      notification.info({
-        message: `Project ${response.metadata.name} successfully created`,
-      });
-    } catch (err) {
-      router.push({ type: "profile", activeTab: "projects" });
-      error.show(
-        new error.Error({
-          code: error.Code.ProjectCreationFailure,
-          message: `Could not create project: ${err.message}`,
-          source: err,
-        })
-      );
-    } finally {
-      modal.hide();
-      loading = false;
-      screen.unlock();
-    }
+        router.push({
+          type: "project",
+          urn: response.urn,
+          activeView: { type: "files" },
+        });
+        notification.info({
+          message: `Project ${response.metadata.name} successfully created`,
+        });
+      } catch (err) {
+        router.push({ type: "profile", activeTab: "projects" });
+        error.show(
+          new error.Error({
+            code: error.Code.ProjectCreationFailure,
+            message: `Could not create project: ${err.message}`,
+            source: err,
+          })
+        );
+      } finally {
+        modal.hide();
+        loading = false;
+      }
+    });
   };
 
   // We unlock the screen already after the request, this is just a fail-safe
@@ -105,7 +105,6 @@
   // destroyed.
   onDestroy(() => {
     clearLocalState();
-    screen.unlock();
   });
 
   $: pathValidation = repositoryPathValidationStore(isNew);

--- a/ui/Screen/Lock.svelte
+++ b/ui/Screen/Lock.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="typescript">
   import * as screen from "../src/screen";
   import * as session from "../src/session";
 
@@ -8,11 +8,11 @@
   let unlockInProgress = false;
 
   const unlock = async () => {
-    unlockInProgress = true;
-    screen.lock();
-    await session.unseal(passphrase).finally(() => {
-      screen.unlock();
-      unlockInProgress = false;
+    await screen.withLock(async () => {
+      unlockInProgress = true;
+      await session.unseal(passphrase).finally(() => {
+        unlockInProgress = false;
+      });
     });
   };
 

--- a/ui/Screen/Onboarding.svelte
+++ b/ui/Screen/Onboarding.svelte
@@ -46,35 +46,35 @@
   };
 
   const onCreateIdentity = async (handle: string, passphrase: string) => {
-    try {
-      screen.lock();
-      createIdentityInProgress = true;
-      await session.createKeystore(passphrase);
-      // Retry until the API is up
-      const identity = await withRetry(
-        () => createIdentity({ handle }),
-        100,
-        50
-      );
-      peerId = identity.peerId;
-      state = State.SuccessView;
-    } catch (err) {
-      animateBackward();
-      state = State.EnterName;
-      error.show(
-        new error.Error({
-          code: error.Code.IdentityCreationFailure,
-          message: `Could not create identity`,
-          details: {
-            handle,
-          },
-          source: err,
-        })
-      );
-    } finally {
-      screen.unlock();
-      createIdentityInProgress = false;
-    }
+    await screen.withLock(async () => {
+      try {
+        createIdentityInProgress = true;
+        await session.createKeystore(passphrase);
+        // Retry until the API is up
+        const identity = await withRetry(
+          () => createIdentity({ handle }),
+          100,
+          50
+        );
+        peerId = identity.peerId;
+        state = State.SuccessView;
+      } catch (err) {
+        animateBackward();
+        state = State.EnterName;
+        error.show(
+          new error.Error({
+            code: error.Code.IdentityCreationFailure,
+            message: `Could not create identity`,
+            details: {
+              handle,
+            },
+            source: err,
+          })
+        );
+      } finally {
+        createIdentityInProgress = false;
+      }
+    });
   };
 </script>
 

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -93,36 +93,35 @@
     project: Project,
     peer: User
   ) => {
-    try {
-      screen.lock();
-      const path = await proxy.client.project.checkout(project.urn, {
-        path: checkoutPath,
-        peerId: peer.identity.peerId,
-      });
+    await screen.withLock(async () => {
+      try {
+        const path = await proxy.client.project.checkout(project.urn, {
+          path: checkoutPath,
+          peerId: peer.identity.peerId,
+        });
 
-      notification.info({
-        message: `${project.metadata.name} checked out to ${path}`,
-        showIcon: true,
-        actions: [
-          {
-            label: "Open folder",
-            handler: () => {
-              openPath(path);
+        notification.info({
+          message: `${project.metadata.name} checked out to ${path}`,
+          showIcon: true,
+          actions: [
+            {
+              label: "Open folder",
+              handler: () => {
+                openPath(path);
+              },
             },
-          },
-        ],
-      });
-    } catch (err) {
-      error.show(
-        new error.Error({
-          code: error.Code.ProjectCheckoutFailure,
-          message: `Checkout failed: ${err.message}`,
-          source: err,
-        })
-      );
-    } finally {
-      screen.unlock();
-    }
+          ],
+        });
+      } catch (err) {
+        error.show(
+          new error.Error({
+            code: error.Code.ProjectCheckoutFailure,
+            message: `Checkout failed: ${err.message}`,
+            source: err,
+          })
+        );
+      }
+    });
   };
 
   const onSelectRevision = ({ detail: revision }: { detail: Branch | Tag }) => {

--- a/ui/src/screen.ts
+++ b/ui/src/screen.ts
@@ -1,16 +1,19 @@
-export const lock = (): void => {
-  document.documentElement.classList.add("lock-screen");
-};
-
-export const unlock = (): void => {
-  document.documentElement.classList.remove("lock-screen");
-};
+let lockRequests = 0;
 
 export const isLocked = (): boolean => {
-  return document.documentElement.classList.contains("lock-screen");
+  return lockRequests > 0;
 };
 
+// Shows a spinning cursor and ignore user clicks while `f` is running.
 export function withLock<T>(f: () => Promise<T>): Promise<T> {
-  lock();
-  return f().finally(() => unlock());
+  if (lockRequests === 0) {
+    document.documentElement.classList.add("lock-screen");
+  }
+  lockRequests += 1;
+  return f().finally(() => {
+    lockRequests -= 1;
+    if (lockRequests === 0) {
+      document.documentElement.classList.remove("lock-screen");
+    }
+  });
 }


### PR DESCRIPTION
* We remove `screen.lock()` and `screen.unlock()` and replace it with `screen.withLock()`. This makes it impossible to forget to unlock.
* We fix a race condition when two actions are run with a lock. Before, the first action that would finish would unlock the screen. Now, we unlock only after all actions have finished.