### PR TITLE
feat: Naming orgs

### DIFF
--- a/scripts/license-header.ts
+++ b/scripts/license-header.ts
@@ -8,7 +8,7 @@
 
 import globby from "globby";
 import yargs from "yargs";
-import * as fs from "fs/promises";
+import { promises as fs } from "fs"
 import * as Path from "path";
 
 // Error that is shown without a stacktrace to the user

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,11 @@
   "exclude": ["native/bundle.js", "node_modules/*", "public/*"],
   "compilerOptions": {
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "target": "ES2018",
+    "target": "ES2020",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "module": "es6",
     /* Specify library files to be included in the compilation. */
-    "lib": ["dom", "es6", "es7"],
+    "lib": ["dom", "es6", "es7", "es2020"],
     /* Allow javascript files to be compiled. */
     "allowJs": true,
     /* Report errors in .js files. */

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -134,6 +134,7 @@
     <NetworkDiagnostics activeTab={$activeRouteStore.activeTab} />
   {:else if $activeRouteStore.type === "singleSigOrg"}
     <SingleSigOrg
+      registration={$activeRouteStore.registration}
       address={$activeRouteStore.address}
       owner={$activeRouteStore.owner}
       projectCount={$activeRouteStore.projectCount}

--- a/ui/DesignSystem/Avatar.svelte
+++ b/ui/DesignSystem/Avatar.svelte
@@ -144,7 +144,7 @@
 
 <div data-cy={dataCy} class={`container ${size}`} {style}>
   {#if imageUrl}
-    <img class={`image ${avatarClass}`} src={imageUrl} alt="user-avatar" />
+    <img class={`avatar ${avatarClass}`} src={imageUrl} alt="user-avatar" />
   {:else if avatarFallback}
     <div
       class={`avatar ${avatarClass}`}

--- a/ui/DesignSystem/Sidebar/OrgList.svelte
+++ b/ui/DesignSystem/Sidebar/OrgList.svelte
@@ -35,7 +35,7 @@
 
 {#if $wallet.status === Wallet.Status.Connected && ethereum.supportedNetwork($ethereumEnvironment) === $wallet.connected.network}
   {#each $orgSidebarStore as org (org.id)}
-    <Tooltip value={org.id}>
+    <Tooltip value={org.registration?.name || org.id}>
       <SidebarItem
         indicator={true}
         onClick={() =>
@@ -46,6 +46,7 @@
         <Avatar
           size="regular"
           variant="square"
+          imageUrl={org.registration?.avatar || undefined}
           avatarFallback={radicleAvatar.generate(
             org.id,
             radicleAvatar.Usage.Any

--- a/ui/DesignSystem/TextInput.svelte
+++ b/ui/DesignSystem/TextInput.svelte
@@ -10,7 +10,7 @@
   import Spinner from "./Spinner.svelte";
   import KeyHint from "./KeyHint.svelte";
 
-  import type { ValidationState } from "ui/src/validation";
+  import { ValidationState, ValidationStatus } from "ui/src/validation";
   import { ValidationStatus as Status } from "ui/src/validation";
 
   export let style = "";
@@ -19,11 +19,13 @@
   export let value = "";
   export let dataCy = "";
   export let disabled: boolean = false;
+  export let suffix: string = "";
   export let inputElement: HTMLInputElement | undefined = undefined;
 
   export let validation: ValidationState | undefined = undefined;
   export let validationStyle = "";
   export let hint = "";
+  export let label = "";
   export let showLeftItem: boolean = false;
   export let showSuccessCheck: boolean = false;
   export let spellcheck: boolean = false;
@@ -39,6 +41,8 @@
   }
 
   $: showHint = hint.length > 0 && value.length === 0;
+
+  $: inputOffset = `${label ? 36 : 0}px`;
 </script>
 
 <style>
@@ -79,6 +83,10 @@
 
   input.left-item {
     padding-left: 2.5rem;
+  }
+
+  .suffix {
+    color: var(--color-foreground-level-5);
   }
 
   input:focus,
@@ -129,9 +137,23 @@
     position: absolute;
     right: 0.75rem;
   }
+
+  .label {
+    text-align: left;
+    padding-left: 12px;
+    margin-bottom: 12px;
+  }
 </style>
 
 <div {style} class="wrapper">
+  {#if label}
+    <p
+      class="label typo-text-bold"
+      style="color: var(--color-foreground-level-6">
+      {label}
+    </p>
+  {/if}
+
   <div bind:clientHeight={inputHeight}>
     <input
       data-cy={dataCy}
@@ -163,25 +185,40 @@
     </div>
   {/if}
 
+  {#if suffix}
+    <p
+      style="position: absolute; top: calc(({inputHeight}px - 24px)/2); right: {validation?.status !==
+      ValidationStatus.NotStarted
+        ? '38px'
+        : '10px'};"
+      class="suffix">
+      {suffix}
+    </p>
+  {/if}
+
   {#if validation}
     {#if validation && validation.status === Status.Loading}
       <Spinner
-        style="justify-content: flex-start; position: absolute; height: 100%;
+        style="justify-content: flex-start; top: calc({inputOffset} - {label
+          ? '18px'
+          : '0px'}); position: absolute; height: 100%;
         right: 10px;" />
     {:else if validation && validation.status === Status.Success && showSuccessCheck}
       <Icon.CheckCircle
         style="fill: var(--color-positive); justify-content: flex-start;
-        position: absolute; top: calc(({inputHeight}px - 24px)/2); right: 10px;" />
+        position: absolute; top: calc({inputOffset} + ({inputHeight}px - 24px)/2); right: 10px;" />
     {:else if validation && validation.status === Status.Error}
       <Icon.ExclamationCircle
         dataCy="validation-error-icon"
         style="fill: var(--color-negative); justify-content: flex-start;
-        position: absolute; top: calc(({inputHeight}px - 24px)/2); right: 10px;" />
+        position: absolute; top: calc({inputOffset} + ({inputHeight}px - 24px)/2); right: 10px;" />
       <div class="validation-row" style={validationStyle}>
         <p>{validation.message}</p>
       </div>
     {:else if showHint}
-      <div class="hint" style={`top: calc((${inputHeight}px - 28px)/2)`}>
+      <div
+        class="hint"
+        style="top: calc({inputOffset} + ({inputHeight}px - 28px)/2)">
         <KeyHint {hint} />
       </div>
     {/if}

--- a/ui/Modal/EnsSetupFlow/EnsSetupFlow.svelte
+++ b/ui/Modal/EnsSetupFlow/EnsSetupFlow.svelte
@@ -1,0 +1,196 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import type { SvelteComponent } from "svelte";
+
+  import * as modal from "ui/src/modal";
+  import type {
+    EnsConfiguration,
+    EnsMetadataPayload,
+    SubmitPayload,
+  } from "./ens-flow.types";
+  import type { Registration } from "ui/src/org/ensResolver";
+  import Modal from "ui/DesignSystem/Modal.svelte";
+
+  import ConfirmEnsName from "./steps/ConfirmEnsName.svelte";
+  import EnsSetupFlowIntro from "./steps/EnsSetupFlowIntro.svelte";
+  import EnterEnsName from "./steps/EnterEnsName.svelte";
+  import WaitingToRegister from "./steps/WaitingToRegister";
+  import ConfirmRegistration from "./steps/ConfirmRegistration.svelte";
+  import RegistrationSuccess from "./steps/RegistrationSuccess.svelte";
+  import PopulateMetadata from "./steps/PopulateMetadata.svelte";
+  import UpdateMetadataSuccess from "./steps/UpdateMetadataSuccess.svelte";
+  import LinkOrgToName from "./steps/LinkOrgToName.svelte";
+  import LinkOrgToNameSuccess from "./steps/LinkOrgToNameSuccess.svelte";
+
+  export let orgAddress: string;
+  export let registration: Registration | undefined = undefined;
+
+  interface Step {
+    name: string;
+    component: typeof SvelteComponent;
+    onSubmit?: (payload: SubmitPayload) => void;
+  }
+
+  let ensConfiguration: Partial<EnsConfiguration> = {};
+
+  let ensMetadataConfiguration: Partial<EnsMetadataPayload> = {
+    ...registration,
+    address: orgAddress,
+  };
+
+  const createNameFlow: Step[] = [
+    {
+      name: "Intro",
+      component: EnsSetupFlowIntro,
+    },
+    {
+      name: "EnterName",
+      component: EnterEnsName,
+      onSubmit: (payload: SubmitPayload) => {
+        if (!payload.ensNameConfiguration) {
+          throw new Error(
+            "Expected EnterName step to return ensNameConfiguration"
+          );
+        }
+
+        ensConfiguration = {
+          ...ensConfiguration,
+          ...payload.ensNameConfiguration,
+        };
+
+        ensMetadataConfiguration = {
+          ...payload.ensMetadata,
+        };
+
+        if (ensConfiguration.registered) {
+          switchFlow(populateNameMetadataFlow);
+        } else {
+          goForward();
+        }
+      },
+    },
+    {
+      name: "ConfirmName",
+      component: ConfirmEnsName,
+      onSubmit: (payload: SubmitPayload) => {
+        if (!payload.ensNameConfiguration?.minAge) {
+          throw new Error(
+            "Expected ConfirmName step to return ensNameConfiguration with minAge"
+          );
+        }
+
+        ensConfiguration = {
+          ...ensConfiguration,
+          ...payload.ensNameConfiguration,
+        };
+
+        goForward();
+      },
+    },
+    {
+      name: "WaitingToRegister",
+      component: WaitingToRegister,
+    },
+    {
+      name: "ConfirmRegistration",
+      component: ConfirmRegistration,
+    },
+    {
+      name: "RegistrationSuccess",
+      component: RegistrationSuccess,
+      onSubmit: () => {
+        switchFlow(populateNameMetadataFlow);
+      },
+    },
+  ];
+
+  const populateNameMetadataFlow: Step[] = [
+    {
+      name: "PopulateMetadata",
+      component: PopulateMetadata,
+      onSubmit: (payload: SubmitPayload) => {
+        if (!payload.ensMetadata) {
+          throw new Error(
+            "Expected PopulateMetadata step to return ensMetadata"
+          );
+        }
+
+        ensMetadataConfiguration = {
+          ...payload.ensMetadata,
+        };
+
+        goForward();
+      },
+    },
+    {
+      name: "UpdateMetadataSuccess",
+      component: UpdateMetadataSuccess,
+      onSubmit: () => {
+        switchFlow(linkRegistrationFlowSingleSign);
+      },
+    },
+  ];
+
+  const linkRegistrationFlowSingleSign: Step[] = [
+    {
+      name: "LinkOrgToName",
+      component: LinkOrgToName,
+    },
+    {
+      name: "LinkOrgToNameSuccess",
+      component: LinkOrgToNameSuccess,
+    },
+  ];
+
+  const onSuccess = () => {
+    modal.hide();
+  };
+
+  let currentStepIndex = 0;
+
+  let currentFlow: Step[] = createNameFlow;
+
+  $: currentStep = currentFlow[currentStepIndex];
+
+  function goForward() {
+    if (currentFlow[currentStepIndex + 1]) {
+      currentStepIndex += 1;
+    } else {
+      onSuccess();
+    }
+  }
+
+  function goToStep(stepNumber: number) {
+    currentStepIndex = stepNumber;
+  }
+
+  function switchFlow(flow: Step[]) {
+    currentFlow = flow;
+    goToStep(0);
+  }
+</script>
+
+<style>
+  #ModalContent {
+    text-align: center;
+    position: relative;
+  }
+</style>
+
+<Modal>
+  <div id="ModalContent" style="position: relative">
+    <svelte:component
+      this={currentStep.component}
+      {ensConfiguration}
+      {ensMetadataConfiguration}
+      {registration}
+      {orgAddress}
+      onSubmit={currentStep.onSubmit || goForward} />
+  </div>
+</Modal>

--- a/ui/Modal/EnsSetupFlow/ens-flow.types.ts
+++ b/ui/Modal/EnsSetupFlow/ens-flow.types.ts
@@ -1,0 +1,25 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import type { BigNumber } from "ethers";
+import type { Registration } from "ui/src/org/ensResolver";
+export interface EnsConfiguration {
+  owner: string;
+  address: string;
+  name: string;
+  fee: BigNumber;
+  minAge: number;
+  commitmentBlock: number;
+  commitmentSalt: Uint8Array;
+  registered: boolean;
+}
+
+export interface SubmitPayload {
+  ensNameConfiguration?: Partial<EnsConfiguration>;
+  ensMetadata?: Partial<EnsMetadataPayload>;
+}
+
+export type EnsMetadataPayload = Registration;

--- a/ui/Modal/EnsSetupFlow/steps/ConfirmEnsName.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/ConfirmEnsName.svelte
@@ -1,0 +1,78 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import type { BigNumber } from "@ethersproject/bignumber";
+  import { ethers } from "ethers";
+  import type { EnsConfiguration, SubmitPayload } from "../ens-flow.types";
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+  import * as wallet from "ui/src/wallet";
+  import * as svelteStore from "ui/src/svelteStore";
+  import { commit } from "ui/src/org/ensRegistrar";
+
+  const walletStore = svelteStore.get(wallet.store);
+
+  export let onSubmit: (payload: SubmitPayload) => void = () => {};
+  export let ensConfiguration: EnsConfiguration;
+
+  let buttonsDisabled = false;
+  let confirmButtonCopy = "Begin registration";
+
+  function formatFee(fee: BigNumber) {
+    return ethers.utils.commify(
+      parseFloat(ethers.utils.formatUnits(fee)).toFixed(2)
+    );
+  }
+
+  async function handleSubmit() {
+    buttonsDisabled = true;
+    confirmButtonCopy = "Waiting for transaction confirmation...";
+
+    try {
+      const salt = ethers.utils.randomBytes(32);
+
+      const commitResult = await commit(
+        walletStore.environment,
+        ensConfiguration.name,
+        salt,
+        ensConfiguration.fee
+      );
+
+      onSubmit({
+        ensNameConfiguration: {
+          minAge: commitResult.minAge,
+          commitmentBlock: commitResult.receipt.blockNumber,
+          commitmentSalt: salt,
+        },
+      });
+    } catch (e) {
+      console.error(e);
+
+      buttonsDisabled = false;
+      confirmButtonCopy = "Begin registration";
+
+      throw new Error(
+        "Transaction failed. Please try again and confirm the signature & transaction in your connected wallet."
+      );
+    }
+  }
+</script>
+
+<div>
+  <HeadlineAndDescription
+    headline="Let’s name your organization"
+    description={`${
+      ensConfiguration.name
+    }.radicle.eth is available for registration for ${formatFee(
+      ensConfiguration.fee
+    )} RAD.`} />
+  <ButtonRow
+    disableButtons={buttonsDisabled}
+    confirmCopy={confirmButtonCopy}
+    onSubmit={handleSubmit} />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/ConfirmRegistration.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/ConfirmRegistration.svelte
@@ -1,0 +1,52 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import { register } from "ui/src/org/ensRegistrar";
+  import type { EnsConfiguration } from "../ens-flow.types";
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import * as wallet from "ui/src/wallet";
+  import * as svelteStore from "ui/src/svelteStore";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+
+  const walletStore = svelteStore.get(wallet.store);
+
+  let buttonsDisabled = false;
+  let confirmButtonCopy = "Confirm registration";
+
+  export let onSubmit: () => void = () => {};
+
+  async function handleSubmit() {
+    buttonsDisabled = true;
+    confirmButtonCopy = "Waiting for transaction confirmation...";
+
+    try {
+      const salt = ensConfiguration.commitmentSalt;
+
+      await register(walletStore.environment, ensConfiguration.name, salt);
+
+      onSubmit();
+    } catch (e) {
+      buttonsDisabled = false;
+      confirmButtonCopy = "Confirm registration";
+
+      throw e;
+    }
+  }
+
+  export let ensConfiguration: EnsConfiguration;
+</script>
+
+<div>
+  <HeadlineAndDescription
+    headline="Almost done"
+    description={`With this last transaction, you’re confirming the registration of your new ENS name ${ensConfiguration.name}.radicle.eth.`} />
+  <ButtonRow
+    disableButtons={buttonsDisabled}
+    onSubmit={handleSubmit}
+    confirmCopy={confirmButtonCopy} />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/EnsSetupFlowIntro.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/EnsSetupFlowIntro.svelte
@@ -1,0 +1,20 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+
+  export let onSubmit: () => void = () => {};
+</script>
+
+<div>
+  <HeadlineAndDescription
+    headline="Register your radicle.eth name"
+    description="Your radicle.eth ENS name allows linking your organization with a name, logo, URL and social media profiles." />
+  <ButtonRow {onSubmit} />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/LinkOrgToName.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/LinkOrgToName.svelte
@@ -1,0 +1,98 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import { onMount } from "svelte";
+
+  import Emoji from "ui/DesignSystem/Emoji.svelte";
+  import TextInput from "ui/DesignSystem/TextInput.svelte";
+  import { setName } from "ui/src/org";
+  import type { Registration } from "ui/src/org/ensResolver";
+
+  import type { EnsConfiguration, EnsMetadataPayload } from "../ens-flow.types";
+
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+
+  export let onSubmit: () => void = () => {};
+  export let registration: Registration | undefined = undefined;
+  export let ensConfiguration: EnsConfiguration;
+  export let ensMetadataConfiguration: EnsMetadataPayload;
+
+  let buttonsDisabled = false;
+  let submitButtonCopy = "Link organization to name";
+
+  onMount(() => {
+    /*
+    There's already a registration for the org, and that
+    registration has the same name as that entered in the name
+    entry step, so we can skip linking.
+    */
+    if (
+      registration &&
+      registration.name === `${ensConfiguration.name}.radicle.eth`
+    ) {
+      onSubmit();
+    }
+  });
+
+  // TODO: Implement this for a multisig org
+  async function handleSubmit() {
+    buttonsDisabled = true;
+    submitButtonCopy = "Waiting for transaction confirmation...";
+
+    if (!ensConfiguration.name || !ensMetadataConfiguration.address) {
+      throw new Error("Name or address undefined");
+    }
+    try {
+      await setName(
+        `${ensConfiguration.name}.radicle.eth`,
+        ensMetadataConfiguration.address
+      );
+
+      onSubmit();
+    } catch (e) {
+      buttonsDisabled = false;
+      submitButtonCopy = "Link organization to name";
+
+      throw e;
+    }
+  }
+</script>
+
+<div>
+  <Emoji emoji="🔗" size="huge" style="margin-bottom: 16px" />
+  <HeadlineAndDescription
+    headline="Let’s link your name"
+    style="margin-bottom: 24px"
+    description={`In this last step, we’re updating your organization to point towards your newly created name. Once that’s done, your organization will appear with your new name across Radicle!`} />
+
+  <TextInput
+    label="Organization address"
+    disabled
+    style="margin-bottom: 24px"
+    value={ensMetadataConfiguration.address || undefined} />
+
+  <TextInput
+    label="Name"
+    disabled
+    style="margin-bottom: 24px"
+    value={`${ensConfiguration.name}.radicle.eth`} />
+
+  <p
+    style="color: var(--color-foreground-level-5; margin: 16px 0;"
+    class="typo-text-small">
+    You can also do this later by selecting "Register ENS Name" and entering
+    your existing name.
+  </p>
+
+  <ButtonRow
+    disableButtons={buttonsDisabled}
+    onSubmit={handleSubmit}
+    canCancel={false}
+    confirmCopy={submitButtonCopy} />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/LinkOrgToNameSuccess.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/LinkOrgToNameSuccess.svelte
@@ -1,0 +1,27 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import Emoji from "ui/DesignSystem/Emoji.svelte";
+
+  import type { EnsConfiguration } from "../ens-flow.types";
+
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+
+  export let onSubmit: () => void = () => {};
+
+  export let ensConfiguration: EnsConfiguration;
+</script>
+
+<div>
+  <Emoji emoji="🎉" size="huge" style="margin-bottom: 16px" />
+  <HeadlineAndDescription
+    headline="That's it!"
+    description={`Great, your organization now points to your new name ${ensConfiguration.name}.radicle.eth. Shortly, your name will start appearing across Radicle in place of your organization address!`} />
+  <ButtonRow {onSubmit} canCancel={false} confirmCopy="Amazing, thanks!" />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/PopulateMetadata.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/PopulateMetadata.svelte
@@ -1,0 +1,240 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import { onMount } from "svelte";
+  import * as svelteStore from "ui/src/svelteStore";
+  import * as wallet from "ui/src/wallet";
+  import TextInput from "ui/DesignSystem/TextInput.svelte";
+  import Tooltip from "ui/DesignSystem/Tooltip.svelte";
+
+  import {
+    EnsRecord,
+    getRegistration,
+    Registration,
+    setRecords,
+  } from "ui/src/org/ensResolver";
+
+  import { CSSPosition } from "ui/src/style";
+  import { ValidationState, ValidationStatus } from "ui/src/validation";
+
+  import type {
+    EnsConfiguration,
+    EnsMetadataPayload,
+    SubmitPayload,
+  } from "../ens-flow.types";
+
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+
+  const walletStore = svelteStore.get(wallet.store);
+
+  export let onSubmit: (payload: SubmitPayload) => void = () => {};
+  export let ensMetadataConfiguration: EnsMetadataPayload | undefined;
+  export let ensConfiguration: EnsConfiguration | undefined;
+  export let orgAddress: string;
+
+  const name: string | undefined =
+    ensConfiguration?.name || ensMetadataConfiguration?.name || undefined;
+  const addressValue: string | undefined = orgAddress || undefined;
+  let urlValue: string | undefined;
+  let avatarValue: string | undefined;
+  let twitterValue: string | undefined;
+  let githubValue: string | undefined;
+
+  let buttonsDisabled = true;
+  let submitButtonCopy = "Update name metadata";
+
+  let validationStatus: ValidationState = {
+    status: ValidationStatus.Loading,
+  };
+
+  let addressValidationStatus: ValidationState = {
+    status: ValidationStatus.NotStarted,
+  };
+
+  let registration: Registration;
+
+  onMount(async () => {
+    if (!ensConfiguration?.name && !ensMetadataConfiguration?.name) {
+      throw new Error(
+        "Expected at least one of ensNameConfiguration or ensMetadataConfiguration props"
+      );
+    }
+
+    /*
+    When a name just got newly created, we need to fetch its ENS record
+    and create a resolver in order to be able to update it. If we're
+    editing an existing name, the resolver & rest of the registration are
+    already populated so we can skip fetching.
+    */
+    if (ensConfiguration && !ensMetadataConfiguration?.resolver) {
+      const registrationLookup = await getRegistration(
+        `${ensConfiguration.name}.radicle.eth`
+      );
+
+      if (!registrationLookup) {
+        throw new Error("Couldn't fetch registration");
+      }
+
+      registration = registrationLookup;
+    } else {
+      if (!ensMetadataConfiguration) {
+        throw new Error("Expected ensMetadataConfiguration to be populated");
+      }
+
+      registration = ensMetadataConfiguration;
+    }
+
+    if (registration.owner !== walletStore.getAddress()) {
+      throw new Error("You don't own this name.");
+    }
+
+    if (
+      registration.address &&
+      registration.address?.toLowerCase() !== addressValue?.toLowerCase()
+    ) {
+      addressValidationStatus = {
+        status: ValidationStatus.Error,
+        message: `This name is currently pointing to an organization with address ${registration.address}.
+          Updating metadata will overwrite the existing organization link for this name.`,
+      };
+    }
+
+    buttonsDisabled = false;
+    validationStatus = {
+      status: ValidationStatus.NotStarted,
+    };
+  });
+
+  // Update field values whenever these here change.
+  $: {
+    ensMetadataConfiguration;
+    ensConfiguration;
+    updateFields();
+  }
+
+  function updateFields() {
+    urlValue = ensMetadataConfiguration?.url || undefined;
+    avatarValue = ensMetadataConfiguration?.avatar || undefined;
+    twitterValue = ensMetadataConfiguration?.twitter || undefined;
+    githubValue = ensMetadataConfiguration?.github || undefined;
+  }
+
+  async function handleSubmit() {
+    if (!addressValue) {
+      throw new Error("Missing address field value");
+    }
+
+    if (!name) {
+      throw new Error("Name is undefined");
+    }
+
+    if (!registration.resolver) {
+      throw new Error("Missing ENS resolver");
+    }
+
+    buttonsDisabled = true;
+    submitButtonCopy = "Waiting for transaction confirmation...";
+
+    try {
+      let records: { name: keyof Registration; value: string | undefined }[] = [
+        { name: "address", value: addressValue },
+        { name: "url", value: urlValue },
+        { name: "avatar", value: avatarValue },
+        { name: "twitter", value: twitterValue },
+        { name: "github", value: githubValue },
+      ];
+
+      // Filter out unchanged records.
+      records = records.filter(r => {
+        if (!ensMetadataConfiguration) {
+          throw new Error("ensMetadataConfiguration is undefined");
+        }
+
+        const existingValue = ensMetadataConfiguration[r.name];
+
+        const normalizedExistingValue =
+          typeof existingValue === "string"
+            ? existingValue.toLowerCase()
+            : existingValue;
+
+        return r.value && normalizedExistingValue !== r.value.toLowerCase();
+      });
+
+      if (records.length > 0) {
+        await setRecords(name, registration.resolver, records as EnsRecord[]);
+      }
+
+      onSubmit({
+        ensMetadata: {
+          ...ensMetadataConfiguration,
+          address: addressValue,
+          url: urlValue,
+          avatar: avatarValue,
+          twitter: twitterValue,
+          github: githubValue,
+        },
+      });
+    } catch (e) {
+      buttonsDisabled = false;
+      submitButtonCopy = "Update name metadata";
+      throw e;
+    }
+  }
+</script>
+
+<div>
+  <HeadlineAndDescription
+    headline="Set your name's metadata"
+    description="This following information will be saved alongside your ENS name, and appears together with your organization across Radicle once linked. You can edit it any time by clicking “Edit name on the organization page."
+    style="margin-bottom: 24px" />
+
+  <Tooltip
+    value="This is the address of your organization and is required to link your ENS name to it."
+    position={CSSPosition.Top}>
+    <TextInput
+      label="Organization address"
+      style="margin-bottom: 24px"
+      disabled
+      value={addressValue}
+      validation={addressValidationStatus} />
+  </Tooltip>
+
+  <TextInput
+    label="Website URL"
+    style="margin-bottom: 24px"
+    placeholder="https://radicle.xyz/"
+    bind:value={urlValue}
+    validation={validationStatus} />
+
+  <TextInput
+    label="Avatar URL"
+    style="margin-bottom: 24px"
+    placeholder="https://radicle.xyz/logo.png"
+    bind:value={avatarValue}
+    validation={validationStatus} />
+
+  <TextInput
+    label="Twitter username"
+    style="margin-bottom: 24px"
+    placeholder="@radicle"
+    bind:value={twitterValue}
+    validation={validationStatus} />
+
+  <TextInput
+    label="GitHub username"
+    style="margin-bottom: 24px"
+    placeholder="radicle-dev"
+    bind:value={githubValue}
+    validation={validationStatus} />
+
+  <ButtonRow
+    disableButtons={buttonsDisabled}
+    confirmCopy={submitButtonCopy}
+    onSubmit={handleSubmit} />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/RegistrationSuccess.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/RegistrationSuccess.svelte
@@ -1,0 +1,36 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import Emoji from "ui/DesignSystem/Emoji.svelte";
+
+  import type { EnsConfiguration } from "../ens-flow.types";
+
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+
+  export let onSubmit: () => void = () => {};
+
+  export let ensConfiguration: EnsConfiguration;
+</script>
+
+<div>
+  <Emoji emoji="🎉" size="huge" style="margin-bottom: 16px" />
+  <HeadlineAndDescription
+    headline="Registration complete"
+    description={`Congratulations, ${ensConfiguration.name}.radicle.eth has successfully been registered with your wallet. Next, let's populate your name with organization metadata.`} />
+  <p
+    style="color: var(--color-foreground-level-5; margin: 16px 0;"
+    class="typo-text-small">
+    You can also do this later by selecting "Register ENS Name" and entering
+    your existing name.
+  </p>
+  <ButtonRow
+    {onSubmit}
+    cancelCopy="Do this later"
+    confirmCopy="Set organization metadata" />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/UpdateMetadataSuccess.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/UpdateMetadataSuccess.svelte
@@ -1,0 +1,27 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import Emoji from "ui/DesignSystem/Emoji.svelte";
+
+  import type { EnsConfiguration } from "../ens-flow.types";
+
+  import ButtonRow from "./shared/ButtonRow.svelte";
+  import HeadlineAndDescription from "./shared/HeadlineAndDescription.svelte";
+
+  export let onSubmit: () => void = () => {};
+
+  export let ensConfiguration: EnsConfiguration;
+</script>
+
+<div>
+  <Emoji emoji="🎉" size="huge" style="margin-bottom: 16px" />
+  <HeadlineAndDescription
+    headline="Metadata successfully updated"
+    description={`Great, your name ${ensConfiguration.name}.radicle.eth has successfully been updated with your supplied metadata.`} />
+  <ButtonRow {onSubmit} canCancel={false} confirmCopy="Continue" />
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/WaitingToRegister/WaitingToRegister.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/WaitingToRegister/WaitingToRegister.svelte
@@ -1,0 +1,26 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import type { EnsConfiguration } from "../../ens-flow.types";
+  import BlockTimer from "./components/BlockTimer.svelte";
+
+  export let onSubmit: () => void = () => {};
+  export let ensConfiguration: Partial<EnsConfiguration>;
+</script>
+
+<div style="color: var(--color-foreground-level-5);">
+  <BlockTimer
+    onFinish={onSubmit}
+    requiredBlocks={ensConfiguration.minAge}
+    startBlock={ensConfiguration.commitmentBlock} />
+  <h3 style="margin-top: 24px">Awaiting registration commitment...</h3>
+  <p style="margin: 24px 0">
+    This will take about one minute. The waiting period is required to ensure
+    another person hasn’t tried to register the same name.
+  </p>
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/WaitingToRegister/components/BlockTimer.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/WaitingToRegister/components/BlockTimer.svelte
@@ -1,0 +1,76 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import * as wallet from "ui/src/wallet";
+  import * as svelteStore from "ui/src/svelteStore";
+  import { onDestroy } from "svelte";
+
+  const walletStore = svelteStore.get(wallet.store);
+
+  export let requiredBlocks = 5;
+  export let startBlock: number = 0;
+  export let onFinish: () => void = () => {};
+
+  let strokeDashOffset: number = 300;
+
+  const needToReachBlock = startBlock + requiredBlocks;
+
+  const onBlock = (latestBlock: number) => {
+    // Adding one more block to required blocks here just to be safe.
+    const percentage = (needToReachBlock + 1 - latestBlock) / requiredBlocks;
+    strokeDashOffset = 300 * percentage;
+
+    if (needToReachBlock + 1 === latestBlock) {
+      onFinish();
+    }
+  };
+
+  walletStore.provider.on("block", onBlock);
+
+  onDestroy(() => {
+    walletStore.provider.off("block", onBlock);
+  });
+</script>
+
+<style>
+  .circle {
+    transition: stroke-dashoffset 1s;
+  }
+
+  .circleFront {
+    stroke: var(--color-primary);
+  }
+
+  .circleBack {
+    stroke: var(--color-primary-level-2);
+  }
+</style>
+
+<div id="wrapper">
+  <svg
+    width="96"
+    height="96"
+    viewBox="0 0 96 96"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <circle
+      style="stroke-dasharray: 300; stroke-dashoffset: {strokeDashOffset}; transform: rotate(-90deg); transform-origin: center;"
+      cx="48"
+      cy="48"
+      r="44"
+      class="circle circleFront"
+      stroke-linecap="round"
+      stroke-width="8" />
+    <circle
+      cx="48"
+      cy="48"
+      r="44"
+      class=".circle circleBack"
+      stroke-width="8" />
+  </svg>
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/WaitingToRegister/index.ts
+++ b/ui/Modal/EnsSetupFlow/steps/WaitingToRegister/index.ts
@@ -1,0 +1,7 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+export { default } from './WaitingToRegister.svelte';

--- a/ui/Modal/EnsSetupFlow/steps/shared/ButtonRow.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/shared/ButtonRow.svelte
@@ -1,0 +1,40 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import Button from "ui/DesignSystem/Button.svelte";
+  import * as modal from "ui/src/modal";
+
+  export let canCancel: boolean = true;
+  export let confirmCopy: string = "Confirm";
+  export let cancelCopy: string = "Cancel";
+  export let canSubmit: boolean = true;
+  export let disableButtons: boolean = false;
+  export let onSubmit: () => void = () => {};
+  export let onCancel: () => void = () => {
+    modal.hide();
+  };
+</script>
+
+<style>
+  #ButtonRow {
+    margin-top: 24px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>
+
+<div id="ButtonRow">
+  {#if canCancel}
+    <Button disabled={disableButtons} variant="transparent" on:click={onCancel}
+      >{cancelCopy}</Button>
+  {/if}
+  {#if canSubmit}
+    <Button disabled={disableButtons} on:click={onSubmit}>{confirmCopy}</Button>
+  {/if}
+</div>

--- a/ui/Modal/EnsSetupFlow/steps/shared/HeadlineAndDescription.svelte
+++ b/ui/Modal/EnsSetupFlow/steps/shared/HeadlineAndDescription.svelte
@@ -1,0 +1,28 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  export let headline: string;
+
+  export let description: string;
+  export let style: string = "";
+</script>
+
+<style>
+  h1 {
+    margin-bottom: 16px;
+  }
+
+  p {
+    color: var(--color-foreground-level-6);
+  }
+</style>
+
+<div {style}>
+  <h1>{headline}</h1>
+  <p>{description}</p>
+</div>

--- a/ui/Screen/Org/OrgHeader.svelte
+++ b/ui/Screen/Org/OrgHeader.svelte
@@ -8,12 +8,14 @@
 <script lang="typescript">
   import * as radicleAvatar from "radicle-avatar";
   import { Avatar, Icon } from "ui/DesignSystem";
+  import type { Registration } from "ui/src/org/ensResolver";
 
   import * as style from "ui/src/style";
 
   export let orgAddress: string;
   export let ownerAddress: string;
   export let threshold: number | undefined = undefined;
+  export let registration: Registration | undefined = undefined;
 </script>
 
 <style>
@@ -33,6 +35,10 @@
     gap: 0.5rem;
     margin-bottom: 0.5rem;
   }
+
+  .name-subdomain {
+    color: var(--color-foreground-level-4);
+  }
 </style>
 
 <div style="display: flex">
@@ -40,6 +46,7 @@
     style="margin-right: 2rem;"
     size="huge"
     variant="square"
+    imageUrl={registration?.avatar || undefined}
     avatarFallback={radicleAvatar.generate(
       orgAddress,
       radicleAvatar.Usage.Any
@@ -47,7 +54,12 @@
 
   <div class="metadata">
     <h1 data-cy="entity-name" class="typo-overflow-ellipsis name">
-      {style.ellipsed(orgAddress)}
+      {#if registration?.name}
+        {registration?.name.replace(".radicle.eth", "").trim()}
+        <span class="name-subdomain">.radicle.eth</span>
+      {:else}
+        {style.ellipsed(orgAddress)}
+      {/if}
     </h1>
     <div class="row">
       {#if threshold}
@@ -62,6 +74,12 @@
         <Icon.Orgs />
         {threshold}
         {threshold === 1 ? "signature" : "signatures"} required for quorum
+      </div>
+    {/if}
+    {#if registration?.url}
+      <div class="row">
+        <Icon.Globe />
+        <a href={registration.url}>{registration.url}</a>
       </div>
     {/if}
   </div>

--- a/ui/Screen/SingleSigOrg.svelte
+++ b/ui/Screen/SingleSigOrg.svelte
@@ -11,6 +11,7 @@
   import * as ipc from "ui/src/ipc";
   import * as notification from "ui/src/notification";
   import * as router from "ui/src/router";
+  import * as modal from "ui/src/modal";
 
   import {
     ActionBar,
@@ -25,11 +26,14 @@
   import ProjectsTab from "ui/Screen/Org/Projects.svelte";
   import OrgHeader from "ui/Screen/Org/OrgHeader.svelte";
   import ProjectsMenu from "ui/Screen/Org/ProjectsMenu.svelte";
+  import Stepper from "ui/Modal/EnsSetupFlow/EnsSetupFlow.svelte";
+  import type { Registration } from "ui/src/org/ensResolver";
 
   export let owner: string;
   export let address: string;
   export let projectCount: number;
   export let anchors: org.OrgAnchors;
+  export let registration: Registration | undefined = undefined;
 
   const tabs = (address: string) => {
     return [
@@ -64,9 +68,12 @@
       {
         title: "Register ENS name",
         icon: Icon.Ethereum,
-        disabled: true,
-        event: () => {},
-        tooltip: "Coming soon",
+        event: () => {
+          modal.toggle(Stepper, () => {}, {
+            orgAddress: address,
+            registration,
+          });
+        },
       },
     ];
   };
@@ -74,7 +81,11 @@
 
 <SidebarLayout>
   <Header>
-    <OrgHeader slot="left" orgAddress={address} ownerAddress={owner} />
+    <OrgHeader
+      {registration}
+      slot="left"
+      orgAddress={address}
+      ownerAddress={owner} />
     <div slot="right" style="display: flex">
       <FollowToggle following disabled style="margin-right: 1rem;" />
       <ThreeDotsMenu menuItems={menuItems(address)} />

--- a/ui/src/ethereum/walletConnectSigner.ts
+++ b/ui/src/ethereum/walletConnectSigner.ts
@@ -102,10 +102,12 @@ export class WalletConnectSigner extends ethers.Signer {
       data: bytesLikeToString(tx.data) || "",
       hash: txHash,
       confirmations: 1,
-      wait: () => {
-        throw new Error("this should never be called");
-      },
+      wait: () => this._provider.waitForTransaction(txHash),
     };
+  }
+
+  async signTypedData(params: unknown[]): Promise<string> {
+    return this.walletConnect.signTypedData(params);
   }
 
   async signTransaction(

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -40,7 +40,7 @@ export const show = (
 export const toggle = (
   modalComponent: typeof SvelteComponent,
   onHide: OnHide = doNothing,
-  modalComponentProps: unknown = {}
+  modalComponentProps: { [propName: string]: unknown } = {}
 ): void => {
   const stored = get(store);
 

--- a/ui/src/org/contract.ts
+++ b/ui/src/org/contract.ts
@@ -25,6 +25,7 @@ const orgFactoryAbi = [
 const orgAbi = [
   "function owner() view returns (address)",
   "function anchor(bytes32, uint32, bytes)",
+  "function setName(string, address) returns (bytes32)",
 ];
 
 function orgFactoryAddress(network: ethereum.Environment): string {
@@ -185,4 +186,18 @@ export function parseAnchorTx(data: string): AnchorData | undefined {
 
     return { projectId: projectId, commitHash: decodedCommitHash };
   }
+}
+
+export async function updateName(
+  name: string,
+  orgAddress: string,
+  provider: ethers.providers.Provider,
+  signer: ethers.Signer,
+): Promise<TransactionResponse> {
+  const org = new ethers.Contract(orgAddress, orgAbi, signer);
+
+  return org.setName(
+    name,
+    (await provider.getNetwork()).ensAddress,
+  );
 }

--- a/ui/src/org/ensRegistrar.ts
+++ b/ui/src/org/ensRegistrar.ts
@@ -1,0 +1,216 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as ethereum from "ui/src/ethereum";
+import * as error from "ui/src/error";
+import * as svelteStore from "ui/src/svelteStore";
+import * as wallet from "ui/src/wallet";
+import { BigNumber, ethers } from "ethers";
+import type { WalletConnectSigner } from "../ethereum/walletConnectSigner";
+
+import {
+  Registrar__factory,
+  RadicleToken__factory,
+} from "radicle-contracts/build/contract-bindings/ethers";
+
+const walletStore = svelteStore.get(wallet.store);
+
+function registrarAddress(network: ethereum.Environment): string {
+  switch (network) {
+    case ethereum.Environment.Local:
+      throw new error.Error({
+        code: error.Code.FeatureNotAvailableForGivenNetwork,
+        message: "ENS Registrar not available on the Local testnet",
+      });
+    case ethereum.Environment.Rinkeby:
+      return "0x80b68878442b6510D768Be1bd88712710B86eAcD";
+    case ethereum.Environment.Mainnet:
+      return "0x37723287Ae6F34866d82EE623401f92Ec9013154";
+  }
+}
+
+function registrar(
+  environment: ethereum.Environment,
+) {
+  return Registrar__factory.connect(registrarAddress(environment), walletStore.signer)
+}
+
+// TODO: Move RAD-related logic to its own file
+function radTokenAddress(network: ethereum.Environment): string {
+  switch (network) {
+    case ethereum.Environment.Local:
+      throw new error.Error({
+        code: error.Code.FeatureNotAvailableForGivenNetwork,
+        message: "ENS Registrar not available on the Local testnet",
+      });
+    case ethereum.Environment.Rinkeby:
+      return "0x7b6CbebC5646D996d258dcD4ca1d334B282e9948";
+    case ethereum.Environment.Mainnet:
+      return "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3";
+  }
+}
+
+function radToken(
+  environment: ethereum.Environment,
+) {
+  return RadicleToken__factory.connect(radTokenAddress(environment), walletStore.signer);
+}
+
+async function checkAvailability(
+  environment: ethereum.Environment,
+  signer: ethers.Signer,
+  name: string,
+): Promise<{
+  available: boolean,
+  fee: BigNumber,
+}> {
+  const r = registrar(environment);
+
+  const [available, fee] = await Promise.all([
+    r.available(name),
+    r.registrationFeeRad(),
+  ]);
+
+  return {
+    available,
+    fee
+  }
+}
+
+async function commit(
+  environment: ethereum.Environment,
+  name: string,
+  salt: Uint8Array,
+  fee: BigNumber,
+): Promise<{
+  receipt: ethers.providers.TransactionReceipt,
+  minAge: number,
+}> {
+  const signer = walletStore.signer;
+  const minAge = (await registrar(environment).minCommitmentAge()).toNumber();
+  const ownerAddr = walletStore.getAddress();
+  const spender = registrarAddress(environment);
+  const deadline = ethers.BigNumber.from(Math.floor(Date.now() / 1000)).add(3600); // Expire one hour from now.
+  const token = radToken(environment);
+  const signature = await permitSignature(walletStore.signer, token, spender, fee, deadline);
+
+  if (!ownerAddr) { throw new Error('Wallet not initialized'); }
+
+  const commitment = createCommitment(name, ownerAddr, salt);
+
+  // TODO: Once upstream wallet is aware of RAD balance, check if the user has enough rads before committing.
+
+  const tx = await registrar(environment)
+    .connect(signer)
+    .commitWithPermit(
+      commitment,
+      ownerAddr.toLowerCase(),
+      fee,
+      deadline,
+      signature.v,
+      signature.r,
+      signature.s
+    );
+
+  await tx.wait(1);
+
+  return {
+    receipt: await walletStore.provider.getTransactionReceipt(tx.hash),
+    minAge,
+  }
+}
+
+async function register(
+  environment: ethereum.Environment,
+  name: string,
+  salt: Uint8Array,
+): Promise<ethers.providers.TransactionReceipt> {
+  const signer = walletStore.signer;
+
+  const address = walletStore.getAddress()
+
+  if (!address) {
+    throw new Error('Wallet not initialized');
+  }
+
+  const tx = await registrar(environment)
+    .connect(signer)
+    .register(
+      name,
+      address,
+      ethers.BigNumber.from(salt),
+    );
+
+  await tx.wait();
+
+  return walletStore.provider.getTransactionReceipt(tx.hash);
+}
+
+async function permitSignature(
+  owner: WalletConnectSigner,
+  token: ethers.Contract,
+  spenderAddr: string,
+  value: ethers.BigNumberish,
+  deadline: ethers.BigNumberish,
+): Promise<ethers.Signature> {
+  const ownerAddr = (await owner.getAddress()).toLowerCase();
+  const nonce = await token.nonces(ownerAddr);
+  const chainId = (await walletStore.provider.getNetwork()).chainId;
+
+  const data = {
+    domain: {
+      name: await token.name(),
+      chainId,
+      verifyingContract: token.address,
+    },
+    primaryType: "Permit",
+    types: {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      Permit: [
+        { "name": "owner", "type": "address" },
+        { "name": "spender", "type": "address" },
+        { "name": "value", "type": "uint256" },
+        { "name": "nonce", "type": "uint256" },
+        { "name": "deadline", "type": "uint256" }
+      ]
+    },
+    message: {
+      "owner": ownerAddr.toLowerCase(),
+      "spender": spenderAddr.toLowerCase(),
+      "value": BigNumber.from(value).toString(),
+      "nonce": BigNumber.from(nonce).toString(),
+      "deadline": BigNumber.from(deadline).toString(),
+    }
+  };
+
+  const sig = await owner.walletConnect.signTypedData([ownerAddr, JSON.stringify(data)]);
+
+  return ethers.utils.splitSignature(sig);
+}
+
+function createCommitment(
+  name: string,
+  ownerAddress: string,
+  salt: Uint8Array
+): string {
+  const bytes = ethers.utils.concat([
+    ethers.utils.toUtf8Bytes(name),
+    ownerAddress,
+    ethers.BigNumber.from(salt).toHexString(),
+  ]);
+
+  return ethers.utils.keccak256(bytes);
+}
+
+export {
+  checkAvailability,
+  commit,
+  register,
+}

--- a/ui/src/org/ensResolver.ts
+++ b/ui/src/org/ensResolver.ts
@@ -1,0 +1,129 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import { ethers } from "ethers";
+import type { EnsResolver } from '@ethersproject/providers';
+import * as svelteStore from "ui/src/svelteStore";
+import * as wallet from "ui/src/wallet";
+import type { TransactionResponse } from "./contract";
+
+import {
+  ENS__factory
+} from "radicle-contracts/build/contract-bindings/ethers";
+
+const walletStore = svelteStore.get(wallet.store);
+
+const resolverAbi = [
+  "function multicall(bytes[] calldata data) returns(bytes[] memory results)",
+  "function setAddr(bytes32 node, address addr)",
+  "function setText(bytes32 node, string calldata key, string calldata value)"
+];
+
+export type EnsRecord = { name: string; value: string };
+
+async function setRecords(name: string, resolver: EnsResolver, records: EnsRecord[]): Promise<TransactionResponse> {
+  const resolverContract = new ethers.Contract(resolver.address, resolverAbi, walletStore.signer);
+  const node = ethers.utils.namehash(`${name}.radicle.eth`);
+
+  const calls = [];
+  const iface = new ethers.utils.Interface(resolverAbi);
+
+  for (const r of records) {
+    switch (r.name) {
+      case "address":
+        calls.push(
+          iface.encodeFunctionData("setAddr", [node, r.value])
+        );
+        break;
+      case "url":
+        calls.push(
+          iface.encodeFunctionData("setText", [node, r.name, r.value])
+        );
+        break;
+      case "avatar":
+        calls.push(
+          iface.encodeFunctionData("setText", [node, r.name, r.value])
+        );
+        break;
+      case "github":
+        calls.push(
+          iface.encodeFunctionData("setText", [node, r.name, r.value])
+        );
+        break;
+      case "twitter":
+        calls.push(
+          iface.encodeFunctionData("setText", [node, `vnd.${r.name}`, r.value])
+        );
+        break;
+      default:
+        console.error(`unknown field "${r.name}"`);
+    }
+  }
+  return resolverContract.multicall(calls);
+}
+
+export interface Registration {
+  name: string;
+  owner: string;
+  address: string | null;
+  url: string | null;
+  avatar: string | null;
+  twitter: string | null;
+  github: string | null;
+  resolver: EnsResolver;
+}
+
+async function getRegistration(name: string): Promise<Registration | null> {
+  const resolver = await walletStore.provider.getResolver(name);
+
+  if (!resolver) {
+    return null;
+  }
+
+  const owner = await getOwner(name);
+
+  const meta = await Promise.allSettled([
+    resolver.getAddress(),
+    resolver.getText('avatar'),
+    resolver.getText('url'),
+    resolver.getText('vnd.twitter'),
+    resolver.getText('vnd.github'),
+  ]);
+
+  const [address, avatar, url, twitter, github] =
+    meta.map((
+      value: PromiseSettledResult<string>
+    ) => value.status === "fulfilled" ? value.value : null);
+
+  return {
+    name,
+    url,
+    avatar,
+    owner,
+    address,
+    twitter,
+    github,
+    resolver,
+  };
+}
+
+async function getOwner(name: string): Promise<string> {
+  const ensAddr = (await walletStore.provider.getNetwork()).ensAddress;
+
+  if (!ensAddr) {
+    throw new Error("Missing ENS address for network");
+  }
+
+  const registry = ENS__factory.connect(ensAddr, walletStore.signer);
+  const owner = await registry.owner(ethers.utils.namehash(name));
+
+  return owner;
+}
+
+export {
+  getRegistration,
+  setRecords
+}

--- a/ui/src/org/theGraphApi.ts
+++ b/ui/src/org/theGraphApi.ts
@@ -15,6 +15,7 @@ import * as error from "ui/src/error";
 import * as ethereum from "ui/src/ethereum";
 import * as urn from "ui/src/urn";
 import * as wallet from "ui/src/wallet";
+import type { Registration } from "./ensResolver";
 
 function createApolloClient(uri: string): apolloCore.ApolloClient<unknown> {
   return new apolloCore.ApolloClient({
@@ -77,6 +78,7 @@ interface GnosisSafeWallet {
 export interface Org {
   id: string;
   owner: string;
+  registration?: Registration;
   creator: string;
   timestamp: number;
 }

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -44,8 +44,8 @@ export interface Wallet extends svelteStore.Readable<State> {
   environment: Environment;
   connect(): Promise<void>;
   disconnect(): Promise<void>;
-  provider: ethers.providers.Provider;
-  signer: ethers.Signer;
+  provider: ethers.providers.InfuraProvider | ethers.providers.JsonRpcProvider;
+  signer: WalletConnectSigner;
   // Returns the address of the wallet account if the wallet is
   // connected.
   getAddress(): string | undefined;
@@ -82,7 +82,7 @@ async function updateAccountBalances(
   }
 }
 
-function getProvider(environment: Environment): ethers.providers.Provider {
+function getProvider(environment: Environment): ethers.providers.InfuraProvider | ethers.providers.JsonRpcProvider {
   switch (environment) {
     case Environment.Local:
       return new ethers.providers.JsonRpcProvider("http://localhost:8545");
@@ -103,7 +103,7 @@ function getProvider(environment: Environment): ethers.providers.Provider {
 
 function build(
   environment: Environment,
-  provider: ethers.providers.Provider
+  provider: ethers.providers.InfuraProvider | ethers.providers.JsonRpcProvider
 ): Wallet {
   const stateStore = svelteStore.writable<State>({
     status: Status.NotConnected,
@@ -264,6 +264,7 @@ export const store: svelteStore.Readable<Wallet> = svelteStore.derived(
     ethereumDebug.install(provider);
 
     const wallet = build(environment, provider);
+
     set(wallet);
     return () => wallet.destroy();
   }


### PR DESCRIPTION
![Frame 876](https://user-images.githubusercontent.com/1018218/126983865-f24e17e6-4bec-4330-a513-ab9207fb6586.png)

This PR enables the registration of new and editing of existing ENS names, allowing users to link rich identities with org names, URLs, avatars & social profiles to their orgs. Users can also update an existing ENS name, link a name that they already own to an org, and re-link an already named org with another name.

## ToDo

### Usecases
- [ ] Support multi-sig orgs. This requires changes to the `LinkOrgToName` step and the succeeding success step's copy, and maybe also some kind of indicator on the multisig org page that indicates that an org link transaction is currently pending approval.
- [x] Register a new ENS name if the user enters a non-existing name.
- [x] Link a name that already points to another org to an org. This should display a warning.
- [x] If you enter a name that is already linked to the current org, just allow updating name metadata and skip the linking step.
- [x] If you enter a name you already own but that is not linked to another org, skip name creation and then allow setting the name's address value to the current org and linking the org to the name.

### Edge cases
- [x] Display an error if the entered name is already registered by someone else.
- [x] Display a warning if the entered name is currently already pointing to a different org.
- [x] After linking a name to a different org than before, ensure that the other org shows up without a name afterward.
- [x] Fetch registration and allow updating metadata when entering a name that has already been registered by the user previously.
- [x] Skip the organization link step when the organization is already linked to the entered name.
- [ ] It may be a good idea to fetch the image URL entered in the `populateMetadata` step and check against a max allowed filesize in order to prevent users setting massive images as their org avatar.
- [ ] Persist a commitment including name & salt in `localStorage` as soon as submitted in order to be able to resume it should the user lose connection or drop out after spending the RAD fee.

### UX & Design
- [x] Fix incorrect alignment of loading / validation error icons on `TextInput` when a label is set
- [x] Display avatar image on org page & sidebar
- [x] Display URL on org page if set
- [ ] Display social media links if set
- [ ] When an org already has a name, we probably want to show an "Edit or link other ENS name" button in the overflow menu instead of the current "Register ENS name" button.
- [ ] We probably want to show a list of any already registered .radicle.eth ENS names for the current user on the `enterName` step in addition to the text field for creating a new name.
- [ ] This PR introduces the first actual RAD transaction in upstream. Probably, it should be released together with adding support for RAD balance & transactions to the wallet page.
- [ ] When upstream is aware of RAD balance, it should check the available balance before starting the commitment in order to avoid the user spending a gas fee but then running into a failure because they don't have enough RADs to cover the name commitment fee.
- [ ] Introduce a way to retry a transaction / signature request (plus maybe a timeout?) in case WalletConnect acts funny and the registration confirmation prompt doesn't appear in the wallet. Currently the button just gets locked in "Waiting for confirmation..." and it's unclear how to retry.
- [ ] In the beginning, to create a new name, the user first needs to confirm a signature and then submit the commitment transaction. Currently, this is presented as a single step, but the UI should probably give feedback after the signature to ensure the user doesn't miss the second transaction prompt and wonder why nothing's happening.
- [ ] We should probably be upfront with the RAD fee required for name registration at the very beginning of the flow.
- [ ] Review & improve design of the steps. They currently look quite bland.

### Behind the scenes
- [ ] Don't fetch name data for each org as frequently as we do right now, as that causes way too many Infura calls.
- [ ] May want to improve state management on the `registerEnsNameFlow` component, as it's currently a bit all over the place.
- [x] Use auto-generated types and contract factories in `ensRegistrar.ts`.
- [ ] Refactor ensRegistrar.ts to not include any usecase-specific logic, instead only wrapping the registrar contract's functions. Move usecase-specific logic to the components that import registrar contract functions.