### PR TITLE
fix: use proxy IP instead of hostname

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -6,7 +6,7 @@
 
 import * as proxy from "../../ui/src/proxy";
 
-const proxyClient = new proxy.Client("http://localhost:17246");
+const proxyClient = new proxy.Client("http://127.0.0.1:17246");
 
 export const resetProxyState = (): void => {
   cy.then(() => proxyClient.control.reset());

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -43,4 +43,4 @@ const query = qs.parse(
 
 // The address of the proxy in `host:port` format.
 export const proxyAddress =
-  typeof query.backend === "string" ? query.backend : "localhost:17246";
+  typeof query.backend === "string" ? query.backend : "127.0.0.1:17246";


### PR DESCRIPTION
We use the IPv4 address the proxy is bound to instead of the `localhost` hostname. This fixes #2181 where `localhost` resolves to the IPv6 localhost address.