### PR TITLE
fix: don’t swallow transaction error source

### DIFF
--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -460,7 +460,7 @@ export function convertError(e: globalThis.Error, label: string): error.Error {
   return new error.Error({
     code,
     message: `${label}: ${message}`,
-    source: error.fromJsError(e),
+    source: e,
   });
 }
 


### PR DESCRIPTION
We don’t call `error.fromJsError` so we also handle other types of errors. By passing `e` as the `source` parameter directly we leverage `error.fromUnknown` which is called internally.