### PR TITLE
feat: integrate org ENS name registration

### DIFF
--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -122,12 +122,14 @@
     <NetworkDiagnostics activeTab={$activeRouteStore.activeTab} />
   {:else if $activeRouteStore.type === "singleSigOrg"}
     <SingleSigOrg
+      registration={$activeRouteStore.registration}
       address={$activeRouteStore.address}
       owner={$activeRouteStore.owner}
       projectCount={$activeRouteStore.projectCount}
       anchors={$activeRouteStore.anchors} />
   {:else if $activeRouteStore.type === "multiSigOrg"}
     <Org
+      registration={$activeRouteStore.registration}
       activeTab={$activeRouteStore.view}
       address={$activeRouteStore.address}
       gnosisSafeAddress={$activeRouteStore.gnosisSafeAddress}

--- a/ui/DesignSystem/Modal.svelte
+++ b/ui/DesignSystem/Modal.svelte
@@ -51,6 +51,9 @@
     gap: 1.5rem;
     justify-content: flex-end;
   }
+  h1 {
+    text-align: center;
+  }
 </style>
 
 <div class="container" data-cy={dataCy}>

--- a/ui/DesignSystem/ProjectAnchorPopover.svelte
+++ b/ui/DesignSystem/ProjectAnchorPopover.svelte
@@ -104,6 +104,7 @@
               size="small"
               style="margin: 0 0.5rem 0 0.5rem;"
               variant="square"
+              imageUrl={anchor.registration?.avatar || undefined}
               avatarFallback={radicleAvatar.generate(
                 anchor.orgAddress,
                 radicleAvatar.Usage.Any
@@ -111,7 +112,7 @@
             <p
               class="typo-text-bold org"
               style="color: var(--color-foreground-level-6);overflow: ellipsed">
-              {anchor.orgAddress}
+              {anchor.registration?.domain || anchor.orgAddress}
             </p>
           {/if}
         </div>

--- a/ui/DesignSystem/Sidebar/OrgList.svelte
+++ b/ui/DesignSystem/Sidebar/OrgList.svelte
@@ -35,7 +35,7 @@
 
 {#if $wallet.status === Wallet.Status.Connected && ethereum.supportedNetwork($ethereumEnvironment) === $wallet.connected.network}
   {#each $orgSidebarStore as org (org.id)}
-    <Tooltip value={org.id}>
+    <Tooltip value={org.registration?.domain || org.id}>
       <SidebarItem
         indicator={true}
         onClick={() =>
@@ -46,6 +46,7 @@
         <Avatar
           size="regular"
           variant="square"
+          imageUrl={org.registration?.avatar || undefined}
           avatarFallback={radicleAvatar.generate(
             org.id,
             radicleAvatar.Usage.Any

--- a/ui/Modal/Org/ConfigureEns.svelte
+++ b/ui/Modal/Org/ConfigureEns.svelte
@@ -1,0 +1,124 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import type * as ethers from "ethers";
+
+  import * as ensResolver from "ui/src/org/ensResolver";
+  import * as modal from "ui/src/modal";
+  import * as error from "ui/src/error";
+  import { unreachable } from "ui/src/unreachable";
+
+  import Intro from "./ConfigureEns/Intro.svelte";
+  import LinkOrgToName from "./ConfigureEns/LinkOrgToName.svelte";
+  import RegisterName from "./ConfigureEns/RegisterName.svelte";
+  import type * as registerName from "./ConfigureEns/RegisterName.svelte";
+  import UpdateMetadata from "./ConfigureEns/UpdateMetadata.svelte";
+
+  export let orgAddress: string;
+  export let registration: ensResolver.Registration | undefined = undefined;
+  export let safeAddress: string | undefined = undefined;
+  export let fee: ethers.BigNumber;
+
+  type State =
+    | { type: "intro" }
+    | { type: "registerName"; currentName: string | undefined }
+    | {
+        type: "updateMetadata";
+        registration: ensResolver.Registration;
+      }
+    | {
+        type: "linkOrgToName";
+        domain: string;
+      };
+
+  let state: State = ((): State => {
+    if (registration) {
+      const currentName = registration.domain.replace(
+        `.${ensResolver.DOMAIN}`,
+        ""
+      );
+      return { type: "registerName", currentName };
+    } else {
+      return { type: "intro" };
+    }
+  })();
+
+  async function registrationDone(result: registerName.Result) {
+    let registration: ensResolver.Registration | undefined;
+
+    if (result.registration) {
+      registration = result.registration;
+    } else {
+      const domain = `${result.name}.${ensResolver.DOMAIN}`;
+      // TODO(thomas): handle exception
+      registration = await ensResolver.getRegistration(domain);
+
+      if (!registration) {
+        throw new error.Error({
+          message: "Domain not registered",
+          details: { domain },
+        });
+      }
+    }
+
+    state = {
+      type: "updateMetadata",
+      registration,
+    };
+  }
+
+  function introDone() {
+    const currentName = registration?.domain.replace(
+      `.${ensResolver.DOMAIN}`,
+      ""
+    );
+
+    state = {
+      type: "registerName",
+      currentName,
+    };
+  }
+
+  function bindUpdateMetadataDone(domain: string) {
+    return () => {
+      // Don't show linkOrgToName step if it is already linked.
+      if (registration?.address?.toLowerCase() === orgAddress.toLowerCase()) {
+        modal.hide();
+        return;
+      }
+
+      state = {
+        type: "linkOrgToName",
+        domain,
+      };
+    };
+  }
+
+  function linkOrgToNameDone() {
+    modal.hide();
+  }
+</script>
+
+{#if state.type === "intro"}
+  <Intro onSubmit={introDone} {fee} />
+{:else if state.type === "registerName"}
+  <RegisterName currentName={state.currentName} {fee} {registrationDone} />
+{:else if state.type === "updateMetadata"}
+  <UpdateMetadata
+    {orgAddress}
+    registration={state.registration}
+    onSubmit={bindUpdateMetadataDone(state.registration.domain)} />
+{:else if state.type === "linkOrgToName"}
+  <LinkOrgToName
+    domain={state.domain}
+    {orgAddress}
+    {safeAddress}
+    onSubmit={linkOrgToNameDone} />
+{:else}
+  {unreachable(state)}
+{/if}

--- a/ui/Modal/Org/ConfigureEns/BlockTimer.svelte
+++ b/ui/Modal/Org/ConfigureEns/BlockTimer.svelte
@@ -1,0 +1,54 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import { onDestroy } from "svelte";
+
+  import * as svelteStore from "ui/src/svelteStore";
+  import * as wallet from "ui/src/wallet";
+
+  export let commitmentBlock: number;
+  export let minimumCommitmentAge: number;
+  export let onFinish: () => void;
+
+  const walletStore = svelteStore.get(wallet.store);
+
+  // There seems to be an off-by-one error in the contract, because if we don't
+  // wait for that one extra block we get an error saying that the commitment
+  // isn't old enough.
+  const requiredBlockCount = minimumCommitmentAge + 1;
+  let confirmedBlockCount: number = 0;
+
+  const onBlock = (currentBlock: number) => {
+    confirmedBlockCount = currentBlock - commitmentBlock;
+
+    if (confirmedBlockCount >= requiredBlockCount) {
+      onFinish();
+      walletStore.provider.off("block", onBlock);
+      // When we resume a saved commitment, it can happen that more blocks have
+      // been included than the minimum required amount in the mean time.
+      // We don't want to overflow the counter that we show to the user.
+      confirmedBlockCount = requiredBlockCount;
+    }
+  };
+
+  walletStore.provider.on("block", onBlock);
+
+  onDestroy(() => {
+    walletStore.provider.off("block", onBlock);
+  });
+</script>
+
+<style>
+  p {
+    color: var(--color-foreground-level-6);
+  }
+</style>
+
+<p class="typo-text-bold">
+  Confirmed {confirmedBlockCount} out of {requiredBlockCount} blocks.
+</p>

--- a/ui/Modal/Org/ConfigureEns/ConfirmRegistration.svelte
+++ b/ui/Modal/Org/ConfigureEns/ConfirmRegistration.svelte
@@ -1,0 +1,117 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import type * as registerName from "./RegisterName.svelte";
+
+  import * as ensRegistrar from "ui/src/org/ensRegistrar";
+  import * as ensResolver from "ui/src/org/ensResolver";
+  import * as error from "ui/src/error";
+  import * as modal from "ui/src/modal";
+  import * as notification from "ui/src/notification";
+  import * as transaction from "ui/src/transaction";
+
+  import { Button, Modal } from "ui/DesignSystem";
+
+  import BlockTimer from "./BlockTimer.svelte";
+
+  let confirmButtonDisabled = true;
+
+  export let commitment: ensRegistrar.Commitment;
+  export let commitmentBlock: number;
+  export let registrationDone: (result: registerName.Result) => void;
+
+  async function register() {
+    confirmButtonDisabled = true;
+
+    const registrationNotification = notification.info({
+      message:
+        "Waiting for you to confirm the registration transaction in your connected wallet",
+      showIcon: true,
+      persist: true,
+    });
+
+    let registrationTx: transaction.ContractTransaction;
+    try {
+      registrationTx = await ensRegistrar.register(
+        commitment.name,
+        commitment.salt
+      );
+    } catch (err) {
+      confirmButtonDisabled = false;
+
+      error.show(
+        new error.Error({
+          message: err.message,
+          source: err,
+        })
+      );
+      // Don't advance flow if the user rejected the tx.
+      return;
+    } finally {
+      registrationNotification.remove();
+    }
+    ensRegistrar.clearCommitment();
+
+    transaction.add(transaction.registerEnsName(registrationTx));
+
+    const txNotification = notification.info({
+      message: "Waiting for the transaction to be included",
+      showIcon: true,
+      persist: true,
+    });
+
+    try {
+      await registrationTx.wait(1);
+    } catch (err) {
+      confirmButtonDisabled = false;
+
+      error.show(
+        new error.Error({
+          message: err.message,
+          source: err,
+        })
+      );
+      // Don't advance flow unless we have the tx receipt.
+      return;
+    } finally {
+      txNotification.remove();
+    }
+
+    notification.info({
+      message: `${commitment.name}.${ensResolver.DOMAIN} has been registered with your wallet`,
+      showIcon: true,
+    });
+    registrationDone({ name: commitment.name, registration: undefined });
+  }
+</script>
+
+<Modal emoji="📇" title="Awaiting registration commitment">
+  <svelte:fragment slot="description">
+    The waiting period is required to ensure another person hasn’t tried to
+    register the same name.
+  </svelte:fragment>
+
+  <div style="display: flex; justify-content: center;">
+    <BlockTimer
+      onFinish={() => {
+        confirmButtonDisabled = false;
+      }}
+      {commitmentBlock}
+      minimumCommitmentAge={commitment.minimumCommitmentAge} />
+  </div>
+
+  <svelte:fragment slot="buttons">
+    <Button
+      variant="transparent"
+      on:click={() => {
+        modal.hide();
+      }}>Cancel</Button>
+    <Button on:click={register} disabled={confirmButtonDisabled}
+      >Confirm registration</Button>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Org/ConfigureEns/Intro.svelte
+++ b/ui/Modal/Org/ConfigureEns/Intro.svelte
@@ -1,0 +1,44 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import type * as ethers from "ethers";
+
+  import * as ethereum from "ui/src/ethereum";
+  import * as ipc from "ui/src/ipc";
+  import * as modal from "ui/src/modal";
+
+  import { Button, Modal } from "ui/DesignSystem";
+
+  export let fee: ethers.BigNumber;
+  export let onSubmit: () => void;
+</script>
+
+<Modal emoji="📇" title={`Register your ENS name`}>
+  <svelte:fragment slot="description">
+    Your ENS name allows linking your org with a name, logo, URL and social
+    media profiles. The registration costs {ethereum.formatTokenAmount(fee)}
+    RAD, and you'll also need sufficient ETH to cover transaction costs.
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
+      class="typo-link"
+      on:click={() => {
+        ipc.openUrl("http://radicle.xyz/buy-rad.html");
+      }}>
+      Buy RAD
+    </a>
+  </svelte:fragment>
+
+  <svelte:fragment slot="buttons">
+    <Button
+      variant="transparent"
+      on:click={() => {
+        modal.hide();
+      }}>Cancel</Button>
+    <Button on:click={onSubmit}>Let’s go</Button>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
+++ b/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
@@ -1,0 +1,155 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import * as configureEns from "ui/src/org/configureEns";
+  import * as error from "ui/src/error";
+  import * as modal from "ui/src/modal";
+  import * as notification from "ui/src/notification";
+  import * as org from "ui/src/org";
+  import * as transaction from "ui/src/transaction";
+
+  import { Button, Modal, TextInput } from "ui/DesignSystem";
+
+  export let onSubmit: () => void;
+  export let domain: string;
+  export let orgAddress: string;
+  export let safeAddress: string | undefined = undefined;
+
+  let continueButtonDisabled = false;
+
+  async function link() {
+    continueButtonDisabled = true;
+
+    if (safeAddress) {
+      const signNotification = notification.info({
+        message:
+          "Waiting for you to sign the proposal in your connected wallet",
+        showIcon: true,
+        persist: true,
+      });
+
+      try {
+        await org.proposeSetNameChange(domain, orgAddress, safeAddress);
+        notification.info({
+          message:
+            "Your org metadata will be updated once the quorum of members have confirmed the transaction",
+          showIcon: true,
+          persist: true,
+          actions: [
+            {
+              label: "View on Gnosis Safe",
+              handler: () => {
+                safeAddress &&
+                  org.openOnGnosisSafe(safeAddress, "transactions");
+              },
+            },
+            {
+              label: "Dismiss",
+              handler: () => {},
+            },
+          ],
+        });
+        onSubmit();
+      } catch (err) {
+        continueButtonDisabled = false;
+
+        error.show(
+          new error.Error({
+            message: err.message,
+            source: err,
+          })
+        );
+      } finally {
+        signNotification.remove();
+      }
+    } else {
+      const setNameNotification = notification.info({
+        message:
+          "Waiting for you to confirm the set name transaction in your connected wallet",
+        showIcon: true,
+        persist: true,
+      });
+
+      let tx: transaction.ContractTransaction | undefined = undefined;
+      let waitingForTxNotification;
+
+      try {
+        tx = await org.setNameSingleSig(domain, orgAddress);
+        transaction.add(transaction.linkEnsNameToOrg(tx));
+        waitingForTxNotification = notification.info({
+          message: `Once the transaction has been included, your org will point to ${domain}`,
+          showIcon: true,
+          persist: true,
+        });
+        onSubmit();
+      } catch (err) {
+        continueButtonDisabled = false;
+
+        error.show(
+          new error.Error({
+            message: err.message,
+            source: err,
+          })
+        );
+        return;
+      } finally {
+        setNameNotification.remove();
+      }
+
+      try {
+        await tx.wait(1);
+      } finally {
+        waitingForTxNotification.remove();
+      }
+
+      await configureEns.updateScreenAndNotifyUser(
+        orgAddress,
+        `Your org ${orgAddress} now points to ${domain}`
+      );
+    }
+  }
+</script>
+
+<style>
+  .label {
+    padding-left: 12px;
+    margin-bottom: 12px;
+    color: var(--color-foreground-level-6);
+  }
+</style>
+
+<Modal emoji="🔗" title="Let’s link your name">
+  <svelte:fragment slot="description">
+    In this last step, we’ll update your org to point to your newly created
+    name. Once that’s done, your org will appear with your new name across
+    Radicle!
+  </svelte:fragment>
+
+  <div class="label typo-text-bold">Org address</div>
+  <TextInput disabled style="margin-bottom: 24px" value={orgAddress} />
+
+  <div class="label typo-text-bold">Name</div>
+  <TextInput disabled style="margin-bottom: 24px" value={domain} />
+
+  <p
+    style="color: var(--color-foreground-level-5; margin: 16px 0;"
+    class="typo-text-small">
+    You can also do this later by selecting “Register ENS Name” from the
+    dropdown on your org’s profile and entering your existing name.
+  </p>
+
+  <svelte:fragment slot="buttons">
+    <Button
+      variant="transparent"
+      on:click={() => {
+        modal.hide();
+      }}>Cancel</Button>
+    <Button on:click={link} disabled={continueButtonDisabled}
+      >Link name to org</Button>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Org/ConfigureEns/RegisterName.svelte
+++ b/ui/Modal/Org/ConfigureEns/RegisterName.svelte
@@ -1,0 +1,316 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript" context="module">
+  export interface Result {
+    registration: ensResolver.Registration | undefined;
+    name: string;
+  }
+</script>
+
+<script lang="typescript">
+  import type * as ethers from "ethers";
+
+  import { sleep } from "ui/src/sleep";
+  import { unreachable } from "ui/src/unreachable";
+  import * as ensRegistrar from "ui/src/org/ensRegistrar";
+  import * as ensResolver from "ui/src/org/ensResolver";
+  import * as error from "ui/src/error";
+  import * as ethereum from "ui/src/ethereum";
+  import * as modal from "ui/src/modal";
+  import * as mutexExecutor from "ui/src/mutexExecutor";
+  import * as notification from "ui/src/notification";
+  import * as svelteStore from "ui/src/svelteStore";
+  import * as transaction from "ui/src/transaction";
+  import * as validation from "ui/src/validation";
+  import * as wallet from "ui/src/wallet";
+
+  import { Button, Modal, TextInput } from "ui/DesignSystem";
+
+  import ConfirmRegistration from "./ConfirmRegistration.svelte";
+
+  export let registrationDone: (result: Result) => void;
+  export let currentName: string | undefined;
+  export let fee: ethers.BigNumber;
+
+  type State =
+    | {
+        type: "validateAndCommit";
+      }
+    | {
+        type: "register";
+        commitment: ensRegistrar.Commitment;
+        commitmentBlock: number;
+      };
+
+  let state: State = { type: "validateAndCommit" };
+  let nameInputValue: string = currentName || "";
+  let commitInProgress: boolean = false;
+  let validatedName: string;
+  let validationState: validation.ValidationState = {
+    status: validation.ValidationStatus.NotStarted,
+  };
+  let registration: ensResolver.Registration | undefined;
+  let userInputStarted: boolean = nameInputValue !== "";
+  const validateFormExecutor = mutexExecutor.create();
+
+  $: (userInputStarted && validateFormAndSetState(nameInputValue)) ||
+    (userInputStarted = true);
+
+  async function validateFormAndSetState(
+    name: string | undefined
+  ): Promise<void> {
+    validationState = {
+      status: validation.ValidationStatus.Loading,
+    };
+
+    const validationResult = await validateFormExecutor.run(
+      async abortSignal => {
+        if (!name) {
+          return {
+            validatedName: "",
+            validationState: {
+              status: validation.ValidationStatus.NotStarted,
+            } as validation.ValidationState,
+            registration: undefined,
+          };
+        }
+
+        // Debouce.
+        await sleep(1000);
+
+        if (abortSignal.aborted) {
+          return;
+        }
+
+        return await runAsyncValidations(name);
+      }
+    );
+
+    if (validationResult) {
+      ({ validatedName, validationState, registration } = validationResult);
+    }
+  }
+
+  async function runAsyncValidations(name: string): Promise<{
+    validatedName: string;
+    validationState: validation.ValidationState;
+    registration: ensResolver.Registration | undefined;
+  }> {
+    const available = await ensRegistrar.isAvailable(name);
+
+    if (available) {
+      const accountBalancesStore = wallet.accountBalancesStore;
+      const radBalance = svelteStore.get(accountBalancesStore).rad;
+
+      if (radBalance && radBalance.lt(fee)) {
+        return {
+          validatedName: name,
+          validationState: {
+            status: validation.ValidationStatus.Error,
+            message: `You don't have enough RAD in your wallet to register this name. Name registration costs ${ethereum.formatTokenAmount(
+              fee
+            )} RAD.`,
+          },
+          registration: undefined,
+        };
+      }
+
+      return {
+        validatedName: name,
+        validationState: {
+          status: validation.ValidationStatus.Success,
+        },
+        registration: undefined,
+      };
+    }
+
+    const registration = await ensResolver.getRegistration(
+      `${name}.${ensResolver.DOMAIN}`
+    );
+
+    const walletStore = svelteStore.get(wallet.store);
+
+    if (registration && registration.owner === walletStore.getAddress()) {
+      return {
+        validatedName: name,
+        validationState: {
+          status: validation.ValidationStatus.Success,
+        },
+        registration,
+      };
+    }
+
+    return {
+      validatedName: name,
+      validationState: {
+        status: validation.ValidationStatus.Error,
+        message: "Sorry, that name is already taken.",
+      },
+      registration: undefined,
+    };
+  }
+
+  async function commitOrGoToUpdateMetadata(): Promise<void> {
+    if (registration) {
+      registrationDone({
+        name: validatedName,
+        registration,
+      });
+    } else {
+      try {
+        commitInProgress = true;
+        state = await commit();
+      } catch (err) {
+        error.show(
+          new error.Error({
+            message: err,
+            source: err,
+          })
+        );
+      } finally {
+        commitInProgress = false;
+      }
+    }
+  }
+
+  async function commit(): Promise<State> {
+    const wallet_ = svelteStore.get(wallet.store);
+    const walletAddress = wallet_.getAddress()?.toLowerCase();
+    const commitment = ensRegistrar.restoreCommitment();
+
+    if (
+      commitment &&
+      commitment.name === validatedName &&
+      commitment.ownerAddress === walletAddress
+    ) {
+      if (commitment.block) {
+        return {
+          type: "register",
+          commitment,
+          commitmentBlock: commitment.block,
+        };
+      } else {
+        const commitNotification = notification.info({
+          message: "Waiting for previous commitment transation to be confirmed",
+          showIcon: true,
+          persist: true,
+        });
+        let commitmentBlock;
+        try {
+          const receipt = await wallet_.provider.waitForTransaction(
+            commitment.txHash
+          );
+          commitmentBlock = receipt.blockNumber;
+        } finally {
+          commitNotification.remove();
+        }
+        return { type: "register", commitment, commitmentBlock };
+      }
+    } else {
+      return submitCommitment(validatedName);
+    }
+  }
+
+  async function submitCommitment(name: string): Promise<State> {
+    const signNotification = notification.info({
+      message:
+        "Waiting for you to sign the commitment permit in your connected wallet",
+      showIcon: true,
+      persist: true,
+    });
+    let signature: ethers.Signature;
+
+    const deadline = ensRegistrar.deadline();
+    try {
+      signature = await ensRegistrar.permitSignature(fee, deadline);
+    } finally {
+      signNotification.remove();
+    }
+
+    const commitNotification = notification.info({
+      message:
+        "Waiting for you to confirm the commitment transaction in your connected wallet",
+      showIcon: true,
+      persist: true,
+    });
+    const salt = ensRegistrar.generateSalt();
+
+    let commitment: ensRegistrar.Commitment;
+    let tx: transaction.ContractTransaction;
+    try {
+      ({ tx, commitment } = await ensRegistrar.commit(
+        name,
+        salt,
+        fee,
+        signature,
+        deadline
+      ));
+    } finally {
+      commitNotification.remove();
+    }
+    ensRegistrar.persistCommitment(commitment);
+    transaction.add(transaction.commitEnsName(tx));
+
+    const txNotification = notification.info({
+      message: "Waiting for the transaction to be included",
+      showIcon: true,
+      persist: true,
+    });
+
+    let receipt;
+    try {
+      receipt = await tx.wait(1);
+    } finally {
+      txNotification.remove();
+    }
+
+    return {
+      type: "register",
+      commitment,
+      commitmentBlock: receipt.blockNumber,
+    };
+  }
+</script>
+
+{#if state.type === "validateAndCommit"}
+  <Modal emoji="📇" title="Let’s name your org">
+    <svelte:fragment slot="description">
+      What should your org be called? This name will show up on the top of your
+      profile and anywhere you interact as an org on Radicle.
+    </svelte:fragment>
+
+    <TextInput
+      bind:value={nameInputValue}
+      showSuccessCheck
+      disabled={commitInProgress}
+      validation={validationState}
+      suffix={`.${ensResolver.DOMAIN}`}
+      placeholder="Your org name"
+      style="margin: 16px auto; width: 352px;" />
+
+    <svelte:fragment slot="buttons">
+      <Button
+        variant="transparent"
+        on:click={() => {
+          modal.hide();
+        }}>Cancel</Button>
+      <Button
+        on:click={commitOrGoToUpdateMetadata}
+        disabled={validationState.status !==
+          validation.ValidationStatus.Success || commitInProgress}
+        >Continue</Button>
+    </svelte:fragment>
+  </Modal>
+{:else if state.type === "register"}
+  <ConfirmRegistration
+    commitment={state.commitment}
+    commitmentBlock={state.commitmentBlock}
+    {registrationDone} />
+{:else}
+  {unreachable(state)}
+{/if}

--- a/ui/Modal/Org/ConfigureEns/UpdateMetadata.svelte
+++ b/ui/Modal/Org/ConfigureEns/UpdateMetadata.svelte
@@ -1,0 +1,212 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import * as configureEns from "ui/src/org/configureEns";
+  import * as ensResolver from "ui/src/org/ensResolver";
+  import * as error from "ui/src/error";
+  import * as modal from "ui/src/modal";
+  import * as notification from "ui/src/notification";
+  import * as transaction from "ui/src/transaction";
+  import * as validation from "ui/src/validation";
+
+  import { Button, Modal, TextInput, Tooltip } from "ui/DesignSystem";
+
+  export let onSubmit: () => void;
+  export let registration: ensResolver.Registration;
+  export let orgAddress: string;
+
+  let urlValue: string | undefined = registration.url || undefined;
+  let avatarValue: string | undefined = registration.avatar || undefined;
+  let twitterValue: string | undefined = registration.twitter || undefined;
+  let githubValue: string | undefined = registration.github || undefined;
+  let seedIdValue: string | undefined = registration.seedId || undefined;
+  let seedApiValue: string | undefined = registration.seedApi || undefined;
+
+  let setRecordsInProgress = false;
+
+  let orgAddressValidationStatus: validation.ValidationState = {
+    status: validation.ValidationStatus.NotStarted,
+  };
+
+  if (
+    registration.address &&
+    registration.address.toLowerCase() !== orgAddress.toLowerCase()
+  ) {
+    orgAddressValidationStatus = {
+      status: validation.ValidationStatus.Error,
+      message: `This name already points to your org with the address ${registration.address}. If you change this here, it will overwrite the existing metadata associated with this ENS name.`,
+    };
+  }
+
+  async function setRecords() {
+    setRecordsInProgress = true;
+
+    let records: {
+      name: keyof ensResolver.Registration;
+      value: string | undefined;
+    }[] = [
+      { name: "address", value: orgAddress },
+      { name: "url", value: urlValue },
+      { name: "avatar", value: avatarValue },
+      { name: "twitter", value: twitterValue },
+      { name: "github", value: githubValue },
+      { name: "seedId", value: seedIdValue },
+      { name: "seedApi", value: seedApiValue },
+    ];
+
+    // Filter out unchanged records.
+    records = records.filter(r => {
+      const existingValue = registration[r.name];
+
+      const normalizedExistingValue =
+        typeof existingValue === "string"
+          ? existingValue.toLowerCase()
+          : existingValue;
+
+      if (
+        r.value === undefined ||
+        (normalizedExistingValue === null && r.value === "")
+      ) {
+        false;
+      } else {
+        return normalizedExistingValue !== r.value.toLowerCase();
+      }
+    });
+
+    if (records.length > 0) {
+      const updateNotification = notification.info({
+        message:
+          "Waiting for you to confirm the metadata update transaction in your connected wallet",
+        showIcon: true,
+        persist: true,
+      });
+
+      let tx: transaction.ContractTransaction | undefined = undefined;
+      let waitingForTxNotification;
+
+      try {
+        tx = await ensResolver.setRecords(
+          registration.domain,
+          records as ensResolver.EnsRecord[]
+        );
+        transaction.add(transaction.updateEnsMetadata(tx));
+        waitingForTxNotification = notification.info({
+          message:
+            "The org’s updated metadata will appear once the transaction has been included",
+          showIcon: true,
+          persist: true,
+        });
+        onSubmit();
+      } catch (err) {
+        setRecordsInProgress = false;
+
+        error.show(
+          new error.Error({
+            message: err.message,
+            source: err,
+          })
+        );
+        return;
+      } finally {
+        updateNotification.remove();
+      }
+
+      try {
+        await tx.wait(1);
+      } finally {
+        waitingForTxNotification.remove();
+      }
+
+      await configureEns.updateScreenAndNotifyUser(
+        orgAddress,
+        "Your org’s metadata has been updated"
+      );
+    } else {
+      onSubmit();
+    }
+  }
+</script>
+
+<style>
+  .label {
+    padding-left: 12px;
+    margin-bottom: 12px;
+    color: var(--color-foreground-level-6);
+  }
+</style>
+
+<Modal emoji="📋" title="Set your org’s metadata">
+  <svelte:fragment slot="description">
+    This will be shown alongside your ENS name, and appears together with your
+    org across Radicle. You can edit it at any time by clicking “Edit ENS name”
+    on the org page.
+  </svelte:fragment>
+
+  <div class="label typo-text-bold">Org address</div>
+  <Tooltip
+    value={"This is the address of your org and is required to link your ENS name to it."}
+    position="top">
+    <TextInput
+      style="margin-bottom: 24px"
+      disabled
+      value={orgAddress}
+      validation={orgAddressValidationStatus} />
+  </Tooltip>
+
+  <div class="label typo-text-bold">Website URL</div>
+  <TextInput
+    disabled={setRecordsInProgress}
+    style="margin-bottom: 24px"
+    placeholder="The URL to your org’s website"
+    bind:value={urlValue} />
+
+  <div class="label typo-text-bold">Avatar URL</div>
+  <TextInput
+    disabled={setRecordsInProgress}
+    style="margin-bottom: 24px"
+    placeholder="A URL that points to the avatar for your org"
+    bind:value={avatarValue} />
+
+  <div class="label typo-text-bold">Twitter username</div>
+  <TextInput
+    disabled={setRecordsInProgress}
+    style="margin-bottom: 24px"
+    placeholder="Your org’s Twitter handle"
+    bind:value={twitterValue} />
+
+  <div class="label typo-text-bold">GitHub username</div>
+  <TextInput
+    disabled={setRecordsInProgress}
+    style="margin-bottom: 24px"
+    placeholder="Your org’s GitHub username"
+    bind:value={githubValue} />
+
+  <div class="label typo-text-bold">Seed ID</div>
+  <TextInput
+    disabled={setRecordsInProgress}
+    style="margin-bottom: 24px"
+    placeholder="The Radicle Link node ID that hosts your org’s entities"
+    bind:value={seedIdValue} />
+
+  <div class="label typo-text-bold">Seed API</div>
+  <TextInput
+    disabled={setRecordsInProgress}
+    style="margin-bottom: 24px"
+    placeholder="The HTTP address of a node that serves Radicle entities"
+    bind:value={seedApiValue} />
+
+  <svelte:fragment slot="buttons">
+    <Button
+      variant="transparent"
+      on:click={() => {
+        modal.hide();
+      }}>Cancel</Button>
+    <Button on:click={setRecords} disabled={setRecordsInProgress}
+      >Update org metadata</Button>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Transaction.svelte
+++ b/ui/Modal/Transaction.svelte
@@ -6,23 +6,23 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Copyable, Icon, Identity, Modal } from "ui/DesignSystem";
   import dayjs from "dayjs";
+  import { Copyable, Icon, Identity, Modal } from "ui/DesignSystem";
   import TxSpinner from "ui/DesignSystem/Transaction/Spinner.svelte";
   import Summary from "ui/DesignSystem/Transaction/Summary.svelte";
 
+  import type { Tx } from "ui/src/transaction";
   import * as format from "ui/src/format";
   import {
+    TxKind,
+    TxStatus,
+    colorForStatus,
     emoji,
+    isIncoming,
     selectedStore,
     store as txs,
-    colorForStatus,
-    isIncoming,
     transferAmount,
-    TxStatus,
-    TxKind,
   } from "ui/src/transaction";
-  import type { Tx } from "ui/src/transaction";
 
   // In reality, the transaction should never be undefined,
   // but because the only way we currently have use it here
@@ -34,6 +34,18 @@
   $: statusColor = colorForStatus(tx?.status || TxStatus.AwaitingInclusion);
   $: transferedAmount = tx ? transferAmount(tx) : undefined;
   $: incoming = tx ? isIncoming(tx) : false;
+
+  function showPoolCard(kind: TxKind): boolean {
+    return !(
+      kind === TxKind.AnchorProject ||
+      kind === TxKind.ClaimRadicleIdentity ||
+      kind === TxKind.CommitEnsName ||
+      kind === TxKind.CreateOrg ||
+      kind === TxKind.LinkEnsNameToOrg ||
+      kind === TxKind.RegisterEnsName ||
+      kind === TxKind.UpdateEnsMetadata
+    );
+  }
 </script>
 
 <style>
@@ -114,7 +126,7 @@
   {#if tx}
     <header>
       <Summary {tx} />
-      {#if !(tx.kind === TxKind.ClaimRadicleIdentity || tx.kind === TxKind.CreateOrg || tx.kind === TxKind.AnchorProject)}
+      {#if showPoolCard(tx.kind)}
         <div class="from-to" class:incoming>
           <div>
             <p class="typo-text-bold" style="margin-bottom: 0.5rem">

--- a/ui/Screen/Org.svelte
+++ b/ui/Screen/Org.svelte
@@ -6,6 +6,9 @@
  LICENSE file.
 -->
 <script lang="typescript">
+  import type * as orgRoute from "./Org/route";
+  import type { Registration } from "ui/src/org/ensResolver";
+
   import * as router from "ui/src/router";
   import * as ipc from "ui/src/ipc";
   import * as notification from "ui/src/notification";
@@ -27,13 +30,13 @@
   import OrgHeader from "ui/Screen/Org/OrgHeader.svelte";
   import ProjectsMenu from "ui/Screen/Org/ProjectsMenu.svelte";
   import MembersMenu from "ui/Screen/Org/MembersMenu.svelte";
-  import type * as orgRoute from "./Org/route";
 
   export let activeTab: orgRoute.MultiSigView;
   export let gnosisSafeAddress: string;
   export let address: string;
   export let members: org.Member[];
   export let threshold: number;
+  export let registration: Registration | undefined = undefined;
 
   const tabs = (address: string, active: orgRoute.MultiSigView) => {
     return [
@@ -82,11 +85,10 @@
         },
       },
       {
-        title: "Register ENS name",
+        title: registration ? "Edit ENS name" : "Register ENS name",
         icon: Icon.Ethereum,
-        disabled: true,
-        event: () => {},
-        tooltip: "Coming soon",
+        event: () =>
+          org.openEnsConfiguration(address, registration, gnosisSafeAddress),
       },
     ];
   };
@@ -95,6 +97,7 @@
 <SidebarLayout>
   <Header>
     <OrgHeader
+      {registration}
       slot="left"
       orgAddress={address}
       ownerAddress={gnosisSafeAddress}

--- a/ui/Screen/Org/OrgHeader.svelte
+++ b/ui/Screen/Org/OrgHeader.svelte
@@ -9,11 +9,23 @@
   import * as radicleAvatar from "radicle-avatar";
   import { Avatar, Icon, Identifier } from "ui/DesignSystem";
 
+  import * as ensResolver from "ui/src/org/ensResolver";
   import * as format from "ui/src/format";
 
   export let orgAddress: string;
   export let ownerAddress: string;
   export let threshold: number | undefined = undefined;
+  export let registration: ensResolver.Registration | undefined = undefined;
+
+  $: name = registration?.domain.replace(`.${ensResolver.DOMAIN}`, "");
+  $: websiteUrl = registration?.url;
+  $: githubUrl =
+    registration?.github && `https://github.com/${registration.github}`;
+  $: twitterUrl =
+    registration?.twitter &&
+    `https://twitter.com/${registration.twitter.replace("@", "")}`;
+  $: seedId = registration?.seedId;
+  $: seedApi = registration?.seedApi;
 </script>
 
 <style>
@@ -23,15 +35,19 @@
     align-self: center;
     width: -webkit-fill-available;
     min-width: 0;
-  }
-  .name {
-    margin-bottom: 0.5rem;
+    white-space: nowrap;
   }
   .row {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.5rem;
+  }
+  .name {
+    margin-bottom: 0.5rem;
+  }
+  .domain {
+    color: var(--color-foreground-level-4);
   }
 </style>
 
@@ -40,6 +56,7 @@
     style="margin-right: 2rem;"
     size="huge"
     variant="square"
+    imageUrl={registration?.avatar || undefined}
     avatarFallback={radicleAvatar.generate(
       orgAddress,
       radicleAvatar.Usage.Any
@@ -47,26 +64,69 @@
 
   <div class="metadata">
     <h1 data-cy="entity-name" class="typo-overflow-ellipsis name">
-      {format.shortEthAddress(orgAddress)}
-    </h1>
-    <div class="row">
-      {#if threshold}
-        <Icon.Gnosis />
+      {#if name}
+        {name}.<span class="domain">{ensResolver.DOMAIN}</span>
       {:else}
-        <Icon.Ethereum />
+        {format.shortEthAddress(orgAddress)}
       {/if}
-      <Identifier
-        value={ownerAddress}
-        kind="ethAddress"
-        name="org owner address"
-        showIcon={false} />
-    </div>
-    {#if threshold}
-      <div class="row">
-        <Icon.Orgs />
-        {threshold}
-        {threshold === 1 ? "signature" : "signatures"} required for quorum
+    </h1>
+    <div style="display: flex; gap: 1rem;">
+      <div>
+        <div class="row">
+          {#if threshold}
+            <Icon.Gnosis />
+          {:else}
+            <Icon.Ethereum />
+          {/if}
+          <Identifier
+            value={ownerAddress}
+            kind="ethAddress"
+            name="org owner address"
+            showIcon={false} />
+        </div>
+        {#if threshold}
+          <div class="row">
+            <Icon.Orgs />
+            {threshold}
+            {threshold === 1 ? "signature" : "signatures"} required for quorum
+          </div>
+        {/if}
       </div>
-    {/if}
+      {#if websiteUrl || githubUrl || twitterUrl || seedId || seedApi}
+        <div>
+          {#if websiteUrl}
+            <div class="row">
+              <Icon.Globe />
+              <a href={websiteUrl}>{websiteUrl}</a>
+            </div>
+          {/if}
+          {#if githubUrl}
+            <div class="row">
+              <Icon.Github />
+              <a href={githubUrl}>{githubUrl}</a>
+            </div>
+          {/if}
+          {#if twitterUrl}
+            <div class="row">
+              <Icon.Twitter />
+              <a href={twitterUrl}>{twitterUrl}</a>
+            </div>
+          {/if}
+        </div>
+        <div>
+          {#if seedId}
+            <div class="row">
+              <Identifier value={seedId} kind="seedAddress" />
+            </div>
+          {/if}
+          {#if seedApi}
+            <div class="row">
+              <Icon.Globe />
+              <a href={seedApi}>{seedApi}</a>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
   </div>
 </div>

--- a/ui/Screen/SingleSigOrg.svelte
+++ b/ui/Screen/SingleSigOrg.svelte
@@ -6,11 +6,12 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import type * as org from "ui/src/org";
+  import type { Registration } from "ui/src/org/ensResolver";
 
   import * as ipc from "ui/src/ipc";
   import * as notification from "ui/src/notification";
   import * as router from "ui/src/router";
+  import * as org from "ui/src/org";
 
   import {
     ActionBar,
@@ -30,6 +31,7 @@
   export let address: string;
   export let projectCount: number;
   export let anchors: org.OrgAnchors;
+  export let registration: Registration | undefined = undefined;
 
   const tabs = (address: string) => {
     return [
@@ -65,11 +67,9 @@
         },
       },
       {
-        title: "Register ENS name",
+        title: registration ? "Edit ENS name" : "Register ENS name",
         icon: Icon.Ethereum,
-        disabled: true,
-        event: () => {},
-        tooltip: "Coming soon",
+        event: () => org.openEnsConfiguration(address, registration),
       },
     ];
   };
@@ -77,7 +77,11 @@
 
 <SidebarLayout>
   <Header>
-    <OrgHeader slot="left" orgAddress={address} ownerAddress={owner} />
+    <OrgHeader
+      {registration}
+      slot="left"
+      orgAddress={address}
+      ownerAddress={owner} />
     <div slot="right" style="display: flex">
       <FollowToggle following disabled style="margin-right: 1rem;" />
       <ThreeDotsMenu menuItems={menuItems(address)} />

--- a/ui/src/ethereum/index.ts
+++ b/ui/src/ethereum/index.ts
@@ -93,3 +93,15 @@ export function etherscanUrl(ethEnv: Environment, query: string): string {
       return `https://etherscan.io/search?f=0&q=${query}`;
   }
 }
+
+export function ensAddress(env: Environment): string {
+  if (env === Environment.Local) {
+    throw new error.Error({
+      code: error.Code.FeatureNotAvailableForGivenNetwork,
+      message: "ENS is not supported on the Local environment",
+    });
+  } else {
+    // https://docs.ens.domains/ens-deployments
+    return "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+  }
+}

--- a/ui/src/ethereum/walletConnectSigner.ts
+++ b/ui/src/ethereum/walletConnectSigner.ts
@@ -9,6 +9,7 @@ import * as ethersBytes from "@ethersproject/bytes";
 import type {
   Provider,
   TransactionRequest,
+  TransactionReceipt,
   TransactionResponse,
 } from "@ethersproject/abstract-provider";
 import {
@@ -89,7 +90,7 @@ export class WalletConnectSigner extends ethers.Signer {
       data: bytesLikeToString(tx.data) || "",
       hash: txHash,
       confirmations: 1,
-      wait: (confirmations: number = 1) =>
+      wait: (confirmations: number = 1): Promise<TransactionReceipt> =>
         this._provider.waitForTransaction(txHash, confirmations),
     };
   }

--- a/ui/src/org/configureEns.ts
+++ b/ui/src/org/configureEns.ts
@@ -1,0 +1,61 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as ensResolver from "ui/src/org/ensResolver";
+import * as notification from "ui/src/notification";
+import * as router from "ui/src/router";
+import * as svelteStore from "ui/src/svelteStore";
+
+// If the user is on the screen of `orgAddress`, populate the screen with the
+// updated registration metadata and show a notification.
+//
+// If the user has navigated away to another screen, show a notification about
+// the updated registration metadata and a button to navigate back to the org
+// screen of `orgAddress`.
+export async function updateScreenAndNotifyUser(
+  orgAddress: string,
+  message: string
+): Promise<void> {
+  const updatedRegistration = await ensResolver.getCachedRegistrationByAddress(
+    orgAddress,
+    true
+  );
+  const activeRoute = svelteStore.get(router.activeRouteStore);
+
+  let actions;
+
+  if (
+    (activeRoute.type === "singleSigOrg" ||
+      activeRoute.type === "multiSigOrg") &&
+    activeRoute.address === orgAddress
+  ) {
+    router.activeRouteStore.set({
+      ...activeRoute,
+      registration: updatedRegistration,
+    });
+  } else {
+    actions = [
+      {
+        label: "Go to org",
+        handler: () => {
+          router.push({
+            type: "org",
+            params: {
+              address: orgAddress,
+              view: "projects",
+            },
+          });
+        },
+      },
+    ];
+  }
+
+  notification.info({
+    message,
+    actions,
+    showIcon: true,
+  });
+}

--- a/ui/src/org/contract.ts
+++ b/ui/src/org/contract.ts
@@ -27,6 +27,7 @@ const orgFactoryAbi = [
 const orgAbi = [
   "function owner() view returns (address)",
   "function anchor(bytes32, uint32, bytes)",
+  "function setName(string, address) returns (bytes32)",
 ];
 
 function orgFactoryAddress(network: ethereum.Environment): string {
@@ -193,4 +194,36 @@ export function parseAnchorTx(data: string): AnchorData | undefined {
 
     return { projectId: projectId, commitHash: decodedCommitHash };
   }
+}
+
+export async function setName(
+  signer: ethers.Signer,
+  orgAddress: string,
+  name: string,
+  ensAddress: string
+): Promise<TransactionResponse> {
+  const org = new ethers.Contract(orgAddress, orgAbi, signer);
+
+  return org.setName(name, ensAddress);
+}
+
+// Returns the hex encoded data for a transaction that will set the
+// org ENS name.
+export async function populateSetNameTransaction(
+  orgAddress: string,
+  name: string,
+  ensAddress: string
+): Promise<string> {
+  const org = new ethers.Contract(orgAddress, orgAbi);
+
+  const unsignedTx = await org.populateTransaction.setName(name, ensAddress);
+  const txData = unsignedTx.data;
+  if (!txData) {
+    throw new error.Error({
+      message: "Could not generate transaction for `setName` call",
+      details: { unsignedTx },
+    });
+  }
+
+  return txData;
 }

--- a/ui/src/org/ensRegistrar.ts
+++ b/ui/src/org/ensRegistrar.ts
@@ -1,0 +1,236 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as error from "ui/src/error";
+import * as ethereum from "ui/src/ethereum";
+import * as ethers from "ethers";
+import * as svelteStore from "ui/src/svelteStore";
+import * as Wallet from "ui/src/wallet";
+import * as zod from "zod";
+
+import { Registrar__factory as RegistrarFactory } from "radicle-contracts/build/contract-bindings/ethers";
+
+function registrarAddress(network: ethereum.Environment): string {
+  switch (network) {
+    case ethereum.Environment.Local:
+      throw new error.Error({
+        code: error.Code.FeatureNotAvailableForGivenNetwork,
+        message: "ENS Registrar not available on the Local testnet",
+      });
+    case ethereum.Environment.Rinkeby:
+      return "0x80b68878442b6510D768Be1bd88712710B86eAcD";
+    case ethereum.Environment.Mainnet:
+      return "0x37723287Ae6F34866d82EE623401f92Ec9013154";
+  }
+}
+
+function registrar() {
+  const wallet = svelteStore.get(Wallet.store);
+  return RegistrarFactory.connect(
+    registrarAddress(wallet.environment),
+    wallet.signer
+  );
+}
+
+export async function isAvailable(name: string): Promise<boolean> {
+  const r = registrar();
+  return r.available(name);
+}
+
+export async function getFee(): Promise<ethers.BigNumber> {
+  const r = registrar();
+  return await r.registrationFeeRad();
+}
+
+export function deadline(): ethers.BigNumber {
+  // Expire one hour from now.
+  return ethers.BigNumber.from(Math.floor(Date.now() / 1000)).add(3600);
+}
+
+// Return salt as a hex string.
+export function generateSalt(): string {
+  return ethers.BigNumber.from(ethers.utils.randomBytes(32)).toHexString();
+}
+
+export interface Commitment {
+  name: string;
+  ownerAddress: string;
+  salt: string;
+  // Commitment tx id.
+  txHash: string;
+  // The number of the block the commitment transaction is included.
+  block?: number;
+  // The minimum number of blocks that must have passed between a commitment
+  // and name registration.
+  minimumCommitmentAge: number;
+}
+
+export const commitmentSchema: zod.Schema<Commitment> = zod.object({
+  name: zod.string(),
+  ownerAddress: zod.string(),
+  salt: zod.string(),
+  txHash: zod.string(),
+  minimumCommitmentAge: zod.number(),
+});
+
+const COMMITMENT_STORAGE_KEY = "radicle.ens.commitment";
+
+export function persistCommitment(commitment: Commitment): void {
+  window.localStorage.setItem(
+    COMMITMENT_STORAGE_KEY,
+    JSON.stringify(commitment)
+  );
+}
+
+export function clearCommitment(): void {
+  window.localStorage.removeItem(COMMITMENT_STORAGE_KEY);
+}
+
+export function restoreCommitment(): Commitment | null {
+  const commitmentJson = window.localStorage.getItem(COMMITMENT_STORAGE_KEY);
+
+  if (!commitmentJson) {
+    return null;
+  }
+
+  const commitment = JSON.parse(commitmentJson);
+  const result = commitmentSchema.safeParse(commitment);
+
+  if (result.success) {
+    return result.data;
+  } else {
+    error.show(
+      new error.Error({
+        message: "Could not validate persisted commitment",
+        details: { commitment, errors: result.error.errors },
+      })
+    );
+    return null;
+  }
+}
+
+export async function commit(
+  name: string,
+  salt: string,
+  fee: ethers.BigNumber,
+  signature: ethers.Signature,
+  deadline: ethers.BigNumber
+): Promise<{ tx: ethers.ContractTransaction; commitment: Commitment }> {
+  const wallet = svelteStore.get(Wallet.store);
+  const ownerAddr = wallet.getAddress()?.toLowerCase();
+  if (!ownerAddr) {
+    throw new error.Error({
+      message: "Wallet not connected",
+    });
+  }
+
+  const minimumCommitmentAge = (
+    await registrar().minCommitmentAge()
+  ).toNumber();
+
+  const commitment = createCommitment(name, ownerAddr, salt);
+
+  const tx = await registrar().commitWithPermit(
+    commitment,
+    ownerAddr,
+    fee,
+    deadline,
+    signature.v,
+    signature.r,
+    signature.s
+  );
+
+  return {
+    tx,
+    commitment: {
+      name,
+      txHash: tx.hash,
+      ownerAddress: ownerAddr,
+      salt,
+      minimumCommitmentAge,
+    },
+  };
+}
+
+export async function register(
+  name: string,
+  salt: string
+): Promise<ethers.ContractTransaction> {
+  const wallet = svelteStore.get(Wallet.store);
+
+  const address = wallet.getAddress();
+
+  if (!address) {
+    throw new error.Error({
+      message: "Wallet not initialized",
+    });
+  }
+
+  return await registrar().register(name, address, ethers.BigNumber.from(salt));
+}
+
+export async function permitSignature(
+  value: ethers.BigNumberish,
+  deadline: ethers.BigNumberish
+): Promise<ethers.Signature> {
+  const wallet = svelteStore.get(Wallet.store);
+  const spenderAddr = registrarAddress(wallet.environment);
+  const owner = wallet.signer;
+
+  const rad = Wallet.radToken.connect(wallet.signer, wallet.environment);
+
+  const ownerAddr = (await owner.getAddress()).toLowerCase();
+  const nonce = await rad.nonces(ownerAddr);
+  const chainId = (await wallet.provider.getNetwork()).chainId;
+
+  const data = {
+    domain: {
+      name: await rad.name(),
+      chainId,
+      verifyingContract: rad.address,
+    },
+    primaryType: "Permit",
+    types: {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      Permit: [
+        { name: "owner", type: "address" },
+        { name: "spender", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    message: {
+      owner: ownerAddr.toLowerCase(),
+      spender: spenderAddr.toLowerCase(),
+      value: ethers.BigNumber.from(value).toString(),
+      nonce: ethers.BigNumber.from(nonce).toString(),
+      deadline: ethers.BigNumber.from(deadline).toString(),
+    },
+  };
+
+  const sig = await owner.signTypedData(ownerAddr, data);
+
+  return ethers.utils.splitSignature(sig);
+}
+
+function createCommitment(
+  name: string,
+  ownerAddress: string,
+  salt: string
+): string {
+  const bytes = ethers.utils.concat([
+    ethers.utils.toUtf8Bytes(name),
+    ownerAddress,
+    salt,
+  ]);
+
+  return ethers.utils.keccak256(bytes);
+}

--- a/ui/src/org/ensResolver.ts
+++ b/ui/src/org/ensResolver.ts
@@ -1,0 +1,209 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import type { TransactionResponse } from "./contract";
+
+import { ethers } from "ethers";
+import LruCache from "lru-cache";
+import { ENS__factory as EnsRegistryFactory } from "radicle-contracts/build/contract-bindings/ethers";
+
+import * as error from "ui/src/error";
+import * as svelteStore from "ui/src/svelteStore";
+import * as Wallet from "ui/src/wallet";
+import * as ethereum from "ui/src/ethereum";
+
+const resolverAbi = [
+  "function multicall(bytes[] calldata data) returns(bytes[] memory results)",
+  "function setAddr(bytes32 node, address addr)",
+  "function setText(bytes32 node, string calldata key, string calldata value)",
+];
+
+export const DOMAIN = "radicle.eth";
+export type EnsRecord = { name: string; value: string };
+
+export interface Registration {
+  // The fully qualified domain name for the registration.
+  domain: string;
+  // Address that owns this registration
+  owner: string;
+  // Address record
+  address: string | null;
+  url: string | null;
+  avatar: string | null;
+  twitter: string | null;
+  github: string | null;
+  seedId: string | null;
+  seedApi: string | null;
+}
+
+export async function setRecords(
+  domain: string,
+  records: EnsRecord[]
+): Promise<TransactionResponse> {
+  const wallet = svelteStore.get(Wallet.store);
+
+  const resolver = await wallet.provider.getResolver(domain);
+
+  // The type definitions of `ethers` are not correct. `getResolver()`
+  // can return `null`.
+  //
+  // See https://github.com/ethers-io/ethers.js/issues/1850
+  if (!resolver) {
+    throw new error.Error({
+      message: "Domain is not registered",
+      details: { domain },
+    });
+  }
+
+  const resolverContract = new ethers.Contract(
+    resolver.address,
+    resolverAbi,
+    wallet.signer
+  );
+  const node = ethers.utils.namehash(domain);
+
+  const calls = [];
+  const iface = new ethers.utils.Interface(resolverAbi);
+
+  for (const record of records) {
+    switch (record.name) {
+      case "address":
+        calls.push(iface.encodeFunctionData("setAddr", [node, record.value]));
+        break;
+      case "url":
+      case "avatar":
+        calls.push(
+          iface.encodeFunctionData("setText", [node, record.name, record.value])
+        );
+        break;
+      case "github":
+      case "twitter":
+        calls.push(
+          iface.encodeFunctionData("setText", [
+            node,
+            `com.${record.name}`,
+            record.value,
+          ])
+        );
+        break;
+      case "seedId":
+        calls.push(
+          iface.encodeFunctionData("setText", [
+            node,
+            "eth.radicle.seed.id",
+            record.value,
+          ])
+        );
+        break;
+      case "seedApi":
+        calls.push(
+          iface.encodeFunctionData("setText", [
+            node,
+            "eth.radicle.seed.api",
+            record.value,
+          ])
+        );
+        break;
+      default:
+        throw new error.Error({
+          message: `Unknown field ${record.name}`,
+          details: { record },
+        });
+    }
+  }
+  return resolverContract.multicall(calls);
+}
+
+export async function getRegistration(
+  domain: string
+): Promise<Registration | undefined> {
+  const wallet = svelteStore.get(Wallet.store);
+  const resolver = await wallet.provider.getResolver(domain);
+
+  // The type definitions of `ethers` are not correct. `getResolver()`
+  // can return `null`.
+  //
+  // See https://github.com/ethers-io/ethers.js/issues/1850
+  if (!resolver) {
+    return;
+  }
+
+  const owner = await getOwner(domain);
+
+  const meta = await Promise.allSettled([
+    resolver.getAddress(),
+    resolver.getText("avatar"),
+    resolver.getText("url"),
+    resolver.getText("com.twitter"),
+    resolver.getText("com.github"),
+    resolver.getText("eth.radicle.seed.id"),
+    resolver.getText("eth.radicle.seed.api"),
+  ]);
+
+  const [address, avatar, url, twitter, github, seedId, seedApi] = meta.map(
+    (value: PromiseSettledResult<string>) =>
+      value.status === "fulfilled" ? value.value : null
+  );
+
+  return {
+    domain,
+    url,
+    avatar,
+    owner,
+    address,
+    twitter,
+    github,
+    seedId,
+    seedApi,
+  };
+}
+
+async function getOwner(domain: string): Promise<string> {
+  const wallet = svelteStore.get(Wallet.store);
+  const ensAddr = ethereum.ensAddress(wallet.environment);
+
+  const registry = EnsRegistryFactory.connect(ensAddr, wallet.signer);
+  const owner = await registry.owner(ethers.utils.namehash(domain));
+
+  return owner;
+}
+
+interface RegistrationCacheEntry {
+  value: Registration | undefined;
+}
+
+const registrationCache = new LruCache<string, RegistrationCacheEntry>({
+  max: 1000,
+  maxAge: 10 * 60 * 1000, // TTL 10 minutes
+});
+
+export async function getCachedRegistrationByAddress(
+  address: string,
+  invalidateCache: boolean = false
+): Promise<Registration | undefined> {
+  const normalisedAddress = address.toLowerCase();
+  const cached: RegistrationCacheEntry | undefined =
+    registrationCache.get(normalisedAddress);
+
+  if (!invalidateCache && cached) {
+    return cached.value;
+  } else {
+    const wallet = svelteStore.get(Wallet.store);
+    const name = await wallet.provider.lookupAddress(normalisedAddress);
+
+    // The type definitions of `ethers` are not correct. `lookupAddress()`
+    // can return `null`.
+    if (!name) {
+      registrationCache.set(normalisedAddress, { value: undefined });
+      return;
+    }
+
+    const registration = await getRegistration(name);
+    registrationCache.set(normalisedAddress, { value: registration });
+
+    return registration;
+  }
+}

--- a/ui/src/org/theGraphApi.ts
+++ b/ui/src/org/theGraphApi.ts
@@ -10,11 +10,13 @@ import * as multihash from "multihashes";
 import * as svelteStore from "svelte/store";
 
 import type * as project from "ui/src/project";
+import type * as ensResolver from "ui/src/org/ensResolver";
 
 import * as error from "ui/src/error";
 import * as ethereum from "ui/src/ethereum";
 import * as urn from "ui/src/urn";
 import * as wallet from "ui/src/wallet";
+import type { Registration } from "./ensResolver";
 
 function createApolloClient(uri: string): apolloCore.ApolloClient<unknown> {
   return new apolloCore.ApolloClient({
@@ -78,6 +80,7 @@ interface GnosisSafeWallet {
 export interface Org {
   id: string;
   owner: string;
+  registration?: Registration;
   creator: string;
   timestamp: number;
 }
@@ -159,7 +162,8 @@ export async function getGnosisSafeMembers(
 }
 
 export async function getOrgProjectAnchors(
-  orgAddress: string
+  orgAddress: string,
+  registration?: ensResolver.Registration
 ): Promise<project.Anchor[]> {
   const response = (
     await orgsSubgraphClient().query({
@@ -205,6 +209,7 @@ export async function getOrgProjectAnchors(
         projectId: decodedProjectId,
         commitHash: decodedCommitHash,
         timestamp: project.anchor.timestamp,
+        registration,
       };
 
       return anchor;

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -6,6 +6,7 @@
 
 import { get, writable } from "svelte/store";
 
+import type * as ensResolver from "./org/ensResolver";
 import * as error from "./error";
 import * as config from "./config";
 import type * as identity from "./identity";
@@ -38,6 +39,7 @@ interface ConfirmedAnchor {
   projectId: string;
   commitHash: string;
   timestamp: number;
+  registration?: ensResolver.Registration;
 }
 
 export interface PendingAnchor {
@@ -48,6 +50,7 @@ export interface PendingAnchor {
   projectId: string;
   commitHash: string;
   timestamp: number;
+  registration?: ensResolver.Registration;
 }
 
 export type Anchor = ConfirmedAnchor | PendingAnchor;

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -22,6 +22,7 @@ import { Icon } from "ui/DesignSystem";
 export const store = persistentStore<Tx[]>("transactions", []);
 
 export type Tx = TxData & MetaTx;
+export type { ContractTransaction };
 
 // The data shared across all types of transactions
 // that we are to deal with.
@@ -48,10 +49,14 @@ type MetaTx =
   | AnchorProject
   | ClaimRadicleIdentity
   | CollectFunds
+  | CommitEnsName
   | CreateOrg
   | Erc20Allowance
+  | LinkEnsNameToOrg
+  | RegisterEnsName
   | SupportOnboarding
   | TopUp
+  | UpdateEnsMetadata
   | UpdateSupport
   | Withdraw;
 
@@ -61,6 +66,22 @@ interface AnchorProject {
 
 interface CreateOrg {
   kind: TxKind.CreateOrg;
+}
+
+interface RegisterEnsName {
+  kind: TxKind.RegisterEnsName;
+}
+
+interface CommitEnsName {
+  kind: TxKind.CommitEnsName;
+}
+
+interface UpdateEnsMetadata {
+  kind: TxKind.UpdateEnsMetadata;
+}
+
+interface LinkEnsNameToOrg {
+  kind: TxKind.LinkEnsNameToOrg;
 }
 
 interface ClaimRadicleIdentity {
@@ -110,10 +131,14 @@ export enum TxKind {
   AnchorProject = "Anchor Project",
   ClaimRadicleIdentity = "Claim Radicle Identity",
   CollectFunds = "Collect Funds",
+  CommitEnsName = "Commit ENS name",
   CreateOrg = "Create Org",
   Erc20Allowance = "ERC-20 Allowance",
+  LinkEnsNameToOrg = "Link Ens Name to Org",
+  RegisterEnsName = "Register ENS name",
   SupportOnboarding = "Support Onboarding",
   TopUp = "Top Up",
+  UpdateEnsMetadata = "Update ENS metadata",
   UpdateSupport = "Update Support",
   Withdraw = "Withdraw",
 }
@@ -135,6 +160,22 @@ export function anchorProject(txc: ContractTransaction): Tx {
 
 export function createOrg(txc: ContractTransaction): Tx {
   return { ...txData(txc), kind: TxKind.CreateOrg };
+}
+
+export function registerEnsName(txc: ContractTransaction): Tx {
+  return { ...txData(txc), kind: TxKind.RegisterEnsName };
+}
+
+export function commitEnsName(txc: ContractTransaction): Tx {
+  return { ...txData(txc), kind: TxKind.CommitEnsName };
+}
+
+export function linkEnsNameToOrg(txc: ContractTransaction): Tx {
+  return { ...txData(txc), kind: TxKind.LinkEnsNameToOrg };
+}
+
+export function updateEnsMetadata(txc: ContractTransaction): Tx {
+  return { ...txData(txc), kind: TxKind.UpdateEnsMetadata };
 }
 
 export function claimRadicleIdentity(
@@ -371,11 +412,15 @@ function direction(tx: Tx): Direction {
       return Direction.Incoming;
 
     case TxKind.AnchorProject:
-    case TxKind.CreateOrg:
     case TxKind.ClaimRadicleIdentity:
+    case TxKind.CommitEnsName:
+    case TxKind.CreateOrg:
     case TxKind.Erc20Allowance:
+    case TxKind.LinkEnsNameToOrg:
+    case TxKind.RegisterEnsName:
     case TxKind.SupportOnboarding:
     case TxKind.TopUp:
+    case TxKind.UpdateEnsMetadata:
     case TxKind.UpdateSupport:
       return Direction.Outgoing;
   }
@@ -389,6 +434,13 @@ export function emoji(tx: Tx): string {
       return "🎪";
     case TxKind.ClaimRadicleIdentity:
       return "🧦";
+    case TxKind.CommitEnsName:
+    case TxKind.RegisterEnsName:
+      return "📇";
+    case TxKind.UpdateEnsMetadata:
+      return "📋";
+    case TxKind.LinkEnsNameToOrg:
+      return "🔗";
     case TxKind.CollectFunds:
     case TxKind.Withdraw:
     case TxKind.Erc20Allowance:
@@ -404,17 +456,19 @@ export function txIcon(tx: Tx): typeof SvelteComponent {
     case TxKind.ClaimRadicleIdentity:
       return Icon.Registered;
     case TxKind.CollectFunds:
-      return Icon.Withdraw;
     case TxKind.Withdraw:
       return Icon.Withdraw;
+    case TxKind.CommitEnsName:
     case TxKind.Erc20Allowance:
+    case TxKind.LinkEnsNameToOrg:
+    case TxKind.RegisterEnsName:
+    case TxKind.UpdateEnsMetadata:
       return Icon.Ethereum;
     case TxKind.SupportOnboarding:
+    case TxKind.UpdateSupport:
       return Icon.TokenStreams;
     case TxKind.TopUp:
       return Icon.Topup;
-    case TxKind.UpdateSupport:
-      return Icon.TokenStreams;
     case TxKind.CreateOrg:
       return Icon.Orgs;
     case TxKind.AnchorProject:

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -23,11 +23,15 @@ import * as ethereumDebug from "ui/src/ethereum/debug";
 import { createWalletConnect, QrDisplay } from "ui/src/ethereum/walletConnect";
 import { INFURA_API_KEY_MAINNET, INFURA_API_KEY_RINKEBY } from "ui/src/config";
 
+export { radToken };
+
 export enum Status {
   Connected = "CONNECTED",
   Connecting = "CONNECTING",
   NotConnected = "NOT_CONNECTED",
 }
+
+export type Provider = ethers.providers.Provider & ethers.providers.EnsProvider;
 
 export type State =
   | { status: Status.NotConnected; error?: globalThis.Error }
@@ -43,8 +47,8 @@ export interface Wallet extends svelteStore.Readable<State> {
   environment: Environment;
   connect(qrDisplay: QrDisplay): Promise<void>;
   disconnect(): Promise<void>;
-  provider: ethers.providers.Provider;
-  signer: ethers.Signer;
+  provider: Provider;
+  signer: WalletConnectSigner;
   // Returns the address of the wallet account if the wallet is
   // connected.
   getAddress(): string | undefined;
@@ -88,7 +92,7 @@ async function updateAccountBalances(
   }
 }
 
-function getProvider(environment: Environment): ethers.providers.Provider {
+function getProvider(environment: Environment): Provider {
   switch (environment) {
     case Environment.Local:
       return new ethers.providers.JsonRpcProvider("http://localhost:8545");
@@ -109,10 +113,7 @@ function getProvider(environment: Environment): ethers.providers.Provider {
 
 const walletConnect = createWalletConnect();
 
-function build(
-  environment: Environment,
-  provider: ethers.providers.Provider
-): Wallet {
+function build(environment: Environment, provider: Provider): Wallet {
   const stateStore = svelteStore.writable<State>({
     status: Status.NotConnected,
   });

--- a/ui/src/wallet/radToken.ts
+++ b/ui/src/wallet/radToken.ts
@@ -8,8 +8,8 @@ import type * as ethers from "ethers";
 import * as ethereum from "ui/src/ethereum";
 
 import {
-  ERC20,
-  ERC20__factory as Erc20Factory,
+  RadicleToken,
+  RadicleToken__factory as RadicleTokenFactory,
 } from "radicle-contracts/build/contract-bindings/ethers";
 
 const addresses = {
@@ -32,6 +32,9 @@ function radTokenAddress(environment: ethereum.Environment): string {
 export function connect(
   signerOrProvider: ethers.Signer | ethers.providers.Provider,
   environment: ethereum.Environment
-): ERC20 {
-  return Erc20Factory.connect(radTokenAddress(environment), signerOrProvider);
+): RadicleToken {
+  return RadicleTokenFactory.connect(
+    radTokenAddress(environment),
+    signerOrProvider
+  );
 }


### PR DESCRIPTION
Working on top of https://github.com/radicle-dev/radicle-upstream/pull/2180.

## ToDo

### Usecases
- [x] Support multi-sig orgs. This requires changes to the `LinkOrgToName` step and the succeeding success step's copy, and maybe also some kind of indicator on the multisig org page that indicates that an org link transaction is currently pending approval.
- [x] Add `Seed ID` and `Seed API` fields to the update metadata form
- [x] Show `Seed ID` and `Seed API` in the org header
- [x] Invalidate ENS data caches properly when data is being updated
- [ ] Provide user with hints on how to resume a previously started flow

### Edge cases
- [ ] ~~It may be a good idea to fetch the image URL entered in the `populateMetadata` step and check against a max allowed filesize in order to prevent users setting massive images as their org avatar.~~ -> Not very important at the moment.
- [x] Persist a commitment including name & salt in `localStorage` as soon as submitted in order to be able to resume it should the user lose connection or drop out after spending the RAD fee.

### UX & Design
- [x] Display social media links if set: https://github.com/radicle-dev/radicle-upstream/issues/2194
- [x] When an org already has a name, we probably want to show an "Edit or link other ENS name" button in the overflow menu instead of the current "Register ENS name" button.
- [ ] ~~We probably want to show a list of any already registered .radicle.eth ENS names for the current user on the `enterName` step in addition to the text field for creating a new name.~~ There's no way to get a list of registered names.
- [x] This PR introduces the first actual RAD transaction in upstream. Probably, it should be released together with adding support for RAD balance & transactions to the wallet page. https://github.com/radicle-dev/radicle-upstream/issues/2222
- [x] When upstream is aware of RAD balance, it should check the available balance before starting the commitment in order to avoid the user spending a gas fee but then running into a failure because they don't have enough RADs to cover the name commitment fee.
- [ ] Introduce a way to retry a transaction / signature request (plus maybe a timeout?) in case WalletConnect acts funny and the registration confirmation prompt doesn't appear in the wallet. Currently the button just gets locked in "Waiting for confirmation..." and it's unclear how to retry.
- [x] In the beginning, to create a new name, the user first needs to confirm a signature and then submit the commitment transaction. Currently, this is presented as a single step, but the UI should probably give feedback after the signature to ensure the user doesn't miss the second transaction prompt and wonder why nothing's happening.
- [x] We should probably be upfront with the RAD fee required for name registration at the very beginning of the flow.
- [x] Review & improve design of the steps. They currently look quite bland.

### Behind the scenes
- [x] Don't fetch name data for each org as frequently as we do right now, as that causes way too many Infura calls.
- [x] May want to improve state management on the `registerEnsNameFlow` component, as it's currently a bit all over the place.
- [x] Refactor ensRegistrar.ts to not include any usecase-specific logic, instead only wrapping the registrar contract's functions. Move usecase-specific logic to the components that import registrar contract functions.