### PR TITLE
fix: increase timeout to unseal

### DIFF
--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -118,7 +118,7 @@ const fetchSession = async (waitUnsealed = false): Promise<void> => {
         }
       },
       100,
-      50
+      200 // 20 seconds timeout
     );
     sessionStore.success({ status: Status.UnsealedSession, ...ses });
   } catch (err) {


### PR DESCRIPTION
As reported in #2252, it may take more than five seconds to unseal the
keystore. We’re increasing the timeout to 20 seconds.