### PR TITLE
fix: tests wait until keystore is sealed

### DIFF
--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -175,6 +175,8 @@ pub struct Unsealed {
     pub auth_token: Arc<RwLock<Option<String>>>,
     /// Reference to the key store.
     pub keystore: Arc<dyn keystore::Keystore + Send + Sync>,
+    /// Notification to shutdown the HTTP server
+    pub shutdown: Arc<tokio::sync::Notify>,
 }
 
 /// Context for HTTP request if the coco peer APIs have not been initialized yet.
@@ -244,6 +246,7 @@ impl Unsealed {
                 service_handle: service::Handle::dummy(),
                 auth_token: Arc::new(RwLock::new(None)),
                 keystore: Arc::new(keystore::memory()),
+                shutdown: Arc::new(tokio::sync::Notify::new()),
             },
             run_handle,
         ))

--- a/proxy/api/src/service.rs
+++ b/proxy/api/src/service.rs
@@ -199,7 +199,7 @@ impl Handle {
                 },
             },
         }
-        self.reload_notify.notify_one();
+        self.reload_notify.notify_waiters()
     }
 
     /// Create a handle where none of the methods have any effect.


### PR DESCRIPTION
We ensure that the tests wait until the proxy has been properly sealed before continuing.

To make this work we also need to ensure that the HTTP server shuts down properly by terminating any event streams.