### PR TITLE
chore: use the default walletconnect bridge

### DIFF
--- a/ui/src/ethereum/walletConnect.ts
+++ b/ui/src/ethereum/walletConnect.ts
@@ -173,7 +173,7 @@ function createConnector(): Connector {
   let modalClosedByWalletConnect = false;
 
   const connector = new Connector({
-    bridge: "https://radicle.bridge.walletconnect.org",
+    bridge: "https://bridge.walletconnect.org",
     qrcodeModal: {
       open: (uri: string, onClose, _opts?: unknown) => {
         modal.toggle(


### PR DESCRIPTION
Since WalletConnect 1.6.0 setting `bridge` to a custom value has no effect anymore. They're urging everyone to use their default infrastructure.