### PR TITLE
feat(dev): check license compliance for NPM packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     ecmaVersion: 2019,
     sourceType: "module",
   },
+  ignorePatterns: ["!.license-compliancerc.js"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   plugins: ["svelte3", "@typescript-eslint", "no-only-tests"],
   overrides: [

--- a/.license-compliancerc.js
+++ b/.license-compliancerc.js
@@ -1,0 +1,43 @@
+module.exports = {
+  report: "detailed",
+  production: "true",
+  exclude: [
+    // twemojji is licensed under MIT and CC-BY-4.0 but uses a
+    // non-standard `license` field so that it cannot be parse
+    // properly. https://github.com/twitter/twemoji/pull/499
+    "twemoji",
+  ],
+  // Must only include licenses that are GPLv3 compatible. This is mostly
+  // sourced from http://www.gnu.org/licenses/license-list.html
+  allow: [
+    // 0BSD is less restrictive than ISC https://opensource.org/licenses/0BSD
+    "0BSD",
+    // http://www.gnu.org/licenses/license-list.html#apache2
+    "Apache-2.0",
+    // http://www.gnu.org/licenses/license-list.html#FreeBSD
+    "BSD-2-Clause",
+    // http://www.gnu.org/licenses/license-list.html#ModifiedBSD
+    "BSD-3-Clause",
+    // http://www.gnu.org/licenses/license-list.html#ccby
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    // http://www.gnu.org/licenses/license-list.html#CC0
+    "CC0-1.0",
+    "GPL-3.0-only",
+    // http://www.gnu.org/licenses/license-list.html#ISC
+    "ISC",
+    // http://www.gnu.org/licenses/license-list.html#LGPLv3
+    "LGPL-3.0",
+    // Named "Expat" on the GNU license overview
+    // http://www.gnu.org/licenses/license-list.html#Expat
+    "MIT",
+    // http://www.gnu.org/licenses/license-list.html#MPL-2.0
+    "MPL-2.0",
+    // http://www.gnu.org/licenses/license-list.html#Unlicense
+    "Unlicense",
+    // http://www.gnu.org/licenses/license-list.html#WTFPL
+    "WTFPL",
+    // http://www.gnu.org/licenses/license-list.html#ZLib
+    "Zlib",
+  ],
+};

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -48,6 +48,10 @@ cp .buildkite/.gitconfig "$HOME/"
 cat "$HOME/.gitconfig"
 log-group-end
 
+log-group-start "License compliance"
+time yarn run license-compliance
+log-group-end
+
 log-group-start "Run proxy fmt"
 time cargo fmt --all -- --check
 log-group-end

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "html-webpack-plugin": "^5.3.1",
     "husky": "^4.3.8",
     "jest": "^27.0.4",
+    "license-compliance": "^1.2.1",
     "lint-staged": "^11.0.0",
     "lodash": "^4.17.21",
     "multibase": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,7 +2707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-find-index@npm:^1.0.1":
+"array-find-index@npm:^1.0.1, array-find-index@npm:^1.0.2":
   version: 1.0.2
   resolution: "array-find-index@npm:1.0.2"
   checksum: 5320b3bd4680eadee5191b8d8a4f01788f8761e11ae5d8d8f67e836308760d453c38300cdef41315e8adf24979083f73c353f651f1dc029ab3c712c1ef5ebf17
@@ -3053,14 +3053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.0.0, bn.js@npm:^5.1.1":
-  version: 5.1.3
-  resolution: "bn.js@npm:5.1.3"
-  checksum: 991c1fefb03bd69315297d454b379d5a5dd4834ab97db3ec985714f00ff7d3cc19642e1ac6bdf0d9f04946cc9f1ad26a5b497b7f4e7fa1230caf68af46fbefe6
-  languageName: node
-  linkType: hard
-
-"bn.js@npm:^5.1.2":
+"bn.js@npm:^5.0.0, bn.js@npm:^5.1.1, bn.js@npm:^5.1.2":
   version: 5.2.0
   resolution: "bn.js@npm:5.2.0"
   checksum: 7a73bdbba63013a7f9953fbbd6ea3351e4cf36d6fdbb5adf7969fcd65255b9c04f2994b0132d89d74ffe608a0eb5a48322526bee20c0e03e71e502603b420f63
@@ -3548,6 +3541,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:4.1.0":
+  version: 4.1.0
+  resolution: "chalk@npm:4.1.0"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: f860285b419f9e925c2db0f45ffa88aa8794c14b80cc5d01ff30930bcfc384996606362706f0829cf557f6d36152a5fb2d227ad63c4bc90e2ec9e9dbed4a3c07
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^1.1.3":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -3904,6 +3907,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:7.2.0, commander@npm:^7.0.0, commander@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: bdc0eca5e25cd24af8440163d3c9a996785bbac4b49a590365699cdc1ed08cefbac8f268153208ab2bc5dc3cb1d3fb573fd1590c681e36e371342186bd331a4c
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -3922,13 +3932,6 @@ __metadata:
   version: 5.1.0
   resolution: "commander@npm:5.1.0"
   checksum: d16141ea7f580945156fb8a06de2834c4647c7d9d3732ebd4534ab8e0b7c64747db301e18f2b840f28ea8fef51f7a8d6178e674b45a21931f0b65ff1c7f476b3
-  languageName: node
-  linkType: hard
-
-"commander@npm:^7.0.0, commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: bdc0eca5e25cd24af8440163d3c9a996785bbac4b49a590365699cdc1ed08cefbac8f268153208ab2bc5dc3cb1d3fb573fd1590c681e36e371342186bd331a4c
   languageName: node
   linkType: hard
 
@@ -4268,7 +4271,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^7.0.0":
+"cosmiconfig@npm:7.0.0, cosmiconfig@npm:^7.0.0":
   version: 7.0.0
   resolution: "cosmiconfig@npm:7.0.0"
   dependencies:
@@ -4548,6 +4551,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 5543570879e2274f6725d4285a034d6e0822d35faefc6f55965933fb440e8c21eb3a0bef934e66f4b6b491f898ee2de37cab980e9d4fd61372136c19d3ce4527
+  languageName: node
+  linkType: hard
+
+"debug@npm:4.3.1":
+  version: 4.3.1
+  resolution: "debug@npm:4.3.1"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 0d41ba5177510e8b388dfd7df143ab0f9312e4abdaba312595461511dac88e9ef8101939d33b4e6d37e10341af6a5301082e4d7d6f3deb4d57bc05fc7d296fad
   languageName: node
   linkType: hard
 
@@ -7916,7 +7931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"joi@npm:^17.3.0":
+"joi@npm:17.4.0, joi@npm:^17.3.0":
   version: 17.4.0
   resolution: "joi@npm:17.4.0"
   dependencies:
@@ -8311,6 +8326,25 @@ __metadata:
     prelude-ls: ~1.1.2
     type-check: ~0.3.2
   checksum: 775861da38dcb7e5f1de5bea2a1c7ffaede6e9e8632cfbac76be145ecb295370f46bb41307613c283d66f1fee5d8cc448ca3323c4a02d0fb1e913b2f78de2abb
+  languageName: node
+  linkType: hard
+
+"license-compliance@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "license-compliance@npm:1.2.1"
+  dependencies:
+    chalk: 4.1.0
+    commander: 7.2.0
+    cosmiconfig: 7.0.0
+    debug: 4.3.1
+    joi: 17.4.0
+    spdx-expression-parse: 3.0.1
+    spdx-satisfies: 5.0.0
+    tslib: 2.2.0
+    xmlbuilder: 15.1.1
+  bin:
+    license-compliance: bin/cli.js
+  checksum: dd238702357a2fc1d4235624f8a079eb909a63aaeba1dd8570e0f2fde0c7a967445c353977962b048c48a45679040a4af8e458660bc292dbcc74d2038d6b9573
   languageName: node
   linkType: hard
 
@@ -10196,6 +10230,7 @@ __metadata:
     html-webpack-plugin: ^5.3.1
     husky: ^4.3.8
     jest: ^27.0.4
+    license-compliance: ^1.2.1
     lint-staged: ^11.0.0
     lodash: ^4.17.21
     marked: ^2.0.7
@@ -11142,6 +11177,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"spdx-compare@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "spdx-compare@npm:1.0.0"
+  dependencies:
+    array-find-index: ^1.0.2
+    spdx-expression-parse: ^3.0.0
+    spdx-ranges: ^2.0.0
+  checksum: f72639fe0d19eee146068fbe30d52f82173ce18e573581b30a43e72863751401e5734cd8ab7e028490ac040752b1ff05b60e84a4ed8b5f2156ed14fea5bc012f
+  languageName: node
+  linkType: hard
+
 "spdx-correct@npm:^3.0.0":
   version: 3.1.1
   resolution: "spdx-correct@npm:3.1.1"
@@ -11159,7 +11205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spdx-expression-parse@npm:^3.0.0":
+"spdx-expression-parse@npm:3.0.1, spdx-expression-parse@npm:^3.0.0":
   version: 3.0.1
   resolution: "spdx-expression-parse@npm:3.0.1"
   dependencies:
@@ -11173,6 +11219,24 @@ __metadata:
   version: 3.0.7
   resolution: "spdx-license-ids@npm:3.0.7"
   checksum: 21e38ec5dd970643f78d37700b6c6ebd42d68c0e4618db914a56cabd2fe4cc1608404ce6abc7535d5165c6555560e821553d06edf6af6ae439617883cf932c0e
+  languageName: node
+  linkType: hard
+
+"spdx-ranges@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "spdx-ranges@npm:2.1.1"
+  checksum: da86cbb8a93ed0e929910f1df831d346986dd8c85bd83330b3b36a224ae35057daa8a8026904a46454a77328d0b4a29e73ee699209accd1ccb9b9d7a06f9febe
+  languageName: node
+  linkType: hard
+
+"spdx-satisfies@npm:5.0.0":
+  version: 5.0.0
+  resolution: "spdx-satisfies@npm:5.0.0"
+  dependencies:
+    spdx-compare: ^1.0.0
+    spdx-expression-parse: ^3.0.0
+    spdx-ranges: ^2.0.0
+  checksum: 1eda45b44cec54b6b4c72be6ba030719f0fb154252ac4143aac6f5755a2ec957f515c09fc07e7bb3dcf884d80b2850e5589b6e99457343c03c5848fccdec1814
   languageName: node
   linkType: hard
 
@@ -12166,17 +12230,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.2.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "tslib@npm:2.2.0"
+  checksum: 2d35468c470410871c5246e43f12dcb6d0fc363b617c176f26443b9530e5c5ee8448966892a42956168d8f495da7865bda33dfe82c26c91991e28999974a618f
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: f44fe7f216946b17d3e3074df3746372703cf24e9127b4c045511456e8e4bf25515fb0a1bb3937676cc305651c5d4fcb6377b0588a4c6a957e748c4c28905d17
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "tslib@npm:2.2.0"
-  checksum: 2d35468c470410871c5246e43f12dcb6d0fc363b617c176f26443b9530e5c5ee8448966892a42956168d8f495da7865bda33dfe82c26c91991e28999974a618f
   languageName: node
   linkType: hard
 
@@ -12999,7 +13063,7 @@ typescript@=4.2.4:
   languageName: node
   linkType: hard
 
-"xmlbuilder@npm:>=11.0.1":
+"xmlbuilder@npm:15.1.1, xmlbuilder@npm:>=11.0.1":
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
   checksum: cfc8892f17b8784998a08d91891957308229299337cda6d62c9e0e1a13f50324bff75f24ead7712f196801b52f82a12bec57abc6a20da01a63931bcae578ac36


### PR DESCRIPTION
We ensure that the licenses of all NPM production dependencies are compatible with GPL-3.0-only. See #2024.