### PR TITLE
fix: retry graph requests on 503

### DIFF
--- a/ui/src/org/theGraphApi.ts
+++ b/ui/src/org/theGraphApi.ts
@@ -211,13 +211,13 @@ export async function getOrgProjectAnchors(
   );
 }
 
-// Returns `true` if `err` is a 502 HTTP response error thrown by
-// requests to the Graph.
-export function is502Error(err: unknown): boolean {
+// Returns `true` if `err` is a 502 or 503 HTTP response error thrown
+// by requests to the Graph.
+export function isUnavailableError(err: unknown): boolean {
   return (
     err instanceof apolloCore.ApolloError &&
     err.networkError !== null &&
     "statusCode" in err.networkError &&
-    err.networkError.statusCode === 502
+    (err.networkError.statusCode === 502 || err.networkError.statusCode === 503)
   );
 }


### PR DESCRIPTION
We don’t show an error when the graph API returns a 503. This behavior mirrors that of the behavior on a 502.

Fixes #2183.