### PR TITLE
fix: race condition when watching claim updates

### DIFF
--- a/ui/src/mutexExecutor.test.ts
+++ b/ui/src/mutexExecutor.test.ts
@@ -8,82 +8,117 @@ import * as mutexExecutor from "./mutexExecutor";
 import { sleep } from "./sleep";
 import * as sinon from "sinon";
 
-test("cancels running task", async () => {
-  const e = mutexExecutor.create();
+describe("executor", () => {
+  test("cancels running task", async () => {
+    const e = mutexExecutor.create();
 
-  const first = e.run(async () => {
-    await sleep(10);
-    return "first";
-  });
-  const second = e.run(async () => {
-    return "second";
+    const first = e.run(async () => {
+      await sleep(10);
+      return "first";
+    });
+    const second = e.run(async () => {
+      return "second";
+    });
+
+    expect(await first).toBe(undefined);
+    expect(await second).toBe("second");
+
+    const third = e.run(async () => {
+      await sleep(10);
+      return "third";
+    });
+    const fourth = e.run(async () => {
+      return "fourth";
+    });
+
+    expect(await third).toBe(undefined);
+    expect(await fourth).toBe("fourth");
   });
 
-  expect(await first).toBe(undefined);
-  expect(await second).toBe("second");
+  test("cancels multiple tasks", async () => {
+    const e = mutexExecutor.create();
 
-  const third = e.run(async () => {
-    await sleep(10);
-    return "third";
-  });
-  const fourth = e.run(async () => {
-    return "fourth";
+    const canceled1 = e.run(async () => {
+      await sleep(10);
+      return true;
+    });
+    const canceled2 = e.run(async () => {
+      await sleep(10);
+      return true;
+    });
+    const canceled3 = e.run(async () => {
+      await sleep(10);
+      return true;
+    });
+    const last = e.run(async () => {
+      return true;
+    });
+
+    expect(await canceled1).toBe(undefined);
+    expect(await canceled2).toBe(undefined);
+    expect(await canceled3).toBe(undefined);
+    expect(await last).toBe(true);
   });
 
-  expect(await third).toBe(undefined);
-  expect(await fourth).toBe("fourth");
+  test("triggers abort signal event", async () => {
+    const e = mutexExecutor.create();
+    const abortListener = sinon.spy();
+
+    e.run(async abort => {
+      abort.addEventListener("abort", abortListener);
+      await sleep(10);
+      return "first";
+    });
+    expect(abortListener.called).toBe(false);
+    e.run(async () => {});
+    expect(abortListener.called).toBe(true);
+  });
+
+  test("don’t throw error on aborted task", async () => {
+    const e = mutexExecutor.create();
+
+    const first = e.run(async () => {
+      await sleep(10);
+      throw new Error();
+    });
+    const second = e.run(async () => {
+      return "second";
+    });
+
+    expect(await first).toBe(undefined);
+    expect(await second).toBe("second");
+  });
 });
 
-test("cancels multiple tasks", async () => {
-  const e = mutexExecutor.create();
+describe("worker", () => {
+  test("sequential work", async () => {
+    const w = mutexExecutor.createWorker(async (value: number) => {
+      await sleep(10);
+      return value;
+    });
 
-  const canceled1 = e.run(async () => {
-    await sleep(10);
-    return true;
-  });
-  const canceled2 = e.run(async () => {
-    await sleep(10);
-    return true;
-  });
-  const canceled3 = e.run(async () => {
-    await sleep(10);
-    return true;
-  });
-  const last = e.run(async () => {
-    return true;
+    const outputs: number[] = [];
+    w.output.onValue(value => outputs.push(value));
+
+    await w.submit(1);
+    await w.submit(2);
+    await w.submit(3);
+
+    expect(outputs).toEqual([1, 2, 3]);
   });
 
-  expect(await canceled1).toBe(undefined);
-  expect(await canceled2).toBe(undefined);
-  expect(await canceled3).toBe(undefined);
-  expect(await last).toBe(true);
-});
+  test("overlapping work cancels", async () => {
+    const w = mutexExecutor.createWorker(async (value: number) => {
+      await sleep(10);
+      return value;
+    });
 
-test("triggers abort signal event", async () => {
-  const e = mutexExecutor.create();
-  const abortListener = sinon.spy();
+    const nextOutput = w.output.firstToPromise();
 
-  e.run(async abort => {
-    abort.addEventListener("abort", abortListener);
-    await sleep(10);
-    return "first";
+    w.submit(1);
+    w.submit(2);
+    w.submit(3);
+
+    expect(await nextOutput).toEqual(3);
   });
-  expect(abortListener.called).toBe(false);
-  e.run(async () => {});
-  expect(abortListener.called).toBe(true);
-});
-
-test("don’t throw error on aborted task", async () => {
-  const e = mutexExecutor.create();
-
-  const first = e.run(async () => {
-    await sleep(10);
-    throw new Error();
-  });
-  const second = e.run(async () => {
-    return "second";
-  });
-
-  expect(await first).toBe(undefined);
-  expect(await second).toBe("second");
 });

--- a/ui/src/mutexExecutor.ts
+++ b/ui/src/mutexExecutor.ts
@@ -4,17 +4,19 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
+import * as Bacon from "ui/src/bacon";
+
 // A task executor that runs only one task concurrently. If a new task
 // is run, any previously running task is aborted and the promise
 // returned from `run()` will return undefined.
 //
 //     import * as mutexExecutor from "ui/src/mutexExecutor"
 //     const executor = mutexExecutor.create()
-//     const first = executor.spwan(async () => {
+//     const first = await executor.run(async () => {
 //       await sleep(1000)
 //       return "first"
 //     })
-//     const second = executor.spwan(async () => "second")
+//     const second = await executor.run(async () => "second")
 //
 // In the example above the promise `first` will resolve to `undefined`
 // while the promise `second` will resolve to "second".
@@ -22,16 +24,38 @@
 // If the first tasks throws after the second task has run the
 // behavior is the same.
 //
-//     const first = executor.spwan(async () => {
+//     const first = await executor.run(async () => {
 //       await sleep(1000)
 //       throw new Error()
 //     })
 //
 // The task call back receives an AbortSignal as a parameter. The abort
 // event is emitted when another task is run.
-
 export function create(): MutexExecutor {
   return new MutexExecutor();
+}
+
+// A worker that asynchronously process one item at a time and provides
+// the result as an event stream.
+//
+//     import * as mutexExecutor from "ui/src/mutexExecutor"
+//     const worker = mutexExecutor.createWorker(async (value) => {
+//       await sleep(1000)
+//       return value
+//     })
+//
+//     const firstPromise = worker.output.firstToPromise()
+//     worker.push("first)
+//     assert.equal(await firstPromise, "first")
+//
+// When an item is submitted to the worker while the previous items is
+// still being processed, the result of the first item will not be
+// emitted to `worker.output`. Instead, only the last item will be
+// emitted.
+export function createWorker<In, Out>(
+  fn: (x: In, abortSignal: AbortSignal) => Promise<Out>
+): MutexWorker<In, Out> {
+  return new MutexWorker(fn);
 }
 
 class MutexExecutor {
@@ -64,5 +88,23 @@ class MutexExecutor {
         }
       }
     );
+  }
+}
+
+class MutexWorker<In, Out> {
+  private outputBus = new Bacon.Bus<Out>();
+  private executor = new MutexExecutor();
+
+  public output: Bacon.EventStream<Out>;
+
+  constructor(private fn: (x: In, abortSignal: AbortSignal) => Promise<Out>) {
+    this.output = this.outputBus.toEventStream();
+  }
+
+  async submit(x: In) {
+    const output = await this.executor.run(abort => this.fn(x, abort));
+    if (output !== undefined) {
+      this.outputBus.push(output);
+    }
   }
 }


### PR DESCRIPTION
We ensure that the `onClaimed` callback is called in the same order as the events that arrive. Before it was possible for `onClaimed` to be called for an event Y that occured _after_ the most recent event X _before_ `onClaimed` was called for `X`. This left the application in a state where the claim from `X` was considered more recent. This behavior was triggered by writing tests against a local Ethereum node.