### PR TITLE
fix: wallet disconnect handling

### DIFF
--- a/ui/src/ethereum/walletConnectSigner.ts
+++ b/ui/src/ethereum/walletConnectSigner.ts
@@ -28,15 +28,13 @@ export class WalletConnectSigner extends ethers.Signer {
   constructor(
     walletConnect: WalletConnect,
     provider: Provider,
-    environment: Environment,
-    onDisconnect: () => void
+    environment: Environment
   ) {
     super();
     defineReadOnly(this, "provider", provider);
     this._provider = provider;
     this._environment = environment;
     this.walletConnect = walletConnect;
-    this.walletConnect.on("disconnect", onDisconnect);
   }
 
   async getAddress(): Promise<string> {


### PR DESCRIPTION
* We don’t call `disconnect()` multiple times when the user disconnects. The second call to `disconnect()` was triggered by the `disconnect` event.
* We properly register the `disconnect` event even after wallet connect is initialized.