### PR TITLE
refactor: make error code optional

### DIFF
--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -7,7 +7,7 @@ import * as ipc from "./ipc";
 
 interface ErrorParams {
   // A unique code for easy identification of the error.
-  code: Code;
+  code?: Code;
   // Message that is displayed to the user if the error is shown.
   message: string;
   // Arbitrary additional information associated with the error
@@ -24,7 +24,7 @@ interface ErrorParams {
 // contextual information.
 export class Error extends globalThis.Error {
   // A unique code for easy identification of the error.
-  readonly code: Code;
+  readonly code?: Code;
   // Message that is displayed to the user if the error is shown.
   readonly message: string;
   // An optional stack trace


### PR DESCRIPTION
We make the `code` property passed to errors optional. This makes it easier to add new errors (which happens frequently) because we don’t need to add it to a global error registry.

Error code’s are beneficial when the cause of the error cannot be deduced from the message or the stack which rarely is the case, or if we want to match on a certain type of error.