### PR TITLE
ci: bump github actions cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,9 +19,9 @@ jobs:
           path: |
             ~/cache/yarn
             ~/cache/cypress
-          key: build-${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
+          key: build-${{ runner.os }}-yarn-v2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            build-${{ runner.os }}-yarn-v1-
+            build-${{ runner.os }}-yarn-v2-
       - name: Cache Rust
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
We bump the version of the yarn cache on Github actions. The old cache was 1.3GiB in size because it held previous versions of Cypress.