### PR TITLE
refactor: align use of setName for org contract

### DIFF
--- a/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
+++ b/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
@@ -36,7 +36,7 @@
       });
     }
     try {
-      await org.setSingleSigName(
+      await org.setNameSingleSig(
         `${ensConfiguration.name}.${ensResolver.DOMAIN}`,
         ensMetadataConfiguration.address
       );
@@ -67,7 +67,7 @@
         details: { ensConfiguration },
       });
     }
-    await org.setNameMultisig(
+    await org.proposeSetNameChange(
       `${ensConfiguration.name}.${ensResolver.DOMAIN}`,
       ensMetadataConfiguration.address,
       safeAddress

--- a/ui/src/ethereum/index.ts
+++ b/ui/src/ethereum/index.ts
@@ -66,3 +66,15 @@ export function etherscanUrl(ethEnv: Environment, query: string): string {
       return `https://etherscan.io/search?f=0&q=${query}`;
   }
 }
+
+export function ensAddress(env: Environment): string {
+  if (env === Environment.Local) {
+    throw new error.Error({
+      code: error.Code.FeatureNotAvailableForGivenNetwork,
+      message: "ENS is not supported on the Local environment",
+    });
+  } else {
+    // https://docs.ens.domains/ens-deployments
+    return "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+  }
+}


### PR DESCRIPTION
We rewrite `org.setNameMultisig` and `org.setSingleSigName` to better align with project anchoring. This means we make the code in `ui/src/org/contract` stateless, i.e. independent of the wallet. We consolidate the stateful code in `ui/src/org`. We also hardcode the ENS addresses since they might not always be available from the provider.