### PR TITLE
fix(tests): forward `stdout` of test node to console

### DIFF
--- a/cypress/plugins/nodeManager/plugin.ts
+++ b/cypress/plugins/nodeManager/plugin.ts
@@ -146,7 +146,10 @@ class Node {
         "--skip-remote-helper-install",
         "--unsafe-fast-keystore",
       ],
-      { env: { ...global.process.env, RAD_HOME: this.radHome } }
+      {
+        env: { ...global.process.env, RAD_HOME: this.radHome },
+        stdio: ["ignore", "inherit", "pipe"],
+      }
     );
 
     process.on("exit", async () => {


### PR DESCRIPTION
We forward the `stdout` of nodes started by the tests to the terminal that cypress runs on. This ensures that it is visible.