### PR TITLE
ci: don’t build on preview agent anymore

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -22,11 +22,6 @@ steps:
   # Build everything but `master` and pull requests from forks
   - if: build.branch != "master" && build.pull_request.repository.fork != true
     <<: *test-linux
-  - branches: "master"
-    <<: *test-linux
-    label: "Test and package app on Linux (preview)"
-    agents:
-      queue: agent-preview
   - label: "Test and package app on macOS"
     if: |
       build.branch == 'master'


### PR DESCRIPTION
I shut down the preview agent because Monadic is not paying for it anymore. We can re-enable it once the team runs it again.