### PR TITLE
fix: on invalid passphrase clear and refocus input

### DIFF
--- a/cypress/integration/lock.spec.ts
+++ b/cypress/integration/lock.spec.ts
@@ -19,12 +19,12 @@ context("lock screen", () => {
   });
 
   it("shows an error notification if the passphrase is wrong", () => {
-    commands.pick("unlock-button").should("exist");
+    commands.pick("passphrase-input").should("have.focus");
     commands.pick("passphrase-input").type("wrong-pw");
     commands.pick("unlock-button").click();
     cy.contains(/That’s the wrong passphrase./).should("exist");
-    commands.pick("passphrase-input").should("have.value", "wrong-pw");
-    commands.pick("unlock-button").should("not.be.disabled");
+    commands.pick("passphrase-input").should("have.value", "");
+    commands.pick("passphrase-input").should("have.focus");
   });
 
   it("routes to the profile page on successful unseal", () => {

--- a/ui/DesignSystem/PasswordInput.svelte
+++ b/ui/DesignSystem/PasswordInput.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
 
   import Icon from "./Icon";
   import KeyHint from "./KeyHint.svelte";
@@ -14,27 +14,35 @@
   import type { ValidationState } from "ui/src/validation";
   import { ValidationStatus } from "ui/src/validation";
 
-  export let style = "";
-  export let inputStyle = "";
-  export let placeholder = "";
   export let value = "";
-  export let dataCy = "";
+  export let style: string | undefined = undefined;
+  export let inputStyle: string | undefined = undefined;
+  export let placeholder: string | undefined = undefined;
+  export let dataCy: string | undefined = undefined;
   export let disabled: boolean = false;
-  export let inputElement: HTMLInputElement | undefined = undefined;
 
   export let validation: ValidationState | undefined = undefined;
   export let hint = "";
   export let spellcheck: boolean = false;
   export let autofocus: boolean = false;
 
+  export const focus = (): void => {
+    inputElement && inputElement.focus();
+  };
+
+  let inputElement: HTMLInputElement | undefined = undefined;
+
   const dispatch = createEventDispatcher();
 
   // Can't use normal `autofocus` attribute on the `input`:
   // "Autofocus processing was blocked because a document's URL has a fragment"
-  // preventScroll is necessary for onboarding animations to work.
-  $: if (autofocus) {
-    inputElement && inputElement.focus({ preventScroll: true });
-  }
+  onMount(() => {
+    console.log({ autofocus, inputElement });
+    if (autofocus && inputElement) {
+      // preventScroll is necessary for onboarding animations to work.
+      inputElement.focus({ preventScroll: true });
+    }
+  });
 
   const onKeydown = (event: KeyboardEvent) => {
     if (event.key === "Enter") {

--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -17,8 +17,8 @@
 
   const dispatch = createEventDispatcher();
 
-  let passphraseInput: HTMLInputElement;
-  let repeatedPassphraseInput: HTMLInputElement;
+  let passphraseInput: PasswordInput;
+  let repeatedPassphraseInput: PasswordInput;
   let passphrase = "";
   let repeatedPassphrase = "";
 
@@ -171,7 +171,7 @@
     </p>
 
     <PasswordInput
-      bind:inputElement={passphraseInput}
+      bind:this={passphraseInput}
       on:enter={() => {
         repeatedPassphraseInput.focus();
       }}
@@ -187,7 +187,7 @@
     <div class="repeat" hidden={!passphrase}>
       <p style="margin-bottom: 0.5rem;">And enter it again, just to be safe.</p>
       <PasswordInput
-        bind:inputElement={repeatedPassphraseInput}
+        bind:this={repeatedPassphraseInput}
         on:enter={next}
         dataCy="repeat-passphrase-input"
         placeholder="Repeat the secure passphrase"

--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -175,10 +175,10 @@ export const log = (error: Error): void => {
 };
 
 // Show an error notification and log the error to the console
-export const show = (error: Error): void => {
+export const show = (error: Error): notification.Handle => {
   log(error);
 
-  notification.error({
+  return notification.error({
     message: error.message,
     showIcon: true,
     persist: true,

--- a/ui/src/proxy/fetcher.ts
+++ b/ui/src/proxy/fetcher.ts
@@ -14,6 +14,11 @@ import qs from "qs";
 export class ResponseError extends Error {
   public response: Response;
   public body: unknown;
+
+  // The "variant" field of the response body, if present. This field
+  // is present in all proxy API errors.
+  public variant: string | undefined;
+
   constructor(response: Response, body_: unknown) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const body: any = body_;
@@ -25,6 +30,14 @@ export class ResponseError extends Error {
       super(body.message);
     } else {
       super("Response error");
+    }
+
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      typeof body.variant === "string"
+    ) {
+      this.variant = body.variant;
     }
 
     this.body = body_;

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -132,22 +132,20 @@ const fetchSession = async (): Promise<void> => {
 
 /**
  * Unseal the key store with the given passphrase and reload the
- * session. Returns `true` if unsealing was successful and `false`
- * otherwise.
+ * session. Returns `false` if the provided passphrase was incorrect.
  */
 export const unseal = async (passphrase: string): Promise<boolean> => {
   try {
     await proxy.client.keyStoreUnseal({ passphrase });
   } catch (err) {
-    error.show(
-      new error.Error({
-        code: error.Code.KeyStoreUnsealFailure,
-        message: `${err.message}`,
-        source: err,
-      })
-    );
-
-    return false;
+    if (
+      err instanceof proxy.ResponseError &&
+      err.variant === "INCORRECT_PASSPHRASE"
+    ) {
+      return false;
+    } else {
+      throw err;
+    }
   }
   sessionStore.loading();
   await fetchSession();


### PR DESCRIPTION
When the user types in an invalid passphrase we clear the input and refocus it.

Fixes #1179