### PR TITLE
fix: silent retries if graph is unavailable

### DIFF
--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -44,7 +44,7 @@ const ORG_POLL_INTERVAL_MS = 2000;
 // immediately but retry again.
 const updateOrgsForever = async (): Promise<never> => {
   let showError = true;
-  let remainingRetriesUnavailable = 0;
+  let remainingRetriesUnavailable = 20;
 
   for (;;) {
     const walletStore = svelteStore.get(wallet.store);


### PR DESCRIPTION
We properly initialize the remaining tries when the graph is
unavailable.