### PR TITLE
Add license header and checks

### DIFF
--- a/builder/notarize.js
+++ b/builder/notarize.js
@@ -1,4 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 const { notarize } = require("electron-notarize");
 const appId = require("../package.json").build.appId;
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,3 +1,9 @@
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 FROM debian:buster-slim
 
 # System packages

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -55,6 +55,7 @@ log-group-end
 
 log-group-start "License compliance"
 time yarn run license-compliance
+time ./scripts/license-header.ts check
 log-group-end
 
 log-group-start "License compliance"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 set -Eeou pipefail
 
 TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'

--- a/ci/setup-buildkite.sh
+++ b/ci/setup-buildkite.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 set -Eeou pipefail
 
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" == "macos" ]]; then

--- a/ci/setup-github-actions.sh
+++ b/ci/setup-github-actions.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 set -Eeou pipefail
 
 export CACHE_FOLDER="$HOME/cache"

--- a/cypress/integration/deep_linking.spec.ts
+++ b/cypress/integration/deep_linking.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 import * as ipcStub from "../support/ipc-stub";
 import * as ipcTypes from "../../native/ipc-types";

--- a/cypress/integration/lock.spec.ts
+++ b/cypress/integration/lock.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 
 context("lock screen", () => {

--- a/cypress/integration/modal.spec.ts
+++ b/cypress/integration/modal.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 
 context("modal", () => {

--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 import * as path from "path";
 import * as ipcStub from "../support/ipc-stub";

--- a/cypress/integration/onboarding.spec.ts
+++ b/cypress/integration/onboarding.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 import { VALID_PEER_MATCH } from "../../ui/src/screen/project";
 

--- a/cypress/integration/project/checkout.spec.ts
+++ b/cypress/integration/project/checkout.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as ipcStub from "../../support/ipc-stub";
 import * as commands from "../../support/commands";
 

--- a/cypress/integration/project/creation.spec.ts
+++ b/cypress/integration/project/creation.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as ipcStub from "../../support/ipc-stub";
 import * as commands from "../../support/commands";
 import * as config from "../../../ui/src/config";

--- a/cypress/integration/project/follow.spec.ts
+++ b/cypress/integration/project/follow.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../../support/commands";
 
 context("project following", () => {

--- a/cypress/integration/project/patches.spec.ts
+++ b/cypress/integration/project/patches.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as path from "path";
 
 import * as commands from "../../support/commands";

--- a/cypress/integration/project/peer_management.spec.ts
+++ b/cypress/integration/project/peer_management.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../../support/commands";
 
 context("project peer management", () => {

--- a/cypress/integration/project/source_browsing.spec.ts
+++ b/cypress/integration/project/source_browsing.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../../support/commands";
 
 context("project source browsing", () => {

--- a/cypress/integration/routing.spec.ts
+++ b/cypress/integration/routing.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as ipcTypes from "../../native/ipc-types";
 import * as ipcStub from "../support/ipc-stub";
 import * as commands from "../support/commands";

--- a/cypress/integration/search.spec.ts
+++ b/cypress/integration/search.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 
 context("search", () => {

--- a/cypress/integration/settings.spec.ts
+++ b/cypress/integration/settings.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 import * as ipcStub from "../support/ipc-stub";
 import type { CyHttpMessages } from "cypress/types/net-stubbing";

--- a/cypress/integration/shortcuts.spec.ts
+++ b/cypress/integration/shortcuts.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 const metaKey = commands.metaKey();
 

--- a/cypress/integration/user_profile.spec.ts
+++ b/cypress/integration/user_profile.spec.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as commands from "../support/commands";
 
 context("user profile", () => {

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { nodeManagerPlugin } from "./nodeManager/plugin";
 
 export default (

--- a/cypress/plugins/nodeManager/plugin.ts
+++ b/cypress/plugins/nodeManager/plugin.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as stream from "stream";
 import { StringDecoder } from "string_decoder";
 import * as path from "path";

--- a/cypress/plugins/nodeManager/shared.ts
+++ b/cypress/plugins/nodeManager/shared.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // Types and constants shared between `plugin.ts` and `commands.ts`. These
 // types can't be in `plugin.ts`, because Cypress plugins run in a separate
 // Nodejs environment and can directly use Nodejs libraries, the Cypress tests

--- a/cypress/support/assertions.js
+++ b/cypress/support/assertions.js
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 const isInViewport = (chai, _utils) => {
   function assertIsInViewport(_options) {
     const subject = this._obj;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as proxy from "../../ui/src/proxy";
 
 const proxyClient = new proxy.Client("http://localhost:17246");

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import "./assertions";
 import * as ipcStub from "./ipc-stub";
 

--- a/cypress/support/ipc-stub.ts
+++ b/cypress/support/ipc-stub.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type {} from "../../native/preload";
 import type { MainMessage, MainProcess } from "../../native/ipc-types";
 import { EventEmitter } from "events";

--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type { NodeSession } from "../plugins/nodeManager/shared";
 import {
   pluginMethods,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 module.exports = {
   roots: ["<rootDir>/ui/src", "<rootDir>/native"],
   transform: {

--- a/native/index.js
+++ b/native/index.js
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 /* eslint-disable @typescript-eslint/no-var-requires */
 require("ts-node").register();
 require("./index.ts");

--- a/native/index.ts
+++ b/native/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import childProcess from "child_process";
 import {
   app,

--- a/native/ipc-types.ts
+++ b/native/ipc-types.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // Messages sent from the main process to the renderer
 export type MainMessage =
   | {

--- a/native/nativeCustomProtocolHandler.test.ts
+++ b/native/nativeCustomProtocolHandler.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { parseRadicleUrl } from "./nativeCustomProtocolHandler";
 
 describe("parseRadicleURL", () => {

--- a/native/nativeCustomProtocolHandler.ts
+++ b/native/nativeCustomProtocolHandler.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import lodash from "lodash";
 
 export const throttled: (callback: () => void) => void = lodash.throttle(

--- a/native/preload.d.ts
+++ b/native/preload.d.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type { MainMessage } from "./ipc-types";
 
 declare global {

--- a/native/preload.js
+++ b/native/preload.js
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { ipcRenderer, contextBridge } = require("electron");
 

--- a/native/proxy-process-manager.test.ts
+++ b/native/proxy-process-manager.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as lodash from "lodash";
 import { ProxyProcessManager } from "./proxy-process-manager";
 

--- a/native/proxy-process-manager.ts
+++ b/native/proxy-process-manager.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { spawn, ChildProcess } from "child_process";
 import { CircularBuffer } from "mnemonist";
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-plugin-svelte3": "^3.2.0",
     "exit-hook": "^2.2.1",
     "ganache-cli": "^6.12.2",
+    "globby": "^11.0.4",
     "html-webpack-plugin": "^5.3.1",
     "husky": "^4.3.8",
     "jest": "^27.0.4",

--- a/proxy/api/src/bin/git-remote-rad.rs
+++ b/proxy/api/src/bin/git-remote-rad.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 use radicle_daemon::{
     keys::{PublicKey, SecretKey},
     profile::Profile,

--- a/proxy/api/src/bin/radicle-proxy.rs
+++ b/proxy/api/src/bin/radicle-proxy.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     api::env::set_if_unset("RUST_BACKTRACE", "full");

--- a/proxy/api/src/browser.rs
+++ b/proxy/api/src/browser.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 use std::convert::TryFrom as _;
 
 use radicle_daemon::{

--- a/proxy/api/src/config.rs
+++ b/proxy/api/src/config.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Configuration vital to the setup and alteration of the application.
 
 use std::{env, io, path};

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Datastructure and machinery to safely share the common dependencies across components.
 
 use std::{net::SocketAddr, sync::Arc};

--- a/proxy/api/src/control.rs
+++ b/proxy/api/src/control.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Utility for fixture data in the monorepo.
 
 use std::{env, io, path, str::FromStr};

--- a/proxy/api/src/env.rs
+++ b/proxy/api/src/env.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Utilities to manipulate the process environment.
 
 use std::env::{set_var, var};

--- a/proxy/api/src/error.rs
+++ b/proxy/api/src/error.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Proxy library errors usable for caller control flow and additional context for API responses.
 
 use std::io;

--- a/proxy/api/src/ethereum/address.rs
+++ b/proxy/api/src/ethereum/address.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 use serde::{Deserialize, Serialize};
 use std::{
     convert::{TryFrom, TryInto},

--- a/proxy/api/src/ethereum/claim_ext.rs
+++ b/proxy/api/src/ethereum/claim_ext.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! The user identity doc extension for Ethereum addresses attestation.
 //! See [the RFC](docs/ethereum_attestation.md).
 

--- a/proxy/api/src/git_helper.rs
+++ b/proxy/api/src/git_helper.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! git-remote-rad git helper related functionality.
 
 use std::{fs, io, os::unix::fs::PermissionsExt as _, path};

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! HTTP API delivering JSON over `RESTish` endpoints.
 
 use serde::Deserialize;

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Endpoints to manipulate app state in test mode.
 
 use serde::{Deserialize, Serialize};

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Recovery and conversion of [`error::Error`] to proper JSON responses, which expose variants
 //! for API consumers to act on.
 

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Manage the state and stateful interactions with the underlying peer API of librad.
 
 use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};

--- a/proxy/api/src/http/keystore.rs
+++ b/proxy/api/src/http/keystore.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Endpoints for handling the keystore.
 
 use serde::{Deserialize, Serialize};

--- a/proxy/api/src/http/notification.rs
+++ b/proxy/api/src/http/notification.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Unidirectional stream of events happening in the proxy. This enables exposing tailing logs to
 //! users, or widgets which show topology information like how many and what peers are connected.
 

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Endpoints and serialisation for [`crate::project::Project`] related types.
 
 use std::path::PathBuf;

--- a/proxy/api/src/http/project/request.rs
+++ b/proxy/api/src/http/project/request.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Endpoints for project search requests.
 
 use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};

--- a/proxy/api/src/http/session.rs
+++ b/proxy/api/src/http/session.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Endpoints and serialisation for [`crate::session::Session`] related types.
 
 use warp::{filters::BoxedFilter, path, Filter, Rejection, Reply};

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Endpoints and serialisation for source code browsing.
 
 use serde::{Deserialize, Serialize};

--- a/proxy/api/src/identifier.rs
+++ b/proxy/api/src/identifier.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! An `Identifier` is the combination of a user handle and the [`radicle_daemon::PeerId`] that
 //! identifies the user.
 

--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Container to bundle and associate information around an identity.
 
 use chrono::{DateTime, Utc};

--- a/proxy/api/src/keystore.rs
+++ b/proxy/api/src/keystore.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // Copyright © 2019-2020 The Radicle Foundation <hello@radicle.foundation>
 //
 // This file is part of radicle-link, distributed under the GPLv3 with Radicle

--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Proxy serving a specialized API to the Upstream UI.
 
 #![warn(

--- a/proxy/api/src/node.rs
+++ b/proxy/api/src/node.rs
@@ -1,0 +1,6 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+

--- a/proxy/api/src/notification.rs
+++ b/proxy/api/src/notification.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Machinery to signal significant events to clients.
 
 use radicle_daemon::request::{RequestState, SomeRequest, Status as PeerRequestStatus};

--- a/proxy/api/src/patch.rs
+++ b/proxy/api/src/patch.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! [`list`] all the [`Patch`]es for project.
 
 use either::Either;

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Provides [`run`] to run the proxy process.
 // Otherwise clippy complains about FromArgs
 #![allow(clippy::default_trait_access)]

--- a/proxy/api/src/project.rs
+++ b/proxy/api/src/project.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Combine the domain `CoCo` domain specific understanding of a Project into a single
 //! abstraction.
 

--- a/proxy/api/src/service.rs
+++ b/proxy/api/src/service.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Utilities for changing the service environment used in [`crate::process`].
 
 use futures::prelude::*;

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! Management of local session state like the currently used identity, wallet related data and
 //! configuration of all sorts.
 

--- a/proxy/api/src/session/settings.rs
+++ b/proxy/api/src/session/settings.rs
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 //! User controlled parameters for application appearance, behaviour and state.
 use serde::{Deserialize, Serialize};
 

--- a/public/colors.css
+++ b/public/colors.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright © 2021 The Radicle Upstream Contributors
+ *
+ * This file is part of radicle-upstream, distributed under the GPLv3
+ * with Radicle Linking Exception. For full terms see the included
+ * LICENSE file.
+ */
 :root {
   --color-primary: rgba(85, 85, 255, 1);
   --color-primary-level-1: rgba(85, 85, 255, 0.17);

--- a/public/elevation.css
+++ b/public/elevation.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright © 2021 The Radicle Upstream Contributors
+ *
+ * This file is part of radicle-upstream, distributed under the GPLv3
+ * with Radicle Linking Exception. For full terms see the included
+ * LICENSE file.
+ */
 :root {
   --elevation-low: 0px 0.139033px 0.370755px rgba(0, 0, 0, 0.0129162),
     0px 0.323263px 0.862035px rgba(0, 0, 0, 0.018661),

--- a/public/global.css
+++ b/public/global.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright © 2021 The Radicle Upstream Contributors
+ *
+ * This file is part of radicle-upstream, distributed under the GPLv3
+ * with Radicle Linking Exception. For full terms see the included
+ * LICENSE file.
+ */
 html,
 body {
   font-family: var(--typeface-regular);

--- a/public/reset.css
+++ b/public/reset.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright © 2021 The Radicle Upstream Contributors
+ *
+ * This file is part of radicle-upstream, distributed under the GPLv3
+ * with Radicle Linking Exception. For full terms see the included
+ * LICENSE file.
+ */
 *,
 *:before,
 *:after {

--- a/public/typography.css
+++ b/public/typography.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright © 2021 The Radicle Upstream Contributors
+ *
+ * This file is part of radicle-upstream, distributed under the GPLv3
+ * with Radicle Linking Exception. For full terms see the included
+ * LICENSE file.
+ */
 /* headers */
 
 h1,

--- a/scripts/env
+++ b/scripts/env
@@ -1,5 +1,11 @@
 #!/usr/bin/bash
 
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 export RAD_HOME="$(realpath ./sandbox/rad_home)"
 export PATH="$(realpath ./target/debug):$PATH"
 export RADICLE_UNSAFE_FAST_KEYSTORE=1

--- a/scripts/ethereum-dev-node.ts
+++ b/scripts/ethereum-dev-node.ts
@@ -1,5 +1,11 @@
 #!/usr/bin/env -S yarn node -r ts-node/register/transpile-only
 
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as fs from "fs/promises";
 import execa from "execa";
 import { deployAll } from "radicle-contracts";

--- a/scripts/install-twemoji-assets.sh
+++ b/scripts/install-twemoji-assets.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 # Download the Twemoji SVGs and put them into public/twemoji
 
 set -Eeou pipefail

--- a/scripts/license-header.ts
+++ b/scripts/license-header.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env -S yarn node -r ts-node/register/transpile-only
+
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import globby from "globby";
+import yargs from "yargs";
+import * as fs from "fs/promises";
+import * as Path from "path";
+
+// Error that is shown without a stacktrace to the user
+class UserError extends Error {
+  constructor(public message: string) {
+    super(message);
+  }
+}
+
+async function main() {
+  yargs
+    .command({
+      command: "check",
+      describe: "Check presence of license headers in files",
+      handler: async () => {
+        let failure = false;
+        for (const path of await paths()) {
+          const content = await fs.readFile(path, "utf8");
+          if (!hasLicenseHeader(content)) {
+            failure = true;
+            console.error(`License missing from ${path}`);
+          }
+        }
+
+        if (failure) {
+          throw new UserError(
+            "License headers missing. Run `./scripts/license-headers.ts add` to fix this."
+          );
+        }
+      },
+    })
+    .command({
+      command: "add",
+      describe: "Add missing license headers to files",
+      handler: async () => {
+        for (const path of await paths()) {
+          const content = await fs.readFile(path, "utf8");
+          if (!hasLicenseHeader(content)) {
+            console.log(`Writing license to ${path}`);
+            const licenseComment = makeLicenseComment(Path.extname(path));
+            const fixedContent = `${licenseComment}${content}`;
+            await fs.writeFile(path, fixedContent, "utf8");
+          }
+        }
+      },
+    })
+    .version(false)
+    .strict()
+    .wrap(Math.min(100, yargs.terminalWidth()))
+    // For `UserError` we don’t show the stack trace. We also don’t show the help
+    // when an error is thrown.
+    .fail((msg, err, yargs) => {
+      if (err === undefined) {
+        yargs.showHelp("error");
+        console.error("");
+        console.error(msg);
+      } else if (err instanceof UserError) {
+        console.error(err.message);
+      } else {
+        console.error(err);
+      }
+      process.exit(1);
+    })
+    .demandCommand().argv;
+}
+
+const licenseHeaderContent = [
+  ` Copyright © ${new Date().getFullYear()} The Radicle Upstream Contributors`,
+  "",
+  " This file is part of radicle-upstream, distributed under the GPLv3",
+  " with Radicle Linking Exception. For full terms see the included",
+  " LICENSE file.",
+];
+
+function makeLicenseComment(extName: string): string {
+  if (extName === ".js" || extName === ".ts" || extName === ".rs") {
+    const commentLines = licenseHeaderContent.map(x => `//${x}`);
+    return `${commentLines.join("\n")}\n\n`;
+  } else if (extName === ".svelte") {
+    return `<!--\n${licenseHeaderContent.join("\n")}\n-->\n`;
+  } else if (extName === ".css") {
+    const commentLines = licenseHeaderContent.map(x => ` *${x}`);
+    return `/**\n${commentLines.join("\n")}\n */\n`;
+  } else {
+    throw new Error(`Unknown file extension ${extName}`);
+  }
+}
+
+// Globs for the files we enforce license headers for.
+const gitIgnore = (async () => {
+  const content = await fs.readFile(
+    Path.resolve(__dirname, "..", ".gitignore"),
+    "utf8"
+  );
+  return content
+    .split(/\r?\n/)
+    .filter(line => line && !line.startsWith("#"))
+    .map(line => {
+      if (line.startsWith("/")) {
+        return line.substr(1);
+      } else {
+        return line;
+      }
+    });
+})();
+
+// Returns the list of file paths that should include license headers.
+async function paths(): Promise<string[]> {
+  const gitIgnore_ = await gitIgnore;
+  const ignore = [...gitIgnore_, "fixtures"];
+
+  return globby(
+    [
+      "ci/**/*",
+      "cypress/**/*.(js|ts)",
+      "native/**/*.(js|ts)",
+      "proxy/**/*.rs",
+      "public/**/*.css",
+      "scripts/**/*",
+      "ui/**/*",
+    ],
+    { ignore }
+  );
+}
+
+// Pattern we use to check for the presence for the license headers in
+// a given line.
+const licenseHeaderPattern =
+  /Copyright © \d{4} The Radicle Upstream Contributors/;
+
+function hasLicenseHeader(fileContent: string): boolean {
+  // We check the first three lines to account for shebangs and comment
+  // starts.
+  const head = fileContent.split("\n").slice(0, 3);
+  return head.some(line => licenseHeaderPattern.test(line));
+}
+
+main();

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,5 +1,11 @@
 #!/usr/bin/env -S node --require ts-node/register/transpile-only
 
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";

--- a/scripts/reset-state.sh
+++ b/scripts/reset-state.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 set -eou pipefail
 
 platform="$(uname)"

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
 set -euo pipefail
 
 git submodule update --init --remote

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const sveltePreprocess = require("svelte-preprocess");
 

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as customProtocolHandler from "ui/src/customProtocolHandler";
   import * as error from "ui/src/error";

--- a/ui/DesignSystem/ActionBar.svelte
+++ b/ui/DesignSystem/ActionBar.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   let wrapper: Element;
   let scrollHeight: number;

--- a/ui/DesignSystem/Avatar.svelte
+++ b/ui/DesignSystem/Avatar.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Avatar } from "ui/src/proxy/identity";
 

--- a/ui/DesignSystem/Badge.svelte
+++ b/ui/DesignSystem/Badge.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { BadgeType } from "ui/src/badge";
 

--- a/ui/DesignSystem/BranchBox.svelte
+++ b/ui/DesignSystem/BranchBox.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Icon from "./Icon";
 

--- a/ui/DesignSystem/Button.svelte
+++ b/ui/DesignSystem/Button.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { SvelteComponent } from "svelte";
 

--- a/ui/DesignSystem/Checkbox.svelte
+++ b/ui/DesignSystem/Checkbox.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   export let checked = null;
 </script>

--- a/ui/DesignSystem/Comment.svelte
+++ b/ui/DesignSystem/Comment.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import Avatar from "./Avatar.svelte";
   import Button from "./Button.svelte";

--- a/ui/DesignSystem/CompareBranches.svelte
+++ b/ui/DesignSystem/CompareBranches.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Icon from "./Icon";
   import BranchBox from "./BranchBox.svelte";

--- a/ui/DesignSystem/Copyable.svelte
+++ b/ui/DesignSystem/Copyable.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { SvelteComponent } from "svelte";
 

--- a/ui/DesignSystem/Dai.svelte
+++ b/ui/DesignSystem/Dai.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Icon from "./Icon";
 

--- a/ui/DesignSystem/DirectoryInput.svelte
+++ b/ui/DesignSystem/DirectoryInput.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import { getDirectoryPath } from "ui/src/ipc";

--- a/ui/DesignSystem/Dropdown.svelte
+++ b/ui/DesignSystem/Dropdown.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Avatar } from "ui/src/proxy/identity";
 

--- a/ui/DesignSystem/Dropdown/Option.svelte
+++ b/ui/DesignSystem/Dropdown/Option.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/Emoji.svelte
+++ b/ui/DesignSystem/Emoji.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import twemoji from "twemoji";
 

--- a/ui/DesignSystem/EmptyState.svelte
+++ b/ui/DesignSystem/EmptyState.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/Error.svelte
+++ b/ui/DesignSystem/Error.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Icon from "./Icon";
 

--- a/ui/DesignSystem/FollowToggle.svelte
+++ b/ui/DesignSystem/FollowToggle.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/Fullscreen.svelte
+++ b/ui/DesignSystem/Fullscreen.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
 

--- a/ui/DesignSystem/Funding/Pool/Receiver.svelte
+++ b/ui/DesignSystem/Funding/Pool/Receiver.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Copyable from "ui/DesignSystem/Copyable.svelte";
   import Button from "ui/DesignSystem/Button.svelte";

--- a/ui/DesignSystem/Funding/Pool/Receivers.svelte
+++ b/ui/DesignSystem/Funding/Pool/Receivers.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Button from "ui/DesignSystem/Button.svelte";
   import Icon from "ui/DesignSystem/Icon";

--- a/ui/DesignSystem/Funding/Pool/TopUp.svelte
+++ b/ui/DesignSystem/Funding/Pool/TopUp.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Button from "ui/DesignSystem/Button.svelte";
   import Dai from "ui/DesignSystem/Dai.svelte";

--- a/ui/DesignSystem/Header.svelte
+++ b/ui/DesignSystem/Header.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <style>
   .banner {
     height: 12.5rem;

--- a/ui/DesignSystem/Hoverable.svelte
+++ b/ui/DesignSystem/Hoverable.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   export let hovering: boolean = false;
   export let style: string = "";

--- a/ui/DesignSystem/Icon/Anchor.svelte
+++ b/ui/DesignSystem/Icon/Anchor.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/AnchorSmall.svelte
+++ b/ui/DesignSystem/Icon/AnchorSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ArrowBoxUpRight.svelte
+++ b/ui/DesignSystem/Icon/ArrowBoxUpRight.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ArrowCollapse.svelte
+++ b/ui/DesignSystem/Icon/ArrowCollapse.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ArrowDown.svelte
+++ b/ui/DesignSystem/Icon/ArrowDown.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ArrowExpand.svelte
+++ b/ui/DesignSystem/Icon/ArrowExpand.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ArrowLeft.svelte
+++ b/ui/DesignSystem/Icon/ArrowLeft.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ArrowRight.svelte
+++ b/ui/DesignSystem/Icon/ArrowRight.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ArrowUp.svelte
+++ b/ui/DesignSystem/Icon/ArrowUp.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/At.svelte
+++ b/ui/DesignSystem/Icon/At.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Box.svelte
+++ b/ui/DesignSystem/Icon/Box.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Branch.svelte
+++ b/ui/DesignSystem/Icon/Branch.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Chat.svelte
+++ b/ui/DesignSystem/Icon/Chat.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Check.svelte
+++ b/ui/DesignSystem/Icon/Check.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/CheckBox.svelte
+++ b/ui/DesignSystem/Icon/CheckBox.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/CheckCircle.svelte
+++ b/ui/DesignSystem/Icon/CheckCircle.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/CheckSmall.svelte
+++ b/ui/DesignSystem/Icon/CheckSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ChevronDown.svelte
+++ b/ui/DesignSystem/Icon/ChevronDown.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ChevronLeft.svelte
+++ b/ui/DesignSystem/Icon/ChevronLeft.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ChevronLeftRight.svelte
+++ b/ui/DesignSystem/Icon/ChevronLeftRight.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ChevronRight.svelte
+++ b/ui/DesignSystem/Icon/ChevronRight.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ChevronUp.svelte
+++ b/ui/DesignSystem/Icon/ChevronUp.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ChevronUpDown.svelte
+++ b/ui/DesignSystem/Icon/ChevronUpDown.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Commit.svelte
+++ b/ui/DesignSystem/Icon/Commit.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Computer.svelte
+++ b/ui/DesignSystem/Icon/Computer.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Copy.svelte
+++ b/ui/DesignSystem/Icon/Copy.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/CopySmall.svelte
+++ b/ui/DesignSystem/Icon/CopySmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Cross.svelte
+++ b/ui/DesignSystem/Icon/Cross.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/CrossCircle.svelte
+++ b/ui/DesignSystem/Icon/CrossCircle.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/CrossSmall.svelte
+++ b/ui/DesignSystem/Icon/CrossSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/CurrencyDAI.svelte
+++ b/ui/DesignSystem/Icon/CurrencyDAI.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   export let dataCy = "";
   export let style = "";

--- a/ui/DesignSystem/Icon/CurrencyUSD.svelte
+++ b/ui/DesignSystem/Icon/CurrencyUSD.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Ellipsis.svelte
+++ b/ui/DesignSystem/Icon/Ellipsis.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/EllipsisSmall.svelte
+++ b/ui/DesignSystem/Icon/EllipsisSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Envelope.svelte
+++ b/ui/DesignSystem/Icon/Envelope.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Ethereum.svelte
+++ b/ui/DesignSystem/Icon/Ethereum.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Exclamation.svelte
+++ b/ui/DesignSystem/Icon/Exclamation.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/ExclamationCircle.svelte
+++ b/ui/DesignSystem/Icon/ExclamationCircle.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/EyeClosed.svelte
+++ b/ui/DesignSystem/Icon/EyeClosed.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/EyeOpen.svelte
+++ b/ui/DesignSystem/Icon/EyeOpen.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/File.svelte
+++ b/ui/DesignSystem/Icon/File.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Folder.svelte
+++ b/ui/DesignSystem/Icon/Folder.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Fork.svelte
+++ b/ui/DesignSystem/Icon/Fork.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Globe.svelte
+++ b/ui/DesignSystem/Icon/Globe.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Gnosis.svelte
+++ b/ui/DesignSystem/Icon/Gnosis.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Heart.svelte
+++ b/ui/DesignSystem/Icon/Heart.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/HeartFaceSmall.svelte
+++ b/ui/DesignSystem/Icon/HeartFaceSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/House.svelte
+++ b/ui/DesignSystem/Icon/House.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/IconWrapper.svelte
+++ b/ui/DesignSystem/Icon/IconWrapper.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   export let dataCy = "";
   export let style = "";

--- a/ui/DesignSystem/Icon/Info.svelte
+++ b/ui/DesignSystem/Icon/Info.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/InfoCircle.svelte
+++ b/ui/DesignSystem/Icon/InfoCircle.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Key.svelte
+++ b/ui/DesignSystem/Icon/Key.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Label.svelte
+++ b/ui/DesignSystem/Icon/Label.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Ledger.svelte
+++ b/ui/DesignSystem/Icon/Ledger.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Lock.svelte
+++ b/ui/DesignSystem/Icon/Lock.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/LockSmall.svelte
+++ b/ui/DesignSystem/Icon/LockSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/MagnifyingGlass.svelte
+++ b/ui/DesignSystem/Icon/MagnifyingGlass.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Merge.svelte
+++ b/ui/DesignSystem/Icon/Merge.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Minus.svelte
+++ b/ui/DesignSystem/Icon/Minus.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Network.svelte
+++ b/ui/DesignSystem/Icon/Network.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Orgs.svelte
+++ b/ui/DesignSystem/Icon/Orgs.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Pen.svelte
+++ b/ui/DesignSystem/Icon/Pen.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Plus.svelte
+++ b/ui/DesignSystem/Icon/Plus.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/PlusSmall.svelte
+++ b/ui/DesignSystem/Icon/PlusSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Registered.svelte
+++ b/ui/DesignSystem/Icon/Registered.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/RegisteredSmall.svelte
+++ b/ui/DesignSystem/Icon/RegisteredSmall.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Review.svelte
+++ b/ui/DesignSystem/Icon/Review.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Revision.svelte
+++ b/ui/DesignSystem/Icon/Revision.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Road.svelte
+++ b/ui/DesignSystem/Icon/Road.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Server.svelte
+++ b/ui/DesignSystem/Icon/Server.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Settings.svelte
+++ b/ui/DesignSystem/Icon/Settings.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/TokenStreams.svelte
+++ b/ui/DesignSystem/Icon/TokenStreams.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Topup.svelte
+++ b/ui/DesignSystem/Icon/Topup.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Transactions.svelte
+++ b/ui/DesignSystem/Icon/Transactions.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Trash.svelte
+++ b/ui/DesignSystem/Icon/Trash.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/User.svelte
+++ b/ui/DesignSystem/Icon/User.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Wallet.svelte
+++ b/ui/DesignSystem/Icon/Wallet.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/Withdraw.svelte
+++ b/ui/DesignSystem/Icon/Withdraw.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import IconWrapper from "./IconWrapper.svelte";
 

--- a/ui/DesignSystem/Icon/index.ts
+++ b/ui/DesignSystem/Icon/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import Anchor from "./Anchor.svelte";
 import AnchorSmall from "./AnchorSmall.svelte";
 import ArrowBoxUpRight from "./ArrowBoxUpRight.svelte";

--- a/ui/DesignSystem/Identity.svelte
+++ b/ui/DesignSystem/Identity.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Avatar from "./Avatar.svelte";
   import Remote from "./Remote.svelte";

--- a/ui/DesignSystem/Illustration.svelte
+++ b/ui/DesignSystem/Illustration.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Variant } from "ui/src/illustration";
 

--- a/ui/DesignSystem/KeyHint.svelte
+++ b/ui/DesignSystem/KeyHint.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { osModifierKey } from "ui/src/hotkeys";
 

--- a/ui/DesignSystem/Label.svelte
+++ b/ui/DesignSystem/Label.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   export let title: string;
   export let color: string;

--- a/ui/DesignSystem/List.svelte
+++ b/ui/DesignSystem/List.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/Markdown.svelte
+++ b/ui/DesignSystem/Markdown.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import marked from "marked";
 

--- a/ui/DesignSystem/Modal.svelte
+++ b/ui/DesignSystem/Modal.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   export let dataCy: string = "";
   export let style: string = "";

--- a/ui/DesignSystem/ModalOverlay.svelte
+++ b/ui/DesignSystem/ModalOverlay.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as modal from "ui/src/modal";
 

--- a/ui/DesignSystem/Notification.svelte
+++ b/ui/DesignSystem/Notification.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { SvelteComponent } from "svelte";
   import type { Notification } from "ui/src/notification";

--- a/ui/DesignSystem/NotificationFaucet.svelte
+++ b/ui/DesignSystem/NotificationFaucet.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { fade, fly } from "svelte/transition";
   import { flip } from "svelte/animate";

--- a/ui/DesignSystem/Overlay.svelte
+++ b/ui/DesignSystem/Overlay.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   // Wrapper for expanding/dismissing overlays
 

--- a/ui/DesignSystem/PasswordInput.svelte
+++ b/ui/DesignSystem/PasswordInput.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/PeerId.svelte
+++ b/ui/DesignSystem/PeerId.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import StyledCopyable from "./StyledCopyable.svelte";
   import Icon from "./Icon";

--- a/ui/DesignSystem/PeerSelector.svelte
+++ b/ui/DesignSystem/PeerSelector.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/PeerSelector/Peer.svelte
+++ b/ui/DesignSystem/PeerSelector/Peer.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { BadgeType } from "ui/src/badge";
   import { PeerRole, PeerType } from "ui/src/project";

--- a/ui/DesignSystem/ProjectAnchorPopover.svelte
+++ b/ui/DesignSystem/ProjectAnchorPopover.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { fade } from "svelte/transition";
 

--- a/ui/DesignSystem/ProjectCard.svelte
+++ b/ui/DesignSystem/ProjectCard.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type * as project from "ui/src/project";
 

--- a/ui/DesignSystem/ProjectList.svelte
+++ b/ui/DesignSystem/ProjectList.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Project } from "ui/src/project";
   import { isMaintainer } from "ui/src/project";

--- a/ui/DesignSystem/RadicleId.svelte
+++ b/ui/DesignSystem/RadicleId.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import StyledCopyable from "./StyledCopyable.svelte";
   import Icon from "./Icon";

--- a/ui/DesignSystem/RadicleLogo.svelte
+++ b/ui/DesignSystem/RadicleLogo.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <svg
   width="151"
   height="40"

--- a/ui/DesignSystem/RadioOption.svelte
+++ b/ui/DesignSystem/RadioOption.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { slide } from "svelte/transition";
 

--- a/ui/DesignSystem/Registration/NavigationButtons.svelte
+++ b/ui/DesignSystem/Registration/NavigationButtons.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { createEventDispatcher } from "svelte";
   import Button from "ui/DesignSystem/Button.svelte";

--- a/ui/DesignSystem/Remote.svelte
+++ b/ui/DesignSystem/Remote.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Readable } from "svelte/store";
 

--- a/ui/DesignSystem/RemoteHelperHint.svelte
+++ b/ui/DesignSystem/RemoteHelperHint.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/SegmentedControl.svelte
+++ b/ui/DesignSystem/SegmentedControl.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   const dispatch = createEventDispatcher();

--- a/ui/DesignSystem/Sidebar.svelte
+++ b/ui/DesignSystem/Sidebar.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { activeRouteStore, push } from "ui/src/router";
 

--- a/ui/DesignSystem/Sidebar/AddOrgButton.svelte
+++ b/ui/DesignSystem/Sidebar/AddOrgButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import Icon from "ui/DesignSystem/Icon";
 

--- a/ui/DesignSystem/Sidebar/ConnectionStatusIndicator.svelte
+++ b/ui/DesignSystem/Sidebar/ConnectionStatusIndicator.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { status, StatusType } from "ui/src/localPeer";
 

--- a/ui/DesignSystem/Sidebar/ConnectionStatusIndicator/Offline.svelte
+++ b/ui/DesignSystem/Sidebar/ConnectionStatusIndicator/Offline.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   export let style = "";
 </script>

--- a/ui/DesignSystem/Sidebar/ConnectionStatusIndicator/Syncing.svelte
+++ b/ui/DesignSystem/Sidebar/ConnectionStatusIndicator/Syncing.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <style>
   #dots {
     animation: blinking-dots 1s ease-in-out infinite;

--- a/ui/DesignSystem/Sidebar/OrgList.svelte
+++ b/ui/DesignSystem/Sidebar/OrgList.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as radicleAvatar from "radicle-avatar";
   import type { Identity } from "ui/src/identity";

--- a/ui/DesignSystem/Sidebar/SidebarItem.svelte
+++ b/ui/DesignSystem/Sidebar/SidebarItem.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   export let active: boolean = false;
   export let indicator: boolean = false;

--- a/ui/DesignSystem/Sidebar/WalletStatusIndicator.svelte
+++ b/ui/DesignSystem/Sidebar/WalletStatusIndicator.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as Wallet from "ui/src/wallet";
   import * as transaction from "ui/src/transaction";

--- a/ui/DesignSystem/SidebarLayout.svelte
+++ b/ui/DesignSystem/SidebarLayout.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as sess from "ui/src/session";
 

--- a/ui/DesignSystem/SourceBrowser/Changeset.svelte
+++ b/ui/DesignSystem/SourceBrowser/Changeset.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { CommitStats } from "ui/src/source";
   import type { Diff } from "ui/src/source/diff";

--- a/ui/DesignSystem/SourceBrowser/CommitTeaser.svelte
+++ b/ui/DesignSystem/SourceBrowser/CommitTeaser.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/SourceBrowser/FileDiff.svelte
+++ b/ui/DesignSystem/SourceBrowser/FileDiff.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import {
     lineNumberL,

--- a/ui/DesignSystem/SourceBrowser/FileSource.svelte
+++ b/ui/DesignSystem/SourceBrowser/FileSource.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { isMarkdown } from "ui/src/source";
   import type { Blob, CommitHeader } from "ui/src/source";

--- a/ui/DesignSystem/SourceBrowser/FileView.svelte
+++ b/ui/DesignSystem/SourceBrowser/FileView.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import type { Readable } from "svelte/store";

--- a/ui/DesignSystem/SourceBrowser/FileView/Blob.svelte
+++ b/ui/DesignSystem/SourceBrowser/FileView/Blob.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Blob } from "ui/src/screen/project/source";
 

--- a/ui/DesignSystem/SourceBrowser/FileView/Root.svelte
+++ b/ui/DesignSystem/SourceBrowser/FileView/Root.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { CommitHeader } from "ui/src/source";
   import type { Root } from "ui/src/screen/project/source";

--- a/ui/DesignSystem/SourceBrowser/History.svelte
+++ b/ui/DesignSystem/SourceBrowser/History.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/SourceBrowser/Readme.svelte
+++ b/ui/DesignSystem/SourceBrowser/Readme.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { isMarkdown } from "ui/src/source";
 

--- a/ui/DesignSystem/SourceBrowser/RevisionSelector.svelte
+++ b/ui/DesignSystem/SourceBrowser/RevisionSelector.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/DesignSystem/SourceBrowser/RevisionSelector/Entry.svelte
+++ b/ui/DesignSystem/SourceBrowser/RevisionSelector/Entry.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { RevisionType } from "ui/src/source";
   import { BadgeType } from "ui/src/badge";

--- a/ui/DesignSystem/SourceBrowser/Tree.svelte
+++ b/ui/DesignSystem/SourceBrowser/Tree.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import type { Readable } from "svelte/store";

--- a/ui/DesignSystem/SourceBrowser/Tree/File.svelte
+++ b/ui/DesignSystem/SourceBrowser/Tree/File.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Icon from "ui/DesignSystem/Icon";
   import Spinner from "ui/DesignSystem/Spinner.svelte";

--- a/ui/DesignSystem/SourceBrowser/Tree/Folder.svelte
+++ b/ui/DesignSystem/SourceBrowser/Tree/Folder.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import type { Readable } from "svelte/store";

--- a/ui/DesignSystem/Spinner.svelte
+++ b/ui/DesignSystem/Spinner.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   export let dataCy: string = "";
   export let height: number = 24;

--- a/ui/DesignSystem/Stats.svelte
+++ b/ui/DesignSystem/Stats.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Icon from "./Icon";
 

--- a/ui/DesignSystem/StyledCopyable.svelte
+++ b/ui/DesignSystem/StyledCopyable.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Copyable from "./Copyable.svelte";
   import Hoverable from "./Hoverable.svelte";

--- a/ui/DesignSystem/SupportButton.svelte
+++ b/ui/DesignSystem/SupportButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   export let style = null;
   export let dataCy = null;

--- a/ui/DesignSystem/TabBar.svelte
+++ b/ui/DesignSystem/TabBar.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { SvelteComponent } from "svelte";
 

--- a/ui/DesignSystem/TextInput.svelte
+++ b/ui/DesignSystem/TextInput.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Icon from "./Icon";
   import Spinner from "./Spinner.svelte";

--- a/ui/DesignSystem/Textarea.svelte
+++ b/ui/DesignSystem/Textarea.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import Icon from "./Icon";
   import Spinner from "./Spinner.svelte";

--- a/ui/DesignSystem/ThreeDotsMenu.svelte
+++ b/ui/DesignSystem/ThreeDotsMenu.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { fade } from "svelte/transition";
   import type { SvelteComponent } from "svelte";

--- a/ui/DesignSystem/Timeline.svelte
+++ b/ui/DesignSystem/Timeline.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import ActionItem from "./Timeline/ActionItem.svelte";
   import CommentItem from "./Timeline/CommentItem.svelte";

--- a/ui/DesignSystem/Timeline/ActionItem.svelte
+++ b/ui/DesignSystem/Timeline/ActionItem.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import Avatar from "ui/DesignSystem/Avatar.svelte";
   import Icon from "ui/DesignSystem/Icon";

--- a/ui/DesignSystem/Timeline/CommentItem.svelte
+++ b/ui/DesignSystem/Timeline/CommentItem.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import Avatar from "ui/DesignSystem/Avatar.svelte";
   import Markdown from "ui/DesignSystem/Markdown.svelte";

--- a/ui/DesignSystem/Tooltip.svelte
+++ b/ui/DesignSystem/Tooltip.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { CSSPosition } from "ui/src/style";
   import { calculatePosition, Visibility } from "ui/src/tooltip";

--- a/ui/DesignSystem/Topbar.svelte
+++ b/ui/DesignSystem/Topbar.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   export let style = null;
 </script>

--- a/ui/DesignSystem/Transaction/Spinner.svelte
+++ b/ui/DesignSystem/Transaction/Spinner.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { TxStatus, colorForStatus } from "ui/src/transaction";
 

--- a/ui/DesignSystem/Transaction/Summary.svelte
+++ b/ui/DesignSystem/Transaction/Summary.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Tx } from "ui/src/transaction";
   import { TxKind } from "ui/src/transaction";

--- a/ui/DesignSystem/TxButton.svelte
+++ b/ui/DesignSystem/TxButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Button from "./Button.svelte";
 

--- a/ui/DesignSystem/Wallet/Connect.svelte
+++ b/ui/DesignSystem/Wallet/Connect.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Button from "ui/DesignSystem/Button.svelte";
   import Emoji from "ui/DesignSystem/Emoji.svelte";

--- a/ui/DesignSystem/Wallet/Panel.svelte
+++ b/ui/DesignSystem/Wallet/Panel.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Copyable from "ui/DesignSystem/Copyable.svelte";
   import Icon from "ui/DesignSystem/Icon";

--- a/ui/DesignSystem/Wallet/Transactions/TxList.svelte
+++ b/ui/DesignSystem/Wallet/Transactions/TxList.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as modal from "ui/src/modal";
   import { selectedStore } from "ui/src/transaction";

--- a/ui/DesignSystem/Wallet/Transactions/TxListItem.svelte
+++ b/ui/DesignSystem/Wallet/Transactions/TxListItem.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Tx } from "ui/src/transaction";
   import { getShortMonth, txIcon } from "ui/src/transaction";

--- a/ui/DesignSystem/Wallet/WrongNetwork.svelte
+++ b/ui/DesignSystem/Wallet/WrongNetwork.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
   import Button from "ui/DesignSystem/Button.svelte";

--- a/ui/DesignSystem/WithContext.svelte
+++ b/ui/DesignSystem/WithContext.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { setContext } from "svelte";
 

--- a/ui/DesignSystem/index.ts
+++ b/ui/DesignSystem/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import ActionBar from "./ActionBar.svelte";
 import Avatar from "./Avatar.svelte";
 import Badge from "./Badge.svelte";

--- a/ui/Hotkeys.svelte
+++ b/ui/Hotkeys.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { pop, push, activeRouteStore } from "ui/src/router";
   import type { SvelteComponent } from "svelte";

--- a/ui/Modal/Funding/LinkAddress.svelte
+++ b/ui/Modal/Funding/LinkAddress.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import {
     Avatar,

--- a/ui/Modal/Funding/Onboarding.svelte
+++ b/ui/Modal/Funding/Onboarding.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import Modal from "ui/DesignSystem/Modal.svelte";
   import Erc20Allowance from "./Onboarding/Erc20Allowance.svelte";

--- a/ui/Modal/Funding/Onboarding/AddReceivers.svelte
+++ b/ui/Modal/Funding/Onboarding/AddReceivers.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Emoji } from "ui/DesignSystem";
 

--- a/ui/Modal/Funding/Onboarding/Erc20Allowance.svelte
+++ b/ui/Modal/Funding/Onboarding/Erc20Allowance.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Emoji, TxButton } from "ui/DesignSystem";
 

--- a/ui/Modal/Funding/Onboarding/Intro.svelte
+++ b/ui/Modal/Funding/Onboarding/Intro.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Emoji } from "ui/DesignSystem";
 

--- a/ui/Modal/Funding/Onboarding/Review.svelte
+++ b/ui/Modal/Funding/Onboarding/Review.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Emoji, TxButton } from "ui/DesignSystem";
 

--- a/ui/Modal/Funding/Onboarding/SetBudget.svelte
+++ b/ui/Modal/Funding/Onboarding/SetBudget.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Dai, Emoji, TextInput } from "ui/DesignSystem";
 

--- a/ui/Modal/Funding/Onboarding/TopUp.svelte
+++ b/ui/Modal/Funding/Onboarding/TopUp.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as svelteStore from "svelte/store";
 

--- a/ui/Modal/Funding/Pool/Collect.svelte
+++ b/ui/Modal/Funding/Pool/Collect.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Dai, Emoji, Remote, TxButton } from "ui/DesignSystem";
 

--- a/ui/Modal/Funding/Pool/TopUp.svelte
+++ b/ui/Modal/Funding/Pool/TopUp.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { get } from "svelte/store";
 

--- a/ui/Modal/Funding/Pool/Withdraw.svelte
+++ b/ui/Modal/Funding/Pool/Withdraw.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { get } from "svelte/store";
 

--- a/ui/Modal/ManagePeers.svelte
+++ b/ui/Modal/ManagePeers.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { PeerId } from "../src/identity";
   import { PeerType, PeerRole } from "../src/project";

--- a/ui/Modal/ManagePeers/Peer.svelte
+++ b/ui/Modal/ManagePeers/Peer.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/Modal/ManagePeers/PeerFollowRequest.svelte
+++ b/ui/Modal/ManagePeers/PeerFollowRequest.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { onDestroy } from "svelte";
 

--- a/ui/Modal/Org/AnchorProject.svelte
+++ b/ui/Modal/Org/AnchorProject.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { User, Project } from "ui/src/project";
   import type * as urn from "ui/src/urn";

--- a/ui/Modal/Org/Create.svelte
+++ b/ui/Modal/Org/Create.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Identity } from "ui/src/identity";
 

--- a/ui/Modal/Search.svelte
+++ b/ui/Modal/Search.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { onDestroy } from "svelte";
 

--- a/ui/Modal/Shortcuts.svelte
+++ b/ui/Modal/Shortcuts.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { isDev } from "../src/config";
 

--- a/ui/Modal/Transaction.svelte
+++ b/ui/Modal/Transaction.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Copyable, Emoji, Icon, Identity, Modal } from "ui/DesignSystem";
   import TxSpinner from "ui/DesignSystem/Transaction/Spinner.svelte";

--- a/ui/Modal/Wallet/QRCode.svelte
+++ b/ui/Modal/Wallet/QRCode.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { qrcode } from "pure-svg-code";
 

--- a/ui/Screen/Blank.svelte
+++ b/ui/Screen/Blank.svelte
@@ -1,0 +1,7 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->

--- a/ui/Screen/Bsod.svelte
+++ b/ui/Screen/Bsod.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { SvelteComponent } from "svelte";
   import type * as svelteStore from "svelte/store";

--- a/ui/Screen/DesignSystemGuide.svelte
+++ b/ui/Screen/DesignSystemGuide.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { Variant as IllustrationVariant } from "../src/illustration.ts";
   import * as notification from "../src/notification.ts";

--- a/ui/Screen/DesignSystemGuide/ColorSwatch.svelte
+++ b/ui/Screen/DesignSystemGuide/ColorSwatch.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { Copyable, Tooltip } from "ui/DesignSystem";
 

--- a/ui/Screen/DesignSystemGuide/IconSwatch.svelte
+++ b/ui/Screen/DesignSystemGuide/IconSwatch.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <style>
   .swatch {
     display: grid;

--- a/ui/Screen/DesignSystemGuide/Section.svelte
+++ b/ui/Screen/DesignSystemGuide/Section.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   export let title = null;
   export let subTitle = null;

--- a/ui/Screen/DesignSystemGuide/Swatch.svelte
+++ b/ui/Screen/DesignSystemGuide/Swatch.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <style>
   .swatch {
     display: flex;

--- a/ui/Screen/DesignSystemGuide/TypographySwatch.svelte
+++ b/ui/Screen/DesignSystemGuide/TypographySwatch.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   export let title = null;
 </script>

--- a/ui/Screen/Discovery/Project.svelte
+++ b/ui/Screen/Discovery/Project.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import {
     Avatar,

--- a/ui/Screen/Lock.svelte
+++ b/ui/Screen/Lock.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as screen from "../src/screen";
   import * as session from "../src/session";

--- a/ui/Screen/NetworkDiagnostics.svelte
+++ b/ui/Screen/NetworkDiagnostics.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
   import { unreachable } from "ui/src/unreachable";

--- a/ui/Screen/NetworkDiagnostics/ConnectedPeers.svelte
+++ b/ui/Screen/NetworkDiagnostics/ConnectedPeers.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { StatusType, status } from "ui/src/localPeer";
 

--- a/ui/Screen/NetworkDiagnostics/StateTable.svelte
+++ b/ui/Screen/NetworkDiagnostics/StateTable.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { RoomState } from "ui/src/waitingRoom";
   import StyledCopyable from "ui/DesignSystem/StyledCopyable.svelte";

--- a/ui/Screen/NetworkDiagnostics/WaitingRoom.svelte
+++ b/ui/Screen/NetworkDiagnostics/WaitingRoom.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import StateTable from "ui/Screen/NetworkDiagnostics/StateTable.svelte";
   import { waitingRoomEventLog, waitingRoomState } from "ui/src/localPeer";

--- a/ui/Screen/Onboarding.svelte
+++ b/ui/Screen/Onboarding.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { fade, fly } from "svelte/transition";
 

--- a/ui/Screen/Onboarding/EnterName.svelte
+++ b/ui/Screen/Onboarding/EnterName.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import validatejs from "validate.js";

--- a/ui/Screen/Onboarding/Success.svelte
+++ b/ui/Screen/Onboarding/Success.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import { isDev } from "ui/src/config";

--- a/ui/Screen/Onboarding/Welcome.svelte
+++ b/ui/Screen/Onboarding/Welcome.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/Screen/Org.svelte
+++ b/ui/Screen/Org.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
   import * as ipc from "ui/src/ipc";

--- a/ui/Screen/Org/Members.svelte
+++ b/ui/Screen/Org/Members.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Avatar, List, StyledCopyable } from "ui/DesignSystem";
   import type * as org from "ui/src/org";

--- a/ui/Screen/Org/MembersMenu.svelte
+++ b/ui/Screen/Org/MembersMenu.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import * as org from "ui/src/org";
 

--- a/ui/Screen/Org/OrgHeader.svelte
+++ b/ui/Screen/Org/OrgHeader.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as radicleAvatar from "radicle-avatar";
   import { Avatar, Icon } from "ui/DesignSystem";

--- a/ui/Screen/Org/Projects.svelte
+++ b/ui/Screen/Org/Projects.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Project } from "ui/src/project";
 

--- a/ui/Screen/Org/ProjectsMenu.svelte
+++ b/ui/Screen/Org/ProjectsMenu.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as style from "ui/src/style";
   import * as org from "ui/src/org";

--- a/ui/Screen/Org/UnresolvedAnchorList.svelte
+++ b/ui/Screen/Org/UnresolvedAnchorList.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { fade } from "svelte/transition";
 

--- a/ui/Screen/Profile.svelte
+++ b/ui/Screen/Profile.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as modal from "../src/modal";
   import * as sess from "../src/session";

--- a/ui/Screen/Profile/Following.svelte
+++ b/ui/Screen/Profile/Following.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { fade } from "svelte/transition";
 

--- a/ui/Screen/Profile/ProfileHeader.svelte
+++ b/ui/Screen/Profile/ProfileHeader.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Avatar as AvatarT } from "ui/src/proxy/identity";
 

--- a/ui/Screen/Profile/Projects.svelte
+++ b/ui/Screen/Profile/Projects.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import ModalNewProject from "../../Modal/NewProject.svelte";
 

--- a/ui/Screen/Project.svelte
+++ b/ui/Screen/Project.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { onDestroy } from "svelte";
 

--- a/ui/Screen/Project/BackButton.svelte
+++ b/ui/Screen/Project/BackButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
 

--- a/ui/Screen/Project/Issue.svelte
+++ b/ui/Screen/Project/Issue.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { Comment, Markdown, Timeline } from "ui/DesignSystem";
   import BackButton from "./BackButton.svelte";

--- a/ui/Screen/Project/Issues.svelte
+++ b/ui/Screen/Project/Issues.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import IssueCard from "./Issues/IssueCard.svelte";
   import { EmptyState, List, SegmentedControl } from "ui/DesignSystem";

--- a/ui/Screen/Project/Issues/IssueCard.svelte
+++ b/ui/Screen/Project/Issues/IssueCard.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { Icon } from "ui/DesignSystem";
 

--- a/ui/Screen/Project/ProjectHeader.svelte
+++ b/ui/Screen/Project/ProjectHeader.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Stats } from "ui/src/project";
 

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { onDestroy } from "svelte";
 

--- a/ui/Screen/Project/Source/AcceptPatchButton.svelte
+++ b/ui/Screen/Project/Source/AcceptPatchButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Copyable, Icon, Overlay } from "ui/DesignSystem";
   import * as Patch from "ui/src/project/patch";

--- a/ui/Screen/Project/Source/CheckoutButton.svelte
+++ b/ui/Screen/Project/Source/CheckoutButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { createEventDispatcher } from "svelte";
 

--- a/ui/Screen/Project/Source/CheckoutPatchButton.svelte
+++ b/ui/Screen/Project/Source/CheckoutPatchButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Copyable, Icon, Overlay } from "ui/DesignSystem";
   import * as Patch from "ui/src/project/patch";

--- a/ui/Screen/Project/Source/Code.svelte
+++ b/ui/Screen/Project/Source/Code.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
   import { selectPath, store } from "ui/src/screen/project/source";

--- a/ui/Screen/Project/Source/Commit.svelte
+++ b/ui/Screen/Project/Source/Commit.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as error from "ui/src/error";
   import { formatCommitTime } from "ui/src/source";

--- a/ui/Screen/Project/Source/Commits.svelte
+++ b/ui/Screen/Project/Source/Commits.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { selectCommit, store } from "ui/src/screen/project/source";
   import type { CommitHeader } from "ui/src/source";

--- a/ui/Screen/Project/Source/Patch.svelte
+++ b/ui/Screen/Project/Source/Patch.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as remote from "ui/src/remote";
   import type { Project } from "ui/src/project";

--- a/ui/Screen/Project/Source/PatchButton.svelte
+++ b/ui/Screen/Project/Source/PatchButton.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Copyable, Icon, Overlay } from "ui/DesignSystem";
   import * as patch from "ui/src/project/patch";

--- a/ui/Screen/Project/Source/PatchCard.svelte
+++ b/ui/Screen/Project/Source/PatchCard.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Avatar, CompareBranches, Icon } from "ui/DesignSystem";
 

--- a/ui/Screen/Project/Source/PatchList.svelte
+++ b/ui/Screen/Project/Source/PatchList.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
   import { unreachable } from "ui/src/unreachable";

--- a/ui/Screen/Project/Source/PatchLoaded.svelte
+++ b/ui/Screen/Project/Source/PatchLoaded.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
   import { isMaintainer } from "ui/src/project";

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as svelteStore from "svelte/store";
 

--- a/ui/Screen/UserProfile.svelte
+++ b/ui/Screen/UserProfile.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { fetchUser, user as store } from "../src/userProfile";
 

--- a/ui/Screen/UserProfile/Projects.svelte
+++ b/ui/Screen/UserProfile/Projects.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as router from "ui/src/router";
 

--- a/ui/Screen/UserProfile/UserProfileHeader.svelte
+++ b/ui/Screen/UserProfile/UserProfileHeader.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import type { Avatar as AvatarT } from "ui/src/proxy/identity";
 

--- a/ui/Screen/Wallet.svelte
+++ b/ui/Screen/Wallet.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import * as config from "ui/src/config";
   import * as router from "ui/src/router";

--- a/ui/Screen/Wallet/LinkAddress.svelte
+++ b/ui/Screen/Wallet/LinkAddress.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Emoji, Spinner } from "ui/DesignSystem";
   import ModalLinkAddress from "../../Modal/Funding/LinkAddress.svelte";

--- a/ui/Screen/Wallet/Pool.svelte
+++ b/ui/Screen/Wallet/Pool.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="ts">
   import { Remote } from "ui/DesignSystem";
 

--- a/ui/Screen/Wallet/Pool/Incoming.svelte
+++ b/ui/Screen/Wallet/Pool/Incoming.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Dai } from "ui/DesignSystem";
 

--- a/ui/Screen/Wallet/Pool/Outgoing.svelte
+++ b/ui/Screen/Wallet/Pool/Outgoing.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="ts">
   import { Remote } from "ui/DesignSystem";
 

--- a/ui/Screen/Wallet/Pool/Outgoing/GetStarted.svelte
+++ b/ui/Screen/Wallet/Pool/Outgoing/GetStarted.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { Button, Emoji } from "ui/DesignSystem";
   import ModalPoolOnboarding from "../../../../Modal/Funding/Onboarding.svelte";

--- a/ui/Screen/Wallet/Pool/Outgoing/Support.svelte
+++ b/ui/Screen/Wallet/Pool/Outgoing/Support.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import { onMount } from "svelte";
   import {

--- a/ui/Screen/Wallet/Transactions.svelte
+++ b/ui/Screen/Wallet/Transactions.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script lang="typescript">
   import {
     store as transactions,

--- a/ui/Theme.svelte
+++ b/ui/Theme.svelte
@@ -1,3 +1,10 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <script>
   import { settings } from "./src/session.ts";
   import { Theme, UIFont, CodeFont } from "./src/settings.ts";

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
 <html>
   <head>
     <meta charset="utf-8" />

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import App from "./App.svelte";
 
 const app = new App({

--- a/ui/src/__mocks__/api.ts
+++ b/ui/src/__mocks__/api.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type * as project from "../project";
 import type * as session from "../session";
 import * as settings from "../settings";

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import qs from "qs";
 
 import * as config from "./config";

--- a/ui/src/attestation/contract.ts
+++ b/ui/src/attestation/contract.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as ethers from "ethers";
 import type { Signer } from "ethers";
 

--- a/ui/src/attestation/lastClaimed.ts
+++ b/ui/src/attestation/lastClaimed.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { writable, Writable } from "svelte/store";
 
 // The last claimed Ethereum address.

--- a/ui/src/attestation/status.ts
+++ b/ui/src/attestation/status.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { Signer, ethers } from "ethers";
 import * as svelteStore from "svelte/store";
 import type { Identity } from "../identity";

--- a/ui/src/bacon.ts
+++ b/ui/src/bacon.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // Facade for the `baconjs` package with extra functions.
 //
 // Re-exports everything from `baconjs`.

--- a/ui/src/badge.ts
+++ b/ui/src/badge.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 export enum BadgeType {
   Maintainer = "maintainer",
   DefaultBranch = "default",

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type {} from "../../native/preload";
 import qs from "qs";
 

--- a/ui/src/customProtocolHandler.ts
+++ b/ui/src/customProtocolHandler.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as ipc from "./ipc";
 import * as session from "./session";
 import * as modal from "./modal";

--- a/ui/src/error.test.ts
+++ b/ui/src/error.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { Error, fromUnknown, Code } from "./error";
 
 describe("fromUnknown", () => {

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as svelteStore from "svelte/store";
 import * as lodash from "lodash";
 

--- a/ui/src/ethereum.ts
+++ b/ui/src/ethereum.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import Big from "big.js";
 import * as ethers from "ethers";
 import persistentStore from "svelte-persistent-store/dist";

--- a/ui/src/event.ts
+++ b/ui/src/event.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 export type Event<K> = {
   kind: K;
 };

--- a/ui/src/funding/contract.ts
+++ b/ui/src/funding/contract.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { BigNumber, ContractTransaction, Signer } from "ethers";
 
 import Big from "big.js";

--- a/ui/src/funding/daiToken.ts
+++ b/ui/src/funding/daiToken.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type { BigNumber, Signer } from "ethers";
 
 import Big from "big.js";

--- a/ui/src/funding/pool.ts
+++ b/ui/src/funding/pool.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as svelteStore from "svelte/store";
 
 import * as contract from "./contract";

--- a/ui/src/hotkeys.ts
+++ b/ui/src/hotkeys.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { get, writable } from "svelte/store";
 
 import { isMac } from "./settings";

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as error from "./error";
 import * as remote from "./remote";
 import * as proxy from "./proxy";

--- a/ui/src/illustration.ts
+++ b/ui/src/illustration.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 export enum Variant {
   Plant = "PLANT",
   Keyboard = "KEYBOARD",

--- a/ui/src/ipc.ts
+++ b/ui/src/ipc.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type {} from "../../native/preload";
 import * as ipcTypes from "../../native/ipc-types";
 import * as config from "./config";

--- a/ui/src/localPeer.ts
+++ b/ui/src/localPeer.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as router from "ui/src/router";
 import type { Readable, Writable } from "svelte/store";
 import { writable } from "svelte/store";

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { derived, get, writable } from "svelte/store";
 import type { SvelteComponent } from "svelte";
 

--- a/ui/src/mutexExecutor.test.ts
+++ b/ui/src/mutexExecutor.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as mutexExecutor from "./mutexExecutor";
 import { sleep } from "./sleep";
 import * as sinon from "sinon";

--- a/ui/src/mutexExecutor.ts
+++ b/ui/src/mutexExecutor.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // A task executor that runs only one task concurrently. If a new task
 // is run, any previously running task is aborted and the promise
 // returned from `run()` will return undefined.

--- a/ui/src/notification.ts
+++ b/ui/src/notification.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { Readable, derived, writable } from "svelte/store";
 import * as config from "./config";
 

--- a/ui/src/onboarding.ts
+++ b/ui/src/onboarding.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as validation from "./validation";
 
 export enum State {

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as lodash from "lodash";
 import * as ethers from "ethers";
 import * as multihash from "multihashes";

--- a/ui/src/org/safe.ts
+++ b/ui/src/org/safe.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as ethers from "ethers";
 import EthersSafe from "@gnosis.pm/safe-core-sdk";
 import SafeServiceClient, {

--- a/ui/src/org/theGraphApi.ts
+++ b/ui/src/org/theGraphApi.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as apolloCore from "@apollo/client/core";
 import * as ethers from "ethers";
 import * as multihash from "multihashes";

--- a/ui/src/overlay.test.ts
+++ b/ui/src/overlay.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { get } from "svelte/store";
 import * as overlay from "./overlay";
 

--- a/ui/src/overlay.ts
+++ b/ui/src/overlay.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { derived, writable } from "svelte/store";
 
 const currentStore = writable<HTMLDivElement | undefined>(undefined);

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { derived, Readable } from "svelte/store";
 
 import * as error from "./error";

--- a/ui/src/project.test.ts
+++ b/ui/src/project.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { get } from "svelte/store";
 
 import * as project from "./project";

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { get, writable } from "svelte/store";
 
 import * as error from "./error";

--- a/ui/src/project/patch.ts
+++ b/ui/src/project/patch.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type { Project } from "ui/src/project";
 import * as source from "ui/src/source";
 import type { Urn } from "ui/src/urn";

--- a/ui/src/proxy/control.ts
+++ b/ui/src/proxy/control.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type { Fetcher, RequestOptions } from "./fetcher";
 
 interface ProjectCreateParams {

--- a/ui/src/proxy/fetcher.ts
+++ b/ui/src/proxy/fetcher.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type * as zod from "zod";
 
 // This module provides low-level capabilities to interact with a typed

--- a/ui/src/proxy/identity.ts
+++ b/ui/src/proxy/identity.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as zod from "zod";
 
 export interface Avatar {

--- a/ui/src/proxy/index.ts
+++ b/ui/src/proxy/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as zod from "zod";
 import * as config from "../config";
 import { sleep } from "ui/src/sleep";

--- a/ui/src/proxy/project.ts
+++ b/ui/src/proxy/project.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as zod from "zod";
 import type { Fetcher, RequestOptions } from "./fetcher";
 import { Identity, identitySchema } from "./identity";

--- a/ui/src/proxy/settings.ts
+++ b/ui/src/proxy/settings.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as zod from "zod";
 
 export interface Settings {

--- a/ui/src/remote.ts
+++ b/ui/src/remote.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { derived, get, writable, Readable } from "svelte/store";
 
 import * as error from "./error";

--- a/ui/src/router/definition.ts
+++ b/ui/src/router/definition.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type * as project from "ui/src/project";
 import { unreachable } from "ui/src/unreachable";
 

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as svelteStore from "svelte/store";
 
 import * as error from "ui/src/error";

--- a/ui/src/screen.ts
+++ b/ui/src/screen.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 let lockRequests = 0;
 
 export const isLocked = (): boolean => {

--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { get, derived, Readable } from "svelte/store";
 
 import * as mutexExecutor from "ui/src/mutexExecutor";

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { derived, get, writable } from "svelte/store";
 import type { Readable, Writable } from "svelte/store";
 

--- a/ui/src/search.ts
+++ b/ui/src/search.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { writable, Writable } from "svelte/store";
 
 import * as proxy from "./proxy";

--- a/ui/src/session.test.ts
+++ b/ui/src/session.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as session from "./session";
 
 describe("waitUnsealed", () => {

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as svelte from "svelte";
 import { Readable, derived, get } from "svelte/store";
 

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as ethereum from "./ethereum";
 
 import {

--- a/ui/src/sleep.ts
+++ b/ui/src/sleep.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 export function sleep(timeMs: number): Promise<void> {
   return new Promise(resolve => {
     setTimeout(resolve, timeMs);

--- a/ui/src/source.ts
+++ b/ui/src/source.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { format } from "timeago.js";
 
 import * as api from "./api";

--- a/ui/src/source/diff.ts
+++ b/ui/src/source/diff.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 export type Line = string;
 
 export enum LineDiffType {

--- a/ui/src/style.ts
+++ b/ui/src/style.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // Shared types and functionality related to styling
 
 export type ButtonVariant =

--- a/ui/src/svelteStore.test.ts
+++ b/ui/src/svelteStore.test.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as sinon from "sinon";
 import { sleep } from "ui/src/sleep";
 

--- a/ui/src/svelteStore.ts
+++ b/ui/src/svelteStore.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import type { Readable } from "svelte/store";
 
 export * from "svelte/store";

--- a/ui/src/tooltip.ts
+++ b/ui/src/tooltip.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import { CSSPosition } from "./style";
 
 export interface Position {

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as svelteStore from "svelte/store";
 import { writable as persistentStore } from "svelte-persistent-store/dist/local";
 

--- a/ui/src/unreachable.ts
+++ b/ui/src/unreachable.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as error from "ui/src/error";
 
 export const unreachable = (value: never): never => {

--- a/ui/src/updateChecker.ts
+++ b/ui/src/updateChecker.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as svelteStore from "svelte/store";
 import persistentStore from "svelte-persistent-store/dist";
 import * as semver from "semver";

--- a/ui/src/urn.test.ts
+++ b/ui/src/urn.test.ts
@@ -1,10 +1,16 @@
+/** @jest-environment node */
+
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 /**
- * The jsdom environment lacks `TextEncoder` required by `multibase`,
- * see https://github.com/multiformats/js-multibase/issues/90,
- * will be solved by https://github.com/jsdom/jsdom/issues/2524
- *
- * @jest-environment node
- *
+ * We are using the 'node' Jest environemtn because the 'jsdom' environment
+ * lacks `TextEncoder` required by `multibase`, see
+ * https://github.com/multiformats/js-multibase/issues/90, will be solved by
+ * https://github.com/jsdom/jsdom/issues/2524
  */
 
 import { Code, Error } from "ui/src/error";

--- a/ui/src/urn.ts
+++ b/ui/src/urn.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as multibase from "multibase";
 
 import * as error from "ui/src/error";

--- a/ui/src/userProfile.ts
+++ b/ui/src/userProfile.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import * as identity from "./identity";
 import * as remote from "./remote";
 import * as error from "./error";

--- a/ui/src/validation.ts
+++ b/ui/src/validation.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import validatejs from "validate.js";
 import { writable, Writable, Readable, get } from "svelte/store";
 

--- a/ui/src/waitingRoom.ts
+++ b/ui/src/waitingRoom.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 // Client representation of proxy waiting room requests, subscriptions, etc.
 import * as zod from "zod";
 

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import WalletConnect from "@walletconnect/client";
 import * as svelteStore from "svelte/store";
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 import path from "path";
 import sveltePreprocess from "svelte-preprocess";
 import webpack from "webpack";

--- a/yarn.lock
+++ b/yarn.lock
@@ -6400,9 +6400,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.3":
-  version: 11.0.3
-  resolution: "globby@npm:11.0.3"
+"globby@npm:^11.0.3, globby@npm:^11.0.4":
+  version: 11.0.4
+  resolution: "globby@npm:11.0.4"
   dependencies:
     array-union: ^2.1.0
     dir-glob: ^3.0.1
@@ -6410,7 +6410,7 @@ __metadata:
     ignore: ^5.1.4
     merge2: ^1.3.0
     slash: ^3.0.0
-  checksum: f17da0f869918656ec8c16c15ad100f025fbd13e4c157286cf340811eb1355a7d06dde77be1685a7a051970ec6abeff96a9b2a1a97525f84bc94fbd518c1d1db
+  checksum: 9f365b35b835c0235880e272fa2a2f5d9d78428e09af8dfc67536f1047953e7b0c66aab9bb6d41e6c0f4c3ec75a22840d9acb892f102daecaadd338b2c763219
   languageName: node
   linkType: hard
 
@@ -10226,6 +10226,7 @@ __metadata:
     execa: ^5.1.1
     exit-hook: ^2.2.1
     ganache-cli: ^6.12.2
+    globby: ^11.0.4
     graphql: ^15.5.0
     html-webpack-plugin: ^5.3.1
     husky: ^4.3.8


### PR DESCRIPTION
As part of #2024 we add license headers to all source files. We also provide a script to automatically add license headers to files and check this. The latter is run on CI.

The PR consists of two commits. The first adds the script, the second updates all files.