### PR TITLE
refactor: consolidate org route loading

### DIFF
--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -140,7 +140,7 @@
       anchors={$activeRouteStore.anchors} />
   {:else if $activeRouteStore.type === "multiSigOrg"}
     <Org
-      activeTab={$activeRouteStore.activeTab}
+      activeTab={$activeRouteStore.view}
       address={$activeRouteStore.address}
       gnosisSafeAddress={$activeRouteStore.gnosisSafeAddress}
       threshold={$activeRouteStore.threshold}

--- a/ui/DesignSystem/Sidebar/OrgList.svelte
+++ b/ui/DesignSystem/Sidebar/OrgList.svelte
@@ -39,7 +39,7 @@
       <SidebarItem
         indicator={true}
         onClick={() =>
-          push({ type: "org", address: org.id, activeTab: "projects" })}
+          push({ type: "org", params: { address: org.id, view: "projects" } })}
         active={($activeRouteStore.type === "singleSigOrg" ||
           $activeRouteStore.type === "multiSigOrg") &&
           $activeRouteStore.address === org.id}>

--- a/ui/Screen/Org.svelte
+++ b/ui/Screen/Org.svelte
@@ -27,21 +27,22 @@
   import OrgHeader from "ui/Screen/Org/OrgHeader.svelte";
   import ProjectsMenu from "ui/Screen/Org/ProjectsMenu.svelte";
   import MembersMenu from "ui/Screen/Org/MembersMenu.svelte";
+  import type * as orgRoute from "./Org/route";
 
-  export let activeTab: router.LoadedOrgTab;
+  export let activeTab: orgRoute.MultiSigView;
   export let gnosisSafeAddress: string;
   export let address: string;
   export let members: org.Member[];
   export let threshold: number;
 
-  const tabs = (address: string, active: router.LoadedOrgTab) => {
+  const tabs = (address: string, active: orgRoute.MultiSigView) => {
     return [
       {
         title: "Anchored Projects",
         icon: Icon.ChevronLeftRight,
         active: active.type === "projects",
         onClick: () => {
-          router.push({ type: "org", activeTab: "projects", address });
+          router.push({ type: "org", params: { view: "projects", address } });
         },
       },
       {
@@ -50,7 +51,7 @@
         active: active.type === "members",
         counter: members.length,
         onClick: () => {
-          router.push({ type: "org", activeTab: "members", address });
+          router.push({ type: "org", params: { view: "members", address } });
         },
       },
     ];

--- a/ui/Screen/Org/route.ts
+++ b/ui/Screen/Org/route.ts
@@ -1,0 +1,97 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as org from "ui/src/org";
+import { unreachable } from "ui/src/unreachable";
+
+export interface Params {
+  address: string;
+  view: View;
+}
+
+export type View = "projects" | "members";
+
+export type LoadedRoute = SingleSigLoaded | MultiSigLoaded;
+
+export type MultiSigView =
+  | {
+      type: "projects";
+      anchors: org.OrgAnchors;
+      gnosisSafeAddress: string;
+      projectCount: number;
+    }
+  | {
+      type: "members";
+      threshold: number;
+      members: org.Member[];
+    };
+
+interface MultiSigLoaded {
+  type: "multiSigOrg";
+  address: string;
+  gnosisSafeAddress: string;
+  view: MultiSigView;
+  threshold: number;
+  members: org.Member[];
+}
+
+interface SingleSigLoaded {
+  type: "singleSigOrg";
+  address: string;
+  owner: string;
+  projectCount: number;
+  anchors: org.OrgAnchors;
+}
+
+export async function load(params: Params): Promise<LoadedRoute> {
+  const owner = await org.getOwner(params.address);
+  const projectCount = await org.getProjectCount();
+  const anchors = await org.resolveProjectAnchors(params.address, owner);
+
+  switch (owner.type) {
+    case "gnosis-safe": {
+      if (params.view === "projects") {
+        return {
+          type: "multiSigOrg",
+          address: params.address,
+          gnosisSafeAddress: owner.address,
+          members: owner.members,
+          threshold: owner.threshold,
+          view: {
+            type: "projects",
+            anchors,
+            gnosisSafeAddress: owner.address,
+            projectCount,
+          },
+        };
+      } else if (params.view === "members") {
+        return {
+          type: "multiSigOrg",
+          address: params.address,
+          gnosisSafeAddress: owner.address,
+          members: owner.members,
+          threshold: owner.threshold,
+          view: {
+            type: "members",
+            members: owner.members,
+            threshold: owner.threshold,
+          },
+        };
+      } else {
+        return unreachable(params.view);
+      }
+    }
+    case "wallet": {
+      return {
+        type: "singleSigOrg",
+        address: params.address,
+        owner: owner.address,
+        projectCount,
+        anchors,
+      };
+    }
+  }
+}

--- a/ui/Screen/SingleSigOrg.svelte
+++ b/ui/Screen/SingleSigOrg.svelte
@@ -38,7 +38,10 @@
         icon: Icon.ChevronLeftRight,
         active: true,
         onClick: () => {
-          router.push({ type: "org", address, activeTab: "projects" });
+          router.push({
+            type: "org",
+            params: { address, view: "projects" },
+          });
         },
       },
     ];

--- a/ui/src/org/contract.ts
+++ b/ui/src/org/contract.ts
@@ -161,7 +161,7 @@ function encodeAnchorData(
   return { encodedProjectUrn, encodedCommitHash };
 }
 
-interface AnchorData {
+export interface AnchorData {
   projectId: string;
   commitHash: string;
 }

--- a/ui/src/router/definition.ts
+++ b/ui/src/router/definition.ts
@@ -4,9 +4,7 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
-import { unreachable } from "ui/src/unreachable";
-
-import * as org from "ui/src/org";
+import * as org from "ui/Screen/Org/route";
 
 export type NetworkDiagnosticsTab = "peers" | "requests";
 export type ProfileTab = "projects" | "following";
@@ -23,7 +21,7 @@ export type Route =
   | { type: "designSystemGuide" }
   | { type: "lock" }
   | { type: "onboarding" }
-  | OrgRoute
+  | { type: "org"; params: org.Params }
   | { type: "profile"; activeTab: ProfileTab }
   | { type: "networkDiagnostics"; activeTab: NetworkDiagnosticsTab }
   | { type: "userProfile"; urn: string }
@@ -35,12 +33,6 @@ export type Route =
   | { type: "wallet"; activeTab: WalletTab }
   | { type: "network" }
   | { type: "settings" };
-
-interface OrgRoute {
-  type: "org";
-  address: string;
-  activeTab: OrgTab;
-}
 
 export type OrgTab = "projects" | "members";
 
@@ -49,7 +41,7 @@ export type LoadedRoute =
   | { type: "designSystemGuide" }
   | { type: "lock" }
   | { type: "onboarding" }
-  | OrgLoadedRoute
+  | org.LoadedRoute
   | { type: "profile"; activeTab: ProfileTab }
   | { type: "networkDiagnostics"; activeTab: NetworkDiagnosticsTab }
   | { type: "userProfile"; urn: string }
@@ -61,38 +53,6 @@ export type LoadedRoute =
   | { type: "wallet"; activeTab: WalletTab }
   | { type: "network" }
   | { type: "settings" };
-
-export type LoadedOrgTab =
-  | {
-      type: "projects";
-      anchors: org.OrgAnchors;
-      gnosisSafeAddress: string;
-      projectCount: number;
-    }
-  | {
-      type: "members";
-      threshold: number;
-      members: org.Member[];
-    };
-
-interface MultiSigOrgLoadedRoute {
-  type: "multiSigOrg";
-  address: string;
-  gnosisSafeAddress: string;
-  activeTab: LoadedOrgTab;
-  threshold: number;
-  members: org.Member[];
-}
-
-interface SingleSigOrgLoadedRoute {
-  type: "singleSigOrg";
-  address: string;
-  owner: string;
-  projectCount: number;
-  anchors: org.OrgAnchors;
-}
-
-type OrgLoadedRoute = SingleSigOrgLoadedRoute | MultiSigOrgLoadedRoute;
 
 export function routeToPath(route: Route): string {
   let subRoute = "";
@@ -109,75 +69,8 @@ export function routeToPath(route: Route): string {
 export async function loadRoute(route: Route): Promise<LoadedRoute> {
   switch (route.type) {
     case "org":
-      return loadOrgRoute(route);
+      return org.load(route.params);
     default:
       return route;
-  }
-}
-
-async function loadOrgRoute(route: OrgRoute): Promise<OrgLoadedRoute> {
-  const owner = await org.getOwner(route.address);
-  const isMultiSig = await org.isMultiSig(owner);
-
-  if (isMultiSig) {
-    if (route.activeTab === "projects") {
-      const [projectCount, { members, threshold }] = await Promise.all([
-        org.getProjectCount(),
-        org.fetchSafeMembers(owner),
-      ]);
-      const anchors = await org.resolveProjectAnchors({
-        orgAddress: route.address,
-        gnosisSafeAddress: owner,
-        members,
-        threshold,
-      });
-
-      return {
-        type: "multiSigOrg",
-        address: route.address,
-        gnosisSafeAddress: owner,
-        members,
-        threshold,
-        activeTab: {
-          type: "projects",
-          anchors,
-          gnosisSafeAddress: owner,
-          projectCount,
-        },
-      };
-    } else if (route.activeTab === "members") {
-      const { members, threshold } = await org.fetchSafeMembers(owner);
-      return {
-        type: "multiSigOrg",
-        address: route.address,
-        gnosisSafeAddress: owner,
-        members,
-        threshold,
-        activeTab: {
-          type: "members",
-          members,
-          threshold,
-        },
-      };
-    } else {
-      return unreachable(route.activeTab);
-    }
-  } else {
-    const projectCount = await org.getProjectCount();
-    const anchors = await org.resolveProjectAnchors({
-      orgAddress: route.address,
-      // TODO The data we pass in here only serves as dummy data that
-      // enriches the project anchor data
-      gnosisSafeAddress: owner,
-      members: [],
-      threshold: 0,
-    });
-    return {
-      type: "singleSigOrg",
-      address: route.address,
-      owner,
-      projectCount,
-      anchors,
-    };
   }
 }


### PR DESCRIPTION
* Instead of having much of the code that loads the org route in the global routing definition we move it to `src/Screen/Org/route.ts`.

* We introduce the org `Owner` type and remove `OrgWithSafe` to better represent owner information and to distinguish between the safe and an externally owned account.