### PR TITLE
style: fix modal centering and margins

### DIFF
--- a/ui/DesignSystem/Modal.svelte
+++ b/ui/DesignSystem/Modal.svelte
@@ -25,6 +25,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-top: 2rem;
+    margin-bottom: 2rem;
   }
   .container:focus {
     outline: none;

--- a/ui/DesignSystem/ModalOverlay.svelte
+++ b/ui/DesignSystem/ModalOverlay.svelte
@@ -39,6 +39,7 @@
 
   .content {
     z-index: 200;
+    margin: auto;
   }
 
   .hide {


### PR DESCRIPTION
Required by: https://github.com/radicle-dev/radicle-upstream/pull/2191.

[Solution](https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container#answer-33455342).

Before:

https://user-images.githubusercontent.com/158411/131133656-33ef7542-11b4-4366-9fa8-560fd87f3e3c.mov

After:

https://user-images.githubusercontent.com/158411/131133690-b042c9d3-2706-42ff-81fb-9b0eec9940f8.mov


