### PR TITLE
fix: correct radicle-contracts types

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "pure-svg-code": "^1.0.6",
     "qs": "^6.10.1",
     "radicle-avatar": "https://github.com/radicle-dev/radicle-avatar.git#commit=28033ef5a562aeb52c2e77c008021d27c3b24f4e",
-    "radicle-contracts": "github:radicle-dev/radicle-contracts#commit=752cf0767c6ba7428c626abf91ae1874de613f26",
+    "radicle-contracts": "github:radicle-dev/radicle-contracts#commit=157a5b59df94704702623765198deb4ba70ace84",
     "semver": "^7.3.5",
     "stream-browserify": "^3.0.0",
     "svelte-persistent-store": "^0.1.6",

--- a/ui/src/attestation/contract.ts
+++ b/ui/src/attestation/contract.ts
@@ -97,7 +97,7 @@ export class ClaimsContract {
     const listener = async (_: unknown, event: ethers.Event) => {
       getClaim.submit(event.transactionHash);
     };
-    await this.contract.on(filter, listener);
+    this.contract.on(filter, listener);
 
     const lastEvent = (await this.contract.queryFilter(filter)).pop();
     let claimed;
@@ -128,17 +128,16 @@ export class ClaimsContract {
     if (tx.from.toLowerCase() !== address.toLowerCase()) {
       throw new Error("Claim transaction sent by an invalid address");
     }
-    if (tx.to.toLowerCase() !== this.contract.address.toLowerCase()) {
+    if (tx.to?.toLowerCase() !== this.contract.address.toLowerCase()) {
       throw new Error("Claim transaction sent to an invalid contract");
     }
-    const [format, payloadRaw]: [ethers.BigNumberish, ethers.BytesLike] =
-      this.contract.interface.decodeFunctionData("claim", tx.data);
-    if (FORMAT_SHA1.eq(format) === false) {
+    const args = this.contract.interface.decodeFunctionData("claim", tx.data);
+    if (FORMAT_SHA1.eq(args[0]) === false) {
       throw new Error(
-        `Bad claim transaction payload format version ${format.toString()}`
+        `Bad claim transaction payload format version ${args[0].toString()}`
       );
     }
-    const payload = ethers.utils.arrayify(payloadRaw);
+    const payload = ethers.utils.arrayify(args[1]);
     if (payload.length !== FORMAT_SHA1_LENGTH) {
       throw new Error(`Bad claim transaction payload size ${payload.length}`);
     }

--- a/ui/src/funding/daiToken.ts
+++ b/ui/src/funding/daiToken.ts
@@ -52,10 +52,15 @@ async function watchDaiTokenAllowance(
   spender: string,
   onUpdated: (allowance: Big) => void
 ): Promise<() => void> {
-  // console.log("ERC20FILTERS " + JSON.stringify(token.eventstoken.events));
   const filter = token.filters.Approval(owner, spender);
-  const listener = (_owner: unknown, _spender: unknown, allowance: BigNumber) =>
+  const listener = (
+    _owner: string,
+    _spender: string,
+    allowance: BigNumber,
+    _event: unknown
+  ) => {
     onUpdated(Big(allowance.toString()));
+  };
   token.on(filter, listener);
   const allowance = await token.allowance(owner, spender);
   onUpdated(Big(allowance.toString()));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9762,15 +9762,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"radicle-contracts@github:radicle-dev/radicle-contracts#commit=752cf0767c6ba7428c626abf91ae1874de613f26":
+"radicle-contracts@github:radicle-dev/radicle-contracts#commit=157a5b59df94704702623765198deb4ba70ace84":
   version: 0.1.0
-  resolution: "radicle-contracts@https://github.com/radicle-dev/radicle-contracts.git#commit=752cf0767c6ba7428c626abf91ae1874de613f26"
+  resolution: "radicle-contracts@https://github.com/radicle-dev/radicle-contracts.git#commit=157a5b59df94704702623765198deb4ba70ace84"
   dependencies:
     "@ethersproject/abi": ^5.1.2
     "@ethersproject/bytes": ^5.1.0
     "@ethersproject/providers": ^5.1.2
     ethers: ^5.1.4
-  checksum: 4ac258434d0042bcbfec457301128b7a8f91006f0a42fb353463ceb395e42db808bb8e9da0e8c771f88646f96855d07b5b9bdc3062583645281e88ea6dc133d9
+  checksum: 852c25f9c61706eca29739af84d8ecf7833c6ae06b74a1d5e5948de0c56c9c826d6d1b695262eb4a22547610aa5e56a559400717ee3819ce4711d0a401923e00
   languageName: node
   linkType: hard
 
@@ -9844,7 +9844,7 @@ __metadata:
     pure-svg-code: ^1.0.6
     qs: ^6.10.1
     radicle-avatar: "https://github.com/radicle-dev/radicle-avatar.git#commit=28033ef5a562aeb52c2e77c008021d27c3b24f4e"
-    radicle-contracts: "github:radicle-dev/radicle-contracts#commit=752cf0767c6ba7428c626abf91ae1874de613f26"
+    radicle-contracts: "github:radicle-dev/radicle-contracts#commit=157a5b59df94704702623765198deb4ba70ace84"
     semver: ^7.3.5
     sinon: ^11.1.1
     spdx-expression-parse: ^3.0.1


### PR DESCRIPTION
We correct the all the radicle-contracts code that failed to type-check after the types were properly included in https://github.com/radicle-dev/radicle-contracts/pull/150.