### PR TITLE
chore: use the safe client api instead of the graph index

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "@ethersproject/properties": "^5.4.1",
     "@gnosis.pm/safe-core-sdk": "^0.3.1",
     "@gnosis.pm/safe-core-sdk-types": "^0.1.1",
-    "@gnosis.pm/safe-service-client": "^0.1.0",
+    "@gnosis.pm/safe-service-client": "^0.1.1",
     "@walletconnect/client": "^1.6.5",
     "assert": "^2.0.0",
     "async-mutex": "^0.3.1",

--- a/ui/src/org/safe.ts
+++ b/ui/src/org/safe.ts
@@ -28,6 +28,31 @@ export async function getPendingTransactions(
   return response.results || [];
 }
 
+export async function getMetadata(
+  ethEnv: Ethereum.Environment,
+  safeAddress: string
+): Promise<{ threshold: number; members: string[] }> {
+  safeAddress = ethers.utils.getAddress(safeAddress);
+  const safeServiceClient = createSafeServiceClient(ethEnv);
+  const response = await safeServiceClient.getSafeInfo(safeAddress);
+
+  return {
+    threshold: response.threshold,
+    members: response.owners,
+  };
+}
+
+export async function getSafesByOwner(
+  ethEnv: Ethereum.Environment,
+  ownerAddress: string
+): Promise<string[]> {
+  ownerAddress = ethers.utils.getAddress(ownerAddress);
+  const safeServiceClient = createSafeServiceClient(ethEnv);
+  const response = await safeServiceClient.getSafesByOwner(ownerAddress);
+
+  return response.safes;
+}
+
 export interface TransactionData {
   readonly to: string;
   readonly value: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,13 +1033,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gnosis.pm/safe-service-client@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@gnosis.pm/safe-service-client@npm:0.1.0"
+"@gnosis.pm/safe-service-client@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@gnosis.pm/safe-service-client@npm:0.1.1"
   dependencies:
     "@gnosis.pm/safe-core-sdk-types": ^0.1.0
     axios: ^0.21.1
-  checksum: 05adbf103987e18682d2153dd45baa8cf5532516a19f7e2671f4262969cba3594ceaec22d49cb27f22e3f77416fcf867bab1468730263468130c1ccf4025cb1c
+  checksum: d20fe5c557035b6783f28e2228f21529ad555750d81ae6561e938faab26e18cf868954401549aaca78bf406d6f84a0107d2d9dcf56455c3863ffa1f1087fed3e
   languageName: node
   linkType: hard
 
@@ -9789,7 +9789,7 @@ __metadata:
     "@ethersproject/properties": ^5.4.1
     "@gnosis.pm/safe-core-sdk": ^0.3.1
     "@gnosis.pm/safe-core-sdk-types": ^0.1.1
-    "@gnosis.pm/safe-service-client": ^0.1.0
+    "@gnosis.pm/safe-service-client": ^0.1.1
     "@tsconfig/svelte": ^2.0.1
     "@types/big.js": ^6.1.1
     "@types/jest": ^27.0.1


### PR DESCRIPTION
Instead of using two different the Graph indexes we use the API provided by gnosis to query gnosis related data.

Closes: https://github.com/radicle-dev/radicle-upstream/issues/2169.