### PR TITLE
improvement: Inserted truncate & expandable in <PeerId /> inside <Settings /> to mimic like in <ProfileHeader />

### DIFF
--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -153,7 +153,7 @@
               >Learn more about managing devices</a>
           </p>
           <div class="action">
-            <PeerId peerId={session.identity.peerId} />
+            <PeerId truncate peerId={session.identity.peerId} />
           </div>
         </div>
       </section>

--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -153,7 +153,10 @@
               >Learn more about managing devices</a>
           </p>
           <div class="action">
-            <PeerId truncate peerId={session.identity.peerId} />
+            <PeerId
+              truncate
+              expandable={false}
+              peerId={session.identity.peerId} />
           </div>
         </div>
       </section>


### PR DESCRIPTION
Signed-off-by: Nishit Prasad <prasad.nishit0@gmail.com>

- [x] Inserted `truncate` and `expandable={false}` properties in `<PeerId />` inside `<Settings />` to mimic like in `<ProfileHeader />` except expand on hover
- [x] This PR fixes #2067 

**BEFORE:**
![ScreenRecord](https://user-images.githubusercontent.com/64563418/124362608-8ebbca00-dc53-11eb-83bd-24f6b5dbc8a9.gif)


**AFTER:**
![ScreenRecord](https://user-images.githubusercontent.com/64563418/124720497-d4afb100-df25-11eb-986f-380981267efc.gif)

