### PR TITLE
fix: don’t use stale wallet

### DIFF
--- a/ui/Modal/Org/ConfigureEns/ConfirmRegistration.svelte
+++ b/ui/Modal/Org/ConfigureEns/ConfirmRegistration.svelte
@@ -11,13 +11,9 @@
   import * as ensRegistrar from "ui/src/org/ensRegistrar";
   import * as ensResolver from "ui/src/org/ensResolver";
   import * as error from "ui/src/error";
-  import * as svelteStore from "ui/src/svelteStore";
-  import * as wallet from "ui/src/wallet";
 
   import ButtonRow from "./shared/ButtonRow.svelte";
   import Header from "./shared/Header.svelte";
-
-  const walletStore = svelteStore.get(wallet.store);
 
   let buttonsDisabled = false;
   let confirmButtonCopy = "Confirm registration";
@@ -32,11 +28,7 @@
     try {
       const salt = ensConfiguration.commitmentSalt;
 
-      await ensRegistrar.register(
-        walletStore.environment,
-        ensConfiguration.name,
-        salt
-      );
+      await ensRegistrar.register(ensConfiguration.name, salt);
 
       onSubmit();
     } catch (err) {

--- a/ui/Modal/Org/ConfigureEns/EnterEnsName.svelte
+++ b/ui/Modal/Org/ConfigureEns/EnterEnsName.svelte
@@ -38,8 +38,6 @@
     status: validation.ValidationStatus.NotStarted,
   };
 
-  const walletStore = svelteStore.get(wallet.store);
-
   async function handleSubmit() {
     if (!name) {
       validationStatus = {
@@ -53,10 +51,7 @@
       status: validation.ValidationStatus.Loading,
     };
 
-    const { available, fee } = await ensRegistrar.checkAvailability(
-      walletStore.environment,
-      name
-    );
+    const { available, fee } = await ensRegistrar.checkAvailability(name);
 
     if (available) {
       onSubmit({
@@ -69,6 +64,8 @@
       const registration = await ensResolver.getRegistration(
         `${name}.${ensResolver.DOMAIN}`
       );
+
+      const walletStore = svelteStore.get(wallet.store);
 
       if (registration && registration.owner === walletStore.getAddress()) {
         onSubmit({


### PR DESCRIPTION
Before, some of the functions in `ensRegistrar` would use a style `Wallet` value because it was set at the module level. Now, we get the most recent wallet when the functions are called.

Since the functions are inherently stateful, we don’t require functions to pass down the `environment` parameter and get it from the wallet instead.