### PR TITLE
refactor: use dayjs for time formatting

### DIFF
--- a/ui/DesignSystem/Wallet/Transactions/TxListItem.svelte
+++ b/ui/DesignSystem/Wallet/Transactions/TxListItem.svelte
@@ -6,8 +6,9 @@
  LICENSE file.
 -->
 <script lang="typescript">
+  import dayjs from "dayjs";
   import type { Tx } from "ui/src/transaction";
-  import { getShortMonth, txIcon } from "ui/src/transaction";
+  import { txIcon } from "ui/src/transaction";
 
   export let tx: Tx;
 </script>
@@ -37,6 +38,7 @@
     align-items: center;
     width: 2rem;
     margin-right: 1rem;
+    text-transform: uppercase;
   }
 
   .date h5 {
@@ -52,8 +54,8 @@
 <div class="container" on:click>
   <div class="left">
     <div class="date">
-      <h5>{getShortMonth(new Date(tx.date))}</h5>
-      <p class="typo-text-bold">{new Date(tx.date).getDate()}</p>
+      <h5>{dayjs(tx.date).format("MMM")}</h5>
+      <p class="typo-text-bold">{dayjs(tx.date).format("D")}</p>
     </div>
     <svelte:component this={txIcon(tx)} />
     <p class="typo-text-bold" style="margin-left: 0.5rem">{tx.kind}</p>

--- a/ui/Modal/Transaction.svelte
+++ b/ui/Modal/Transaction.svelte
@@ -6,6 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
+  import dayjs from "dayjs";
   import { Copyable, Emoji, Icon, Identity, Modal } from "ui/DesignSystem";
   import TxSpinner from "ui/DesignSystem/Transaction/Spinner.svelte";
   import Summary from "ui/DesignSystem/Transaction/Summary.svelte";
@@ -17,7 +18,6 @@
     store as txs,
     colorForStatus,
     isIncoming,
-    formatDate,
     transferAmount,
     TxStatus,
     TxKind,
@@ -177,7 +177,9 @@
         </div>
         <div class="row">
           <p>Timestamp</p>
-          <p>{formatDate(new Date(tx.date))}</p>
+          <p>
+            {dayjs(tx.date).format("HH:mm:ss [on] D MMMM YYYY")}
+          </p>
         </div>
       </div>
     </div>

--- a/ui/Screen/Wallet/Transactions.svelte
+++ b/ui/Screen/Wallet/Transactions.svelte
@@ -6,11 +6,8 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import {
-    store as transactions,
-    getShortMonth,
-    TxStatus,
-  } from "ui/src/transaction";
+  import dayjs from "dayjs";
+  import { store as transactions, TxStatus } from "ui/src/transaction";
   import type { Tx } from "ui/src/transaction";
 
   import TxList from "ui/DesignSystem/Wallet/Transactions/TxList.svelte";
@@ -26,15 +23,15 @@
     // Sort from newest to oldest
     txs.sort((a, b) => b.date - a.date);
     for (const tx of txs) {
-      const txDate = new Date(tx.date);
-      const txMonth = txDate.getMonth();
-      const txYear = txDate.getFullYear();
+      const txDate = dayjs(tx.date);
+      const txMonth = txDate.month();
+      const txYear = txDate.year();
       const key = `${txYear}-${txMonth}`;
       const currentSection = sections[sections.length - 1];
       if (currentSection && currentSection.key === key) {
         currentSection.items.push(tx);
       } else {
-        const title = `${getShortMonth(txDate)} ${txYear}`;
+        const title = txDate.format("MMM YYYY").toUpperCase();
         sections.push({
           key,
           title,

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -4,6 +4,13 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone"; // dependent on utc plugin
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 import App from "./App.svelte";
 
 const app = new App({

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -419,46 +419,6 @@ export function transferAmount(tx: Tx): Big | undefined {
   }
 }
 
-export function formatDate(date: Date): string {
-  return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()} on ${date.getUTCDate()} ${
-    monthNames[date.getMonth()]
-  } ${date.getFullYear()}`;
-}
-
-const monthNames = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];
-
-export function getShortMonth(date: Date): string {
-  return `${shortMonthNames[date.getMonth()]}`;
-}
-
-const shortMonthNames = [
-  "JAN",
-  "FEB",
-  "MAR",
-  "APR",
-  "MAY",
-  "JUN",
-  "JUL",
-  "AUG",
-  "SEP",
-  "OCT",
-  "NOV",
-  "DEC",
-];
-
 // Convert a transaction-related `globalThis.Error` to `error.Error`.
 export function convertError(e: globalThis.Error, label: string): error.Error {
   let code: error.Code;


### PR DESCRIPTION
We use `dayjs` to format dates and times instead of our custom formatters. This reduces the amount of code we need to write and also eliminates some bugs already present in our code, like not including leading zeros in minutes and seconds (e.g. “17:3:5” instead of “17:03:05”).