### PR TITLE
refactor: improve Avatar component

### DIFF
--- a/ui/App/CreateOrgModal.svelte
+++ b/ui/App/CreateOrgModal.svelte
@@ -132,12 +132,13 @@
         First member
       </p>
       <div class="member-box">
-        <Avatar
-          style="margin-right: 1rem;"
-          size="small"
-          variant="circle"
-          title={identity.metadata.handle}
-          avatarFallback={identity.avatarFallback} />
+        <div style="display: flex;">
+          <Avatar
+            style="margin-right: 0.625rem;"
+            size="small"
+            kind={{ type: "userEmoji", uniqueIdentifier: identity.urn }} />
+          <p class="typo-text">{identity.metadata.handle}</p>
+        </div>
         <Identifier value={walletAddress} kind="ethAddress" />
       </div>
     </div>

--- a/ui/App/DesignSystemGuideModal.svelte
+++ b/ui/App/DesignSystemGuideModal.svelte
@@ -70,24 +70,6 @@
     ),
   ];
 
-  const avatarFallback1 = {
-    emoji: "📐",
-    background: {
-      r: 24,
-      g: 105,
-      b: 216,
-    },
-  };
-
-  const avatarFallback2 = {
-    background: {
-      r: 122,
-      g: 112,
-      b: 90,
-    },
-    emoji: "💡",
-  };
-
   const threeDotsMenuItems = [
     {
       title: "Add something",
@@ -458,127 +440,110 @@
 
     <h1 style="margin-bottom: 92px">Components</h1>
 
-    <Section
-      title="Avatars"
-      subTitle="User, project, etc avatars in various sizes and shapes.">
+    <Section title="Avatars" subTitle="User and Org avatars in various sizes.">
       <Swatch>
         <Avatar
           style="margin-right: 16px"
           size="small"
-          variant="circle"
-          avatarFallback={avatarFallback1} />
+          kind={{
+            type: "userImage",
+            url: "https://avatars.githubusercontent.com/u/4406983",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="small"
-          variant="square"
-          avatarFallback={avatarFallback2} />
+          kind={{
+            type: "userEmoji",
+            uniqueIdentifier: "rad:git:hnrk8cgbe4mgkubojmkdt6enka84ryfkdxhcy",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="small"
-          variant="circle"
-          imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+          kind={{
+            type: "orgImage",
+            url: "https://app.radicle.network/images/alt-clients.png",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="small"
-          variant="circle"
-          avatarFallback={avatarFallback1}
-          title="cloudhead" />
+          kind={{
+            type: "orgEmoji",
+            uniqueIdentifier: "0x8152237402E0f194176154c3a6eA1eB99b611482",
+          }} />
+        <Avatar
+          style="margin-right: 16px"
+          size="small"
+          kind={{ type: "pendingOrg" }} />
       </Swatch>
 
       <Swatch>
         <Avatar
           style="margin-right: 16px"
           size="regular"
-          variant="circle"
-          avatarFallback={avatarFallback1} />
+          kind={{
+            type: "userImage",
+            url: "https://avatars.githubusercontent.com/u/4406983",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="regular"
-          variant="square"
-          avatarFallback={avatarFallback2} />
+          kind={{
+            type: "userEmoji",
+            uniqueIdentifier: "rad:git:hnrk8cgbe4mgkubojmkdt6enka84ryfkdxhcy",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="regular"
-          variant="circle"
-          imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+          kind={{
+            type: "orgImage",
+            url: "https://app.radicle.network/images/alt-clients.png",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="regular"
-          variant="circle"
-          avatarFallback={avatarFallback1}
-          title="cloudhead" />
-      </Swatch>
-
-      <Swatch>
+          kind={{
+            type: "orgEmoji",
+            uniqueIdentifier: "0x8152237402E0f194176154c3a6eA1eB99b611482",
+          }} />
         <Avatar
           style="margin-right: 16px"
-          size="medium"
-          variant="circle"
-          avatarFallback={avatarFallback1} />
-        <Avatar
-          style="margin-right: 16px"
-          size="medium"
-          variant="square"
-          avatarFallback={avatarFallback2} />
-        <Avatar
-          style="margin-right: 16px"
-          size="medium"
-          variant="circle"
-          imageUrl="https://avatars1.githubusercontent.com/u/40774" />
-        <Avatar
-          style="margin-right: 16px"
-          size="medium"
-          variant="circle"
-          avatarFallback={avatarFallback1}
-          title="cloudhead" />
-      </Swatch>
-
-      <Swatch>
-        <Avatar
-          style="margin-right: 16px"
-          size="big"
-          variant="circle"
-          avatarFallback={avatarFallback1} />
-        <Avatar
-          style="margin-right: 16px"
-          size="big"
-          variant="square"
-          avatarFallback={avatarFallback2} />
-        <Avatar
-          style="margin-right: 16px"
-          size="big"
-          variant="circle"
-          imageUrl="https://avatars1.githubusercontent.com/u/40774" />
-        <Avatar
-          style="margin-right: 16px"
-          size="big"
-          variant="circle"
-          avatarFallback={avatarFallback1}
-          title="cloudhead" />
+          size="regular"
+          kind={{ type: "pendingOrg" }} />
       </Swatch>
 
       <Swatch>
         <Avatar
           style="margin-right: 16px"
           size="huge"
-          variant="circle"
-          avatarFallback={avatarFallback1} />
+          kind={{
+            type: "userImage",
+            url: "https://avatars.githubusercontent.com/u/4406983",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="huge"
-          variant="square"
-          avatarFallback={avatarFallback2} />
+          kind={{
+            type: "userEmoji",
+            uniqueIdentifier: "rad:git:hnrk8cgbe4mgkubojmkdt6enka84ryfkdxhcy",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="huge"
-          variant="circle"
-          imageUrl="https://avatars1.githubusercontent.com/u/40774" />
+          kind={{
+            type: "orgImage",
+            url: "https://app.radicle.network/images/alt-clients.png",
+          }} />
         <Avatar
           style="margin-right: 16px"
           size="huge"
-          variant="circle"
-          avatarFallback={avatarFallback1}
-          title="cloudhead" />
+          kind={{
+            type: "orgEmoji",
+            uniqueIdentifier: "0x8152237402E0f194176154c3a6eA1eB99b611482",
+          }} />
+        <Avatar
+          style="margin-right: 16px"
+          size="huge"
+          kind={{ type: "pendingOrg" }} />
       </Swatch>
     </Section>
 

--- a/ui/App/OrgScreen/Members.svelte
+++ b/ui/App/OrgScreen/Members.svelte
@@ -31,18 +31,10 @@
   .list-item {
     display: flex;
     width: 100%;
-    height: 70px;
+    height: 56px;
     justify-content: space-between;
     padding: 1rem;
     align-items: center;
-    min-width: 0;
-  }
-
-  .member-details {
-    display: flex;
-    flex-direction: column;
-    align-self: center;
-    width: -webkit-fill-available;
     min-width: 0;
   }
 </style>
@@ -52,16 +44,15 @@
     <div class="list-item">
       {#if member.identity}
         <div style="display: flex">
-          <Avatar
-            style="margin-right: 10px"
-            size="medium"
-            variant="circle"
-            avatarFallback={member.identity.avatarFallback} />
-          <div
-            class="member-details"
-            data-cy="entity-name"
-            title={member.identity.metadata.handle}>
-            {member.identity.metadata.handle}
+          <div style="display: flex;">
+            <Avatar
+              style="margin-right: 0.625rem;"
+              size="small"
+              kind={{
+                type: "userEmoji",
+                uniqueIdentifier: member.identity.urn,
+              }} />
+            <p class="typo-text">{member.identity.metadata.handle}</p>
           </div>
         </div>
         <Identifier
@@ -71,7 +62,10 @@
           tooltipPosition="left" />
       {:else}
         <div style="display: flex; align-items: center;">
-          <Avatar style="margin-right: 10px" size="medium" variant="circle" />
+          <Avatar
+            style="margin-right: 10px"
+            size="small"
+            kind={{ type: "unknownUser" }} />
           <Identifier
             value={member.ethereumAddress}
             kind="ethAddress"

--- a/ui/App/OrgScreen/OrgHeader.svelte
+++ b/ui/App/OrgScreen/OrgHeader.svelte
@@ -6,7 +6,6 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import * as radicleAvatar from "radicle-avatar";
   import { Avatar, Icon, Identifier } from "ui/DesignSystem";
 
   import * as ensResolver from "ui/src/org/ensResolver";
@@ -55,12 +54,9 @@
   <Avatar
     style="margin-right: 2rem;"
     size="huge"
-    variant="square"
-    imageUrl={registration?.avatar || undefined}
-    avatarFallback={radicleAvatar.generate(
-      orgAddress,
-      radicleAvatar.Usage.Any
-    )} />
+    kind={registration?.avatar
+      ? { type: "orgImage", url: registration.avatar }
+      : { type: "orgEmoji", uniqueIdentifier: orgAddress }} />
 
   <div class="metadata">
     <h1 data-cy="entity-name" class="typo-overflow-ellipsis name">

--- a/ui/App/OrgScreen/ProjectAnchorPopover.svelte
+++ b/ui/App/OrgScreen/ProjectAnchorPopover.svelte
@@ -11,7 +11,6 @@
   import type * as project from "ui/src/project";
 
   import * as org from "ui/src/org";
-  import * as radicleAvatar from "radicle-avatar";
   import * as router from "ui/src/router";
   import * as format from "ui/src/format";
 
@@ -101,12 +100,9 @@
             <Avatar
               size="small"
               style="margin: 0 0.5rem 0 0.5rem;"
-              variant="square"
-              imageUrl={anchor.registration?.avatar || undefined}
-              avatarFallback={radicleAvatar.generate(
-                anchor.orgAddress,
-                radicleAvatar.Usage.Any
-              )} />
+              kind={anchor.registration?.avatar
+                ? { type: "orgImage", url: anchor.registration.avatar }
+                : { type: "orgEmoji", uniqueIdentifier: anchor.orgAddress }} />
             <p
               class="typo-text-bold org"
               style="color: var(--color-foreground-level-6);overflow: ellipsed">

--- a/ui/App/ProfileScreen.svelte
+++ b/ui/App/ProfileScreen.svelte
@@ -54,7 +54,7 @@
   <Header>
     <ProfileHeader
       slot="left"
-      avatarFallback={session.identity.avatarFallback}
+      urn={session.identity.urn}
       name={session.identity.metadata.handle}
       peerId={session.identity.peerId} />
 

--- a/ui/App/ProfileScreen/ProfileHeader.svelte
+++ b/ui/App/ProfileScreen/ProfileHeader.svelte
@@ -6,14 +6,11 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import type { Avatar as AvatarT } from "ui/src/proxy/identity";
-
   import { Avatar, Identifier } from "ui/DesignSystem";
 
   export let name: string;
   export let peerId: string;
-
-  export let avatarFallback: AvatarT;
+  export let urn: string;
 </script>
 
 <style>
@@ -30,8 +27,7 @@
   <Avatar
     style="margin-right: 32px"
     size="huge"
-    variant="circle"
-    {avatarFallback} />
+    kind={{ type: "userEmoji", uniqueIdentifier: urn }} />
 
   <div class="metadata">
     <h1 data-cy="entity-name" class="typo-overflow-ellipsis" title={name}>

--- a/ui/App/ProjectScreen/ManagePeers/Peer.svelte
+++ b/ui/App/ProjectScreen/ManagePeers/Peer.svelte
@@ -53,10 +53,9 @@
         dispatch("userProfileClick", { urn: peer.identity.urn });
       }}>
       <Avatar
-        avatarFallback={peer.identity.avatarFallback}
+        kind={{ type: "userEmoji", uniqueIdentifier: peer.identity.urn }}
         size="small"
-        style="display: flex; justify-content: flex-start; margin-right: 0.5rem;"
-        variant="circle" />
+        style="display: flex; justify-content: flex-start; margin-right: 0.5rem;" />
       <p class="typo-text-bold" style="color: var(--color-foreground-level-6);">
         {peer.identity.metadata.handle}
       </p>

--- a/ui/App/ProjectScreen/PeerSelector/Peer.svelte
+++ b/ui/App/ProjectScreen/PeerSelector/Peer.svelte
@@ -29,9 +29,8 @@
 
 <div class="peer" data-peer-handle={peer.identity.metadata.handle}>
   <Avatar
-    avatarFallback={peer.identity.avatarFallback}
-    size="small"
-    variant="circle" />
+    kind={{ type: "userEmoji", uniqueIdentifier: peer.identity.urn }}
+    size="small" />
   <p class="name typo-text-bold typo-overflow-ellipsis">
     {peer.identity.metadata.handle}
   </p>

--- a/ui/App/ProjectScreen/Source/PatchCard.svelte
+++ b/ui/App/ProjectScreen/Source/PatchCard.svelte
@@ -72,12 +72,16 @@
         <div class="desc-row">
           <p style="color: var(--color-foreground-level-5);">Opened by</p>
           {#if patch.identity}
-            <Avatar
-              avatarFallback={patch.identity.avatarFallback}
-              size="small"
-              style="display: flex; justify-content: flex-start; margin-left: 0.5rem;"
-              title={patch.identity.metadata.handle}
-              variant="circle" />
+            <div style="display: flex;">
+              <Avatar
+                kind={{
+                  type: "userEmoji",
+                  uniqueIdentifier: patch.identity.urn,
+                }}
+                size="small"
+                style="display: flex; justify-content: flex-start; margin-left: 0.5rem; margin-right: 0.625rem;" />
+              <p class="typo-text">{patch.identity.metadata.handle}</p>
+            </div>
           {:else}
             <p style="margin-left: 0.5rem;">{patch.peerId}</p>
           {/if}

--- a/ui/App/ProjectScreen/Source/PatchLoaded.svelte
+++ b/ui/App/ProjectScreen/Source/PatchLoaded.svelte
@@ -93,12 +93,13 @@
     <div class="metadata">
       <span> Opened by </span>
       {#if patch.identity}
-        <Avatar
-          avatarFallback={patch.identity.avatarFallback}
-          size="small"
-          style="display: flex; justify-content: flex-start; margin-left: 0.5rem;"
-          title={patch.identity.metadata.handle}
-          variant="circle" />
+        <div style="display: flex;">
+          <Avatar
+            kind={{ type: "userEmoji", uniqueIdentifier: patch.identity.urn }}
+            size="small"
+            style="display: flex; justify-content: flex-start; margin-left: 0.5rem; margin-right: 0.625rem;" />
+          <p class="typo-text">{patch.identity.metadata.handle}</p>
+        </div>
       {:else}
         <p style="margin-left: 0.5rem;">{patch.peerId}</p>
       {/if}

--- a/ui/App/Sidebar.svelte
+++ b/ui/App/Sidebar.svelte
@@ -76,8 +76,10 @@
         onClick={() => push({ type: "profile", activeTab: "projects" })}>
         <Avatar
           size="regular"
-          avatarFallback={identity.avatarFallback}
-          variant="circle" />
+          kind={{
+            type: "userEmoji",
+            uniqueIdentifier: identity.urn,
+          }} />
       </SidebarItem>
     </Tooltip>
     <OrgList {identity} />

--- a/ui/App/Sidebar/OrgList.svelte
+++ b/ui/App/Sidebar/OrgList.svelte
@@ -6,7 +6,6 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import * as radicleAvatar from "radicle-avatar";
   import type { Identity } from "ui/src/identity";
   import { range } from "lodash";
 
@@ -42,30 +41,16 @@
           $activeRouteStore.address === org.id}>
         <Avatar
           size="regular"
-          variant="square"
-          imageUrl={org.registration?.avatar || undefined}
-          avatarFallback={radicleAvatar.generate(
-            org.id,
-            radicleAvatar.Usage.Any
-          )} />
+          kind={org.registration?.avatar
+            ? { type: "orgImage", url: org.registration.avatar }
+            : { type: "orgEmoji", uniqueIdentifier: org.id }} />
       </SidebarItem>
     </Tooltip>
   {/each}
   {#each range($pendingOrgs) as i (i)}
     <Tooltip value="Your org is being created">
       <SidebarItem>
-        <Avatar
-          size="regular"
-          variant="square"
-          animate={true}
-          avatarFallback={{
-            background: {
-              r: 51,
-              g: 62,
-              b: 71,
-            },
-            emoji: "",
-          }} />
+        <Avatar size="regular" kind={{ type: "pendingOrg" }} />
       </SidebarItem>
     </Tooltip>
   {/each}

--- a/ui/App/UserProfileScreen.svelte
+++ b/ui/App/UserProfileScreen.svelte
@@ -42,7 +42,7 @@
         slot="left"
         identityMetadata={$userProfileStore.data.metadata}
         deviceIds={$userProfileStore.data.peerIds}
-        avatarFallback={$userProfileStore.data.avatarFallback} />
+        {urn} />
     </Header>
 
     <ActionBar>

--- a/ui/App/UserProfileScreen/UserProfileHeader.svelte
+++ b/ui/App/UserProfileScreen/UserProfileHeader.svelte
@@ -10,7 +10,7 @@
   import { Avatar, Identifier } from "ui/DesignSystem";
 
   export let identityMetadata: proxyIdentity.Metadata;
-  export let avatarFallback: proxyIdentity.Avatar;
+  export let urn: string;
   export let deviceIds: string[];
 </script>
 
@@ -31,8 +31,7 @@
 <Avatar
   style="margin-right: 32px"
   size="huge"
-  variant="circle"
-  {avatarFallback} />
+  kind={{ type: "userEmoji", uniqueIdentifier: urn }} />
 
 <div class="metadata">
   <h1

--- a/ui/App/WalletScreen/LinkAddressModal.svelte
+++ b/ui/App/WalletScreen/LinkAddressModal.svelte
@@ -55,11 +55,6 @@
     padding: calc(var(--content-padding) / 2);
     border-radius: 1rem;
   }
-
-  .radicle-user {
-    display: flex;
-    align-items: center;
-  }
 </style>
 
 <Remote store={session} let:data={it}>
@@ -69,14 +64,13 @@
     </svelte:fragment>
 
     <div class="data">
-      <p class="radicle-user typo-text-bold">
+      <div style="display: flex;">
         <Avatar
           size="small"
-          avatarFallback={it.identity.avatarFallback}
-          variant="circle"
-          style="margin-right: 10px" />
-        {it.identity.metadata.handle}
-      </p>
+          kind={{ type: "userEmoji", uniqueIdentifier: it.identity.urn }}
+          style="margin-right: 0.625rem;" />
+        <p class="typo-text">{it.identity.metadata.handle}</p>
+      </div>
       <Icon.ChevronUpDown />
       <p class="address typo-text">
         <Identifier value={address} kind="ethAddress" />

--- a/ui/App/WalletScreen/TransactionModal/Identity.svelte
+++ b/ui/App/WalletScreen/TransactionModal/Identity.svelte
@@ -33,8 +33,7 @@
     <div class="display">
       <Avatar
         size="small"
-        avatarFallback={it.identity.avatarFallback}
-        variant="circle"
+        kind={{ type: "userEmoji", uniqueIdentifier: it.identity.urn }}
         style="margin-right: 10px" />
       <p class="typo-text-bold">{it.identity.metadata.handle}</p>
     </div>


### PR DESCRIPTION
Improve the Avatar component interface and decouple it from Upstream code. To generate emojis, we use the `radicle-avatar` library. To cut down on the amount of variants this component has, we remove unused sizes.

Refs: https://github.com/radicle-dev/radicle-upstream/issues/1877.