### PR TITLE
refactor: simplify transaction modal

### DIFF
--- a/ui/DesignSystem/Wallet/Transactions/TxList.svelte
+++ b/ui/DesignSystem/Wallet/Transactions/TxList.svelte
@@ -7,7 +7,6 @@
 -->
 <script lang="typescript">
   import * as modal from "ui/src/modal";
-  import { selectedStore } from "ui/src/transaction";
   import type { Tx } from "ui/src/transaction";
 
   import ModalTransaction from "ui/Modal/Transaction.svelte";
@@ -17,9 +16,9 @@
   export let txs: Tx[];
 
   const onSelect = (hash: string) => {
-    selectedStore.set(hash);
-    modal.hide();
-    modal.toggle(ModalTransaction);
+    modal.toggle(ModalTransaction, () => {}, {
+      transactionHash: hash,
+    });
   };
 </script>
 

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -320,10 +320,6 @@ export const colorForStatus = (status: TxStatus): string => {
   }
 };
 
-// A store containing the hash of a transaction selected by the
-// user in the TransactionCenter.
-export const selectedStore = svelteStore.writable<string>("");
-
 // Convert a transaction-related error to `error.Error`.
 export function convertError(e: unknown, label: string): error.Error {
   let code = error.Code.UnkownTransactionFailure;


### PR DESCRIPTION
* Pass transaction hash via modal props instead of store
* Throw error when selected transaction is not found instead of handling `undefined` and showing nothing.