### PR TITLE
style(ui): parametrise PeerSelector border styling

### DIFF
--- a/ui/DesignSystem/Component/PeerSelector.svelte
+++ b/ui/DesignSystem/Component/PeerSelector.svelte
@@ -12,8 +12,10 @@
   import Peer from "./PeerSelector/Peer.svelte";
 
   export let expanded: boolean = false;
+  export let rounded: boolean = false;
   export let peers: User[];
   export let selected: User;
+  export let showProfile: boolean = isExperimental;
   let dropdownHeight: number;
 
   const orderPeers = (peers: User[]): User[] => {
@@ -41,7 +43,6 @@
     hide();
     dispatch("select", peer);
   };
-  const showProfile = isExperimental;
 </script>
 
 <style>
@@ -105,6 +106,14 @@
     justify-content: center;
   }
 
+  .rounded {
+    border-top-right-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem !important;
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+    border: 1px solid var(--color-foreground-level-3);
+  }
+
   .entry {
     align-items: center;
     background-color: var(--color-background);
@@ -135,6 +144,7 @@
   style="position: relative; user-select: none;">
   <div
     class="peer-selector typo-overflow-ellipsis"
+    class:rounded
     data-cy="peer-selector"
     hidden={expanded}
     on:click|stopPropagation={show}>
@@ -149,6 +159,7 @@
       bind:clientHeight={dropdownHeight}
       class="peer-dropdown"
       hidden={!expanded}
+      class:rounded
       style={`border-bottom-right-radius: ${
         dropdownHeight > 40 ? "0.5rem" : "0"
       }`}>


### PR DESCRIPTION
We'll need this for [orgs](https://github.com/radicle-dev/radicle-upstream/pull/1813), because we want to reuse the peer selector in a different context.
Additionally parametrise whether to show the "Go to profile" link.

Right now it is used in the project source view with a button on the right-hand side:
<img width="265" alt="Screenshot 2021-06-17 at 18 45 23" src="https://user-images.githubusercontent.com/158411/122439800-3ec6dd00-cf9c-11eb-9a6a-0fca3e834682.png">

And we want to reuse it without the right-hand side button:
<img width="336" alt="Screenshot 2021-06-17 at 18 45 14" src="https://user-images.githubusercontent.com/158411/122439916-5bfbab80-cf9c-11eb-871f-34e9cc33d1e8.png">

<img width="385" alt="Screenshot 2021-06-17 at 18 44 42" src="https://user-images.githubusercontent.com/158411/122439978-6ae25e00-cf9c-11eb-9995-2e24dedbc6ac.png">
