### PR TITLE
feat(ui): add Rinkeby testnet and Mainnet

### DIFF
--- a/FUNDING.md
+++ b/FUNDING.md
@@ -52,11 +52,21 @@ The funding experiences can take place in three different environments:
   Token, deployed in the Ropsten network. Reach out to the team to get some Radicle
   Tokens into your account.
 
-3. `Mainnet`
+3. `Rinkeby`
 
-  In this environment, to be introduced in the future once we are ready to go mainnet,
-  the wallet will plug itself to the Radicle Contracts (to be) deployed in the Ethereum
-  Mainnet. This environment is not currently supported.
+  Any Org related testing can only happen on Rinkeby because Gnosis Safe only
+  provides a UI for the Rinkeby testnet.
+
+  We're using the official Rinkeby DAI contract:
+    0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea
+
+  Faucet: https://app.compound.finance/ -> DAI -> Withdraw -> Faucet
+
+4. `Mainnet`
+
+  Production environment where everything costs real money. So far only the Org
+  and Attestation features is available on `Mainnet`, the contracts for the
+  funding (aka token streams) feature are not yet deployed on mainnet.
 
 
 #### Local environment

--- a/ui/DesignSystem/Component/WalletStatusIndicator.svelte
+++ b/ui/DesignSystem/Component/WalletStatusIndicator.svelte
@@ -5,6 +5,7 @@
   import { Icon } from "../Primitive";
   import Tooltip from "./Tooltip.svelte";
   import SidebarItem from "./SidebarItem.svelte";
+  import * as ethereum from "ui/src/ethereum";
 
   export let active: boolean;
 
@@ -14,6 +15,15 @@
     tx => tx.status === "Awaiting inclusion"
   );
   $: wallet = $store;
+
+  const tooltipMessage = (environment: ethereum.Environment): string => {
+    switch (environment) {
+      case ethereum.Environment.Mainnet:
+        return "Wallet · Connected";
+      default:
+        return `Wallet · Connected to ${environment}`;
+    }
+  };
 </script>
 
 <div>
@@ -32,7 +42,7 @@
         </SidebarItem>
       </Tooltip>
     {:else}
-      <Tooltip value={`Wallet · Connected to ${wallet.environment}`}>
+      <Tooltip value={tooltipMessage(wallet.environment)}>
         <SidebarItem
           dataCy="wallet"
           indicator

--- a/ui/src/attestation/contract.ts
+++ b/ui/src/attestation/contract.ts
@@ -14,6 +14,8 @@ const addresses = {
   claims: {
     local: "0x785e8de68df899d77ce689f863e4166849c8bfd5",
     ropsten: "0xF8F22AA794DDA79aC0C634a381De0226f369bCCe",
+    rinkeby: "0x6c7b50EA0AFB02d73AE3846B3B9EBC31808300a6",
+    mainnet: "0x4a7DFda4F2e9F062965cC87f775841fB58AEA83e",
   },
 };
 
@@ -24,6 +26,10 @@ export function claimsAddress(environment: ethereum.Environment): string {
       return addresses.claims.local;
     case ethereum.Environment.Ropsten:
       return addresses.claims.ropsten;
+    case ethereum.Environment.Rinkeby:
+      return addresses.claims.rinkeby;
+    case ethereum.Environment.Mainnet:
+      return addresses.claims.mainnet;
   }
 }
 

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -72,11 +72,12 @@ export enum Code {
   UnsealedSessionExpected = "UnsealedSessionExpected",
   EmptyHistory = "EmptyHistory",
 
-  // Funding related error codes
+  // Ethereum related error codes
   WalletConnectionFailure = "WalletConnectionFailure",
   FailedOrRejectedTransaction = "FailedOrRejectedTransaction",
   UnkownTransactionFailure = "UnkownTransactionFailure",
   InsufficientGas = "InsufficientGas",
+  FeatureNotAvailableForGivenNetwork = "FeatureNotAvailableForGivenNetwork",
 
   // Custom protocol error codes
   CustomProtocolUnsupportedVersion = "CustomProtocolUnsupportedVersion",

--- a/ui/src/ethereum.ts
+++ b/ui/src/ethereum.ts
@@ -1,6 +1,7 @@
 import Big from "big.js";
 import * as ethers from "ethers";
 import persistentStore from "svelte-persistent-store/dist";
+import * as config from "ui/src/config";
 
 // The Ethereum environments we support and may connect to.
 export enum Environment {
@@ -11,7 +12,10 @@ export enum Environment {
   Local = "Local",
   // The Ropsten testnet network
   Ropsten = "Ropsten",
-  // N.B: We will support 'Mainnet' in the future
+  // The Rinkeby testnet for testing Orgs and Gnosis Safe functionality
+  Rinkeby = "Rinkeby",
+  // Production deployment
+  Mainnet = "Mainnet",
 }
 
 // The ethereum networks we may parse from a connected wallet across
@@ -19,6 +23,7 @@ export enum Environment {
 // each Environment supports.
 export enum Network {
   Ropsten = "Ropsten",
+  Rinkeby = "Rinkeby",
   Mainnet = "Mainnet",
   Other = "Other",
 }
@@ -30,6 +35,10 @@ export function supportedNetwork(environment: Environment): Network {
       return Network.Mainnet;
     case Environment.Ropsten:
       return Network.Ropsten;
+    case Environment.Rinkeby:
+      return Network.Rinkeby;
+    case Environment.Mainnet:
+      return Network.Mainnet;
   }
 }
 
@@ -41,6 +50,8 @@ export function networkFromChainId(chainId: number): Network {
       return Network.Mainnet;
     case 3:
       return Network.Ropsten;
+    case 4:
+      return Network.Rinkeby;
     default:
       return Network.Other;
   }
@@ -49,7 +60,7 @@ export function networkFromChainId(chainId: number): Network {
 // The store where the selected Ethereum environment is persisted.
 export const selectedEnvironment = persistentStore.local.writable<Environment>(
   "ethereum-environment-v0",
-  Environment.Ropsten
+  config.isDev ? Environment.Rinkeby : Environment.Mainnet
 );
 
 // EIP-20 token decimals for the tokens we operate with across

--- a/ui/src/funding/contract.ts
+++ b/ui/src/funding/contract.ts
@@ -1,6 +1,7 @@
 import { BigNumber, ContractTransaction, Signer } from "ethers";
 
 import Big from "big.js";
+import * as error from "ui/src/error";
 
 import {
   Erc20Pool,
@@ -14,6 +15,7 @@ import * as ethereum from "../ethereum";
 const addresses = {
   local: "0x56a32c0c857f1ae733562078a693ea845d9bb423",
   ropsten: "0x22B39d2F5768CE402077223b3f871d9b4393A5f2",
+  rinkeby: "0x8c6E1E293346cc4cD31A1972D94DaDcecEd98997",
 };
 
 interface SenderUpdatedArgs {
@@ -46,6 +48,13 @@ export function poolAddress(environment: ethereum.Environment): string {
       return addresses.local;
     case ethereum.Environment.Ropsten:
       return addresses.ropsten;
+    case ethereum.Environment.Rinkeby:
+      return addresses.rinkeby;
+    case ethereum.Environment.Mainnet:
+      throw new error.Error({
+        code: error.Code.FeatureNotAvailableForGivenNetwork,
+        message: "Token streaming contracts are not yet deployed on mainnet",
+      });
   }
 }
 

--- a/ui/src/funding/daiToken.ts
+++ b/ui/src/funding/daiToken.ts
@@ -14,6 +14,8 @@ export { ERC20 };
 const addresses = {
   local: "0xff1d4d289bf0aaaf918964c57ac30481a67728ef",
   ropsten: "0x31f42841c2db5173425b5223809cf3a38fede360",
+  rinkeby: "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
+  mainnet: "0x6b175474e89094c44da98b954eedeac495271d0f",
 };
 
 // Get the address of the Pool Contract for the given environment
@@ -23,6 +25,10 @@ export function daiTokenAddress(environment: ethereum.Environment): string {
       return addresses.local;
     case ethereum.Environment.Ropsten:
       return addresses.ropsten;
+    case ethereum.Environment.Rinkeby:
+      return addresses.rinkeby;
+    case ethereum.Environment.Mainnet:
+      return addresses.mainnet;
   }
 }
 

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -81,6 +81,14 @@ export const fundingEnvironmentOptions: Option<ethereum.Environment>[] = [
     title: ethereum.Environment.Ropsten.toString(),
     value: ethereum.Environment.Ropsten,
   },
+  {
+    title: ethereum.Environment.Rinkeby.toString(),
+    value: ethereum.Environment.Rinkeby,
+  },
+  {
+    title: ethereum.Environment.Mainnet.toString(),
+    value: ethereum.Environment.Mainnet,
+  },
 ];
 
 // gives back the OS you're using in hotkeys.svelte & shortcuts.svelte

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -65,6 +65,17 @@ function getProvider(
         "ropsten",
         "66fa0f92a54e4d8c9483ffdc6840d77b"
       );
+    case ethereum.Environment.Rinkeby:
+      return new ethers.providers.InfuraProvider(
+        "rinkeby",
+        "de5e2a8780c04964950e73b696d1bfb1"
+      );
+    case ethereum.Environment.Mainnet:
+      // This account is registered on rudolfs@monadic.xyz.
+      return new ethers.providers.InfuraProvider(
+        "mainnet",
+        "7a19a4bf0af84fcc86ffb693a257fad4"
+      );
   }
 }
 


### PR DESCRIPTION
Backporting these changes from the [orgs](https://github.com/radicle-dev/radicle-upstream/pull/1813) PR to make it easier to review.

We'll need the Rinkeby testnet to test Orgs and Gnosis Safe functionality and Mainnet for our production builds.