### PR TITLE
style: fix QR code style in light mode

### DIFF
--- a/ui/Modal/Wallet/QRCode.svelte
+++ b/ui/Modal/Wallet/QRCode.svelte
@@ -31,14 +31,13 @@
     padding: calc(var(--content-padding) / 2);
     border-radius: 1rem;
     background-color: white;
+    box-shadow: var(--elevation-medium);
   }
 
   .connector {
     display: flex;
     align-items: center;
     justify-content: center;
-
-    padding-top: 0.625rem;
     color: var(--color-foreground-level-5);
   }
 </style>
@@ -55,10 +54,11 @@
     <div data-cy="qr-code">
       {@html svgString}
     </div>
-    <p class="typo-text-bold connector">
-      <Copyable showIcon={true} styleContent={false} copyContent={uri}>
-        <p class="typo-text-small-mono">{ellipsed(uri, 5)}</p>
-      </Copyable>
-    </p>
   </div>
+
+  <p class="typo-text-bold connector">
+    <Copyable showIcon={true} styleContent={false} copyContent={uri}>
+      <p class="typo-text-small-mono">{ellipsed(uri, 5)}</p>
+    </Copyable>
+  </p>
 </Modal>


### PR DESCRIPTION
Before:
<img width="1552" alt="Screenshot 2021-08-19 at 09 46 50" src="https://user-images.githubusercontent.com/158411/130029077-4533969b-6df7-4f9c-881f-b26f5e75375d.png">
<img width="1552" alt="Screenshot 2021-08-19 at 09 46 55" src="https://user-images.githubusercontent.com/158411/130029093-c228120d-de58-4be7-bf87-36ac1dff1bfd.png">
<img width="1552" alt="Screenshot 2021-08-19 at 09 47 01" src="https://user-images.githubusercontent.com/158411/130029100-bebc6305-e3c8-46c6-a7f0-4d2d5f9bad60.png">

After:


<img width="1552" alt="Screenshot 2021-08-19 at 09 49 08" src="https://user-images.githubusercontent.com/158411/130029382-410fe133-c4d1-4c07-885b-d30f9e9524ef.png">
<img width="1552" alt="Screenshot 2021-08-19 at 09 49 12" src="https://user-images.githubusercontent.com/158411/130029397-33601b9d-0b9c-4384-b68b-528927c57da8.png">
<img width="1552" alt="Screenshot 2021-08-19 at 09 49 17" src="https://user-images.githubusercontent.com/158411/130029405-9c33176f-8945-44ac-bb61-ed63ab73c0c8.png">
