### PR TITLE
feat(dev): add cargo-deny

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@
     platform: "linux"
   timeout_in_minutes: 60
   env:
-    DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.10.0"
+    DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-upstream:0.11.0"
     SHARED_MASTER_CACHE: true
   artifact_paths:
     - "dist/*.AppImage"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != 'radicle-dev/radicle-upstream'
     runs-on: ubuntu-latest
     container:
-      image: "gcr.io/opensourcecoin/radicle-upstream:0.9.0"
+      image: "gcr.io/opensourcecoin/radicle-upstream:0.11.0"
     steps:
       - uses: actions/checkout@master
       - name: Cache Yarn

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -50,8 +50,8 @@ ENV RUST_VERSION=nightly-2021-05-09 \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_HOME=/usr/local/rustup \
-    RUSTUP_VERSION=1.23.1 \
-    RUSTUP_SHA256=ed7773edaf1d289656bdec2aacad12413b38ad0193fff54b2231f5140a4b07c5
+    RUSTUP_VERSION=1.24.3 \
+    RUSTUP_SHA256=3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 
 RUN set -eux; \
     curl -sfLSO "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init"; \
@@ -63,7 +63,10 @@ RUN set -eux; \
     rustup --version; \
     cargo --version; \
     rustc --version; \
-    rustup component add clippy rustfmt;
+    rustup component add clippy rustfmt; \
+    cargo install cargo-deny; \
+    rm -rf /usr/local/cargo/registry; \
+    rm /usr/local/cargo/.package-cache;
 
 VOLUME /cache
 ENV CARGO_HOME=/cache/cargo

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -21,10 +21,15 @@ log-group-start "Installing yarn dependencies"
 yarn install --immutable
 log-group-end
 
-log-group-start "Loading proxy target cache"
+log-group-start "Linking cache"
 declare -r rust_target_cache="$CACHE_FOLDER/proxy-target"
 mkdir -p "$rust_target_cache"
 ln -s "${rust_target_cache}" ./target
+
+declare -r cargo_deny_cache="$CACHE_FOLDER/cargo-deny"
+mkdir -p "$cargo_deny_cache"
+mkdir -p ~/.cargo
+ln -s "$cargo_deny_cache" ~/.cargo/advisory-db
 
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" != "macos" ]]; then
   free_cache_space_kb=$(df --output=avail /cache | sed -n 2p)
@@ -50,6 +55,10 @@ log-group-end
 
 log-group-start "License compliance"
 time yarn run license-compliance
+log-group-end
+
+log-group-start "License compliance"
+time cargo deny check
 log-group-end
 
 log-group-start "Run proxy fmt"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,191 @@
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold = 
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+unlicensed = "deny"
+# Must only include licenses that are GPLv3 compatible. This is mostly
+# sourced from http://www.gnu.org/licenses/license-list.html
+allow = [
+    # 0BSD is less restrictive than ISC https://opensource.org/licenses/0BSD
+    "0BSD",
+    # http://www.gnu.org/licenses/license-list.html#apache2
+    "Apache-2.0",
+    # I couldn't find any reference stating compatibility. As a
+    # modern permissive license it should be compatible with GPL-3.0
+    "BlueOak-1.0.0",
+    # http://www.gnu.org/licenses/license-list.html#FreeBSD
+    "BSD-2-Clause",
+    # http://www.gnu.org/licenses/license-list.html#ModifiedBSD
+    "BSD-3-Clause",
+    # http://www.gnu.org/licenses/license-list.html#CC0
+    "CC0-1.0",
+    # https://www.gnu.org/licenses/license-list.html#GNUGPLv2
+    "GPL-2.0 WITH Classpath-exception-2.0",
+    # https://www.gnu.org/licenses/license-list.html#GNUGPLv3
+    "GPL-3.0",
+    # http://www.gnu.org/licenses/license-list.html#ISC
+    "ISC",
+    # http://www.gnu.org/licenses/license-list.html#LGPLv3
+    "LGPL-3.0",
+    # Named "Expat" on the GNU license overview
+    # http://www.gnu.org/licenses/license-list.html#Expat
+    "MIT",
+    # http://www.gnu.org/licenses/license-list.html#MPL-2.0
+    "MPL-2.0",
+    # http://www.gnu.org/licenses/license-list.html#Unlicense
+    "Unlicense",
+    # http://www.gnu.org/licenses/license-list.html#ZLib
+    "Zlib",
+]
+
+# We deny everything that is not explicitly in the allow list
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+deny = []
+
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # See https://github.com/radicle-dev/radicle-link/blob/f583f7b1de41ef91f7d3d3e161ec3b73eb0202cb/deny.toml#L129-L132
+    # for an explanation.
+    { allow = ["ISC", "MIT", "OpenSSL"], name = "ring" }
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "allow"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate 
+# detection. Unlike skip, it also includes the entire tree of transitive 
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "deny"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = [
+    "https://github.com/ZcashFoundation/ed25519-zebra",
+]
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = ["radicle-dev"]
+# 1 or more gitlab.com organizations to allow git sources for
+# gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+# bitbucket = [""]


### PR DESCRIPTION
We add cargo deny to check our rust dependencies. The deny configuration is copied from `radicle-link`. The main difference is the explicit allow list for licenses.