### PR TITLE
fix: wait until session is unsealed

### DIFF
--- a/ui/Screen/Onboarding.svelte
+++ b/ui/Screen/Onboarding.svelte
@@ -8,7 +8,7 @@
 <script lang="typescript">
   import { fade, fly } from "svelte/transition";
 
-  import { withRetry } from "ui/src/api";
+  import { retryFetch } from "ui/src/retryOnError";
   import { State } from "ui/src/onboarding";
   import { createIdentity } from "ui/src/identity";
   import * as error from "ui/src/error";
@@ -58,7 +58,7 @@
         createIdentityInProgress = true;
         await session.createKeystore(passphrase);
         // Retry until the API is up
-        const identity = await withRetry(
+        const identity = await retryFetch(
           () => createIdentity({ handle }),
           100,
           50

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -7,7 +7,6 @@
 import qs from "qs";
 
 import * as config from "./config";
-import { sleep } from "ui/src/sleep";
 
 interface Options {
   query?: Record<string, unknown>;
@@ -121,20 +120,3 @@ export const set = async <T>(
       ...options,
     })
   );
-
-export const withRetry = async <T>(
-  request: () => Promise<T>,
-  delayTime: number,
-  retries: number
-): Promise<T> => {
-  for (; ; retries--) {
-    try {
-      return await request();
-    } catch (error) {
-      if (error.message !== "Failed to fetch" || retries < 0) {
-        throw error;
-      }
-    }
-    await sleep(delayTime);
-  }
-};

--- a/ui/src/proxy/index.ts
+++ b/ui/src/proxy/index.ts
@@ -6,7 +6,6 @@
 
 import * as zod from "zod";
 import * as config from "../config";
-import { sleep } from "ui/src/sleep";
 
 import * as settings from "./settings";
 import * as identity from "./identity";
@@ -160,20 +159,3 @@ export class Client {
 }
 
 export const client = new Client(`http://${config.proxyAddress}`);
-
-export const withRetry = async <T>(
-  request: () => Promise<T>,
-  delayTime: number,
-  retries: number
-): Promise<T> => {
-  for (; ; retries--) {
-    try {
-      return await request();
-    } catch (error) {
-      if (error.message !== "Failed to fetch" || retries < 0) {
-        throw error;
-      }
-    }
-    await sleep(delayTime);
-  }
-};

--- a/ui/src/retryOnError.test.ts
+++ b/ui/src/retryOnError.test.ts
@@ -1,0 +1,71 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import { retryOnError } from "./retryOnError";
+
+const TRY_COUNT = 10;
+
+test("retries exhausted", async () => {
+  const error = new Error("ERROR");
+  let callCount = 0;
+  const action = async () => {
+    callCount += 1;
+    throw error;
+  };
+
+  const result = await retryOnError(action, () => true, 0, TRY_COUNT).catch(
+    e => e
+  );
+  expect(result).toBe(error);
+  expect(callCount).toBe(TRY_COUNT);
+});
+
+test("rethrows unmatched errors", async () => {
+  const unmatchedError = new Error("UNMATCHED");
+  const retryError = new Error("RETRY");
+
+  let callCount = 0;
+  const action = async () => {
+    callCount += 1;
+    if (callCount < TRY_COUNT / 2) {
+      throw retryError;
+    } else {
+      throw unmatchedError;
+    }
+  };
+
+  const result = await retryOnError(
+    action,
+    e => e === retryError,
+    0,
+    TRY_COUNT
+  ).catch(e => e);
+  expect(result).toBe(unmatchedError);
+  expect(callCount).toBe(TRY_COUNT / 2);
+});
+
+test("passes valid results", async () => {
+  const error = new Error("ERROR");
+
+  let callCount = 0;
+  const action = async () => {
+    callCount += 1;
+    if (callCount < TRY_COUNT / 2) {
+      throw error;
+    } else {
+      return "RESULT";
+    }
+  };
+
+  const result = await retryOnError(
+    action,
+    e => e === error,
+    0,
+    TRY_COUNT
+  ).catch(e => e);
+  expect(result).toBe("RESULT");
+  expect(callCount).toBe(TRY_COUNT / 2);
+});

--- a/ui/src/retryOnError.ts
+++ b/ui/src/retryOnError.ts
@@ -1,0 +1,48 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import { sleep } from "ui/src/sleep";
+
+// Retries calling `action` if it throws an error that matches
+// `retryPredicate`. Otherwise the result from `action()` is returned
+// or the unmatched error is re-thrown.
+//
+// `delayMs` is the delay between retries in milliseconds. The first
+// try is called immediately.
+//
+// `tryCount` is the maximum number of times that `action` is called.
+export async function retryOnError<T>(
+  action: () => Promise<T>,
+  retryPredicate: (error: unknown) => boolean,
+  delayMs: number,
+  tryCount: number
+): Promise<T> {
+  for (; ; tryCount--) {
+    try {
+      return await action();
+    } catch (error) {
+      if (!retryPredicate(error) || tryCount <= 1) {
+        throw error;
+      }
+    }
+    await sleep(delayMs);
+  }
+}
+
+// Convenience wrapper for `retryOnError` that retries on `fetch()`
+// errors.
+export async function retryFetch<T>(
+  action: () => Promise<T>,
+  delayMs: number,
+  tryCount: number
+): Promise<T> {
+  return retryOnError(
+    action,
+    error => error instanceof Error && error.message === "Failed to fetch",
+    delayMs,
+    tryCount
+  );
+}

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -6,6 +6,8 @@
 
 import { Readable, derived, get } from "svelte/store";
 
+import { retryFetch } from "ui/src/retryOnError";
+
 import * as proxy from "./proxy";
 import * as error from "./error";
 import type * as identity from "./identity";
@@ -93,7 +95,7 @@ export const settings: Readable<Settings> = derived(sessionStore, sess => {
 
 const fetchSession = async (): Promise<void> => {
   try {
-    const ses = await proxy.withRetry(() => proxy.client.sessionGet(), 100, 50);
+    const ses = await retryFetch(() => proxy.client.sessionGet(), 100, 50);
     sessionStore.success({ status: Status.UnsealedSession, ...ses });
   } catch (err) {
     if (err instanceof proxy.ResponseError) {


### PR DESCRIPTION
*Review commit-by-commit*

When unsealing the session we’ll wait until it is actually unsealed. This fixes a race condition where we fetch the session before the proxy has had time to restart.

This includes a separate commit that extracts the retry functionality in it’s own module and generalizes it.