### PR TITLE
chore: check that error in catch block is unknown

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
 module.exports = {
   env: {
     node: true,
@@ -61,6 +67,7 @@ module.exports = {
     // We are ok with empty functions. Often we need a no-op function
     // as an argument.
     "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-implicit-any-catch": "error",
   },
   settings: {
     "svelte3/typescript": true,

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -221,7 +221,7 @@ async function waitSealed() {
     try {
       await proxyClient.sessionGet();
       await sleep(10);
-    } catch (err) {
+    } catch (err: unknown) {
       if (
         err instanceof proxy.ResponseError &&
         [404, 403].includes(err.response.status)

--- a/native/index.ts
+++ b/native/index.ts
@@ -203,7 +203,7 @@ installMainProcessHandler({
         "git config --global --get init.defaultBranch"
       );
       return stderr ? undefined : stdout.trim();
-    } catch (error) {
+    } catch (error: unknown) {
       return undefined;
     }
   },

--- a/scripts/ethereum-dev-node.ts
+++ b/scripts/ethereum-dev-node.ts
@@ -23,9 +23,11 @@ async function main() {
   let devEthAccount;
   try {
     devEthAccount = (await fs.readFile(ethAccountFile, "utf-8")).trim();
-  } catch (err) {
+  } catch (err: unknown) {
     throw new Error(
-      `Failed to read address of development account from ${ethAccountFile}:\n  ${err.message}`
+      `Failed to read address of development account from ${ethAccountFile}:\n  ${
+        (err as Error).message
+      }`
     );
   }
 

--- a/ui/DesignSystem/TxButton.svelte
+++ b/ui/DesignSystem/TxButton.svelte
@@ -31,7 +31,7 @@
         showIcon: true,
       });
       await onClick();
-    } catch (e) {
+    } catch (e: unknown) {
       error.show(transaction.convertError(e, errorLabel));
     } finally {
       running = false;

--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -92,12 +92,18 @@
         notification.info({
           message: `Project ${response.metadata.name} was created!`,
         });
-      } catch (err) {
+      } catch (err: unknown) {
         router.push({ type: "profile", activeTab: "projects" });
+        let message;
+        if (err instanceof proxy.ResponseError) {
+          message = `Could not create project: ${err.message}`;
+        } else {
+          message = `Could not create project`;
+        }
         error.show(
           new error.Error({
             code: error.Code.ProjectCreationFailure,
-            message: `Could not create project: ${err.message}`,
+            message,
             source: err,
           })
         );

--- a/ui/Modal/Org/ConfigureEns/ConfirmRegistration.svelte
+++ b/ui/Modal/Org/ConfigureEns/ConfirmRegistration.svelte
@@ -41,15 +41,10 @@
         commitment.name,
         commitment.salt
       );
-    } catch (err) {
+    } catch (err: unknown) {
       confirmButtonDisabled = false;
 
-      error.show(
-        new error.Error({
-          message: err.message,
-          source: err,
-        })
-      );
+      error.show(error.fromUnknown(err));
       // Don't advance flow if the user rejected the tx.
       return;
     } finally {
@@ -67,15 +62,10 @@
 
     try {
       await registrationTx.wait(1);
-    } catch (err) {
+    } catch (err: unknown) {
       confirmButtonDisabled = false;
 
-      error.show(
-        new error.Error({
-          message: err.message,
-          source: err,
-        })
-      );
+      error.show(error.fromUnknown(err));
       // Don't advance flow unless we have the tx receipt.
       return;
     } finally {

--- a/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
+++ b/ui/Modal/Org/ConfigureEns/LinkOrgToName.svelte
@@ -55,15 +55,10 @@
           ],
         });
         onSubmit();
-      } catch (err) {
+      } catch (err: unknown) {
         continueButtonDisabled = false;
 
-        error.show(
-          new error.Error({
-            message: err.message,
-            source: err,
-          })
-        );
+        error.show(error.fromUnknown(err));
       } finally {
         signNotification.remove();
       }
@@ -87,15 +82,10 @@
           persist: true,
         });
         onSubmit();
-      } catch (err) {
+      } catch (err: unknown) {
         continueButtonDisabled = false;
 
-        error.show(
-          new error.Error({
-            message: err.message,
-            source: err,
-          })
-        );
+        error.show(error.fromUnknown(err));
         return;
       } finally {
         setNameNotification.remove();

--- a/ui/Modal/Org/ConfigureEns/RegisterName.svelte
+++ b/ui/Modal/Org/ConfigureEns/RegisterName.svelte
@@ -165,13 +165,8 @@
       try {
         commitInProgress = true;
         state = await commit();
-      } catch (err) {
-        error.show(
-          new error.Error({
-            message: err,
-            source: err,
-          })
-        );
+      } catch (err: unknown) {
+        error.show(error.fromUnknown(err));
       } finally {
         commitInProgress = false;
       }

--- a/ui/Modal/Org/ConfigureEns/UpdateMetadata.svelte
+++ b/ui/Modal/Org/ConfigureEns/UpdateMetadata.svelte
@@ -102,15 +102,10 @@
           persist: true,
         });
         onSubmit();
-      } catch (err) {
+      } catch (err: unknown) {
         setRecordsInProgress = false;
 
-        error.show(
-          new error.Error({
-            message: err.message,
-            source: err,
-          })
-        );
+        error.show(error.fromUnknown(err));
         return;
       } finally {
         updateNotification.remove();

--- a/ui/Screen/Lock.svelte
+++ b/ui/Screen/Lock.svelte
@@ -44,8 +44,13 @@
             persist: true,
           });
         }
-      } catch (err) {
-        errorNotificationHandle = error.show(err);
+      } catch (err: unknown) {
+        errorNotificationHandle = error.show(
+          new error.Error({
+            message: "Failed to unseal session",
+            source: err,
+          })
+        );
       } finally {
         unlockInProgress = false;
       }

--- a/ui/Screen/Onboarding.svelte
+++ b/ui/Screen/Onboarding.svelte
@@ -65,7 +65,7 @@
         );
         peerId = identity.peerId;
         state = State.SuccessView;
-      } catch (err) {
+      } catch (err: unknown) {
         animateBackward();
         state = State.EnterName;
         error.show(

--- a/ui/Screen/Project/Source.svelte
+++ b/ui/Screen/Project/Source.svelte
@@ -118,11 +118,17 @@
             },
           ],
         });
-      } catch (err) {
+      } catch (err: unknown) {
+        let message;
+        if (err instanceof proxy.ResponseError) {
+          message = `Checkout failed: ${err.message}`;
+        } else {
+          message = `Checkout failed`;
+        }
         error.show(
           new error.Error({
             code: error.Code.ProjectCheckoutFailure,
-            message: `Checkout failed: ${err.message}`,
+            message,
             source: err,
           })
         );

--- a/ui/Screen/Wallet.svelte
+++ b/ui/Screen/Wallet.svelte
@@ -85,7 +85,7 @@
         },
       });
       modal.hide();
-    } catch (err) {
+    } catch (err: unknown) {
       error.show(
         new error.Error({
           message: "Failed to connect to wallet",

--- a/ui/src/ethereum/walletConnect.ts
+++ b/ui/src/ethereum/walletConnect.ts
@@ -116,9 +116,9 @@ export class WalletConnectClient implements WalletConnect {
         const sessionStatus = await this.connector.connect();
         this.setConnection(sessionStatus);
         return true;
-      } catch (e) {
+      } catch (e: unknown) {
         this.reinit();
-        if (e.message.includes("User close")) {
+        if (e instanceof globalThis.Error && e.message.includes("User close")) {
           return false;
         } else {
           throw e;

--- a/ui/src/funding/pool.ts
+++ b/ui/src/funding/pool.ts
@@ -14,6 +14,7 @@ import * as validation from "../validation";
 import { Wallet, Status as WalletStatus } from "../wallet";
 import * as remote from "../remote";
 import { toBaseUnit } from "../ethereum";
+import * as error from "ui/src/error";
 
 import Big from "big.js";
 import { ContractTransaction, ethers } from "ethers";
@@ -105,8 +106,8 @@ export function make(wallet: Wallet): Pool {
     const ethAddr = storedWallet.connected.address;
     try {
       data.success(await watcher.poolData(ethAddr));
-    } catch (error) {
-      data.error(error);
+    } catch (err: unknown) {
+      data.error(error.fromUnknown(err));
     }
   }
 

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -48,12 +48,12 @@ const updateEthereumClaim = async (
       ...metadata,
       ethereum,
     });
-  } catch (err) {
+  } catch (err: unknown) {
     error.show(
       new error.Error({
         code: error.Code.UpdateEthereumClaimFailure,
-        message: `Failed to update the Ethereum claim in your identity: ${err.message}`,
-        source: error.fromUnknown(err),
+        message: `Failed to update the Ethereum claim in your identity`,
+        source: err,
       })
     );
     return;

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -500,7 +500,7 @@ export async function resolveProjectAnchors(
       try {
         const project = await proxy.client.project.get(anchor.projectId);
         anchoredProjects.push({ ...project, anchor });
-      } catch (error) {
+      } catch (_error: unknown) {
         // TODO: only catch when backend can't find project, reraise other errors
         unresolvedAnchors.push(anchor);
       }
@@ -588,7 +588,7 @@ async function getClaimedIdentity(
   let identity;
   try {
     identity = await proxy.client.remoteIdentityGet(urn);
-  } catch (error) {
+  } catch (error: unknown) {
     if (error instanceof proxy.ResponseError && error.response.status === 404) {
       return undefined;
     }

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -98,12 +98,12 @@ export const showNotificationsForFailedProjects = async (): Promise<void> => {
         })
       );
     });
-  } catch (error) {
+  } catch (err: unknown) {
     error.show(
       new error.Error({
         code: error.Code.ProjectRequestFailure,
         message: "Failed to get failed projects",
-        source: error,
+        source: err,
       })
     );
   }

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -134,14 +134,12 @@ const fetchBranches = async (path: string) => {
   let state: source.LocalState;
   try {
     state = await source.getLocalState(path);
-  } catch (err) {
-    error.log(
-      new error.Error({
-        code: error.Code.LocalStateFetchFailure,
-        message: err.message,
-        source: err,
-      })
+  } catch (unknownErr: unknown) {
+    const err = error.fromUnknown(
+      unknownErr,
+      error.Code.LocalStateFetchFailure
     );
+    error.log(err);
     localStateError.set(err.message);
     return;
   }

--- a/ui/src/proxy/fetcher.ts
+++ b/ui/src/proxy/fetcher.ts
@@ -127,7 +127,7 @@ export class Fetcher {
       let responseBody = await response.text();
       try {
         responseBody = JSON.parse(responseBody);
-      } catch (_e) {
+      } catch (_e: unknown) {
         // We keep the original text response body
       }
       throw new ResponseError(response, responseBody);

--- a/ui/src/retryOnError.ts
+++ b/ui/src/retryOnError.ts
@@ -23,7 +23,7 @@ export async function retryOnError<T>(
   for (; ; tryCount--) {
     try {
       return await action();
-    } catch (error) {
+    } catch (error: unknown) {
       if (!retryPredicate(error) || tryCount <= 1) {
         throw error;
       }

--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -65,7 +65,7 @@ export const refreshPeers = async (): Promise<void> => {
         peers,
         peerSelection,
       });
-    } catch (err) {
+    } catch (err: unknown) {
       screenStore.error(error.fromUnknown(err));
     }
   }

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -120,7 +120,7 @@ export const fetch = async (project: Project, peer: User): Promise<void> => {
       },
       tree: writable<source.Tree>(tree),
     });
-  } catch (err) {
+  } catch (err: unknown) {
     screenStore.error(error.fromUnknown(err));
   }
 };
@@ -263,7 +263,7 @@ export const selectRevision = async (
           selected: revision,
         },
       });
-    } catch (err) {
+    } catch (err: unknown) {
       screenStore.error(error.fromUnknown(err));
     }
   }
@@ -282,7 +282,7 @@ export const fetchCommit = async (sha1: string): Promise<void> => {
 
     try {
       commitStore.success(await source.fetchCommit(project.urn, sha1));
-    } catch (err) {
+    } catch (err: unknown) {
       commitStore.error(error.fromUnknown(err));
       error.show(
         new error.Error({
@@ -358,9 +358,9 @@ const fetchCode = async (
     } else {
       code = await fetchBlob(project, peer, revision, path, request.signal);
     }
-  } catch (err) {
+  } catch (err: unknown) {
     // An in-flight request was aborted, we wait for the next one to arrive.
-    if (err.name === "AbortError") {
+    if (err instanceof globalThis.Error && err.name === "AbortError") {
       code = {
         lastCommit: tree.info.lastCommit,
         path,
@@ -374,7 +374,7 @@ const fetchCode = async (
         path,
         view: {
           kind: ViewKind.Error,
-          error: err,
+          error: error.fromUnknown(err),
         },
       };
     }

--- a/ui/src/search.ts
+++ b/ui/src/search.ts
@@ -31,7 +31,7 @@ export const requestProject = async (urn: string): Promise<void> => {
   try {
     const projectRequest = await proxy.client.project.requestSubmit(urn);
     projectRequestStore.success(projectRequest);
-  } catch (err) {
+  } catch (err: unknown) {
     projectRequestStore.error(error.fromUnknown(err));
   }
 };
@@ -41,7 +41,7 @@ export const searchProject = async (urn: string): Promise<void> => {
   try {
     const project = await proxy.client.project.get(urn);
     projectSearchStore.success(project);
-  } catch (err) {
+  } catch (err: unknown) {
     projectSearchStore.error(error.fromUnknown(err));
   }
 };

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -121,7 +121,7 @@ const fetchSession = async (waitUnsealed = false): Promise<void> => {
       200 // 20 seconds timeout
     );
     sessionStore.success({ status: Status.UnsealedSession, ...ses });
-  } catch (err) {
+  } catch (err: unknown) {
     if (err instanceof proxy.ResponseError) {
       if (err.response.status === 404) {
         sessionStore.success({ status: Status.NoSession });
@@ -136,7 +136,7 @@ const fetchSession = async (waitUnsealed = false): Promise<void> => {
       new error.Error({
         code: error.Code.SessionFetchFailure,
         message: "Failed to load the session",
-        source: error.fromJsError(err),
+        source: err,
       })
     );
   }
@@ -149,7 +149,7 @@ const fetchSession = async (waitUnsealed = false): Promise<void> => {
 export const unseal = async (passphrase: string): Promise<boolean> => {
   try {
     await proxy.client.keyStoreUnseal({ passphrase });
-  } catch (err) {
+  } catch (err: unknown) {
     if (
       err instanceof proxy.ResponseError &&
       err.variant === "INCORRECT_PASSPHRASE"
@@ -176,12 +176,12 @@ export const fetch = async (): Promise<void> => {
 const setSettings = async (settings: Settings): Promise<void> => {
   try {
     await proxy.client.sessionSettingsSet(settings);
-  } catch (err) {
+  } catch (err: unknown) {
     error.show(
       new error.Error({
         code: error.Code.SessionSettingsUpdateFailure,
-        message: `Failed to update settings: ${err.message}`,
-        source: error.fromJsError(err),
+        message: `Failed to update settings`,
+        source: err,
       })
     );
     return;

--- a/ui/src/source.ts
+++ b/ui/src/source.ts
@@ -185,7 +185,7 @@ export const fetchReadme = async (
     } else {
       return null;
     }
-  } catch (err) {
+  } catch (err: unknown) {
     error.log(error.fromUnknown(err));
     return null;
   }

--- a/ui/src/svelteStore.ts
+++ b/ui/src/svelteStore.ts
@@ -27,7 +27,7 @@ export function waitUntil<T>(
       let matched;
       try {
         matched = predicate(value);
-      } catch (err) {
+      } catch (err: unknown) {
         reject(err);
         return;
       }

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -324,21 +324,20 @@ export const colorForStatus = (status: TxStatus): string => {
 // user in the TransactionCenter.
 export const selectedStore = svelteStore.writable<string>("");
 
-// Convert a transaction-related `globalThis.Error` to `error.Error`.
-export function convertError(e: globalThis.Error, label: string): error.Error {
-  let code: error.Code;
-  let message: string;
+// Convert a transaction-related error to `error.Error`.
+export function convertError(e: unknown, label: string): error.Error {
+  let code = error.Code.UnkownTransactionFailure;
+  let message = "an unkown transaction error occurred";
 
-  if (e.message.includes("gas")) {
-    code = error.Code.InsufficientGas;
-    message = "you seem to have insufficient gas to cover this transaction.";
-  } else if (e.message.toLowerCase().includes("rejected request")) {
-    code = error.Code.FailedOrRejectedTransaction;
-    message =
-      "you have rejected this transaction or it has failed for some unkown reason.";
-  } else {
-    code = error.Code.UnkownTransactionFailure;
-    message = "an unkown transaction error occurred";
+  if (e instanceof globalThis.Error) {
+    if (e.message.includes("gas")) {
+      code = error.Code.InsufficientGas;
+      message = "you seem to have insufficient gas to cover this transaction.";
+    } else if (e.message.toLowerCase().includes("rejected request")) {
+      code = error.Code.FailedOrRejectedTransaction;
+      message =
+        "you have rejected this transaction or it has failed for some unkown reason.";
+    }
   }
 
   return new error.Error({

--- a/ui/src/validation.ts
+++ b/ui/src/validation.ts
@@ -149,7 +149,7 @@ export const createValidationStore = (
 
             break;
           }
-        } catch (error) {
+        } catch (error: unknown) {
           remoteSuccess = false;
 
           update(store => {
@@ -159,8 +159,9 @@ export const createValidationStore = (
             }
             return {
               status: ValidationStatus.Error,
-              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
-              message: `Cannot validate "${input}": ${error.message}`,
+              message: `Cannot validate "${input}": ${
+                (error as Error).message
+              }`,
             };
           });
 

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -82,7 +82,7 @@ async function updateAccountBalances(
     if (result) {
       accountBalancesStore.set(result);
     }
-  } catch (err) {
+  } catch (err: unknown) {
     error.show(
       new error.Error({
         message: "Failed to get account balances",
@@ -140,15 +140,14 @@ function build(environment: Environment, provider: Provider): Wallet {
       if (!connected) {
         stateStore.set({ status: Status.NotConnected });
       }
-    } catch (e) {
-      stateStore.set({ status: Status.NotConnected, error: e });
+    } catch (unknownErr: unknown) {
+      const err = error.fromUnknown(unknownErr);
+      stateStore.set({ status: Status.NotConnected, error: err });
       error.show(
         new error.Error({
           code: error.Code.WalletConnectionFailure,
-          message: `Failed to connect wallet: ${e
-            .toString()
-            .replace("Error: ", "")}`,
-          source: error.fromJsError(e),
+          message: `Failed to connect wallet: ${err.message}`,
+          source: err,
         })
       );
       return;


### PR DESCRIPTION
We enable an eslint rule that enforces the `unknown` type for errors in `catch` blocks. Before, these errors where typed as `any` which lead to runtime errors.