### PR TITLE
refactor: enforce curly braces for if/else statments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,8 @@ module.exports = {
     "no-only-tests/no-only-tests": "error",
     // Require `===` and `!==` comparisons
     eqeqeq: "error",
+    // Enforce curly braces for if/else statements for better clarity.
+    curly: "error",
 
     // We are ok with providing explict type annotations for additional
     // clarity.

--- a/ui/DesignSystem/Component/Copyable.svelte
+++ b/ui/DesignSystem/Component/Copyable.svelte
@@ -22,10 +22,14 @@
   let copied = false;
 
   export const copy = (): void => {
-    if (copied) return;
+    if (copied) {
+      return;
+    }
 
     const content = copyContent.length ? copyContent : slotContent.textContent;
-    if (content) copyToClipboard(content.trim());
+    if (content) {
+      copyToClipboard(content.trim());
+    }
 
     notification.info({ message: notificationText });
 

--- a/ui/DesignSystem/Component/FollowToggle.svelte
+++ b/ui/DesignSystem/Component/FollowToggle.svelte
@@ -14,7 +14,9 @@
 
   const dispatch = createEventDispatcher();
   const click = () => {
-    if (disabled) return;
+    if (disabled) {
+      return;
+    }
 
     following = !following;
     dispatch(following ? "follow" : "unfollow");

--- a/ui/DesignSystem/Component/Funding/Pool/Receivers.svelte
+++ b/ui/DesignSystem/Component/Funding/Pool/Receivers.svelte
@@ -20,7 +20,9 @@
 
   function toggleReceiver(address: pool.Address) {
     const status = receivers.get(address);
-    if (!status) return;
+    if (!status) {
+      return;
+    }
 
     switch (status) {
       case ReceiverStatus.Added:
@@ -72,8 +74,12 @@
   $: validation = receiverValidationStore();
   $: receiverStore.set(newValue);
   $: {
-    if ($receiverStore && $receiverStore.length > 0) validating = true;
-    if (validating) validation.validate($receiverStore);
+    if ($receiverStore && $receiverStore.length > 0) {
+      validating = true;
+    }
+    if (validating) {
+      validation.validate($receiverStore);
+    }
   }
 
   let disabled = true;

--- a/ui/DesignSystem/Component/Funding/Pool/TopUp.svelte
+++ b/ui/DesignSystem/Component/Funding/Pool/TopUp.svelte
@@ -19,8 +19,12 @@
   $: validation = balanceValidationStore(balance);
   $: amountStore.set(amount);
   $: {
-    if ($amountStore && $amountStore.length > 0) validating = true;
-    if (validating) validation.validate($amountStore);
+    if ($amountStore && $amountStore.length > 0) {
+      validating = true;
+    }
+    if (validating) {
+      validation.validate($amountStore);
+    }
   }
 
   $: disabled = $validation.status !== ValidationStatus.Success;

--- a/ui/DesignSystem/Component/Overlay.svelte
+++ b/ui/DesignSystem/Component/Overlay.svelte
@@ -15,11 +15,17 @@
   const handleClick = (ev: MouseEvent) => {
     const component = $current;
     const inside = component && component.contains(ev.target as HTMLDivElement);
-    if (!inside) close();
+    if (!inside) {
+      close();
+    }
   };
 
-  $: if (expanded) open(container);
-  $: if ($current !== container) dispatch("hide");
+  $: if (expanded) {
+    open(container);
+  }
+  $: if ($current !== container) {
+    dispatch("hide");
+  }
 </script>
 
 <svelte:window on:click={handleClick} />

--- a/ui/DesignSystem/Primitive/Input/Directory.svelte
+++ b/ui/DesignSystem/Primitive/Input/Directory.svelte
@@ -18,7 +18,9 @@
 
   const openFileDialog = async () => {
     path = await getDirectoryPath();
-    if (path) dispatch("selected");
+    if (path) {
+      dispatch("selected");
+    }
   };
 </script>
 

--- a/ui/DesignSystem/Primitive/Input/Password.svelte
+++ b/ui/DesignSystem/Primitive/Input/Password.svelte
@@ -25,7 +25,9 @@
   // Can't use normal `autofocus` attribute on the `input`:
   // "Autofocus processing was blocked because a document's URL has a fragment"
   // preventScroll is necessary for onboarding animations to work.
-  $: if (autofocus) inputElement && inputElement.focus({ preventScroll: true });
+  $: if (autofocus) {
+    inputElement && inputElement.focus({ preventScroll: true });
+  }
 
   const onKeydown = (event: KeyboardEvent) => {
     if (event.key === "Enter") {

--- a/ui/DesignSystem/Primitive/Input/Text.svelte
+++ b/ui/DesignSystem/Primitive/Input/Text.svelte
@@ -27,7 +27,9 @@
   // Can't use normal `autofocus` attribute on the `inputElement`:
   // "Autofocus processing was blocked because a document's URL has a fragment".
   // preventScroll is necessary for onboarding animations to work.
-  $: if (autofocus) inputElement && inputElement.focus({ preventScroll: true });
+  $: if (autofocus) {
+    inputElement && inputElement.focus({ preventScroll: true });
+  }
 
   $: showHint = hint.length > 0 && value.length === 0;
 </script>

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -48,7 +48,9 @@
       return shortcut.modifierKey ? match && modifierKey : match;
     });
 
-    if (!shortcut) return;
+    if (!shortcut) {
+      return;
+    }
 
     switch (shortcut.key) {
       case hotkeys.ShortcutKey.Help:

--- a/ui/Modal/Funding/Onboarding/SetBudget.svelte
+++ b/ui/Modal/Funding/Onboarding/SetBudget.svelte
@@ -16,8 +16,12 @@
   $: validation = weeklyBudgetValidationStore();
   $: budgetStore.set(budget);
   $: {
-    if ($budgetStore && $budgetStore.length > 0) validating = true;
-    if (validating) validation.validate($budgetStore);
+    if ($budgetStore && $budgetStore.length > 0) {
+      validating = true;
+    }
+    if (validating) {
+      validation.validate($budgetStore);
+    }
   }
 
   let disabled = true;

--- a/ui/Modal/Funding/Pool/Withdraw.svelte
+++ b/ui/Modal/Funding/Pool/Withdraw.svelte
@@ -27,8 +27,12 @@
 
   $: amountStore.set(amount);
   $: {
-    if ($amountStore && $amountStore.length > 0) validatingAmount = true;
-    if (validatingAmount) validation.validate($amountStore);
+    if ($amountStore && $amountStore.length > 0) {
+      validatingAmount = true;
+    }
+    if (validatingAmount) {
+      validation.validate($amountStore);
+    }
   }
 
   $: disableAmountConfirmation =

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -45,7 +45,9 @@
   const trackTooltip = "Unfollowing is not yet supported";
 
   export const copy = (content: string): void => {
-    if (content) copyToClipboard(content.trim());
+    if (content) {
+      copyToClipboard(content.trim());
+    }
     notification.info({ message: "Copied to your clipboard" });
   };
 

--- a/ui/Screen/Wallet/Pool/Outgoing/Support.svelte
+++ b/ui/Screen/Wallet/Pool/Outgoing/Support.svelte
@@ -44,8 +44,12 @@
   $: budgetValidation = weeklyBudgetValidationStore();
   $: budgetStore.set(budget);
   $: {
-    if ($budgetStore && $budgetStore.length > 0) validatingBudget = true;
-    if (validatingBudget) budgetValidation.validate($budgetStore);
+    if ($budgetStore && $budgetStore.length > 0) {
+      validatingBudget = true;
+    }
+    if (validatingBudget) {
+      budgetValidation.validate($budgetStore);
+    }
   }
 
   // Flags whether the view is in editing mode.

--- a/ui/src/funding/contract.ts
+++ b/ui/src/funding/contract.ts
@@ -287,10 +287,14 @@ async function getSenderData(
     // The Ethereum timestamps are in seconds
     const timestampNow = Math.floor(now.getTime() / 1000);
     // Block timestamp in the future
-    if (timestampNow < timestamp) return balance;
+    if (timestampNow < timestamp) {
+      return balance;
+    }
     const spent = amtPerSec.mul(timestampNow - timestamp);
     // Spent everything, return the unspendable reminder
-    if (spent > balance) return balance.mod(amtPerSec);
+    if (spent > balance) {
+      return balance.mod(amtPerSec);
+    }
     return balance.minus(spent);
   };
 

--- a/ui/src/funding/pool.ts
+++ b/ui/src/funding/pool.ts
@@ -97,7 +97,9 @@ export function make(wallet: Wallet): Pool {
 
   async function loadPoolData(watcher: PoolWatcher) {
     const storedWallet = svelteStore.get(wallet);
-    if (storedWallet.status !== WalletStatus.Connected) return;
+    if (storedWallet.status !== WalletStatus.Connected) {
+      return;
+    }
     const ethAddr = storedWallet.connected.account.address;
     try {
       data.success(await watcher.poolData(ethAddr));

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -225,7 +225,9 @@ export const addSeed = async (seed: string): Promise<boolean> => {
   // async then the seed input form will have to be submitted twice to take any
   // effect.
   await seedValidation.validate(seed);
-  if (get(seedValidation).status !== ValidationStatus.Success) return false;
+  if (get(seedValidation).status !== ValidationStatus.Success) {
+    return false;
+  }
 
   updateCoCo({ seeds: [...get(settings).coco.seeds, seed] });
   return true;

--- a/ui/src/validation.ts
+++ b/ui/src/validation.ts
@@ -132,7 +132,9 @@ export const createValidationStore = (
 
             update(store => {
               // If the input has changed since this request was fired off, don't update
-              if (getInput() !== input) return store;
+              if (getInput() !== input) {
+                return store;
+              }
               return {
                 status: ValidationStatus.Error,
                 message: remoteValidation.validationMessage,
@@ -146,7 +148,9 @@ export const createValidationStore = (
 
           update(store => {
             // If the input has changed since this request was fired off, don't update
-            if (getInput() !== input) return store;
+            if (getInput() !== input) {
+              return store;
+            }
             return {
               status: ValidationStatus.Error,
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
@@ -166,7 +170,9 @@ export const createValidationStore = (
     // If we made it here, it's valid
     update(store => {
       // If the input has changed since this request was fired off, don't update
-      if (getInput() !== input) return store;
+      if (getInput() !== input) {
+        return store;
+      }
       return { status: ValidationStatus.Success };
     });
   };


### PR DESCRIPTION
We enforce curly braces in if/else statments. This makes the code more consistent and arguably [aides readability][1]. It also reduces the number of changes required when a statement is added to a branch.

[1]: https://nakedsecurity.sophos.com/2014/02/24/anatomy-of-a-goto-fail-apples-ssl-bug-explained-plus-an-unofficial-patch/