### PR TITLE
refactor: reorganize ethereum modules

### DIFF
--- a/ui/src/ethereum/debug.ts
+++ b/ui/src/ethereum/debug.ts
@@ -1,0 +1,43 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+// This module adds a helper object to `window.ethereumDebug` that
+// allows developers to control an Ethereum development node.
+import * as ethers from "ethers";
+
+declare global {
+  interface Window {
+    ethereumDebug: EthereumDebug;
+  }
+}
+
+export function install(provider: ethers.providers.Provider): void {
+  if (provider instanceof ethers.providers.JsonRpcProvider) {
+    window.ethereumDebug = new EthereumDebug(provider);
+  }
+}
+
+class EthereumDebug {
+  private provider: ethers.providers.JsonRpcProvider;
+
+  constructor(provider: ethers.providers.JsonRpcProvider) {
+    this.provider = provider;
+  }
+  async mineBlocks(blocks = 1) {
+    while (blocks) {
+      blocks -= 1;
+      await this.provider.send("evm_mine", []);
+    }
+  }
+
+  async setBlockTime(seconds = 5) {
+    await this.provider.send("evm_setTime", [seconds]);
+  }
+
+  async increaseTime(seconds = 5) {
+    await this.provider.send("evm_increaseTime", [seconds]);
+  }
+}

--- a/ui/src/ethereum/environment.ts
+++ b/ui/src/ethereum/environment.ts
@@ -4,11 +4,6 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
-import Big from "big.js";
-import * as ethers from "ethers";
-import persistentStore from "svelte-persistent-store/dist";
-import * as config from "ui/src/config";
-
 // The Ethereum environments we support and may connect to.
 export enum Environment {
   // A local node for testing and development. The test wallet we use
@@ -54,30 +49,4 @@ export function networkFromChainId(chainId: number): Network {
     default:
       return Network.Other;
   }
-}
-
-// The store where the selected Ethereum environment is persisted.
-export const selectedEnvironment = persistentStore.local.writable<Environment>(
-  "ethereum-environment-v0",
-  config.isDev ? Environment.Rinkeby : Environment.Mainnet
-);
-
-// EIP-20 token decimals for the tokens we operate with across
-// the diferent environments. We hardcode this value since it
-// is well-settled and since we would need to request it from
-// the token contract for each number conversion otherwise.
-// We have, however, to keep in mind that new versions of the
-// token might change it.
-const TOKEN_DECIMALS = Big(10).pow(18);
-
-// Big.PE determines the exponent at which its `toString()` representation
-// starts being displayed in exponential notation. We never want to do that.
-Big.PE = Number.MAX_SAFE_INTEGER;
-
-export function toBaseUnit(n: ethers.BigNumber | Big): Big {
-  return Big(n.toString()).div(TOKEN_DECIMALS).round(2);
-}
-
-export function fromBaseUnit(n: Big): ethers.BigNumber {
-  return ethers.BigNumber.from(n.mul(TOKEN_DECIMALS).round().toString());
 }

--- a/ui/src/ethereum/index.ts
+++ b/ui/src/ethereum/index.ts
@@ -1,0 +1,40 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import Big from "big.js";
+import * as ethers from "ethers";
+import persistentStore from "svelte-persistent-store/dist";
+import * as config from "ui/src/config";
+
+import { Environment, Network, supportedNetwork } from "./environment";
+
+export { Environment, supportedNetwork, Network };
+
+// The store where the selected Ethereum environment is persisted.
+export const selectedEnvironment = persistentStore.local.writable<Environment>(
+  "ethereum-environment-v0",
+  config.isDev ? Environment.Rinkeby : Environment.Mainnet
+);
+
+// EIP-20 token decimals for the tokens we operate with across
+// the diferent environments. We hardcode this value since it
+// is well-settled and since we would need to request it from
+// the token contract for each number conversion otherwise.
+// We have, however, to keep in mind that new versions of the
+// token might change it.
+const TOKEN_DECIMALS = Big(10).pow(18);
+
+// Big.PE determines the exponent at which its `toString()` representation
+// starts being displayed in exponential notation. We never want to do that.
+Big.PE = Number.MAX_SAFE_INTEGER;
+
+export function toBaseUnit(n: ethers.BigNumber | Big): Big {
+  return Big(n.toString()).div(TOKEN_DECIMALS).round(2);
+}
+
+export function fromBaseUnit(n: Big): ethers.BigNumber {
+  return ethers.BigNumber.from(n.mul(TOKEN_DECIMALS).round().toString());
+}

--- a/ui/src/ethereum/walletConnectSigner.ts
+++ b/ui/src/ethereum/walletConnectSigner.ts
@@ -1,0 +1,153 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import type WalletConnect from "@walletconnect/client";
+import * as ethers from "ethers";
+import * as ethersBytes from "@ethersproject/bytes";
+import type {
+  Provider,
+  TransactionRequest,
+  TransactionResponse,
+} from "@ethersproject/abstract-provider";
+import {
+  Deferrable,
+  defineReadOnly,
+  resolveProperties,
+} from "@ethersproject/properties";
+
+import { Environment } from "./environment";
+
+export class WalletConnectSigner extends ethers.Signer {
+  public walletConnect: WalletConnect;
+  private _provider: ethers.providers.Provider;
+  private _environment: Environment;
+
+  constructor(
+    walletConnect: WalletConnect,
+    provider: Provider,
+    environment: Environment,
+    onDisconnect: () => void
+  ) {
+    super();
+    defineReadOnly(this, "provider", provider);
+    this._provider = provider;
+    this._environment = environment;
+    this.walletConnect = walletConnect;
+    this.walletConnect.on("disconnect", onDisconnect);
+  }
+
+  async getAddress(): Promise<string> {
+    const accountAddress = this.walletConnect.accounts[0];
+    if (!accountAddress) {
+      throw new Error(
+        "The connected wallet has no accounts or there is a connection problem"
+      );
+    }
+    return accountAddress;
+  }
+
+  async signMessage(message: ethers.Bytes | string): Promise<string> {
+    const prefix = ethers.utils.toUtf8Bytes(
+      `\x19Ethereum Signed Message:\n${message.length}`
+    );
+    const msg = ethers.utils.concat([prefix, message]);
+    const address = await this.getAddress();
+    const keccakMessage = ethers.utils.keccak256(msg);
+    const signature = await this.walletConnect.signMessage([
+      address.toLowerCase(),
+      keccakMessage,
+    ]);
+    return signature;
+  }
+
+  async sendTransaction(
+    transaction: Deferrable<TransactionRequest>
+  ): Promise<TransactionResponse> {
+    // When using a local Ethereum environment, we want our app to send
+    // the transaction to the local Ethereum node and have the external
+    // wallet just sign the transaction. In all other environments, we
+    // want the external wallet to submit the transaction to the network.
+    if (this._environment === Environment.Local) {
+      return super.sendTransaction(transaction);
+    }
+
+    const tx = await resolveProperties(transaction);
+    const from = tx.from || (await this.getAddress());
+
+    const txHash = await this.walletConnect.sendTransaction({
+      from,
+      to: tx.to,
+      value: maybeBigNumberToString(tx.value),
+      data: bytesLikeToString(tx.data),
+    });
+
+    return {
+      from,
+      value: ethers.BigNumber.from(tx.value || 0),
+      get chainId(): number {
+        throw new Error("this should never be called");
+      },
+      get nonce(): number {
+        throw new Error("this should never be called");
+      },
+      get gasLimit(): ethers.BigNumber {
+        throw new Error("this should never be called");
+      },
+      get gasPrice(): ethers.BigNumber {
+        throw new Error("this should never be called");
+      },
+      data: bytesLikeToString(tx.data) || "",
+      hash: txHash,
+      confirmations: 1,
+      wait: () => {
+        throw new Error("this should never be called");
+      },
+    };
+  }
+
+  async signTransaction(
+    transaction: Deferrable<TransactionRequest>
+  ): Promise<string> {
+    const tx = await resolveProperties(transaction);
+    const from = tx.from || (await this.getAddress());
+    const nonce = await this._provider.getTransactionCount(from);
+
+    const signedTx = await this.walletConnect.signTransaction({
+      from,
+      to: tx.to,
+      value: maybeBigNumberToString(tx.value || 0),
+      gasLimit: maybeBigNumberToString(tx.gasLimit || 200 * 1000),
+      gasPrice: maybeBigNumberToString(tx.gasPrice || 0),
+      nonce,
+      data: bytesLikeToString(tx.data),
+    });
+    return signedTx;
+  }
+
+  connect(_provider: Provider): ethers.Signer {
+    throw new Error("WalletConnectSigner.connect should never be called");
+  }
+}
+
+function maybeBigNumberToString(
+  bn: ethers.BigNumberish | undefined
+): string | undefined {
+  if (bn === undefined) {
+    return undefined;
+  } else {
+    return ethers.BigNumber.from(bn).toString();
+  }
+}
+
+function bytesLikeToString(
+  bytes: ethersBytes.BytesLike | undefined
+): string | undefined {
+  if (bytes === undefined) {
+    return undefined;
+  } else {
+    return ethersBytes.hexlify(bytes);
+  }
+}


### PR DESCRIPTION
This change is one step towards moving all Ethereum infrastructure into the `ui/src/ethereum` folder.

* We extract `WalletConnectSigner` from `ui/src/wallet` and move it under `ui/src/ethereum`.
* We extract the environment types from `ui/src/ethereum` and move it into `ui/src/ethereum/environments`.
* We extract the debug object from `ui/src/wallet` and move it into `ui/src/ethereum/debug`.

No logic has been changed.

As a follow-up we will do the same for `ui/src/wallet` and `ui/src/transaction`