### PR TITLE
refactor: mutex executor to manage concurrent fetches

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,6 +1,7 @@
 import qs from "qs";
 
 import * as config from "./config";
+import { sleep } from "ui/src/sleep";
 
 interface Options {
   query?: Record<string, unknown>;
@@ -115,12 +116,6 @@ export const set = async <T>(
     })
   );
 
-const delay = (delay: number) => {
-  return new Promise((resolve, _reject) => {
-    setTimeout(resolve, delay);
-  });
-};
-
 export const withRetry = async <T>(
   request: () => Promise<T>,
   delayTime: number,
@@ -134,6 +129,6 @@ export const withRetry = async <T>(
         throw error;
       }
     }
-    await delay(delayTime);
+    await sleep(delayTime);
   }
 };

--- a/ui/src/mutexExecutor.test.ts
+++ b/ui/src/mutexExecutor.test.ts
@@ -1,0 +1,83 @@
+import * as mutexExecutor from "./mutexExecutor";
+import { sleep } from "./sleep";
+import * as sinon from "sinon";
+
+test("cancels running task", async () => {
+  const e = mutexExecutor.create();
+
+  const first = e.run(async () => {
+    await sleep(10);
+    return "first";
+  });
+  const second = e.run(async () => {
+    return "second";
+  });
+
+  expect(await first).toBe(undefined);
+  expect(await second).toBe("second");
+
+  const third = e.run(async () => {
+    await sleep(10);
+    return "third";
+  });
+  const fourth = e.run(async () => {
+    return "fourth";
+  });
+
+  expect(await third).toBe(undefined);
+  expect(await fourth).toBe("fourth");
+});
+
+test("cancels multiple tasks", async () => {
+  const e = mutexExecutor.create();
+
+  const canceled1 = e.run(async () => {
+    await sleep(10);
+    return true;
+  });
+  const canceled2 = e.run(async () => {
+    await sleep(10);
+    return true;
+  });
+  const canceled3 = e.run(async () => {
+    await sleep(10);
+    return true;
+  });
+  const last = e.run(async () => {
+    return true;
+  });
+
+  expect(await canceled1).toBe(undefined);
+  expect(await canceled2).toBe(undefined);
+  expect(await canceled3).toBe(undefined);
+  expect(await last).toBe(true);
+});
+
+test("triggers abort signal event", async () => {
+  const e = mutexExecutor.create();
+  const abortListener = sinon.spy();
+
+  e.run(async abort => {
+    abort.addEventListener("abort", abortListener);
+    await sleep(10);
+    return "first";
+  });
+  expect(abortListener.called).toBe(false);
+  e.run(async () => {});
+  expect(abortListener.called).toBe(true);
+});
+
+test("don’t throw error on aborted task", async () => {
+  const e = mutexExecutor.create();
+
+  const first = e.run(async () => {
+    await sleep(10);
+    throw new Error();
+  });
+  const second = e.run(async () => {
+    return "second";
+  });
+
+  expect(await first).toBe(undefined);
+  expect(await second).toBe("second");
+});

--- a/ui/src/mutexExecutor.ts
+++ b/ui/src/mutexExecutor.ts
@@ -1,0 +1,62 @@
+// A task executor that runs only one task concurrently. If a new task
+// is run, any previously running task is aborted and the promise
+// returned from `run()` will return undefined.
+//
+//     import * as mutexExecutor from "ui/src/mutexExecutor"
+//     const executor = mutexExecutor.create()
+//     const first = executor.spwan(async () => {
+//       await sleep(1000)
+//       return "first"
+//     })
+//     const second = executor.spwan(async () => "second")
+//
+// In the example above the promise `first` will resolve to `undefined`
+// while the promise `second` will resolve to "second".
+//
+// If the first tasks throws after the second task has run the
+// behavior is the same.
+//
+//     const first = executor.spwan(async () => {
+//       await sleep(1000)
+//       throw new Error()
+//     })
+//
+// The task call back receives an AbortSignal as a parameter. The abort
+// event is emitted when another task is run.
+
+export function create(): MutexExecutor {
+  return new MutexExecutor();
+}
+
+class MutexExecutor {
+  private runningTaskId = 0;
+  private abortController: AbortController | null = null;
+
+  async run<T>(
+    f: (abortSignal: AbortSignal) => Promise<T>
+  ): Promise<T | undefined> {
+    this.runningTaskId += 1;
+    const taskId = this.runningTaskId;
+
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.abortController = new AbortController();
+    return f(this.abortController.signal).then(
+      data => {
+        if (this.runningTaskId === taskId) {
+          return data;
+        } else {
+          return undefined;
+        }
+      },
+      err => {
+        if (this.runningTaskId === taskId) {
+          throw err;
+        } else {
+          return undefined;
+        }
+      }
+    );
+  }
+}

--- a/ui/src/proxy/index.ts
+++ b/ui/src/proxy/index.ts
@@ -1,5 +1,6 @@
 import * as zod from "zod";
 import * as config from "../config";
+import { sleep } from "ui/src/sleep";
 
 import * as settings from "./settings";
 import * as identity from "./identity";
@@ -152,10 +153,4 @@ export const withRetry = async <T>(
     }
     await sleep(delayTime);
   }
-};
-
-const sleep = (delay: number) => {
-  return new Promise((resolve, _reject) => {
-    setTimeout(resolve, delay);
-  });
 };

--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -1,5 +1,6 @@
 import { get, derived, Readable } from "svelte/store";
 
+import * as mutexExecutor from "ui/src/mutexExecutor";
 import * as error from "../error";
 import type { PeerId } from "../identity";
 import * as project from "../project";
@@ -12,9 +13,10 @@ interface Screen {
   peers: project.Peer[];
   peerSelection: project.User[];
   project: project.Project;
-  requestInProgress: AbortController | null;
   selectedPeer: project.User;
 }
+
+const refreshExecutor = mutexExecutor.create();
 
 const screenStore = remote.createStore<Screen>();
 export const store = screenStore.readable;
@@ -24,51 +26,42 @@ export const fetch = (projectUrn: Urn): void => {
 
   proxy.client.project
     .get(projectUrn)
-    .then(async current => {
+    .then(async prj => {
       const peers = await proxy.client.project.listPeers(projectUrn);
       const peerSelection = project.userList(peers);
       throwUnlessPeersPresent(peerSelection, projectUrn);
       screenStore.success({
         peers,
         peerSelection,
-        project: current,
-        requestInProgress: null,
+        project: prj,
         selectedPeer: peerSelection[0],
       });
     })
     .catch(err => screenStore.error(error.fromUnknown(err)));
 };
 
-export const refreshPeers = (): void => {
+export const refreshPeers = async (): Promise<void> => {
   const screen = get(screenStore);
 
   if (screen.status === remote.Status.Success) {
-    const { data: current } = screen;
-    const { requestInProgress } = current;
+    try {
+      const peers = await refreshExecutor.run(abort =>
+        proxy.client.project.listPeers(screen.data.project.urn, { abort })
+      );
+      if (peers === undefined) {
+        return;
+      }
 
-    if (requestInProgress) {
-      requestInProgress.abort();
+      const peerSelection = project.userList(peers);
+      throwUnlessPeersPresent(peerSelection, screen.data.project.urn);
+      screenStore.success({
+        ...screen.data,
+        peers,
+        peerSelection,
+      });
+    } catch (err) {
+      screenStore.error(error.fromUnknown(err));
     }
-
-    const request = new AbortController();
-    screenStore.success({
-      ...current,
-      requestInProgress: request,
-    });
-
-    proxy.client.project
-      .listPeers(current.project.urn, { abort: request.signal })
-      .then(peers => {
-        const peerSelection = project.userList(peers);
-        throwUnlessPeersPresent(peerSelection, current.project.urn);
-        screenStore.success({
-          ...current,
-          peers,
-          peerSelection,
-          requestInProgress: null,
-        });
-      })
-      .catch(err => screenStore.error(error.fromUnknown(err)));
   }
 };
 

--- a/ui/src/sleep.ts
+++ b/ui/src/sleep.ts
@@ -1,0 +1,5 @@
+export function sleep(timeMs: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeMs);
+  });
+}


### PR DESCRIPTION
We introduce `MutexExecutor` that allows us to abstract over behavior were we need to abort previous requests issued by the user. We apply this abstraction in `ui/src/screen/project.ts` where it simplifies the code significantly.

The abstraction can also be used in other places like `ui/src/screen/project/source.ts` and the upcoming changes to the router.