### PR TITLE
ens integration preparation

### DIFF
--- a/ui/DesignSystem/Avatar.svelte
+++ b/ui/DesignSystem/Avatar.svelte
@@ -120,12 +120,6 @@
     flex-shrink: 0;
   }
 
-  .image {
-    width: 32px;
-    height: 32px;
-    border-radius: 16px;
-  }
-
   .pulsate {
     opacity: 1;
     animation: pulsate 3.5s ease-out infinite;
@@ -144,7 +138,7 @@
 
 <div data-cy={dataCy} class={`container ${size}`} {style}>
   {#if imageUrl}
-    <img class={`image ${avatarClass}`} src={imageUrl} alt="user-avatar" />
+    <img class={`avatar ${avatarClass}`} src={imageUrl} alt="user-avatar" />
   {:else if avatarFallback}
     <div
       class={`avatar ${avatarClass}`}

--- a/ui/src/ethereum/walletConnect.ts
+++ b/ui/src/ethereum/walletConnect.ts
@@ -38,6 +38,11 @@ export interface WalletConnect {
   // Sign a message with the key for `address`. `message` must be
   // hex-encoded.
   signMessage(address: string, message: string): Promise<string>;
+
+  // Sign typed data for the given address as specified in
+  // [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
+  signTypedData(address: string, typedData: unknown): Promise<string>;
+
   // Submit a transaction to the network via the wallet and return the
   // transaction hash. Requires user confirmation. Throws when no
   // wallet is connected.
@@ -103,6 +108,10 @@ export class WalletConnectClient implements WalletConnect {
 
   signMessage(address: string, message: string): Promise<string> {
     return this.connector.signMessage([address, message]);
+  }
+
+  signTypedData(address: string, typedData: unknown): Promise<string> {
+    return this.connector.signTypedData([address, JSON.stringify(typedData)]);
   }
 
   sendTransaction(tx: ITxData): Promise<string> {

--- a/ui/src/ethereum/walletConnectSigner.ts
+++ b/ui/src/ethereum/walletConnectSigner.ts
@@ -103,10 +103,12 @@ export class WalletConnectSigner extends ethers.Signer {
       data: bytesLikeToString(tx.data) || "",
       hash: txHash,
       confirmations: 1,
-      wait: () => {
-        throw new Error("this should never be called");
-      },
+      wait: () => this._provider.waitForTransaction(txHash),
     };
+  }
+
+  async signTypedData(address: string, typedData: unknown): Promise<string> {
+    return this.walletConnect.signTypedData(address, typedData);
   }
 
   async signTransaction(

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -40,7 +40,7 @@ export const show = (
 export const toggle = (
   modalComponent: typeof SvelteComponent,
   onHide: OnHide = doNothing,
-  modalComponentProps: unknown = {}
+  modalComponentProps: { [propName: string]: unknown } = {}
 ): void => {
   const stored = get(store);
 


### PR DESCRIPTION
A couple of commits that make prepartional changes for #2191


* fix: properly scale avatar images

  We remove the `image` class that fixed the size. Instead the size is determined by the `size` class, just like for the avatar fallback.

* feat: add signTypedData to wallet connect
* refactor: improve modal prop interface