### PR TITLE
feat: implement signMessage for test wallet

### DIFF
--- a/ui/src/ethereum/walletConnectSigner.ts
+++ b/ui/src/ethereum/walletConnectSigner.ts
@@ -51,15 +51,16 @@ export class WalletConnectSigner extends ethers.Signer {
   }
 
   async signMessage(message: ethers.Bytes | string): Promise<string> {
-    const prefix = ethers.utils.toUtf8Bytes(
-      `\x19Ethereum Signed Message:\n${message.length}`
-    );
-    const msg = ethers.utils.concat([prefix, message]);
+    let messageBytes: Uint8Array;
+    if (typeof message === "string") {
+      messageBytes = ethers.utils.toUtf8Bytes(message);
+    } else {
+      messageBytes = ethers.utils.arrayify(message);
+    }
     const address = await this.getAddress();
-    const keccakMessage = ethers.utils.keccak256(msg);
     const signature = await this.walletConnect.signMessage(
-      address.toLowerCase(),
-      keccakMessage
+      address,
+      messageBytes
     );
     return signature;
   }


### PR DESCRIPTION
We implement `signMessage` for the test wallet. This requires us to move the computation of the EIP-191 message hash from `WalletConnectSigner` to implementations of `WalletConnect`. We also use `ethers.utils.hashMessage` to compute the message.