### PR TITLE
refactor: text input without label

### DIFF
--- a/ui/DesignSystem/TextInput.svelte
+++ b/ui/DesignSystem/TextInput.svelte
@@ -25,7 +25,6 @@
   export let validation: ValidationState | undefined = undefined;
   export let validationStyle = "";
   export let hint = "";
-  export let label = "";
   export let showLeftItem: boolean = false;
   export let showSuccessCheck: boolean = false;
   export let spellcheck: boolean = false;
@@ -41,8 +40,6 @@
   }
 
   $: showHint = hint.length > 0 && value.length === 0;
-
-  $: inputOffset = `${label ? 36 : 0}px`;
 </script>
 
 <style>
@@ -137,23 +134,9 @@
     position: absolute;
     right: 0.75rem;
   }
-
-  .label {
-    text-align: left;
-    padding-left: 12px;
-    margin-bottom: 12px;
-  }
 </style>
 
 <div {style} class="wrapper">
-  {#if label}
-    <p
-      class="label typo-text-bold"
-      style="color: var(--color-foreground-level-6">
-      {label}
-    </p>
-  {/if}
-
   <div bind:clientHeight={inputHeight}>
     <input
       data-cy={dataCy}
@@ -199,26 +182,22 @@
   {#if validation}
     {#if validation && validation.status === Status.Loading}
       <Spinner
-        style="justify-content: flex-start; top: calc({inputOffset} - {label
-          ? '18px'
-          : '0px'}); position: absolute; height: 100%;
+        style="justify-content: flex-start; position: absolute; height: 100%;
         right: 10px;" />
     {:else if validation && validation.status === Status.Success && showSuccessCheck}
       <Icon.CheckCircle
         style="fill: var(--color-positive); justify-content: flex-start;
-        position: absolute; top: calc({inputOffset} + ({inputHeight}px - 24px)/2); right: 10px;" />
+        position: absolute; top: calc(({inputHeight}px - 24px)/2); right: 10px;" />
     {:else if validation && validation.status === Status.Error}
       <Icon.ExclamationCircle
         dataCy="validation-error-icon"
         style="fill: var(--color-negative); justify-content: flex-start;
-        position: absolute; top: calc({inputOffset} + ({inputHeight}px - 24px)/2); right: 10px;" />
+        position: absolute; top: calc(({inputHeight}px - 24px)/2); right: 10px;" />
       <div class="validation-row" style={validationStyle}>
         <p>{validation.message}</p>
       </div>
     {:else if showHint}
-      <div
-        class="hint"
-        style="top: calc({inputOffset} + ({inputHeight}px - 28px)/2)">
+      <div class="hint" style={`top: calc((${inputHeight}px - 28px)/2)`}>
         <KeyHint {hint} />
       </div>
     {/if}

--- a/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
+++ b/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
@@ -77,6 +77,14 @@
   }
 </script>
 
+<style>
+  .label {
+    padding-left: 12px;
+    margin-bottom: 12px;
+    color: var(--color-foreground-level-6);
+  }
+</style>
+
 <div>
   <Emoji emoji="🔗" size="huge" style="margin-bottom: 16px" />
   <Header
@@ -86,14 +94,14 @@
       `point towards your newly created name. Once that’s done, your ` +
       `organization will appear with your new name across Radicle!`} />
 
+  <div class="label typo-text-bold">Organization address</div>
   <TextInput
-    label="Organization address"
     disabled
     style="margin-bottom: 24px"
     value={ensMetadataConfiguration.address || undefined} />
 
+  <div class="label typo-text-bold">Name</div>
   <TextInput
-    label="Name"
     disabled
     style="margin-bottom: 24px"
     value={`${ensConfiguration.name}.${ensResolver.DOMAIN}`} />

--- a/ui/Modal/Org/ConfigureEns/PopulateMetadata.svelte
+++ b/ui/Modal/Org/ConfigureEns/PopulateMetadata.svelte
@@ -221,6 +221,14 @@
   }
 </script>
 
+<style>
+  .label {
+    padding-left: 12px;
+    margin-bottom: 12px;
+    color: var(--color-foreground-level-6);
+  }
+</style>
+
 <div>
   <Header
     title="Set your name's metadata"
@@ -230,41 +238,41 @@
       "the organization page."}
     style="margin-bottom: 24px" />
 
+  <div class="label typo-text-bold">Organization address</div>
   <Tooltip
     value={"This is the address of your organization and is required to " +
       "link your ENS name to it."}
     position={style.CSSPosition.Top}>
     <TextInput
-      label="Organization address"
       style="margin-bottom: 24px"
       disabled
       value={addressValue}
       validation={addressValidationStatus} />
   </Tooltip>
 
+  <div class="label typo-text-bold">Website URL</div>
   <TextInput
-    label="Website URL"
     style="margin-bottom: 24px"
     placeholder="https://radicle.xyz/"
     bind:value={urlValue}
     validation={validationStatus} />
 
+  <div class="label typo-text-bold">Avatar URL</div>
   <TextInput
-    label="Avatar URL"
     style="margin-bottom: 24px"
     placeholder="https://radicle.xyz/logo.png"
     bind:value={avatarValue}
     validation={validationStatus} />
 
+  <div class="label typo-text-bold">Twitter username</div>
   <TextInput
-    label="Twitter username"
     style="margin-bottom: 24px"
     placeholder="@radicle"
     bind:value={twitterValue}
     validation={validationStatus} />
 
+  <div class="label typo-text-bold">GitHub username</div>
   <TextInput
-    label="GitHub username"
     style="margin-bottom: 24px"
     placeholder="radicle-dev"
     bind:value={githubValue}


### PR DESCRIPTION
Remove the option to specify a label from TextInput. Instead, the label is created next to the input. This simplifies the TextInput component. Since it is not clear how re-usable the label part is (it is only used in two forms) we also avoid having to adjust the TextInput component over and over in the future.