### PR TITLE
chore: use Modal component consistently

### DIFF
--- a/ui/DesignSystem/Funding/Pool/TopUp.svelte
+++ b/ui/DesignSystem/Funding/Pool/TopUp.svelte
@@ -8,7 +8,7 @@
 <script lang="typescript">
   import Button from "ui/DesignSystem/Button.svelte";
   import Dai from "ui/DesignSystem/Dai.svelte";
-  import Emoji from "ui/DesignSystem/Emoji.svelte";
+  import Modal from "ui/DesignSystem/Modal.svelte";
   import TextInput from "ui/DesignSystem/TextInput.svelte";
 
   import { amountStore, balanceValidationStore } from "ui/src/funding/pool";
@@ -37,50 +37,37 @@
 </script>
 
 <style>
-  h1,
-  p,
-  .submit {
-    margin-top: 1.5rem;
-  }
-
-  h1,
-  p {
-    padding: 0 2.5rem;
-  }
-
-  .submit {
+  .wrapper {
     display: flex;
-    justify-content: flex-end;
-    width: 100%;
+    justify-content: center;
   }
 </style>
 
-<Emoji emoji="💸" size="huge" />
-<h1>Top up your account</h1>
-<p>
-  You can top up a couple of weeks worth of support or just enough for this
-  week.
-</p>
-<TextInput
-  dataCy="modal-amount-input"
-  bind:value={amount}
-  validation={$validation}
-  showLeftItem
-  autofocus
-  style={"width: 125px; margin-top: 1.5rem"}>
-  <div slot="left" style="position: absolute; top: 1px; left: 12px;">
-    <Dai />
-  </div>
-</TextInput>
-<div class="submit">
-  <Button
-    variant="transparent"
-    dataCy="cancel"
-    on:click={onBack[1]}
-    style="margin-right: 1rem">
-    {onBack[0]}
-  </Button>
+<Modal emoji="💸" title="Top up your account">
+  <svelte:fragment slot="description">
+    You can top up a couple of weeks worth of support or just enough for this
+    week.
+  </svelte:fragment>
 
-  <!-- Continue button provided by the parent view !-->
-  <slot />
-</div>
+  <div class="wrapper">
+    <TextInput
+      dataCy="modal-amount-input"
+      bind:value={amount}
+      validation={$validation}
+      showLeftItem
+      autofocus
+      style={"width: 125px; margin-top: 1.5rem"}>
+      <div slot="left" style="position: absolute; top: 1px; left: 12px;">
+        <Dai />
+      </div>
+    </TextInput>
+  </div>
+  <svelte:fragment slot="buttons">
+    <Button variant="transparent" dataCy="cancel" on:click={onBack[1]}>
+      {onBack[0]}
+    </Button>
+
+    <!-- Continue button provided by the parent view !-->
+    <slot />
+  </svelte:fragment>
+</Modal>

--- a/ui/DesignSystem/Modal.svelte
+++ b/ui/DesignSystem/Modal.svelte
@@ -7,11 +7,12 @@
 -->
 <script lang="typescript">
   import { Emoji } from "ui/DesignSystem";
+
   export let dataCy: string | undefined = undefined;
   export let style: string | undefined = undefined;
+
   export let emoji: string | undefined = undefined;
   export let title: string | undefined = undefined;
-  export let desc: string | undefined = undefined;
 </script>
 
 <style>
@@ -28,14 +29,25 @@
   .container:focus {
     outline: none;
   }
-  .content {
-    width: 100%;
-    margin-top: 1.5rem;
+  h1 {
+    text-align: center;
+    margin-bottom: 1rem;
   }
-
-  .desc {
+  .description {
     color: var(--color-foreground-level-6);
     text-align: center;
+    margin-bottom: 1rem;
+  }
+  .content {
+    margin-bottom: 1rem;
+    width: 100%;
+  }
+  .buttons {
+    margin-top: 1rem;
+    display: flex;
+    width: 100%;
+    gap: 1.5rem;
+    justify-content: flex-end;
   }
 </style>
 
@@ -43,13 +55,24 @@
   {#if emoji}
     <Emoji {emoji} size="huge" style="margin-bottom: 1rem;" />
   {/if}
+
   {#if title}
-    <h1 style="margin-bottom: 1rem">{title}</h1>
+    <h1>{title}</h1>
   {/if}
-  {#if desc}
-    <p class="desc">{desc}</p>
+
+  {#if $$slots.description}
+    <p class="description">
+      <slot name="description" />
+    </p>
   {/if}
+
   <div class="content" {style}>
     <slot />
   </div>
+
+  {#if $$slots.buttons}
+    <div class="buttons">
+      <slot name="buttons" />
+    </div>
+  {/if}
 </div>

--- a/ui/DesignSystem/TxButton.svelte
+++ b/ui/DesignSystem/TxButton.svelte
@@ -40,16 +40,12 @@
 </script>
 
 <style>
-  .tx-button {
-    margin-left: 0.4375rem;
-  }
-
   .running {
     cursor: wait;
   }
 </style>
 
-<span class="tx-button" class:running data-cy={dataCy} {style}>
+<span class:running data-cy={dataCy} {style}>
   <Button disabled={disabled || running} {variant} on:click={userDidClick}>
     <slot />
   </Button>

--- a/ui/Modal/Funding/LinkAddress.svelte
+++ b/ui/Modal/Funding/LinkAddress.svelte
@@ -10,8 +10,8 @@
     Avatar,
     Button,
     Copyable,
-    Emoji,
     Icon,
+    Modal,
     Remote,
     TxButton,
   } from "ui/DesignSystem";
@@ -46,23 +46,6 @@
 </script>
 
 <style>
-  .wrapper {
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    flex-direction: column;
-    min-height: 31.25rem;
-    text-align: center;
-    padding: var(--content-padding);
-    width: 37.5rem;
-    background: var(--color-background);
-    border-radius: 0.5rem;
-  }
-
-  header {
-    padding: 0 var(--content-padding);
-  }
-
   .data {
     display: flex;
     flex-direction: column;
@@ -84,26 +67,13 @@
     display: flex;
     align-items: center;
   }
-  .submit {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-    margin-top: 1.5rem;
-  }
 </style>
 
 <Remote store={session} let:data={it}>
-  <div class="wrapper">
-    <Emoji emoji="🧦" size="huge" />
-
-    <header>
-      <h1 style="margin-top: 1.5rem;">
-        Link your Radicle Identity and Ethereum address
-      </h1>
-      <p style="margin-top: 1.5rem; padding: 0 4rem" class="typo-text">
-        An Ethereum transaction will be sent
-      </p>
-    </header>
+  <Modal emoji="🧦" title="Link your Radicle Identity and Ethereum address">
+    <svelte:fragment slot="description">
+      An Ethereum transaction will be sent
+    </svelte:fragment>
 
     <div class="data">
       <p class="radicle-user typo-text-bold">
@@ -126,7 +96,7 @@
       </p>
     </div>
 
-    <div class="submit">
+    <svelte:fragment slot="buttons">
       <Button variant="transparent" dataCy="cancel-topup" on:click={onCancel}>
         Cancel
       </Button>
@@ -134,10 +104,9 @@
       <TxButton
         dataCy="confirm-button"
         onClick={() => claim(it.identity)}
-        style="margin-left: 14px;"
         errorLabel="Failed to claim your Radicle Identity on Ethereum">
         Link your ID
       </TxButton>
-    </div>
-  </div>
+    </svelte:fragment>
+  </Modal>
 </Remote>

--- a/ui/Modal/Funding/Onboarding.svelte
+++ b/ui/Modal/Funding/Onboarding.svelte
@@ -6,7 +6,6 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import Modal from "ui/DesignSystem/Modal.svelte";
   import Erc20Allowance from "./Onboarding/Erc20Allowance.svelte";
   import Intro from "./Onboarding/Intro.svelte";
   import SetBudget from "./Onboarding/SetBudget.svelte";
@@ -100,19 +99,16 @@
   let receivers: Receivers = new Map();
 </script>
 
-<Modal
-  style="text-align: center; display: flex; flex-direction: column; align-items: center;">
-  {#if currentStep === Step.Erc20Allowance}
-    <Erc20Allowance {onCancel} onConfirm={approveErc20} />
-  {:else if currentStep === Step.Intro}
-    <Intro {onCancel} {onContinue} />
-  {:else if currentStep === Step.SetBudget}
-    <SetBudget bind:budget {onCancel} {onContinue} />
-  {:else if currentStep === Step.AddReceivers}
-    <AddReceivers bind:receivers {onBack} {onContinue} />
-  {:else if currentStep === Step.TopUp}
-    <TopUp bind:amount={topUp} {onBack} {onContinue} />
-  {:else}
-    <Review {budget} {receivers} {topUp} {onBack} {onConfirmed} />
-  {/if}
-</Modal>
+{#if currentStep === Step.Erc20Allowance}
+  <Erc20Allowance {onCancel} onConfirm={approveErc20} />
+{:else if currentStep === Step.Intro}
+  <Intro {onCancel} {onContinue} />
+{:else if currentStep === Step.SetBudget}
+  <SetBudget bind:budget {onCancel} {onContinue} />
+{:else if currentStep === Step.AddReceivers}
+  <AddReceivers bind:receivers {onBack} {onContinue} />
+{:else if currentStep === Step.TopUp}
+  <TopUp bind:amount={topUp} {onBack} {onContinue} />
+{:else}
+  <Review {budget} {receivers} {topUp} {onBack} {onConfirmed} />
+{/if}

--- a/ui/Modal/Funding/Onboarding/AddReceivers.svelte
+++ b/ui/Modal/Funding/Onboarding/AddReceivers.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Button, Emoji } from "ui/DesignSystem";
+  import { Button, Modal } from "ui/DesignSystem";
 
   import Receivers from "ui/DesignSystem/Funding/Pool/Receivers.svelte";
   import type { Receivers as PoolReceivers } from "ui/src/funding/pool";
@@ -22,50 +22,26 @@
   };
 </script>
 
-<style>
-  h1,
-  p,
-  .submit {
-    margin-top: 1.5rem;
-  }
-
-  h1,
-  p {
-    padding: 0 2.5rem;
-  }
-
-  .submit {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
-</style>
-
 <svelte:window on:keydown={onKeydown} />
 
-<Emoji emoji="💸" size="huge" />
-<h1>Add receivers</h1>
-<p>
-  Add receivers to your outgoing support by clicking the “Support” button on
-  profiles or project pages.
-</p>
-<p class="typo-text-small" style="color: var(--color-foreground-level-5)">
-  Tip: You can also add new receivers later on by clicking on “Support” on their
-  profile.
-</p>
-<Receivers
-  bind:receivers
-  editing={true}
-  style="margin-top: 1.5rem"
-  alignment="center" />
-<div class="submit">
-  <Button
-    variant="transparent"
-    dataCy="cancel"
-    on:click={onBack}
-    style="margin-right: 1rem">
-    Back
-  </Button>
+<Modal emoji="💸" title="Add receivers">
+  <svelte:fragment slot="description">
+    Add receivers to your outgoing support by clicking the “Support” button on
+    profiles or project pages.
+  </svelte:fragment>
 
-  <Button dataCy="confirm-button" on:click={onContinue}>Continue</Button>
-</div>
+  <Receivers bind:receivers editing={true} alignment="center" />
+  <p
+    class="typo-text-small"
+    style="margin-top: 1.5rem; color: var(--color-foreground-level-5)">
+    Tip: You can also add new receivers later on by clicking on “Support” on
+    their profile.
+  </p>
+  <svelte:fragment slot="buttons">
+    <Button variant="transparent" dataCy="cancel" on:click={onBack}>
+      Back
+    </Button>
+
+    <Button dataCy="confirm-button" on:click={onContinue}>Continue</Button>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Funding/Onboarding/Erc20Allowance.svelte
+++ b/ui/Modal/Funding/Onboarding/Erc20Allowance.svelte
@@ -6,54 +6,28 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Button, Emoji, TxButton } from "ui/DesignSystem";
+  import { Button, Modal, TxButton } from "ui/DesignSystem";
 
   export let onCancel: () => void;
   export let onConfirm: () => Promise<void>;
 </script>
 
-<style>
-  h1 {
-    padding: 0 var(--content-padding);
-  }
+<Modal emoji="🧐" title="One thing before you start">
+  <svelte:fragment slot="description">
+    Radicle Pools use DAI, an ERC-20 token. To use it, we need you to send a
+    signed transaction.
+  </svelte:fragment>
 
-  h1,
-  p,
-  .submit {
-    margin-top: 1.5rem;
-  }
+  <svelte:fragment slot="buttons">
+    <Button variant="transparent" dataCy="cancel" on:click={onCancel}>
+      Cancel
+    </Button>
 
-  h1,
-  p {
-    padding: 0 2.5rem;
-  }
-
-  .submit {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
-</style>
-
-<Emoji emoji="🧐" size="huge" />
-<h1>One thing before you start</h1>
-<p>
-  Radicle Pools use DAI, an ERC-20 token. To use it, we need you to send a
-  signed transaction.
-</p>
-<div class="submit">
-  <Button
-    variant="transparent"
-    dataCy="cancel"
-    on:click={onCancel}
-    style="margin-right: 1rem">
-    Cancel
-  </Button>
-
-  <TxButton
-    dataCy="confirm-button"
-    onClick={onConfirm}
-    errorLabel="Failed to approve ERC-20 for the Radicle Pool">
-    Confirm in your wallet
-  </TxButton>
-</div>
+    <TxButton
+      dataCy="confirm-button"
+      onClick={onConfirm}
+      errorLabel="Failed to approve ERC-20 for the Radicle Pool">
+      Confirm in your wallet
+    </TxButton>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Funding/Onboarding/Intro.svelte
+++ b/ui/Modal/Funding/Onboarding/Intro.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Button, Emoji } from "ui/DesignSystem";
+  import { Button, Modal } from "ui/DesignSystem";
 
   export let onCancel: () => void;
   export let onContinue: () => void;
@@ -18,45 +18,19 @@
   };
 </script>
 
-<style>
-  h1 {
-    padding: 0 var(--content-padding);
-  }
-
-  h1,
-  p,
-  .submit {
-    margin-top: 1.5rem;
-  }
-
-  h1,
-  p {
-    padding: 0 2.5rem;
-  }
-
-  .submit {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
-</style>
-
 <svelte:window on:keydown={onKeydown} />
 
-<Emoji emoji="💸" size="huge" />
-<h1>Stream digital money to all your favorites</h1>
-<p>
-  Streaming sets up an Ethereum smart contract that sends money out certain
-  speed, defined by you, to a group of people or projects.
-</p>
-<div class="submit">
-  <Button
-    variant="transparent"
-    dataCy="cancel"
-    on:click={onCancel}
-    style="margin-right: 1rem">
-    Cancel
-  </Button>
+<Modal emoji="💸" title="Stream digital money to all your favorites">
+  <svelte:fragment slot="description">
+    Streaming sets up an Ethereum smart contract that sends money out certain
+    speed, defined by you, to a group of people or projects.
+  </svelte:fragment>
 
-  <Button dataCy="confirm-button" on:click={onContinue}>Continue</Button>
-</div>
+  <svelte:fragment slot="buttons">
+    <Button variant="transparent" dataCy="cancel" on:click={onCancel}>
+      Cancel
+    </Button>
+
+    <Button dataCy="confirm-button" on:click={onContinue}>Continue</Button>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Funding/Onboarding/Review.svelte
+++ b/ui/Modal/Funding/Onboarding/Review.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Button, Emoji, TxButton } from "ui/DesignSystem";
+  import { Button, Modal, TxButton } from "ui/DesignSystem";
 
   import Receivers from "ui/DesignSystem/Funding/Pool/Receivers.svelte";
 
@@ -21,59 +21,50 @@
 </script>
 
 <style>
-  h1,
-  p,
-  .submit {
-    margin-top: 1.5rem;
-  }
-
-  h1,
-  p {
-    padding: 0 2.5rem;
-  }
-
-  .submit {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
-
   strong {
     font-weight: bold;
   }
+  .wrapper {
+    display: flex;
+    justify-content: center;
+  }
+  p {
+    color: var(--color-foreground-level-6);
+    margin-bottom: 1rem;
+  }
 </style>
 
-<Emoji emoji="💸" size="huge" />
-<h1>Stream digital money</h1>
-<p>
-  {#if receivers.size === 0}
-    Top up
-    <strong>{topUp} DAI</strong>. You haven’t added any receivers yet, but as
-    soon as you do, money will begin streaming to them at a rate of
-    <strong>{budget} DAI</strong>
-    per week.
-  {:else}
-    Top up
-    <strong>{topUp} DAI</strong>
-    and stream
-    <strong>{budget} DAI</strong>
-    per week to these users:
-  {/if}
-</p>
-<Receivers {receivers} style="margin-top: 1.5rem" />
-<div class="submit">
-  <Button
-    variant="transparent"
-    dataCy="back"
-    on:click={onBack}
-    style="margin-right: 1rem">
-    Back
-  </Button>
+<Modal emoji="💸" title="Stream digital money">
+  <div class="wrapper">
+    <p>
+      {#if receivers.size === 0}
+        Top up
+        <strong>{topUp} DAI</strong>. You haven’t added any receivers yet, but
+        as soon as you do, money will begin streaming to them at a rate of
+        <strong>{budget} DAI</strong>
+        per week.
+      {:else}
+        Top up
+        <strong>{topUp} DAI</strong>
+        and stream
+        <strong>{budget} DAI</strong>
+        per week to these users:
+      {/if}
+    </p>
+  </div>
 
-  <TxButton
-    dataCy="confirm-button"
-    onClick={onConfirmed}
-    errorLabel="Failed to onboard your pool">
-    Confirm in your wallet
-  </TxButton>
-</div>
+  <div class="wrapper">
+    <Receivers {receivers} />
+  </div>
+
+  <svelte:fragment slot="buttons">
+    <Button variant="transparent" dataCy="back" on:click={onBack}>Back</Button>
+
+    <TxButton
+      dataCy="confirm-button"
+      onClick={onConfirmed}
+      errorLabel="Failed to onboard your pool">
+      Confirm in your wallet
+    </TxButton>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Funding/Onboarding/SetBudget.svelte
+++ b/ui/Modal/Funding/Onboarding/SetBudget.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Button, Dai, Emoji, TextInput } from "ui/DesignSystem";
+  import { Button, Dai, Modal, TextInput } from "ui/DesignSystem";
 
   import {
     budgetStore,
@@ -41,53 +41,40 @@
 </script>
 
 <style>
-  h1,
-  p,
-  .submit {
-    margin-top: 1.5rem;
-  }
-
-  h1,
-  p {
-    padding: 0 2.5rem;
-  }
-
-  .submit {
+  .wrapper {
     display: flex;
-    justify-content: flex-end;
-    width: 100%;
+    justify-content: center;
   }
 </style>
 
 <svelte:window on:keydown={onKeydown} />
+<Modal emoji="💸" title="Set a weekly budget">
+  <svelte:fragment slot="description">
+    Set your weekly budget for outgoing support. This amount will flow to your
+    receivers in real time.
+  </svelte:fragment>
 
-<Emoji emoji="💸" size="huge" />
-<h1>Set a weekly budget</h1>
-<p>
-  Set your weekly budget for outgoing support. This amount will flow to your
-  receivers in real time.
-</p>
-<TextInput
-  dataCy="modal-amount-input"
-  bind:value={budget}
-  validation={$validation}
-  showLeftItem
-  autofocus
-  style={"width: 125px; padding: 0; margin-top: 1.5rem;"}>
-  <div slot="left" style="position: absolute; top: 1px; left: 12px;">
-    <Dai />
+  <div class="wrapper">
+    <TextInput
+      dataCy="modal-amount-input"
+      bind:value={budget}
+      validation={$validation}
+      showLeftItem
+      autofocus
+      style={"width: 125px; padding: 0; margin-top: 1.5rem;"}>
+      <div slot="left" style="position: absolute; top: 1px; left: 12px;">
+        <Dai />
+      </div>
+    </TextInput>
   </div>
-</TextInput>
-<div class="submit">
-  <Button
-    variant="transparent"
-    dataCy="cancel"
-    on:click={onCancel}
-    style="margin-right: 1rem">
-    Cancel
-  </Button>
 
-  <Button dataCy="confirm-button" {disabled} on:click={onContinue}>
-    Continue
-  </Button>
-</div>
+  <svelte:fragment slot="buttons">
+    <Button variant="transparent" dataCy="cancel" on:click={onCancel}>
+      Cancel
+    </Button>
+
+    <Button dataCy="confirm-button" {disabled} on:click={onContinue}>
+      Continue
+    </Button>
+  </svelte:fragment>
+</Modal>

--- a/ui/Modal/Funding/Pool/Collect.svelte
+++ b/ui/Modal/Funding/Pool/Collect.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Button, Dai, Emoji, Remote, TxButton } from "ui/DesignSystem";
+  import { Button, Dai, Modal, Remote, TxButton } from "ui/DesignSystem";
 
   import * as modal from "ui/src/modal";
   import { store } from "ui/src/funding/pool";
@@ -24,45 +24,15 @@
 </script>
 
 <style>
-  .wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-direction: column;
-
-    text-align: center;
-
-    padding: var(--content-padding);
-    background: var(--color-background);
-    border-radius: 0.5rem;
-
-    width: 37.5rem;
-  }
-
-  h1,
-  .description {
-    margin-top: 1.5rem;
-  }
-
   .description {
     display: flex;
-    align-items: center;
-  }
-
-  .submit {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-    margin-top: var(--content-padding);
+    justify-content: center;
   }
 </style>
 
 {#if pool}
-  <Remote store={pool.data} let:data={poolData}>
-    <div class="wrapper" data-cy="collect-incoming-support-modal">
-      <Emoji emoji="💸" size="huge" />
-      <h1>Collect</h1>
-
+  <Modal emoji="💸" title="Collect">
+    <Remote store={pool.data} let:data={poolData}>
       <div class="typo-text description">
         Collect the
         <div class="typo-text-bold">
@@ -70,22 +40,18 @@
         </div>
         waiting on you from supporters.
       </div>
+    </Remote>
 
-      <div class="submit">
-        <Button
-          variant="transparent"
-          dataCy="cancel"
-          on:click={onCancel}
-          style="margin-right: 1rem">
-          Cancel
-        </Button>
+    <svelte:fragment slot="buttons">
+      <Button variant="transparent" dataCy="cancel" on:click={onCancel}>
+        Cancel
+      </Button>
 
-        <TxButton
-          onClick={onConfirmed}
-          errorLabel="Failed to collect incoming support">
-          Confirm in your wallet
-        </TxButton>
-      </div>
-    </div>
-  </Remote>
+      <TxButton
+        onClick={onConfirmed}
+        errorLabel="Failed to collect incoming support">
+        Confirm in your wallet
+      </TxButton>
+    </svelte:fragment>
+  </Modal>
 {/if}

--- a/ui/Modal/Funding/Pool/TopUp.svelte
+++ b/ui/Modal/Funding/Pool/TopUp.svelte
@@ -32,27 +32,8 @@
   $: balance = ethereum.toBaseUnit($accountBalancesStore.dai || Big(0));
 </script>
 
-<style>
-  .wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-direction: column;
-
-    text-align: center;
-
-    padding: var(--content-padding);
-    background: var(--color-background);
-    border-radius: 0.5rem;
-
-    width: 37.5rem;
-  }
-</style>
-
-<div class="wrapper" data-cy="top-up-modal">
-  <TopUp bind:amount {balance} onBack={["Cancel", onCancel]} bind:disabled>
-    <TxButton onClick={onConfirmed} {disabled} errorLabel="Failed top up">
-      Confirm in your wallet
-    </TxButton>
-  </TopUp>
-</div>
+<TopUp bind:amount {balance} onBack={["Cancel", onCancel]} bind:disabled>
+  <TxButton onClick={onConfirmed} {disabled} errorLabel="Failed top up">
+    Confirm in your wallet
+  </TxButton>
+</TopUp>

--- a/ui/Modal/Funding/Pool/Withdraw.svelte
+++ b/ui/Modal/Funding/Pool/Withdraw.svelte
@@ -8,7 +8,7 @@
 <script lang="typescript">
   import { get } from "svelte/store";
 
-  import { Button, Dai, Emoji, TextInput, TxButton } from "ui/DesignSystem";
+  import { Button, Dai, Modal, TextInput, TxButton } from "ui/DesignSystem";
 
   import * as modal from "ui/src/modal";
   import {
@@ -71,22 +71,6 @@
 </script>
 
 <style>
-  .wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-direction: column;
-
-    text-align: center;
-
-    padding: var(--content-padding);
-    background: var(--color-background);
-    border-radius: 0.5rem;
-
-    width: 37.5rem;
-  }
-
-  h1,
   p,
   .note,
   .input {
@@ -101,20 +85,10 @@
     text-align: center;
     color: var(--color-foreground-level-5);
   }
-
-  .submit {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-    margin-top: var(--content-padding);
-  }
 </style>
 
-<div class="wrapper" data-cy="pool-withdraw-modal">
-  <Emoji emoji="💸" size="huge" />
-  <h1>Cash out</h1>
-
-  {#if mode === Mode.SpecifyAmount}
+{#if mode === Mode.SpecifyAmount}
+  <Modal emoji="💸" title="Cash out">
     <p>
       Enter the amount you’d like to transfer to your linked Ethereum account
       below.
@@ -136,7 +110,7 @@
         </div>
       </TextInput>
     </div>
-    <div class="submit">
+    <svelte:fragment slot="buttons">
       <Button
         variant="transparent"
         dataCy="cancel"
@@ -151,8 +125,10 @@
         errorLabel="Failed to withdraw funds">
         Confirm in your wallet
       </TxButton>
-    </div>
-  {:else}
+    </svelte:fragment>
+  </Modal>
+{:else}
+  <Modal emoji="💸" title="Cash out">
     <p>Stop support and transfer the entire remaining balance out.</p>
 
     <div class="note">
@@ -160,12 +136,11 @@
       to your linked account will be a bit less than your current balance.
     </div>
 
-    <div class="submit">
+    <svelte:fragment slot="buttons">
       <Button
         variant="transparent"
         dataCy="back"
-        on:click={() => (mode = Mode.SpecifyAmount)}
-        style="margin-right: 1rem">
+        on:click={() => (mode = Mode.SpecifyAmount)}>
         Back
       </Button>
 
@@ -175,6 +150,6 @@
         errorLabel="Failed withdraw">
         Stop support and cash out everything
       </TxButton>
-    </div>
-  {/if}
-</div>
+    </svelte:fragment>
+  </Modal>
+{/if}

--- a/ui/Modal/ManagePeers.svelte
+++ b/ui/Modal/ManagePeers.svelte
@@ -73,11 +73,11 @@
 </style>
 
 <Remote {store} let:data={{ peerSelection, project }}>
-  <Modal
-    dataCy="remotes-modal"
-    emoji="💻"
-    title="Edit remotes"
-    desc="Add a user’s Device ID to collaborate with them on this project.">
+  <Modal dataCy="remotes-modal" emoji="💻" title="Edit remotes">
+    <svelte:fragment slot="description">
+      Add a user’s Device ID to collaborate with them on this project.
+    </svelte:fragment>
+
     <form class="peer-entry-form" on:submit|preventDefault>
       <div class="peer-entry-field">
         <TextInput

--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -175,18 +175,6 @@
     margin-bottom: 2rem;
   }
 
-  .btn-container {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 1rem;
-  }
-
-  .double-button {
-    display: grid;
-    grid-template-columns: auto auto;
-    grid-column-gap: 1rem;
-  }
-
   .default-branch-row {
     display: flex;
     align-items: center;
@@ -289,23 +277,21 @@
       placeholder="Project description"
       validation={$descriptionValidation}
       bind:value={description} />
-
-    <div class="btn-container">
-      <div class="double-button">
-        <Button
-          dataCy="cancel-button"
-          variant="transparent"
-          on:click={() => modal.hide()}>
-          Cancel
-        </Button>
-        <Button
-          dataCy="create-project-button"
-          disabled={disableSubmit}
-          variant="primary"
-          on:click={createProject}>
-          Create project
-        </Button>
-      </div>
-    </div>
   </div>
+
+  <svelte:fragment slot="buttons">
+    <Button
+      dataCy="cancel-button"
+      variant="transparent"
+      on:click={() => modal.hide()}>
+      Cancel
+    </Button>
+    <Button
+      dataCy="create-project-button"
+      disabled={disableSubmit}
+      variant="primary"
+      on:click={createProject}>
+      Create project
+    </Button>
+  </svelte:fragment>
 </Modal>

--- a/ui/Modal/Org/AnchorProject.svelte
+++ b/ui/Modal/Org/AnchorProject.svelte
@@ -132,13 +132,6 @@
 </script>
 
 <style>
-  .actions {
-    display: flex;
-    width: 100%;
-    gap: 1.5rem;
-    justify-content: flex-end;
-  }
-
   .revision-dropdown-container {
     display: flex;
     width: 100%;
@@ -211,9 +204,9 @@
     <CommitTeaser {commit} style="width: 100%; margin-bottom: 1.5rem" />
   {/if}
 
-  <div class="actions">
+  <svelte:fragment slot="buttons">
     <Button variant="transparent" on:click={() => modal.hide()}>Cancel</Button>
     <Button disabled={!commit} on:click={createAnchor}
       >Confirm in your wallet</Button>
-  </div>
+  </svelte:fragment>
 </Modal>

--- a/ui/Modal/Org/Create.svelte
+++ b/ui/Modal/Org/Create.svelte
@@ -68,19 +68,14 @@
     border-radius: 0.5rem;
     color: var(--color-foreground-level-6);
   }
-  .actions {
-    display: flex;
-    width: 100%;
-    gap: 1.5rem;
-    justify-content: flex-end;
-  }
 </style>
 
-<Modal
-  emoji="🎪"
-  title="Create a new org"
-  desc="This will create a Gnosis Safe that manages the org contract where the wallet
-you’ve connected to upstream will be the first member.">
+<Modal emoji="🎪" title="Create a new org">
+  <svelte:fragment slot="description">
+    This will create a Gnosis Safe that manages the org contract where the
+    wallet you’ve connected to upstream will be the first member.
+  </svelte:fragment>
+
   <RadioOption
     active={isMultiSig !== undefined && !isMultiSig}
     on:click={ev => {
@@ -155,12 +150,12 @@ you’ve connected to upstream will be the first member.">
     </div>
   </RadioOption>
 
-  <div class="actions">
+  <svelte:fragment slot="buttons">
     <Button variant="transparent" on:click={() => modal.hide()}>Cancel</Button>
     <Button
       disabled={isMultiSig === undefined || (!isMultiSig && !validOwnerAddress)}
       on:click={() => createOrg()}>
       Confirm in your wallet
     </Button>
-  </div>
+  </svelte:fragment>
 </Modal>


### PR DESCRIPTION
- use `<Modal>` component consistently in the funding feature
- introduce a `buttons` slot
- convert the `description` prop into a slot, this will allow us to add partial styling to the description, e.g. **bold** parts of the text

Required for https://github.com/radicle-dev/radicle-upstream/pull/2191.

For visual review, here's all of the modals after this change:
<img width="1552" alt="Screenshot 2021-08-20 at 16 35 30" src="https://user-images.githubusercontent.com/158411/130252726-5fbca8ec-c1fb-47bd-85ed-cd3d90a92d21.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 35 36" src="https://user-images.githubusercontent.com/158411/130252742-2de00b1e-b05b-48f9-8127-8d6bdd7ab6fc.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 35 44" src="https://user-images.githubusercontent.com/158411/130252746-481cbef8-273c-40bf-b5b9-e8fa6b7d74ea.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 35 50" src="https://user-images.githubusercontent.com/158411/130252750-abf5ecf4-869f-445f-9b34-0dbc613a1565.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 44 58" src="https://user-images.githubusercontent.com/158411/130252786-c7ea8bc8-b856-484c-a1ea-3e9579b75bd3.png">
<img width="1552" alt="Screenshot 2021-08-20 at 17 45 48" src="https://user-images.githubusercontent.com/158411/130259202-c61b4c7a-5ecc-45ce-b39f-d1d4f8ceebb9.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 36 28" src="https://user-images.githubusercontent.com/158411/130252753-cf79e0f3-af96-4e91-8d92-eb43b4aa626c.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 36 34" src="https://user-images.githubusercontent.com/158411/130252755-c72e79cf-4939-424c-ad6d-a50bea811f96.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 36 40" src="https://user-images.githubusercontent.com/158411/130252757-757c26b6-7b57-4278-8aae-1e46fc827f18.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 36 43" src="https://user-images.githubusercontent.com/158411/130252761-366ca81e-fb2c-49fa-a6e5-9a098c8274c9.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 36 49" src="https://user-images.githubusercontent.com/158411/130252762-de4c62b3-0456-4e2a-b7ee-f6996a3c8c4b.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 36 53" src="https://user-images.githubusercontent.com/158411/130252765-bca6534b-1b51-4f92-ab70-10732d1c64d2.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 36 57" src="https://user-images.githubusercontent.com/158411/130252767-3af51dd0-ab42-4cfb-9c31-68264e345e2d.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 37 01" src="https://user-images.githubusercontent.com/158411/130252770-b92da5cf-a9de-427f-ac7a-5d0c4b0bbb0d.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 37 26" src="https://user-images.githubusercontent.com/158411/130252772-d8872183-66f7-4220-9aa0-1da5080829f0.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 38 15" src="https://user-images.githubusercontent.com/158411/130252775-d3ae50ce-89c8-422c-b191-4330fc6d9a4e.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 38 19" src="https://user-images.githubusercontent.com/158411/130252778-a31f7094-5aea-4024-beef-c8cb09aef1a8.png">
<img width="1552" alt="Screenshot 2021-08-20 at 16 38 51" src="https://user-images.githubusercontent.com/158411/130252783-3e3ad192-cb26-4132-9330-51d5979d2398.png">
