### PR TITLE
fix: use tracing for logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,11 +82,9 @@ dependencies = [
  "http",
  "kv",
  "lazy_static",
- "log",
  "nonempty 0.6.0",
  "percent-encoding",
  "pretty_assertions",
- "pretty_env_logger",
  "radicle-avatar",
  "radicle-daemon",
  "radicle-git-ext",
@@ -92,6 +99,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "warp",
 ]
@@ -210,17 +219,6 @@ name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "autocfg"
@@ -711,19 +709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,15 +1196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=276df21c303653c2fb0faa4ecc423f9ca573600e#276df21c303653c2fb0faa4ecc423f9ca573600e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=2fe2f9198ae1df5030917ae6b4e7614a2c075437#2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1569,6 +1545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2099,21 +2084,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "ctor",
  "difference",
  "output_vt100",
-]
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
-dependencies = [
- "chrono",
- "env_logger",
- "log",
 ]
 
 [[package]]
@@ -2156,12 +2130,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2220,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "radicle-daemon"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=276df21c303653c2fb0faa4ecc423f9ca573600e#276df21c303653c2fb0faa4ecc423f9ca573600e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=2fe2f9198ae1df5030917ae6b4e7614a2c075437#2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2230,7 +2198,6 @@ dependencies = [
  "kv",
  "lazy_static",
  "librad",
- "log",
  "nonempty 0.6.0",
  "radicle-git-ext",
  "radicle-git-helpers",
@@ -2238,12 +2205,13 @@ dependencies = [
  "serde_millis",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "radicle-data"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=276df21c303653c2fb0faa4ecc423f9ca573600e#276df21c303653c2fb0faa4ecc423f9ca573600e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=2fe2f9198ae1df5030917ae6b4e7614a2c075437#2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 dependencies = [
  "minicbor",
  "nonempty 0.6.0",
@@ -2254,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "radicle-git-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=276df21c303653c2fb0faa4ecc423f9ca573600e#276df21c303653c2fb0faa4ecc423f9ca573600e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=2fe2f9198ae1df5030917ae6b4e7614a2c075437#2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 dependencies = [
  "git2",
  "minicbor",
@@ -2269,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "radicle-git-helpers"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=276df21c303653c2fb0faa4ecc423f9ca573600e#276df21c303653c2fb0faa4ecc423f9ca573600e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=2fe2f9198ae1df5030917ae6b4e7614a2c075437#2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 dependencies = [
  "anyhow",
  "git2",
@@ -2302,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "radicle-macros"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=276df21c303653c2fb0faa4ecc423f9ca573600e#276df21c303653c2fb0faa4ecc423f9ca573600e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=2fe2f9198ae1df5030917ae6b4e7614a2c075437#2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 dependencies = [
  "quote",
  "radicle-git-ext",
@@ -2328,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "radicle-std-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?rev=276df21c303653c2fb0faa4ecc423f9ca573600e#276df21c303653c2fb0faa4ecc423f9ca573600e"
+source = "git+https://github.com/radicle-dev/radicle-link.git?rev=2fe2f9198ae1df5030917ae6b4e7614a2c075437#2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 
 [[package]]
 name = "radicle-surf"
@@ -2517,6 +2485,15 @@ checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -2821,6 +2798,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,15 +3035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3052,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -3254,6 +3240,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project 1.0.7",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/native/proxy-process-manager.ts
+++ b/native/proxy-process-manager.ts
@@ -6,6 +6,7 @@
 
 import { spawn, ChildProcess } from "child_process";
 import { CircularBuffer } from "mnemonist";
+import stripAnsi from "strip-ansi";
 
 export interface ProcessResult {
   status: number | null;
@@ -68,7 +69,7 @@ export class ProxyProcessManager {
       split[0] = stdoutBuf + split[0];
       stdoutBuf = split.pop() || "";
       for (const line of split) {
-        outputBuffer.push(line);
+        outputBuffer.push(stripAnsi(line));
       }
     });
 
@@ -84,7 +85,7 @@ export class ProxyProcessManager {
       split[0] = stderrBuf + split[0];
       stderrBuf = split.pop() || "";
       for (const line of split) {
-        outputBuffer.push(line);
+        outputBuffer.push(stripAnsi(line));
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "radicle-contracts": "github:radicle-dev/radicle-contracts#commit=157a5b59df94704702623765198deb4ba70ace84",
     "semver": "^7.3.5",
     "stream-browserify": "^3.0.0",
+    "strip-ansi": "^6.0.0",
     "svelte-persistent-store": "^0.1.6",
     "timeago.js": "^4.0.2",
     "twemoji": "13.1.0",

--- a/proxy/api/Cargo.toml
+++ b/proxy/api/Cargo.toml
@@ -28,10 +28,8 @@ either = "1"
 futures = { version = "0.3", features = [ "compat" ] }
 kv = { version = "0.22", features = [ "json-value" ] }
 lazy_static = "1.4"
-log = "0.4"
 nonempty = { version = "0.6", features = [ "serialize" ] }
 percent-encoding = "2.1"
-pretty_env_logger = "0.3"
 rand = "0.7"
 radicle-keystore = "0.1"
 serde = { version = "1.0", features = [ "derive" ] }
@@ -39,6 +37,8 @@ serde_json = "1.0"
 serde_qs = "0.6"
 secstr = { version = "0.3.2", features = [ "serde" ] }
 tempfile = "3.1"
+tracing = "0.1"
+tracing-subscriber = "0.2.19"
 thiserror = "1.0"
 tokio = { version = "1.2", features = [ "macros", "process", "signal", "time" ] }
 url = "2.1"
@@ -46,15 +46,15 @@ warp = { version = "0.3", default-features = false }
 
 [dependencies.radicle-daemon]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "276df21c303653c2fb0faa4ecc423f9ca573600e"
+rev = "2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 
 [dependencies.radicle-git-ext]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "276df21c303653c2fb0faa4ecc423f9ca573600e"
+rev = "2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 
 [dependencies.radicle-git-helpers]
 git = "https://github.com/radicle-dev/radicle-link.git"
-rev = "276df21c303653c2fb0faa4ecc423f9ca573600e"
+rev = "2fe2f9198ae1df5030917ae6b4e7614a2c075437"
 
 [dependencies.radicle-avatar]
 git = "https://github.com/radicle-dev/radicle-avatar.git"

--- a/proxy/api/src/bin/radicle-proxy.rs
+++ b/proxy/api/src/bin/radicle-proxy.rs
@@ -8,7 +8,17 @@
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     api::env::set_if_unset("RUST_BACKTRACE", "full");
     api::env::set_if_unset("RUST_LOG", "info,quinn=warn");
-    pretty_env_logger::init_timed();
+
+    let builder = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env());
+
+    match std::env::var("TRACING_FMT").as_deref() {
+        Ok("pretty") => builder.pretty().init(),
+        Ok("compact") => builder.compact().init(),
+        Ok("json") => builder.json().init(),
+        _ => builder.init(),
+    };
 
     api::run(argh::from_env()).await
 }

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -222,7 +222,7 @@ impl Unsealed {
             let peer_control = coco_peer.control();
             let run_handle = async move {
                 if let Err(err) = coco_peer.run().await {
-                    log::error!("peer run error: {:?}", err);
+                    tracing::error!(?err, "peer run error");
                 }
             };
             (peer_control, peer, run_handle)

--- a/proxy/api/src/control.rs
+++ b/proxy/api/src/control.rs
@@ -107,7 +107,7 @@ pub fn push_tags(
 
     match tags {
         None => {
-            log::debug!("No tags to push to remote");
+            tracing::debug!("No tags to push to remote");
             Ok(())
         },
         Some(tags) => {

--- a/proxy/api/src/git_helper.rs
+++ b/proxy/api/src/git_helper.rs
@@ -38,7 +38,7 @@ pub fn setup(src_dir: &path::Path, dst_dir: &path::Path) -> Result<(), Error> {
     permissions.set_mode(0o755);
     fs::set_permissions(&helper_bin_dst, permissions)?;
 
-    tracing::info!(destination = %helper_bin_dst, "copied git remote helper binary");
+    tracing::info!(destination = ?helper_bin_dst, "copied git remote helper binary");
 
     Ok(())
 }

--- a/proxy/api/src/git_helper.rs
+++ b/proxy/api/src/git_helper.rs
@@ -38,7 +38,7 @@ pub fn setup(src_dir: &path::Path, dst_dir: &path::Path) -> Result<(), Error> {
     permissions.set_mode(0o755);
     fs::set_permissions(&helper_bin_dst, permissions)?;
 
-    log::info!("Copied git remote helper to: {:?}", helper_bin_dst);
+    tracing::info!(destination = %helper_bin_dst, "copied git remote helper binary");
 
     Ok(())
 }

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -87,14 +87,13 @@ pub fn api(
             warp::http::Method::OPTIONS,
         ]);
     let log = warp::log::custom(|info| {
-        log::info!(
+        tracing::info!(
             target: "proxy::http",
-            "\"{} {} {:?}\" {} {:?}",
+            elapsed = ?info.elapsed(),
+            "{} {} {}",
             info.method(),
             info.path(),
-            info.version(),
             info.status().as_u16(),
-            info.elapsed(),
         );
     });
 

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -101,7 +101,7 @@ mod handler {
     /// Abort the server task, which causes `main` to restart it.
     #[allow(clippy::unused_async)]
     pub async fn reset(mut ctx: context::Context) -> Result<impl Reply, Rejection> {
-        log::warn!("reload requested");
+        tracing::info!("reload requested");
         ctx.service_handle().reset();
         Ok(reply::json(&()))
     }
@@ -109,7 +109,7 @@ mod handler {
     /// Seals the keystore.
     #[allow(clippy::unused_async)]
     pub async fn seal(mut ctx: context::Context) -> Result<impl Reply, Rejection> {
-        log::warn!("keystore seal requested");
+        tracing::info!("keystore seal requested");
         ctx.service_handle().seal();
         Ok(reply::with_status("keystore sealed", StatusCode::OK))
     }

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -82,7 +82,7 @@ fn recover_source(err: &radicle_source::error::Error) -> (StatusCode, &'static s
 /// Handler to convert [`error::Error`] to [`Error`] response.
 #[allow(clippy::too_many_lines, clippy::unused_async)]
 pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
-    log::error!("{:?}", err);
+    tracing::error!(?err, "request error");
 
     let (code, variant, message) = {
         if err.is_not_found() {

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -443,7 +443,7 @@ mod test {
 
     #[tokio::test]
     async fn create_new() -> Result<(), Box<dyn std::error::Error>> {
-        pretty_env_logger::init();
+        tracing_subscriber::fmt().with_test_writer();
         let tmp_dir = tempfile::tempdir()?;
         let repos_dir = tempfile::tempdir_in(tmp_dir.path())?;
         let dir = tempfile::tempdir_in(repos_dir.path())?;

--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -79,7 +79,7 @@ impl From<DaemonPerson> for Person {
         let ethereum = match person.payload().get_ext::<EthereumClaimExtV1>() {
             Ok(ext_opt) => ext_opt.map(Ethereum::from),
             Err(err) => {
-                log::warn!("Ethereum claim of user {} is malformed: {}", urn, err);
+                tracing::warn!(%urn, ?err, "Ethereum claim of user is malformed");
                 // Ignore the malformed extension payload, the identity itself is still valid
                 None
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9861,6 +9861,7 @@ __metadata:
     spdx-whitelisted: ^1.0.0
     standard-version: ^9.3.0
     stream-browserify: ^3.0.0
+    strip-ansi: ^6.0.0
     svelte: ^3.38.2
     svelte-check: ^2.1.0
     svelte-loader: ^3.1.1


### PR DESCRIPTION
We use the `tracing` and `tracing-subscriber` to do logging. This gives us nicer output and structured logs.

Includes https://github.com/radicle-dev/radicle-link/pull/727