### PR TITLE
improvement-ui: Setting PeerId on Profile not expandable on hover

### DIFF
--- a/ui/Screen/Profile/ProfileHeader.svelte
+++ b/ui/Screen/Profile/ProfileHeader.svelte
@@ -37,6 +37,6 @@
     <h1 data-cy="entity-name" class="typo-overflow-ellipsis" title={name}>
       {name}
     </h1>
-    <PeerId truncate {peerId} style="margin-top: 0.5rem;" />
+    <PeerId truncate expandable={false} {peerId} style="margin-top: 0.5rem;" />
   </div>
 </div>


### PR DESCRIPTION
Signed-off-by: Nishit Prasad <prasad.nishit0@gmail.com>

This PR fixes #2068 
- [x] Set `expandable={false}` prop on PeerId component. (Based on the discussion in #2068 comments thread)

The change (GIF):
![ScreenRecord](https://user-images.githubusercontent.com/64563418/125894315-439d7770-a1e0-4a13-93b3-716de8d2fd55.gif)
