### PR TITLE
fix(dev): jest module name mapping for TS paths

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,9 @@ module.exports = {
   transform: {
     "^.+\\.ts$": "ts-jest",
   },
+  moduleNameMapper: {
+    "^ui/(.*)$": "<rootDir>/ui/$1",
+  },
   testEnvironment: "jsdom",
   testRegex: "(/__tests__/.*|(\\.|/)(test))\\.ts$",
   moduleFileExtensions: ["ts", "js", "json"],


### PR DESCRIPTION
We set the `moduleNameMapper` option for Jest to match the `paths` option from `tsconfig.json` so that we can use absolute imports also in modules required by Jest.