### PR TITLE
chore: improve org notifications

### DIFF
--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -116,24 +116,32 @@ export async function anchorProject(
     persist: true,
   });
 
-  await Safe.signAndProposeTransaction(walletStore, gnosisSafeAddress, {
-    to: orgAddress,
-    value: "0",
-    data: txData,
-    operation: OperationType.Call,
-  });
-  confirmNotification.remove();
+  try {
+    await Safe.signAndProposeTransaction(walletStore, gnosisSafeAddress, {
+      to: orgAddress,
+      value: "0",
+      data: txData,
+      operation: OperationType.Call,
+    });
+  } finally {
+    confirmNotification.remove();
+  }
 
   notification.info({
     message:
       "Your anchored project will appear once the quorum of members have confirmed the transaction",
     showIcon: true,
+    persist: true,
     actions: [
       {
         label: "View on Gnosis Safe",
         handler: () => {
           openOnGnosisSafe(gnosisSafeAddress, "transactions");
         },
+      },
+      {
+        label: "Dismiss",
+        handler: () => {},
       },
     ],
   });


### PR DESCRIPTION
- hide the "Waiting for you to confirm the anchor transaction in your connected wallet" message when the user rejects signing in their wallet

https://user-images.githubusercontent.com/158411/123279930-9fa86500-d508-11eb-8867-cf53e9d80882.mov

- make "View on Gnosis Safe" message sticky

<img width="986" alt="Screenshot 2021-06-24 at 16 21 49" src="https://user-images.githubusercontent.com/158411/123279791-7be51f00-d508-11eb-9cf2-0eab39b1d8d6.png">
