### PR TITLE
fix: don’t show intermittent 502 errors from Graph requests

### DIFF
--- a/ui/src/org/theGraphApi.ts
+++ b/ui/src/org/theGraphApi.ts
@@ -206,3 +206,14 @@ export async function getOrgProjectAnchors(
     }
   );
 }
+
+// Returns `true` if `err` is a 502 HTTP response error thrown by
+// requests to the Graph.
+export function is502Error(err: unknown): boolean {
+  return (
+    err instanceof apolloCore.ApolloError &&
+    err.networkError !== null &&
+    "statusCode" in err.networkError &&
+    err.networkError.statusCode === 502
+  );
+}


### PR DESCRIPTION
We retry for 20 seconds after a 502 until we issue an error for fetching graph data.

Fixes #2042