### PR TITLE
fix: reapply commit to truncate device ID in settings screen

### DIFF
--- a/ui/Screen/Settings.svelte
+++ b/ui/Screen/Settings.svelte
@@ -153,7 +153,10 @@
               >Learn more about managing devices</a>
           </p>
           <div class="action">
-            <PeerId peerId={session.identity.peerId} />
+            <PeerId
+              truncate
+              expandable={false}
+              peerId={session.identity.peerId} />
           </div>
         </div>
       </section>


### PR DESCRIPTION
Re-applies c2cc5319fe5557475f0eaa48ac129942bc41276f after it was overriden by #2087.