### PR TITLE
refactor: decouple account balance store

### DIFF
--- a/ui/DesignSystem/Sidebar/OrgList.svelte
+++ b/ui/DesignSystem/Sidebar/OrgList.svelte
@@ -79,7 +79,7 @@
           identity,
           walletAddress:
             $wallet.status === Wallet.Status.Connected
-              ? $wallet.connected.account.address
+              ? $wallet.connected.address
               : null,
         })}>
       <Icon.Plus />

--- a/ui/DesignSystem/Wallet/Panel.svelte
+++ b/ui/DesignSystem/Wallet/Panel.svelte
@@ -6,17 +6,29 @@
  LICENSE file.
 -->
 <script lang="typescript">
+  import type { BigNumber } from "ethers";
+
   import Copyable from "ui/DesignSystem/Copyable.svelte";
   import Icon from "ui/DesignSystem/Icon";
   import Tooltip from "ui/DesignSystem/Tooltip.svelte";
 
-  import * as wallet from "ui/src/wallet";
+  import * as ethereum from "ui/src/ethereum";
   import { ellipsed } from "ui/src/style";
   import { Button } from "ui/DesignSystem";
 
-  export let account: wallet.Account;
+  export let dai: BigNumber | null;
+  export let eth: BigNumber | null;
+  export let address: string;
   export let onDisconnect: () => void;
   export let style = "";
+
+  function formatBalance(balance: BigNumber | null): string {
+    if (balance === null) {
+      return "–";
+    } else {
+      return ethereum.toBaseUnit(balance).toNumber().toLocaleString("en-US");
+    }
+  }
 </script>
 
 <style>
@@ -63,12 +75,12 @@
   <div class="balances">
     <h3>Balance</h3>
     <h2>
-      {wallet.formattedBalance(account.ethBalance.toNumber())} ETH
+      {formatBalance(eth)} ETH
     </h2>
     <div class="supported">
       <h5>Supported tokens</h5>
       <h3>
-        {wallet.formattedBalance(account.daiBalance.toNumber())} DAI
+        {formatBalance(dai)} DAI
       </h3>
     </div>
   </div>
@@ -78,9 +90,9 @@
       showIcon={false}
       styleContent={false}
       style="padding-left: 0;"
-      copyContent={account.address}
+      copyContent={address}
       notificationText="Address copied to the clipboard">
-      {ellipsed(account.address)}
+      {ellipsed(address)}
     </Copyable>
     <Tooltip value="Disconnect">
       <Button

--- a/ui/Modal/Funding/LinkAddress.svelte
+++ b/ui/Modal/Funding/LinkAddress.svelte
@@ -31,7 +31,7 @@
     modal.hide();
   }
 
-  $: address = $walletStore.account()?.address || "";
+  $: address = $walletStore.getAddress() || "";
 
   async function claim(ident: identity.Identity) {
     $lastClaimed = address.toLowerCase();

--- a/ui/Modal/Funding/Onboarding/TopUp.svelte
+++ b/ui/Modal/Funding/Onboarding/TopUp.svelte
@@ -6,23 +6,20 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import * as svelteStore from "svelte/store";
+  import Big from "big.js";
+  import * as ethereum from "ui/src/ethereum";
 
   import { Button } from "ui/DesignSystem";
   import TopUp from "ui/DesignSystem/Funding/Pool/TopUp.svelte";
 
-  import { store as walletStore } from "../../../src/wallet";
-
-  import Big from "big.js";
+  import { accountBalancesStore } from "ui/src/wallet";
 
   export let amount = "";
   export let onBack: () => void;
   export let onContinue: () => void;
 
   let disabled = true;
-  let accountBalance = Big(0);
-  $: accountBalance =
-    svelteStore.get(walletStore).account()?.daiBalance || accountBalance;
+  $: balance = ethereum.toBaseUnit($accountBalancesStore.dai || Big(0));
 
   const onKeydown = (event: KeyboardEvent) => {
     if (event.key === "Enter" && !disabled) {
@@ -33,10 +30,6 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<TopUp
-  bind:amount
-  balance={accountBalance}
-  onBack={["Back", onBack]}
-  bind:disabled>
+<TopUp bind:amount {balance} onBack={["Back", onBack]} bind:disabled>
   <Button on:click={onContinue} {disabled}>Continue</Button>
 </TopUp>

--- a/ui/Modal/Funding/Pool/TopUp.svelte
+++ b/ui/Modal/Funding/Pool/TopUp.svelte
@@ -13,6 +13,8 @@
 
   import * as modal from "ui/src/modal";
   import { store } from "ui/src/funding/pool";
+  import { accountBalancesStore } from "ui/src/wallet";
+  import * as ethereum from "ui/src/ethereum";
 
   import Big from "big.js";
 
@@ -27,8 +29,7 @@
   }
 
   let disabled = true;
-  let balance = Big(0);
-  $: balance = $store?.getAccount()?.daiBalance || balance;
+  $: balance = ethereum.toBaseUnit($accountBalancesStore.dai || Big(0));
 </script>
 
 <style>

--- a/ui/Screen/Wallet.svelte
+++ b/ui/Screen/Wallet.svelte
@@ -19,7 +19,7 @@
     attestationStatus,
     AttestationStatus,
   } from "ui/src/attestation/status";
-  import { store, Status } from "ui/src/wallet";
+  import { store, Status, accountBalancesStore } from "ui/src/wallet";
 
   import ConnectWallet from "ui/DesignSystem/Wallet/Connect.svelte";
   import WalletPanel from "ui/DesignSystem/Wallet/Panel.svelte";
@@ -94,7 +94,9 @@
           <h1 class="title">Wallet</h1>
           <WalletPanel
             onDisconnect={wallet.disconnect}
-            account={w.connected.account} />
+            dai={$accountBalancesStore.dai}
+            eth={$accountBalancesStore.eth}
+            address={w.connected.address} />
         </div>
         {#if supportedNetwork($ethereumEnvironment) === w.connected.network}
           {#if $attestationStatus === AttestationStatus.Fetching}

--- a/ui/Screen/Wallet/LinkAddress.svelte
+++ b/ui/Screen/Wallet/LinkAddress.svelte
@@ -13,7 +13,7 @@
   import { lastClaimed } from "../../src/attestation/lastClaimed";
   import { store as walletStore } from "../../src/wallet";
 
-  $: address = $walletStore.account()?.address.toLowerCase();
+  $: address = $walletStore.getAddress()?.toLowerCase();
 
   function onLink() {
     modal.toggle(ModalLinkAddress);

--- a/ui/src/attestation/status.ts
+++ b/ui/src/attestation/status.ts
@@ -61,14 +61,10 @@ async function updateAttesttationStatus(
 ): Promise<void> {
   const wallet = svelteStore.get(walletStore);
   const sess: UnsealedSession | undefined = session.unsealed();
-  const ethAccount = wallet.account();
-  if (sess && ethAccount) {
+  const address = wallet.getAddress();
+  if (sess && address) {
     attestationStatus.set(
-      await getAttestationStatus(
-        sess.identity,
-        ethAccount.address,
-        claimWatcher
-      )
+      await getAttestationStatus(sess.identity, address, claimWatcher)
     );
   } else {
     attestationStatus.set(AttestationStatus.Fetching);

--- a/ui/src/funding/daiToken.ts
+++ b/ui/src/funding/daiToken.ts
@@ -5,6 +5,7 @@
 // LICENSE file.
 
 import type { BigNumber, Signer } from "ethers";
+import type * as ethers from "ethers";
 
 import Big from "big.js";
 
@@ -35,8 +36,11 @@ export function daiTokenAddress(environment: ethereum.Environment): string {
   }
 }
 
-export function connect(signer: Signer, address: string): ERC20 {
-  return Erc20Factory.connect(address, signer);
+export function connect(
+  signerOrProvider: Signer | ethers.providers.Provider,
+  address: string
+): ERC20 {
+  return Erc20Factory.connect(address, signerOrProvider);
 }
 
 // Start watching an allowance on a given token.

--- a/ui/src/funding/pool.ts
+++ b/ui/src/funding/pool.ts
@@ -11,7 +11,7 @@ import * as daiToken from "./daiToken";
 import * as transaction from "../transaction";
 import * as validation from "../validation";
 
-import { Wallet, Account, Status as WalletStatus } from "../wallet";
+import { Wallet, Status as WalletStatus } from "../wallet";
 import * as remote from "../remote";
 import { toBaseUnit } from "../ethereum";
 
@@ -23,9 +23,6 @@ export const store = svelteStore.writable<Pool | null>(null);
 
 export interface Pool {
   data: remote.Store<PoolData>;
-
-  // Get the account that owns this pool.
-  getAccount: () => Account | undefined;
 
   // Onboard the user's pool with the intial values
   onboard(topUp: Big, weeklyBudget: Big, receivers: Receivers): Promise<void>;
@@ -106,19 +103,12 @@ export function make(wallet: Wallet): Pool {
     if (storedWallet.status !== WalletStatus.Connected) {
       return;
     }
-    const ethAddr = storedWallet.connected.account.address;
+    const ethAddr = storedWallet.connected.address;
     try {
       data.success(await watcher.poolData(ethAddr));
     } catch (error) {
       data.error(error);
     }
-  }
-
-  function getAccount(): Account | undefined {
-    const w = svelteStore.get(wallet);
-    return w.status === WalletStatus.Connected
-      ? w.connected.account
-      : undefined;
   }
 
   async function onboard(
@@ -202,7 +192,6 @@ export function make(wallet: Wallet): Pool {
 
   return {
     data,
-    getAccount,
     onboard,
     updateSettings,
     topUp,

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -284,7 +284,7 @@ async function fetchOrgs(): Promise<void> {
     });
   }
 
-  const orgs = await graph.getOrgs(w.connected.account.address);
+  const orgs = await graph.getOrgs(w.connected.address);
   const sortedOrgs = lodash.sortBy(orgs, org => org.timestamp);
   orgSidebarStore.set(sortedOrgs);
 }


### PR DESCRIPTION
We create a separate store for account balances instead of storing that information in the wallet state.

In addition to the decoupling yielding cleaner code it also fixes some bugs. Before, we retrieved the balances as part of `loadAccountData` which delayed updating the connection state. This lead to the UI only updating some time after we were connected. This also lead to some race conditions where a disconnect was overriden by a pending `loadAccountData` call.

In addition to this we also remove `formattedBalance` and inline it.