### PR TITLE
refactor: move constants out of config module

### DIFF
--- a/cypress/integration/project/creation.spec.ts
+++ b/cypress/integration/project/creation.spec.ts
@@ -6,7 +6,7 @@
 
 import * as ipcStub from "../../support/ipc-stub";
 import * as commands from "../../support/commands";
-import * as config from "../../../ui/src/config";
+import * as project from "../../../ui/src/project";
 
 context("project creation", () => {
   const withEmptyDirectoryStub = (callback: () => void) => {
@@ -341,7 +341,7 @@ context("project creation", () => {
           ipcStub.getStubs().then(stubs => {
             stubs.getGitGlobalDefaultBranch.returns(undefined);
           });
-          go(config.UPSTREAM_DEFAULT_BRANCH);
+          go(project.UPSTREAM_DEFAULT_BRANCH);
         });
       });
 

--- a/ui/Modal/NewProject.svelte
+++ b/ui/Modal/NewProject.svelte
@@ -8,21 +8,21 @@
 <script lang="typescript">
   import { onDestroy } from "svelte";
 
-  import { UPSTREAM_DEFAULT_BRANCH } from "ui/src/config";
   import * as notification from "ui/src/notification";
   import * as error from "ui/src/error";
   import * as modal from "ui/src/modal";
   import * as remote from "ui/src/remote";
   import * as router from "ui/src/router";
   import {
+    UPSTREAM_DEFAULT_BRANCH,
     clearLocalState,
     defaultBranch,
     defaultBranchForNewRepository,
+    descriptionValidationStore,
+    extractName,
+    formatNameInput,
     localState,
     nameValidationStore,
-    descriptionValidationStore,
-    formatNameInput,
-    extractName,
     repositoryPathValidationStore,
   } from "ui/src/project";
   import * as proxy from "ui/src/proxy";

--- a/ui/Screen/Profile/Following.svelte
+++ b/ui/Screen/Profile/Following.svelte
@@ -10,7 +10,6 @@
 
   import ModalSearch from "../../Modal/Search.svelte";
 
-  import { FADE_DURATION } from "ui/src/config";
   import * as modal from "ui/src/modal";
   import { following as store, fetchFollowing } from "../../src/profile";
   import * as proxy from "../../src/proxy";
@@ -31,6 +30,7 @@
     Remote,
   } from "ui/DesignSystem";
 
+  const FADE_DURATION = 200;
   const session = Session.unsealed();
   const onCancel = (urn: Urn): void => {
     proxy.client.project.requestCancel(urn).then(fetchFollowing);

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -8,11 +8,6 @@ import type {} from "../../native/preload";
 import qs from "qs";
 import * as zod from "zod";
 
-export const HIDDEN_BRANCHES = ["rad/contributor", "rad/project"];
-export const UPSTREAM_DEFAULT_BRANCH = "main";
-export const GIT_DEFAULT_BRANCH = "master";
-export const NOTIFICATION_TIMEOUT = 8000; // ms
-export const FADE_DURATION = 200;
 export const INFURA_API_KEY_RINKEBY = "de5e2a8780c04964950e73b696d1bfb1";
 export const INFURA_API_KEY_MAINNET = "7a19a4bf0af84fcc86ffb693a257fad4";
 

--- a/ui/src/notification.ts
+++ b/ui/src/notification.ts
@@ -5,7 +5,6 @@
 // LICENSE file.
 
 import { Readable, derived, writable } from "svelte/store";
-import * as config from "./config";
 
 export enum Variant {
   Error = "ERROR",
@@ -117,7 +116,7 @@ const show = (variant: Variant, params: NotificationParams): Handle => {
   if (params.persist !== true) {
     setTimeout(() => {
       remove(notification.id);
-    }, config.NOTIFICATION_TIMEOUT);
+    }, 8000);
   }
 
   return {

--- a/ui/src/project.test.ts
+++ b/ui/src/project.test.ts
@@ -8,7 +8,6 @@ import { get } from "svelte/store";
 
 import * as project from "./project";
 import * as remote from "./remote";
-import { UPSTREAM_DEFAULT_BRANCH } from "./config";
 
 import { localStateMock } from "./__mocks__/api";
 
@@ -63,7 +62,9 @@ describe("creating a project", () => {
       validation.validate("/repository/path");
 
       process.nextTick(() => {
-        expect(get(project.defaultBranch)).toEqual(UPSTREAM_DEFAULT_BRANCH);
+        expect(get(project.defaultBranch)).toEqual(
+          project.UPSTREAM_DEFAULT_BRANCH
+        );
       });
     });
   });

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -8,7 +8,6 @@ import { get, writable } from "svelte/store";
 
 import type * as ensResolver from "./org/ensResolver";
 import * as error from "./error";
-import * as config from "./config";
 import type * as identity from "./identity";
 import * as ipc from "./ipc";
 import * as remote from "./remote";
@@ -96,9 +95,12 @@ const fetchLocalState = (path: string): void => {
     .catch(err => localStateStore.error(error.fromUnknown(err)));
 };
 
+export const UPSTREAM_DEFAULT_BRANCH = "main";
+const GIT_DEFAULT_BRANCH = "master";
+
 // NEW PROJECT
 export const localStateError = writable<string>("");
-export const defaultBranch = writable<string>(config.UPSTREAM_DEFAULT_BRANCH);
+export const defaultBranch = writable<string>(UPSTREAM_DEFAULT_BRANCH);
 
 const projectNameMatch = "^[a-z0-9][a-z0-9._-]+$";
 
@@ -109,15 +111,10 @@ export const extractName = (repoPath: string): string =>
 
 // The default branches supported for preselection when importing
 // a new project. Sorted by preference of preselection.
-const DEFAULT_BRANCHES = [
-  config.UPSTREAM_DEFAULT_BRANCH,
-  config.GIT_DEFAULT_BRANCH,
-];
+const DEFAULT_BRANCHES = [UPSTREAM_DEFAULT_BRANCH, GIT_DEFAULT_BRANCH];
 
 export const defaultBranchForNewRepository = async (): Promise<string> => {
-  return (
-    (await ipc.getGitGlobalDefaultBranch()) || config.UPSTREAM_DEFAULT_BRANCH
-  );
+  return (await ipc.getGitGlobalDefaultBranch()) || UPSTREAM_DEFAULT_BRANCH;
 };
 
 const fetchBranches = async (path: string) => {


### PR DESCRIPTION
We move some of the constants back to their respective modules, because they're not really configuration.