### PR TITLE
fix: fix race conditions in source browsing tests

### DIFF
--- a/ui/src/proxy/fetcher.ts
+++ b/ui/src/proxy/fetcher.ts
@@ -155,7 +155,7 @@ export class Fetcher {
       headers,
       body: body === undefined ? null : JSON.stringify(body),
       credentials: "include",
-      ...options,
+      signal: options.abort,
     });
   }
 }


### PR DESCRIPTION
We fix race conditions in source browsing tests by ensuring that abort signals for superseded requests are properly delivered.