### PR TITLE
refactor: consolidate cypress test config

### DIFF
--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -18,9 +18,13 @@ export const isNodeTestEnv = Boolean(
   globalThis.process && globalThis.process.env["NODE_ENV"] === "test"
 );
 
+// `true` if Upstream is tested with cypress.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isCypressTestEnv = (globalThis as any).isCypressTestEnv === true;
+
 // `true` if this code is run by the Cypress test driver.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isCypressTestEnv = Boolean((globalThis as any).cy);
+export const isCypressTestRunner = Boolean((globalThis as any).cy);
 
 // `true` if the app is running in development mode or in test mode
 export const isDev =

--- a/ui/src/ipc.ts
+++ b/ui/src/ipc.ts
@@ -41,7 +41,7 @@ export const getGitGlobalDefaultBranch = mainProcess.getGitGlobalDefaultBranch;
 export function listenProxyError(
   f: (proxyError: ipcTypes.ProxyError) => void
 ): void {
-  if (config.isNodeTestEnv || config.isCypressTestEnv) {
+  if (config.isNodeTestEnv || config.isCypressTestRunner) {
     return;
   }
 
@@ -59,7 +59,7 @@ export function listenProxyError(
 export function listenCustomProtocolInvocation(
   f: (customProtocolInvocation: ipcTypes.CustomProtocolInvocation) => void
 ): void {
-  if (config.isNodeTestEnv || config.isCypressTestEnv) {
+  if (config.isNodeTestEnv || config.isCypressTestRunner) {
     return;
   }
 

--- a/ui/src/updateChecker.ts
+++ b/ui/src/updateChecker.ts
@@ -13,6 +13,7 @@ import * as ipc from "./ipc";
 import * as modal from "./modal";
 import * as notification from "./notification";
 import * as session from "./session";
+import * as config from "ui/src/config";
 
 interface LatestVersionInfo {
   version: string;
@@ -25,16 +26,13 @@ const fetchLatestVersion = async (): Promise<LatestVersionInfo> => {
   return body;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isCypressTestEnv: boolean = (globalThis as any).isCypressTestEnv;
-
 // Check for new version every 30 minutes. In testing mode, check every
 // second.
-const VERSION_CHECK_INTERVAL = isCypressTestEnv ? 1000 : 30 * 60 * 1000;
+const VERSION_CHECK_INTERVAL = config.isCypressTestEnv ? 1000 : 30 * 60 * 1000;
 
 // Only notify about new version 14 days after the last notification.
 // In testing mode, check 5 seconds.
-const VERSION_NOTIFY_SILENCE_INTERVAL = isCypressTestEnv
+const VERSION_NOTIFY_SILENCE_INTERVAL = config.isCypressTestEnv
   ? 5000
   : 14 * 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
We move detection of the cypress test environment to `ui/src/config` so it can be reused. We also update the name of the similar configuration to better reflect what it does.