### PR TITLE
fix(ui) use revision icon for patches

### DIFF
--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -74,7 +74,7 @@
       {
         title: "Patches",
         active: active.type === "patches",
-        icon: Icon.Commit,
+        icon: Icon.Revision,
         counter: screen.patches.filter(patch => !patch.merged).length,
         onClick: () => {
           router.push({


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-upstream/issues/2015.
<img width="436" alt="Screenshot 2021-06-17 at 15 42 02" src="https://user-images.githubusercontent.com/158411/122408535-c30c6680-cf82-11eb-96b5-00096e6fc034.png">
