### PR TITLE
chore(ui): drop the Ropsten testnet

### DIFF
--- a/ETHEREUM.md
+++ b/ETHEREUM.md
@@ -1,8 +1,5 @@
-## Radicle Funding
-
-Welcome to the developer's documentation on the Radicle Funding.
-
-### Overview
+## Features based on Ethereum
+### Funding
 
 Three moving pieces back the Radicle Funding experiences:
 
@@ -16,60 +13,61 @@ incoming support funds, and others, translate into ethereum transactions.
 
 For users to approve those transactions originated in the app, they need to
 establish a connection between an Ethereum wallet and the app. We provide this
-capability through a WalletConnect integration. A substantial number of Ethereum
-wallets support WalletConnect. [You can find the complete list here][wcw].
+capability through a WalletConnect integration. A substantial number of
+Ethereum wallets support WalletConnect. You can find the complete list
+[here][wcw].
 
 Once a wallet is connected to the app, the funding experiences become available
-to the user. The user can now set up and edit their support, receive funds, etc.
-All of these actions translate into transactions the user must review, (i.e.,
-approve or reject) on their connected wallet.
+to the user. The user can now set up and edit their support, receive funds,
+etc.  All of these actions translate into transactions the user must review,
+(i.e., approve or reject) on their connected wallet.
 
-These same transactions are provided and ran by the [Radicle Contracts][rc], our
-custom Ethereum smart-contracts.
+These same transactions are provided and ran by the [Radicle Contracts][rc],
+our custom Ethereum smart-contracts.
 
-### Ethereum environments
+### Orgs
 
-The funding experiences can take place in three different environments:
+Radicle orgs allow users to maintain an auditable and transparent history of
+project state on Ethereum. This enables new workflows around your main branch
+that is now anchored and secured on Ethereum. Anchors can be used to trigger
+off-chain actions like the distribution of developer rewards, software
+releases, or any job you’d like. Org contracts may be controlled by arbitrary
+addresses. At the moment we deploy a [Gnosis safe contract][gnosis] as the
+controller when creating an org.
+
+Read more about Orgs [here][org].
+
+## Ethereum environments
 
 1. `Local`
 
-  In this environment, the Radicle Contracts are deployed to development Ethereum
-  node running locally and we use a local test wallet that can communicate with it.
-  The "DAI" token used in this environment is our custom Radicle Token. See the
-  [local environment](#local-environment) section to learn how to get set up.
+  In this environment Radicle Contracts are deployed to a development Ethereum
+  node running locally and we use a local test wallet that can communicate with
+  it. The "DAI" token used in this environment is our custom Radicle Token.
+  See the [local environment][loc] section to learn how to get set up.
 
+2. `Rinkeby`
 
-2. `Ropsten`
+  In this environment, the app will plug itself with the Radicle Contracts
+  deployed in the Rinkeby network and Infura is used as a service provider. We
+  recommend that you use a real wallet to ensure that we are testing using
+  real-world conditions.
 
-  In this environment, the app will plug itself with the Radicle Contracts deployed
-  in the Ropsten network and Infura is used as a service provider. We recommend that
-  you use a real wallet to ensure that we are testing using real-world conditions.
-
-  You will need fake Ropsten Eth (aka `rEth`) to pay the incurring transactions fees.
-  No real money will be charged.
-
-  As in the `Local` environment, here the "DAI" token used is also our custom Radicle
-  Token, deployed in the Ropsten network. Reach out to the team to get some Radicle
-  Tokens into your account.
-
-3. `Rinkeby`
-
-  Any Org related testing can only happen on Rinkeby because Gnosis Safe only
-  provides a UI for the Rinkeby testnet.
+  You will need [Rinkeby Eth] to pay the incurring transactions fees. No real
+  money will be used.
 
   We're using the official Rinkeby DAI contract:
     0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea
 
   Faucet: https://app.compound.finance/ -> DAI -> Withdraw -> Faucet
 
-4. `Mainnet`
+3. `Mainnet`
 
   Production environment where everything costs real money. So far only the Org
   and Attestation features is available on `Mainnet`, the contracts for the
-  funding (aka token streams) feature are not yet deployed on mainnet.
+  funding (aka token streams) feature are not yet deployed.
 
-
-#### Local environment
+### Local environment
 
 In the local environment, we set up these three pieces as follows:
 
@@ -82,13 +80,13 @@ In the local environment, we set up these three pieces as follows:
 
 - A local ganache instance
 
-  Ganache provides a local Ethereum RPC client for testing and development. We deploy the
-  Radicle Contracts to this instance. Here, we also set an initial
+  Ganache provides a local Ethereum RPC client for testing and development. We
+  deploy the Radicle Contracts to this instance. Here, we also set an initial
   balance of the account we choose for development purposes.
 
-  For peace of mind, note that this instance has no connection to other networks
-  such as mainnet or testnet. Therefore, no real assets used ever. Feel free
-  to play around!
+  For peace of mind, note that this instance has no connection to other
+  networks such as mainnet or testnet. Therefore, no real assets used ever.
+  Feel free to play around!
 
 ![Radicle Funding Development Set up][dev-setup]
 
@@ -125,7 +123,12 @@ tabs:
 - Once the app is running, enable the funding feature in the Upstream settings
 
 
+
 [wcw]:https://walletconnect.org/wallets/
 [wctw]:https://github.com/radicle-dev/walletconnect-test-wallet
 [rc]:https://github.com/radicle-dev/radicle-contracts
 [dev-setup]:./funding-dev-setup.svg "Radicle Funding Development Set up"
+[org]: https://radicle.community/t/feature-update-orgs/2132
+[fauc]: https://faucet.rinkeby.io
+[loc]: #local-environment
+[gnosis]: https://help.gnosis-safe.io/en/articles/3876456-what-is-gnosis-safe

--- a/ui/src/attestation/contract.ts
+++ b/ui/src/attestation/contract.ts
@@ -13,7 +13,6 @@ import { parseIdentitySha1 } from "../urn";
 const addresses = {
   claims: {
     local: "0x785e8de68df899d77ce689f863e4166849c8bfd5",
-    ropsten: "0xF8F22AA794DDA79aC0C634a381De0226f369bCCe",
     rinkeby: "0x6c7b50EA0AFB02d73AE3846B3B9EBC31808300a6",
     mainnet: "0x4a7DFda4F2e9F062965cC87f775841fB58AEA83e",
   },
@@ -24,8 +23,6 @@ export function claimsAddress(environment: ethereum.Environment): string {
   switch (environment) {
     case ethereum.Environment.Local:
       return addresses.claims.local;
-    case ethereum.Environment.Ropsten:
-      return addresses.claims.ropsten;
     case ethereum.Environment.Rinkeby:
       return addresses.claims.rinkeby;
     case ethereum.Environment.Mainnet:

--- a/ui/src/ethereum.ts
+++ b/ui/src/ethereum.ts
@@ -6,12 +6,10 @@ import * as config from "ui/src/config";
 // The Ethereum environments we support and may connect to.
 export enum Environment {
   // A local node for testing and development. The test wallet we use
-  // for this environment may be in the 'Ropsten', 'Mainnet', or other
-  // network. However, those would not be the real 'Ropsten' and 'Mainnet'
+  // for this environment may be in the 'Rinkeby', 'Mainnet', or other
+  // network. However, those would not be the real 'Rinkeby' and 'Mainnet'
   // networks, respectively, but simply fake ones for testing purposes.
   Local = "Local",
-  // The Ropsten testnet network
-  Ropsten = "Ropsten",
   // The Rinkeby testnet for testing Orgs and Gnosis Safe functionality
   Rinkeby = "Rinkeby",
   // Production deployment
@@ -22,7 +20,6 @@ export enum Environment {
 // all `Environment`s. See `supportedNetwork` to learn which networks
 // each Environment supports.
 export enum Network {
-  Ropsten = "Ropsten",
   Rinkeby = "Rinkeby",
   Mainnet = "Mainnet",
   Other = "Other",
@@ -33,8 +30,6 @@ export function supportedNetwork(environment: Environment): Network {
   switch (environment) {
     case Environment.Local:
       return Network.Mainnet;
-    case Environment.Ropsten:
-      return Network.Ropsten;
     case Environment.Rinkeby:
       return Network.Rinkeby;
     case Environment.Mainnet:
@@ -48,8 +43,6 @@ export function networkFromChainId(chainId: number): Network {
   switch (chainId) {
     case 1:
       return Network.Mainnet;
-    case 3:
-      return Network.Ropsten;
     case 4:
       return Network.Rinkeby;
     default:

--- a/ui/src/funding/contract.ts
+++ b/ui/src/funding/contract.ts
@@ -14,7 +14,6 @@ import * as ethereum from "../ethereum";
 
 const addresses = {
   local: "0x56a32c0c857f1ae733562078a693ea845d9bb423",
-  ropsten: "0x22B39d2F5768CE402077223b3f871d9b4393A5f2",
   rinkeby: "0x8c6E1E293346cc4cD31A1972D94DaDcecEd98997",
 };
 
@@ -46,8 +45,6 @@ export function poolAddress(environment: ethereum.Environment): string {
   switch (environment) {
     case ethereum.Environment.Local:
       return addresses.local;
-    case ethereum.Environment.Ropsten:
-      return addresses.ropsten;
     case ethereum.Environment.Rinkeby:
       return addresses.rinkeby;
     case ethereum.Environment.Mainnet:

--- a/ui/src/funding/daiToken.ts
+++ b/ui/src/funding/daiToken.ts
@@ -13,7 +13,6 @@ export { ERC20 };
 
 const addresses = {
   local: "0xff1d4d289bf0aaaf918964c57ac30481a67728ef",
-  ropsten: "0x31f42841c2db5173425b5223809cf3a38fede360",
   rinkeby: "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
   mainnet: "0x6b175474e89094c44da98b954eedeac495271d0f",
 };
@@ -23,8 +22,6 @@ export function daiTokenAddress(environment: ethereum.Environment): string {
   switch (environment) {
     case ethereum.Environment.Local:
       return addresses.local;
-    case ethereum.Environment.Ropsten:
-      return addresses.ropsten;
     case ethereum.Environment.Rinkeby:
       return addresses.rinkeby;
     case ethereum.Environment.Mainnet:

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -54,8 +54,6 @@ const orgFactoryAddress = (network: ethereum.Environment): string => {
         code: error.Code.FeatureNotAvailableForGivenNetwork,
         message: "Orgs not available on the Local testnet",
       });
-    case ethereum.Environment.Ropsten:
-      return "0xf36fbaB8BA78683D23c5021bfcE8A5c88731200F";
     case ethereum.Environment.Rinkeby:
       return "0xF3D04e874D07d680e8b26332eEae5b9B1c263121";
     case ethereum.Environment.Mainnet:

--- a/ui/src/org/safe.ts
+++ b/ui/src/org/safe.ts
@@ -70,11 +70,6 @@ export function appUrl(
         code: error.Code.FeatureNotAvailableForGivenNetwork,
         message: "Gnosis Safe links are not supported on the Local testnet",
       });
-    case Ethereum.Environment.Ropsten:
-      throw new error.Error({
-        code: error.Code.FeatureNotAvailableForGivenNetwork,
-        message: "Gnosis Safe links are not supported on the Ropsten testnet",
-      });
     case Ethereum.Environment.Rinkeby:
       domain = `rinkeby.gnosis-safe.io`;
       break;
@@ -95,12 +90,6 @@ function createSafeServiceClient(
         code: error.Code.FeatureNotAvailableForGivenNetwork,
         message:
           "Pending Gnosis Safe transactions are not available on the Local testnet.",
-      });
-    case Ethereum.Environment.Ropsten:
-      throw new error.Error({
-        code: error.Code.FeatureNotAvailableForGivenNetwork,
-        message:
-          "Pending Gnosis Safe transactions are not available on the Ropsten testnet.",
       });
     case Ethereum.Environment.Rinkeby:
       uri = "https://safe-transaction.rinkeby.gnosis.io";

--- a/ui/src/org/theGraphApi.ts
+++ b/ui/src/org/theGraphApi.ts
@@ -31,10 +31,6 @@ const gnosisSubgraphClient = (): apolloCore.ApolloClient<unknown> => {
         code: error.Code.FeatureNotAvailableForGivenNetwork,
         message: "Orgs is not available on the Local testnet.",
       });
-    case ethereum.Environment.Ropsten:
-      uri =
-        "https://api.thegraph.com/subgraphs/name/radicle-dev/gnosis-safe-ropsten";
-      break;
     case ethereum.Environment.Rinkeby:
       uri =
         "https://api.thegraph.com/subgraphs/name/radicle-dev/gnosis-safe-rinkeby";
@@ -56,10 +52,6 @@ const orgsSubgraphClient = () => {
         code: error.Code.FeatureNotAvailableForGivenNetwork,
         message: "Orgs is not available on the Local testnet.",
       });
-    case ethereum.Environment.Ropsten:
-      uri =
-        "https://api.thegraph.com/subgraphs/name/radicle-dev/radicle-orgs-ropsten";
-      break;
     case ethereum.Environment.Rinkeby:
       uri =
         "https://api.thegraph.com/subgraphs/name/radicle-dev/radicle-orgs-rinkeby";

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -78,10 +78,6 @@ export const fundingEnvironmentOptions: Option<ethereum.Environment>[] = [
     value: ethereum.Environment.Local,
   },
   {
-    title: ethereum.Environment.Ropsten.toString(),
-    value: ethereum.Environment.Ropsten,
-  },
-  {
     title: ethereum.Environment.Rinkeby.toString(),
     value: ethereum.Environment.Rinkeby,
   },

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -486,9 +486,6 @@ export const openTxOnEtherscan = (transactionId: string): void => {
         code: error.Code.FeatureNotAvailableForGivenNetwork,
         message: "Etherscan links are not supported on the Local testnet",
       });
-    case ethereum.Environment.Ropsten:
-      ipc.openUrl(`https://ropsten.etherscan.io/tx/${transactionId}`);
-      break;
     case ethereum.Environment.Rinkeby:
       ipc.openUrl(`https://rinkeby.etherscan.io/tx/${transactionId}`);
       break;

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -60,11 +60,6 @@ function getProvider(
   switch (environment) {
     case ethereum.Environment.Local:
       return new ethers.providers.JsonRpcProvider("http://localhost:8545");
-    case ethereum.Environment.Ropsten:
-      return new ethers.providers.InfuraProvider(
-        "ropsten",
-        "66fa0f92a54e4d8c9483ffdc6840d77b"
-      );
     case ethereum.Environment.Rinkeby:
       // This account is registered on igor.zuk@protonmail.com.
       return new ethers.providers.InfuraProvider(


### PR DESCRIPTION
We're well served by `Rinkeby` and don't want to spend time unnecessarily on maintaining multiple test nets.
See individual commits for the doc changes.