### PR TITLE
feature[ui]: #2142 show/hide passphrase button with (eye) icon below passphrase fields (in Lock screen & new user form)

### DIFF
--- a/ui/DesignSystem/PasswordInput.svelte
+++ b/ui/DesignSystem/PasswordInput.svelte
@@ -25,15 +25,10 @@
   export let hint = "";
   export let spellcheck: boolean = false;
   export let autofocus: boolean = false;
+  export let visible: boolean = false;
 
   export const focus = (): void => {
     inputElement && inputElement.focus();
-  };
-
-  export const setType = (type: string): void => {
-    if (inputElement) {
-      inputElement.type = type;
-    }
   };
 
   let inputElement: HTMLInputElement | undefined = undefined;
@@ -56,6 +51,10 @@
   };
 
   $: showHint = hint.length > 0 && value.length === 0;
+
+  $: if (inputElement) {
+    inputElement.type = visible ? "text" : "password";
+  }
 </script>
 
 <style>

--- a/ui/DesignSystem/PasswordInput.svelte
+++ b/ui/DesignSystem/PasswordInput.svelte
@@ -26,11 +26,12 @@
   export let spellcheck: boolean = false;
   export let autofocus: boolean = false;
 
-  let visible: boolean = false;
-  let highlightStyle: string = "";
-
   export const focus = (): void => {
     inputElement && inputElement.focus();
+  };
+
+  export const setType = (type: string): void => {
+    if (inputElement) {inputElement.type = type;}
   };
 
   let inputElement: HTMLInputElement | undefined = undefined;
@@ -51,15 +52,6 @@
       dispatch("enter");
     }
   };
-
-  const togglePasswordDisplay = () => {
-    visible = !visible;
-    if (inputElement) {inputElement.type = visible ? "text" : "password";}
-  };
-
-  const eyeIconHighlight = () =>
-    (highlightStyle = "fill: var(--color-foreground);");
-  const removeEyeIconHighlight = () => (highlightStyle = "");
 
   $: showHint = hint.length > 0 && value.length === 0;
 </script>
@@ -143,14 +135,6 @@
     top: 50%;
     transform: translateY(-50%);
   }
-
-  .the-eye-button {
-    cursor: pointer;
-    justify-content: flex-start;
-    position: absolute;
-    right: -2rem;
-    top: 20%;
-  }
 </style>
 
 <div {style} class="wrapper">
@@ -187,22 +171,5 @@
     <div class="hint">
       <KeyHint {hint} />
     </div>
-  {/if}
-
-  {#if value}
-    <button
-      class="the-eye-button"
-      on:mousedown={togglePasswordDisplay}
-      on:mouseover={eyeIconHighlight}
-      on:mouseout={removeEyeIconHighlight}
-      style={validation && validation.status === ValidationStatus.Error
-        ? "top: 10%;"
-        : ""}>
-      {#if visible}
-        <Icon.EyeClosed style={highlightStyle} />
-      {:else}
-        <Icon.EyeOpen style={highlightStyle} />
-      {/if}
-    </button>
   {/if}
 </div>

--- a/ui/DesignSystem/PasswordInput.svelte
+++ b/ui/DesignSystem/PasswordInput.svelte
@@ -26,6 +26,9 @@
   export let spellcheck: boolean = false;
   export let autofocus: boolean = false;
 
+  let visible: boolean = false;
+  let highlightStyle: string = "";
+
   export const focus = (): void => {
     inputElement && inputElement.focus();
   };
@@ -48,6 +51,15 @@
       dispatch("enter");
     }
   };
+
+  const togglePasswordDisplay = () => {
+    visible = !visible;
+    if (inputElement) {inputElement.type = visible ? "text" : "password";}
+  };
+
+  const eyeIconHighlight = () =>
+    (highlightStyle = "fill: var(--color-foreground);");
+  const removeEyeIconHighlight = () => (highlightStyle = "");
 
   $: showHint = hint.length > 0 && value.length === 0;
 </script>
@@ -131,6 +143,14 @@
     top: 50%;
     transform: translateY(-50%);
   }
+
+  .the-eye-button {
+    cursor: pointer;
+    justify-content: flex-start;
+    position: absolute;
+    right: -2rem;
+    top: 20%;
+  }
 </style>
 
 <div {style} class="wrapper">
@@ -167,5 +187,22 @@
     <div class="hint">
       <KeyHint {hint} />
     </div>
+  {/if}
+
+  {#if value}
+    <button
+      class="the-eye-button"
+      on:mousedown={togglePasswordDisplay}
+      on:mouseover={eyeIconHighlight}
+      on:mouseout={removeEyeIconHighlight}
+      style={validation && validation.status === ValidationStatus.Error
+        ? "top: 10%;"
+        : ""}>
+      {#if visible}
+        <Icon.EyeClosed style={highlightStyle} />
+      {:else}
+        <Icon.EyeOpen style={highlightStyle} />
+      {/if}
+    </button>
   {/if}
 </div>

--- a/ui/DesignSystem/PasswordInput.svelte
+++ b/ui/DesignSystem/PasswordInput.svelte
@@ -31,7 +31,9 @@
   };
 
   export const setType = (type: string): void => {
-    if (inputElement) {inputElement.type = type;}
+    if (inputElement) {
+      inputElement.type = type;
+    }
   };
 
   let inputElement: HTMLInputElement | undefined = undefined;
@@ -150,6 +152,7 @@
     on:change
     on:input
     on:keydown={onKeydown}
+    on:keypress
     bind:this={inputElement}
     {spellcheck}
     style={inputStyle} />

--- a/ui/Screen/Lock.svelte
+++ b/ui/Screen/Lock.svelte
@@ -58,6 +58,13 @@
     }
   };
 
+  const resetCheck = () => {
+    if (passphrase.length === 0) {
+      visible = false;
+      input.setType("password");
+    }
+  };
+
   const togglePassphraseDisplay = () => {
     visible = !visible;
     input.setType(visible ? "text" : "password");
@@ -105,6 +112,8 @@
       disabled={unlockInProgress}
       dataCy="passphrase-input"
       on:enter={onEnter}
+      on:change={resetCheck}
+      on:keypress={resetCheck}
       style="width: 20rem;" />
 
     <div class="buttons">

--- a/ui/Screen/Lock.svelte
+++ b/ui/Screen/Lock.svelte
@@ -61,13 +61,7 @@
   const resetCheck = () => {
     if (passphrase.length === 0) {
       visible = false;
-      input.setType("password");
     }
-  };
-
-  const togglePassphraseDisplay = () => {
-    visible = !visible;
-    input.setType(visible ? "text" : "password");
   };
 </script>
 
@@ -105,6 +99,7 @@
 
   <div class="form">
     <PasswordInput
+      {visible}
       bind:this={input}
       autofocus
       placeholder="Enter your passphrase"
@@ -122,7 +117,7 @@
         variant="transparent"
         style={passphrase.length === 0 ? "visibility:hidden;" : ""}
         icon={visible ? Icon.EyeClosed : Icon.EyeOpen}
-        on:click={togglePassphraseDisplay}>
+        on:click={() => (visible = !visible)}>
         {visible ? "Hide" : "Show"} Passphrase
       </Button>
       <Button

--- a/ui/Screen/Lock.svelte
+++ b/ui/Screen/Lock.svelte
@@ -12,11 +12,12 @@
   import * as error from "ui/src/error";
   import * as notification from "ui/src/notification";
 
-  import { Button, Emoji, PasswordInput } from "ui/DesignSystem";
+  import { Button, Emoji, Icon, PasswordInput } from "ui/DesignSystem";
 
   let passphrase = "";
   let unlockInProgress = false;
   let input: PasswordInput;
+  let visible: boolean = false;
 
   let errorNotificationHandle: notification.Handle | undefined;
 
@@ -56,6 +57,11 @@
       unlock();
     }
   };
+
+  const togglePassphraseDisplay = () => {
+    visible = !visible;
+    input.setType(visible ? "text" : "password");
+  };
 </script>
 
 <style>
@@ -72,7 +78,14 @@
   }
   .form {
     display: flex;
+    flex-direction: column;
+    justify-content: space-between;
     margin-top: 1.5rem;
+  }
+  .buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 1rem;
   }
 </style>
 
@@ -92,12 +105,23 @@
       disabled={unlockInProgress}
       dataCy="passphrase-input"
       on:enter={onEnter}
-      style="width: 16rem; margin-right: 1rem;" />
-    <Button
-      dataCy="unlock-button"
-      disabled={passphrase.length === 0 || unlockInProgress}
-      on:click={unlock}>
-      Unlock
-    </Button>
+      style="width: 20rem;" />
+
+    <div class="buttons">
+      <Button
+        dataCy={`${visible ? "hide" : "show"}-passphrase`}
+        variant="transparent"
+        style={passphrase.length === 0 ? "visibility:hidden;" : ""}
+        icon={visible ? Icon.EyeClosed : Icon.EyeOpen}
+        on:click={togglePassphraseDisplay}>
+        {visible ? "Hide" : "Show"} Passphrase
+      </Button>
+      <Button
+        dataCy="unlock-button"
+        disabled={passphrase.length === 0 || unlockInProgress}
+        on:click={unlock}>
+        Unlock
+      </Button>
+    </div>
   </div>
 </div>

--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -131,6 +131,14 @@
         }
     }
   };
+
+  const resetCheck = () => {
+    if (passphrase.length === 0) {
+      visible = false;
+      passphraseInput.setType("password");
+      repeatedPassphraseInput.setType("password");
+    }
+  };
 </script>
 
 <style>
@@ -201,6 +209,8 @@
       <PasswordInput
         bind:this={repeatedPassphraseInput}
         on:enter={next}
+        on:change={resetCheck}
+        on:keypress={resetCheck}
         dataCy="repeat-passphrase-input"
         placeholder="Repeat the secure passphrase"
         hint="↵"

--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -110,12 +110,6 @@
     }
   };
 
-  const togglePassphraseDisplay = () => {
-    visible = !visible;
-    passphraseInput.setType(visible ? "text" : "password");
-    repeatedPassphraseInput.setType(visible ? "text" : "password");
-  };
-
   const onKeydown = (event: KeyboardEvent) => {
     switch (event.code) {
       case "Enter":
@@ -135,8 +129,6 @@
   const resetCheck = () => {
     if (passphrase.length === 0) {
       visible = false;
-      passphraseInput.setType("password");
-      repeatedPassphraseInput.setType("password");
     }
   };
 </script>
@@ -195,6 +187,8 @@
       on:enter={() => {
         repeatedPassphraseInput.focus();
       }}
+      on:change={resetCheck}
+      on:keypress={resetCheck}
       autofocus={true}
       dataCy="passphrase-input"
       placeholder="Enter a secure passphrase"
@@ -202,6 +196,7 @@
       style="margin-top: 1.5rem;"
       validation={passphraseValidation}
       bind:value={passphrase}
+      {visible}
       {disabled} />
 
     <div class="repeat" hidden={!passphrase}>
@@ -216,6 +211,7 @@
         hint="↵"
         validation={repeatedPassphraseValidation}
         bind:value={repeatedPassphrase}
+        {visible}
         {disabled} />
     </div>
 
@@ -227,7 +223,7 @@
           passphrase.length === 0 ? "visibility:hidden;" : ""
         }`}
         icon={visible ? Icon.EyeClosed : Icon.EyeOpen}
-        on:click={togglePassphraseDisplay}>
+        on:click={() => (visible = !visible)}>
         {visible ? "Hide" : "Show"} Passphrase
       </Button>
       <div class="back-and-set-buttons">

--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -110,7 +110,7 @@
     }
   };
 
-  const togglePasswordDisplay = () => {
+  const togglePassphraseDisplay = () => {
     visible = !visible;
     passphraseInput.setType(visible ? "text" : "password");
     repeatedPassphraseInput.setType(visible ? "text" : "password");
@@ -211,12 +211,14 @@
 
     <div class="buttons">
       <Button
-        dataCy={`${visible ? "hide" : "show"}-password`}
+        dataCy={`${visible ? "hide" : "show"}-passphrase`}
         variant="transparent"
-        style="margin-right: 1rem;"
+        style={`margin-right: 1rem; ${
+          passphrase.length === 0 ? "visibility:hidden;" : ""
+        }`}
         icon={visible ? Icon.EyeClosed : Icon.EyeOpen}
-        on:click={togglePasswordDisplay}>
-        {visible ? "Hide" : "Show"} Password
+        on:click={togglePassphraseDisplay}>
+        {visible ? "Hide" : "Show"} Passphrase
       </Button>
       <div class="back-and-set-buttons">
         <Button

--- a/ui/Screen/Onboarding/EnterPassphrase.svelte
+++ b/ui/Screen/Onboarding/EnterPassphrase.svelte
@@ -11,7 +11,7 @@
   import { ValidationStatus, getValidationState } from "../../src/validation";
   import type { ValidationState } from "../../src/validation";
 
-  import { Button, PasswordInput } from "ui/DesignSystem";
+  import { Button, Icon, PasswordInput } from "ui/DesignSystem";
 
   export let disabled = false;
 
@@ -21,6 +21,7 @@
   let repeatedPassphraseInput: PasswordInput;
   let passphrase = "";
   let repeatedPassphrase = "";
+  let visible: boolean = false;
 
   let validations: { [key: string]: string[] } | false = false;
   let beginValidation = false;
@@ -109,6 +110,12 @@
     }
   };
 
+  const togglePasswordDisplay = () => {
+    visible = !visible;
+    passphraseInput.setType(visible ? "text" : "password");
+    repeatedPassphraseInput.setType(visible ? "text" : "password");
+  };
+
   const onKeydown = (event: KeyboardEvent) => {
     switch (event.code) {
       case "Enter":
@@ -146,8 +153,13 @@
 
   .buttons {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
     margin-top: 1.5rem;
+  }
+
+  .back-and-set-buttons {
+    display: flex;
+    justify-content: flex-end;
   }
 
   .repeat {
@@ -199,20 +211,30 @@
 
     <div class="buttons">
       <Button
-        dataCy="back-button"
+        dataCy={`${visible ? "hide" : "show"}-password`}
         variant="transparent"
         style="margin-right: 1rem;"
-        on:click={() => dispatch("previous")}
-        {disabled}>
-        Back
+        icon={visible ? Icon.EyeClosed : Icon.EyeOpen}
+        on:click={togglePasswordDisplay}>
+        {visible ? "Hide" : "Show"} Password
       </Button>
+      <div class="back-and-set-buttons">
+        <Button
+          dataCy="back-button"
+          variant="transparent"
+          style="margin-right: 1rem;"
+          on:click={() => dispatch("previous")}
+          {disabled}>
+          Back
+        </Button>
 
-      <Button
-        dataCy="set-passphrase-button"
-        disabled={!allowNext}
-        on:click={next}>
-        Set passphrase
-      </Button>
+        <Button
+          dataCy="set-passphrase-button"
+          disabled={!allowNext}
+          on:click={next}>
+          Set passphrase
+        </Button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR introduced feature as mentioned in #2142 

**Note:** PR description/content changed. Up-to-date based on several conversations (in this PR comment thread).

Changes (modified) satisfying as per the issue/feature requirements:
- [x] to have show/eye icon in a button at the bottom of passphrase input field(s).
- [x] the button with icon displays only when at least one character is entered.
- [x] when the button is clicked, the hidden characters are shown to the user. (toggle on/off)

Key changes:
- `<Icon.EyeClosed />` is rendered first. (implying to click it to show the password)
- `<Icon.EyeOpen />` is rendered when clicked. (implying to click it to hide the password)
- the above icons are wrapped around the `button`.

Additional changes made:
- [x] This button renders both on lock screen and on new user form.
- [x] Fixed the styling of [Unlock] button a bit to match the [mock](https://github.com/radicle-dev/radicle-upstream/pull/2145#issuecomment-883902601)
- [x] inserted `on:keypress` event inside `<PasswordInput />` component to support cut/paste/text-clear events for better UX.
- [x] This helps in one use case for example, when the input is cleared - the button will **reset** its state to [Show Password].

## New User Form
**Before:**
![ScreenRecord](https://user-images.githubusercontent.com/64563418/126070983-4a5f6dc8-6471-4a96-a39a-ff5c27c8f8af.gif)

**After:** 
![ScreenRecord1](https://user-images.githubusercontent.com/64563418/126538215-65f22cb8-cb45-4736-854e-c200cdd63826.gif)


## Lock Screen
**Before:**
![ScreenRecord3-1](https://user-images.githubusercontent.com/64563418/126538366-14661ce6-a30f-43c7-aa2a-ceade5bfef1d.gif)

**After:** 
![ScreenRecord3-1](https://user-images.githubusercontent.com/64563418/126545889-78aeb325-fc48-4128-a93a-5093989a9dd9.gif)
