### PR TITLE
fix: disable placeholder anchor button when there are no projects

### DIFF
--- a/ui/DesignSystem/EmptyState.svelte
+++ b/ui/DesignSystem/EmptyState.svelte
@@ -9,10 +9,12 @@
   import { createEventDispatcher } from "svelte";
 
   import { Variant as IllustrationVariant } from "ui/src/illustration";
+  import * as Style from "ui/src/style";
 
   import Button from "./Button.svelte";
   import Emoji from "./Emoji.svelte";
   import Illustration from "./Illustration.svelte";
+  import Tooltip from "./Tooltip.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -23,6 +25,10 @@
   export let headerText: string = "";
   export let primaryActionText: string = "";
   export let secondaryActionText: string = "";
+  export let primaryActionDisabled = false;
+  export let primaryActionTooltipMessage: string | undefined = undefined;
+
+  $: tooltipMessage = primaryActionDisabled ? primaryActionTooltipMessage : "";
 
   const onPrimaryAction = () => {
     dispatch("primaryAction");
@@ -82,12 +88,14 @@
     <p class="text">{text}</p>
   {/if}
   {#if primaryActionText.length}
-    <Button
-      dataCy="primary-action"
-      on:click={() => onPrimaryAction()}
-      style="margin-bottom: 0.75rem;">
-      {primaryActionText}
-    </Button>
+    <Tooltip value={tooltipMessage} position={Style.CSSPosition.Bottom}>
+      <Button
+        disabled={primaryActionDisabled}
+        dataCy="primary-action"
+        on:click={() => onPrimaryAction()}>
+        {primaryActionText}
+      </Button>
+    </Tooltip>
   {/if}
   {#if secondaryActionText.length}
     <button data-cy="secondary-action" on:click={() => onSecondaryAction()}>

--- a/ui/Screen/Org.svelte
+++ b/ui/Screen/Org.svelte
@@ -126,6 +126,7 @@
     <ProjectsTab
       {address}
       {gnosisSafeAddress}
+      disableAnchorCreation={activeTab.projectCount === 0}
       anchoredProjects={activeTab.anchoredProjects}
       unresolvedAnchors={activeTab.unresolvedAnchors} />
   {:else if activeTab.type === "members"}

--- a/ui/Screen/Org/Projects.svelte
+++ b/ui/Screen/Org/Projects.svelte
@@ -25,6 +25,7 @@
   export let anchoredProjects: project.Project[];
   export let unresolvedAnchors: project.Anchor[];
   export let gnosisSafeAddress: string;
+  export let disableAnchorCreation = false;
 
   const select = ({ detail: project }: { detail: Project }) => {
     router.push({
@@ -56,6 +57,8 @@
       illustration={IllustrationVariant.Plant}
       text="Get started by anchoring your organization’s first project with the radicle gnosis safe app."
       primaryActionText="Anchor with Gnosis Safe"
+      primaryActionDisabled={disableAnchorCreation}
+      primaryActionTooltipMessage="Create or follow a project first"
       on:primaryAction={() => {
         org.openAnchorProjectModal(address, gnosisSafeAddress);
       }} />

--- a/ui/Screen/Org/ProjectsMenu.svelte
+++ b/ui/Screen/Org/ProjectsMenu.svelte
@@ -12,7 +12,7 @@
 
   export let orgAddress: string;
   export let gnosisSafeAddress: string;
-  export let disabled: boolean = false;
+  export let disabled = false;
 
   $: tooltipMessage = disabled ? "Create or follow a project first" : "";
 </script>


### PR DESCRIPTION
We are already disabling the action bar anchoring button on the right-hand-side when there are no projects to anchor. But we forgot to disable the button in the `EmptyState` component, this takes care of that.

There's a problem with the tooltip alignment, we should fix that in a follow-up.

<img width="1552" alt="Screenshot 2021-06-24 at 11 08 23" src="https://user-images.githubusercontent.com/158411/123236277-f5ffae80-d4dc-11eb-9f77-789079c472b9.png">
<img width="513" alt="Screenshot 2021-06-24 at 11 08 35" src="https://user-images.githubusercontent.com/158411/123236294-f8fa9f00-d4dc-11eb-9d64-f0fd8dd7a3c9.png">
<img width="485" alt="Screenshot 2021-06-24 at 11 08 41" src="https://user-images.githubusercontent.com/158411/123236305-fac46280-d4dc-11eb-9875-92b661f8cefb.png">
