### PR TITLE
fix: don’t handle unhandled errors in cypress runner

### DIFF
--- a/ui/src/error.ts
+++ b/ui/src/error.ts
@@ -227,7 +227,13 @@ ipc.listenProxyError(proxyError => {
   setFatal({ kind: FatalErrorKind.ProxyExit, data: proxyError });
 });
 
-if (!config.isCypressTestEnv && !config.isNodeTestEnv) {
+// If we’re not in any kind of test environment we show unhandled
+// errors to the user.
+if (
+  !config.isCypressTestEnv &&
+  !config.isCypressTestRunner &&
+  !config.isNodeTestEnv
+) {
   window.addEventListener("unhandledrejection", ev => {
     ev.preventDefault();
     show(fromUnknown(ev.reason, Code.UnhandledRejection));


### PR DESCRIPTION
When the code is executed by the cypress test runner (i.e. the code were tests are defined) we also don’t want to handle errors and show them to the user. Instead they should be unhandled errors that make the tests fail.