### PR TITLE
Wait until wallet is connected before fetching orgs

### DIFF
--- a/ui/src/svelteStore.test.ts
+++ b/ui/src/svelteStore.test.ts
@@ -1,0 +1,43 @@
+import * as sinon from "sinon";
+import { sleep } from "ui/src/sleep";
+
+import * as svelteStore from "./svelteStore";
+
+describe("waitUntil", () => {
+  test("current value matches", async () => {
+    const store = svelteStore.writable(true);
+    const value = await svelteStore.waitUntil(store, x => x);
+    expect(value).toBe(true);
+  });
+
+  test("future value matches", async () => {
+    const store = svelteStore.writable(false);
+    const promise = svelteStore.waitUntil(store, x => x);
+    const resolved = sinon.spy();
+    promise.then(resolved);
+
+    store.set(false);
+    await sleep(5);
+    store.set(false);
+    await sleep(5);
+    expect(resolved.called).toBe(false);
+    store.set(true);
+    expect(await promise).toBe(true);
+  });
+
+  test("predicate throws", async () => {
+    const store = svelteStore.writable(false);
+    const error = new Error();
+    const promise = svelteStore.waitUntil(store, x => {
+      if (x === true) {
+        throw error;
+      } else {
+        return false;
+      }
+    });
+
+    store.set(true);
+
+    expect(await promise.catch(e => e)).toBe(error);
+  });
+});

--- a/ui/src/svelteStore.ts
+++ b/ui/src/svelteStore.ts
@@ -1,0 +1,42 @@
+import type { Readable } from "svelte/store";
+
+export * from "svelte/store";
+
+// Waits until the value in `store` matches the predicate and resolves
+// the promise with the value.
+//
+// If `predicate` throws then the error is rethrown by the returned
+// promise.
+export function waitUntil<T>(
+  store: Readable<T>,
+  predicate: (t: T) => boolean
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let resolvedNow = false;
+    let unsubscribe: () => void | undefined;
+    // We’re using `let` so that we can access `unsubscribe` if the
+    // `susbscribe` callback is called synchronously.
+    // eslint-disable-next-line prefer-const
+    unsubscribe = store.subscribe(value => {
+      let matched;
+      try {
+        matched = predicate(value);
+      } catch (err) {
+        reject(err);
+        return;
+      }
+
+      if (matched) {
+        if (unsubscribe) {
+          unsubscribe();
+        } else {
+          resolvedNow = true;
+        }
+        resolve(value);
+      }
+    });
+    if (resolvedNow) {
+      unsubscribe();
+    }
+  });
+}


### PR DESCRIPTION
In the tasks that polls for org updates we wait until the wallet has been connected.  This ensures that we poll as soon as possible after connecting even if the poll interval is quite large.

To achieve this we introduce the `svelteStore.waitUntil` abstraction. This abstraction can also be used to implement `waitUnsealed` more succinctly.