### PR TITLE
refactor: remove unused shareable_entity_identifier attribute

### DIFF
--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -179,7 +179,6 @@ mod test {
 
         http::test::assert_response(&res, StatusCode::CREATED, |have| {
             let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
-            let shareable_entity_identifier = format!("cloudhead@{}", peer_id);
             assert_eq!(
                 have,
                 json!({
@@ -193,7 +192,6 @@ mod test {
                             "expiration": "2021-03-19T23:15:30.001Z",
                         }
                     },
-                    "shareableEntityIdentifier": &shareable_entity_identifier,
                 })
             );
         });
@@ -259,7 +257,6 @@ mod test {
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
             let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
-            let shareable_entity_identifier = format!("cloudhead_next@{}", peer_id);
             assert_eq!(
                 have,
                 json!({
@@ -273,7 +270,6 @@ mod test {
                             "expiration": "2021-03-19T23:15:30.001Z",
                         }
                     },
-                    "shareableEntityIdentifier": &shareable_entity_identifier,
                 })
             );
         });
@@ -339,7 +335,6 @@ mod test {
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
             let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
-            let shareable_entity_identifier = format!("cloudhead@{}", peer_id);
             assert_eq!(
                 have,
                 json!({
@@ -350,7 +345,6 @@ mod test {
                         "handle": "cloudhead",
                         "ethereum": null
                     },
-                    "shareableEntityIdentifier": &shareable_entity_identifier,
                 })
             );
         });
@@ -375,7 +369,6 @@ mod test {
         let handle = user.subject().name.to_string();
         let peer_id = ctx.peer.peer_id();
         let urn = user.urn();
-        let shareable_entity_identifier = (peer_id, user.into_inner().into_inner()).into();
 
         let have: Value = serde_json::from_slice(res.body()).unwrap();
         assert_eq!(res.status(), StatusCode::OK);
@@ -384,7 +377,6 @@ mod test {
             json!(identity::Identity {
                 peer_id,
                 urn: urn.clone(),
-                shareable_entity_identifier,
                 metadata: identity::Metadata {
                     handle,
                     ethereum: None

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -491,7 +491,6 @@ mod test {
                 ],
                 "name": "Upstream",
             },
-            "shareableEntityIdentifier": format!("%{}", meta.urn.to_string()),
             "stats": {
                 "branches": 1,
                 "commits": 1,
@@ -572,7 +571,6 @@ mod test {
                     maintainer
                 ],
             },
-            "shareableEntityIdentifier": format!("%{}", meta.urn.to_string()),
             "stats": {
                 "branches": 2,
                 "commits": 15,

--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -22,7 +22,6 @@ use radicle_daemon::{
 use crate::{
     error,
     ethereum::{address::Address, claim_ext::V1 as EthereumClaimExtV1},
-    identifier::Identifier,
 };
 
 use std::convert::TryFrom;
@@ -35,8 +34,6 @@ pub struct Identity {
     pub peer_id: PeerId,
     /// The coco URN.
     pub urn: Urn,
-    /// Unambiguous identifier pointing at this identity.
-    pub shareable_entity_identifier: Identifier,
     /// Bundle of user provided data.
     pub metadata: Metadata,
     /// Generated fallback avatar to be used if actual avatar url is missing or can't be loaded.
@@ -46,14 +43,9 @@ pub struct Identity {
 impl From<(PeerId, DaemonPerson)> for Identity {
     fn from((peer_id, user): (PeerId, DaemonPerson)) -> Self {
         let identity = Person::from(user);
-        let shareable_entity_identifier = Identifier {
-            handle: identity.metadata.handle.clone(),
-            peer_id,
-        };
         Self {
             peer_id,
             urn: identity.urn,
-            shareable_entity_identifier,
             metadata: identity.metadata,
             avatar_fallback: identity.avatar_fallback,
         }

--- a/proxy/api/src/project.rs
+++ b/proxy/api/src/project.rs
@@ -72,8 +72,6 @@ impl TryFrom<RadProject> for Metadata {
 pub struct Project<S> {
     /// Unique identifier of the project in the network.
     pub urn: Urn,
-    /// Unambiguous identifier pointing at this identity.
-    pub shareable_entity_identifier: String,
     /// Attached metadata, mostly for human pleasure.
     pub metadata: Metadata,
     /// High-level statistics about the project
@@ -92,7 +90,6 @@ impl Partial {
     pub fn fulfill(self, stats: Stats) -> Full {
         Project {
             urn: self.urn,
-            shareable_entity_identifier: self.shareable_entity_identifier,
             metadata: self.metadata,
             stats,
         }
@@ -110,8 +107,7 @@ impl TryFrom<RadProject> for Partial {
         let metadata = Metadata::try_from(project)?;
 
         Ok(Self {
-            urn: urn.clone(),
-            shareable_entity_identifier: format!("%{}", urn),
+            urn,
             metadata,
             stats: (),
         })
@@ -129,8 +125,7 @@ impl TryFrom<(RadProject, Stats)> for Full {
         let metadata = Metadata::try_from(project)?;
 
         Ok(Self {
-            urn: urn.clone(),
-            shareable_entity_identifier: format!("%{}", urn),
+            urn,
             metadata,
             stats,
         })

--- a/ui/src/__mocks__/api.ts
+++ b/ui/src/__mocks__/api.ts
@@ -19,7 +19,6 @@ type MockedResponse =
 
 export const upstreamProjectMock: project.Project = {
   urn: "rad:git:hwd1yregn1xe4krjs5h7ag5ceut9rwmjssr8e8t4pw6nrwdxgc761o3x4sa",
-  shareableEntityIdentifier: "sos@{}",
   metadata: {
     name: "radicle-upstream",
     defaultBranch: "eichhoernchen",
@@ -36,8 +35,6 @@ export const upstreamProjectMock: project.Project = {
 
 const surfProjectMock: project.Project = {
   urn: "rad:git:hwd1yref66p4r3z1prxwdjr7ig6ihhrfzsawnc6us4zxtapfukrf6r7mupw",
-  shareableEntityIdentifier:
-    "%rad:git:hwd1yref66p4r3z1prxwdjr7ig6ihhrfzsawnc6us4zxtapfukrf6r7mupw",
   metadata: {
     name: "radicle-surf",
     defaultBranch: "schildkroete",

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -88,7 +88,5 @@ export const fallback: Identity = {
     ethereum: null,
   },
   peerId: "hwd1yreyza9z77xzp1rwyxw9uk4kdrrzag5uybd7w1ihke18xxhxn6qu4oy",
-  shareableEntityIdentifier:
-    "rad:git:hwd1yreyza9z77xzp1rwyxw9uk4kdrrzag5uybd7w1ihke18xxhxn6qu4oy",
   urn: "rad:git:hwd1yreyza9z77xzp1rwyxw9uk4kdrrzag5uybd7w1ihke18xxhxn6qu4oy",
 };

--- a/ui/src/proxy/identity.ts
+++ b/ui/src/proxy/identity.ts
@@ -32,7 +32,6 @@ export interface RemoteIdentity {
 
 export interface Identity extends RemoteIdentity {
   peerId: string;
-  shareableEntityIdentifier: string;
 }
 
 export interface Metadata {
@@ -63,5 +62,4 @@ export const remoteIdentitySchema = zod.object({
 
 export const identitySchema = remoteIdentitySchema.extend({
   peerId: zod.string(),
-  shareableEntityIdentifier: zod.string(),
 });

--- a/ui/src/proxy/project.ts
+++ b/ui/src/proxy/project.ts
@@ -30,14 +30,12 @@ export interface CreateParams {
 
 export interface Project {
   urn: string;
-  shareableEntityIdentifier: string;
   metadata: Metadata;
   stats: Stats;
 }
 
 const projectSchema: zod.Schema<Project> = zod.object({
   urn: zod.string(),
-  shareableEntityIdentifier: zod.string(),
   metadata: metadataSchema,
   stats: zod.object({
     branches: zod.number(),
@@ -48,13 +46,11 @@ const projectSchema: zod.Schema<Project> = zod.object({
 
 export interface FailedProject {
   urn: string;
-  shareableEntityIdentifier: string;
   metadata: Metadata;
 }
 
 const failedProjectSchema: zod.Schema<FailedProject> = zod.object({
   urn: zod.string(),
-  shareableEntityIdentifier: zod.string(),
   metadata: metadataSchema,
 });
 


### PR DESCRIPTION
It was never used. On the first public release we opted for sharing project `URN`s and `DeviceId`s.