### PR TITLE
fix: get rid of typescript warning

### DIFF
--- a/ui/DesignSystem/Wallet/Transactions/TxListItem.svelte
+++ b/ui/DesignSystem/Wallet/Transactions/TxListItem.svelte
@@ -7,9 +7,11 @@
 -->
 <script lang="typescript">
   import type { SvelteComponent } from "svelte";
+  import type { Tx } from "ui/src/transaction";
+
   import { Icon } from "ui/DesignSystem";
   import dayjs from "dayjs";
-  import { Tx, TxKind } from "ui/src/transaction";
+  import { TxKind } from "ui/src/transaction";
 
   export let tx: Tx;
 


### PR DESCRIPTION
Gets rid of:
```
  WARNING in ./ui/DesignSystem/Wallet/Transactions/TxListItem.svelte 230:47-49
  export 'Tx' (imported as 'Tx') was not found in 'ui/src/transaction' (possible exports: TxKind, TxStatus, add, anchorProject, claimRadicleIdentity, collect, colorForStatus, commitEnsName, convertError, createOrg, erc20Allowance, initialize, linkEnsNameToOrg, ongoing, registerEnsName, store, supportOnboarding, topUp, updateEnsMetadata, updateSupport, withdraw)
   @ ./ui/DesignSystem/Wallet/Transactions/TxList.svelte 32:0-45 54:18-28 248:2-12
   @ ./ui/Screen/Wallet/Transactions.svelte 30:0-71 216:14-20 273:14-20 330:14-20 492:2-8
   @ ./ui/Screen/Wallet.svelte 55:0-56 643:20-32 970:2-14
   @ ./ui/App.svelte 55:0-45 285:16-22 1083:2-8
   @ ./ui/index.ts 11:0-31 12:16-19
```