### PR TITLE
chore: remove radicle-avatar dependency from proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,6 @@ dependencies = [
  "nonempty 0.6.0",
  "percent-encoding",
  "pretty_assertions",
- "radicle-avatar",
  "radicle-daemon",
  "radicle-git-ext",
  "radicle-git-helpers",
@@ -2579,14 +2578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "radicle-avatar"
-version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-avatar.git?rev=4e34e6b992fd9f465b0547a5693b47b0d41dea01#4e34e6b992fd9f465b0547a5693b47b0d41dea01"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/proxy/api/Cargo.toml
+++ b/proxy/api/Cargo.toml
@@ -60,10 +60,6 @@ rev = "c4704a998d1909548d8d5064790522b3b3a4d673"
 git = "https://github.com/radicle-dev/radicle-link.git"
 rev = "c4704a998d1909548d8d5064790522b3b3a4d673"
 
-[dependencies.radicle-avatar]
-git = "https://github.com/radicle-dev/radicle-avatar.git"
-rev = "4e34e6b992fd9f465b0547a5693b47b0d41dea01"
-
 [dependencies.radicle-source]
 version = "^0.2.0"
 features = ["syntax"]

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -127,7 +127,6 @@ mod test {
     use std::convert::TryInto;
     use warp::{http::StatusCode, test::request};
 
-    use radicle_avatar as avatar;
     use radicle_daemon::state;
 
     use crate::{context, error, http, identity, session};
@@ -178,12 +177,10 @@ mod test {
         }
 
         http::test::assert_response(&res, StatusCode::CREATED, |have| {
-            let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
             assert_eq!(
                 have,
                 json!({
                     "peerId": peer_id,
-                    "avatarFallback": avatar,
                     "urn": urn,
                     "metadata": {
                         "handle": "cloudhead",
@@ -256,12 +253,10 @@ mod test {
         }
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
-            let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
             assert_eq!(
                 have,
                 json!({
                     "peerId": peer_id,
-                    "avatarFallback": avatar,
                     "urn": urn,
                     "metadata": {
                         "handle": "cloudhead_next",
@@ -334,12 +329,10 @@ mod test {
         }
 
         http::test::assert_response(&res, StatusCode::OK, |have| {
-            let avatar = avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity);
             assert_eq!(
                 have,
                 json!({
                     "peerId": peer_id,
-                    "avatarFallback": avatar,
                     "urn": urn,
                     "metadata": {
                         "handle": "cloudhead",
@@ -376,12 +369,11 @@ mod test {
             have,
             json!(identity::Identity {
                 peer_id,
-                urn: urn.clone(),
+                urn,
                 metadata: identity::Metadata {
                     handle,
                     ethereum: None
                 },
-                avatar_fallback: avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity),
             })
         );
 

--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -10,8 +10,6 @@ use chrono::{DateTime, Utc};
 
 use serde::{Deserialize, Serialize};
 
-use radicle_avatar as avatar;
-
 use link_crypto::BoxedSigner;
 use radicle_daemon::{
     identities::payload::{self, ExtError, PersonPayload},
@@ -35,8 +33,6 @@ pub struct Identity {
     pub urn: Urn,
     /// Bundle of user provided data.
     pub metadata: Metadata,
-    /// Generated fallback avatar to be used if actual avatar url is missing or can't be loaded.
-    pub avatar_fallback: avatar::Avatar,
 }
 
 impl From<(PeerId, DaemonPerson)> for Identity {
@@ -46,7 +42,6 @@ impl From<(PeerId, DaemonPerson)> for Identity {
             peer_id,
             urn: identity.urn,
             metadata: identity.metadata,
-            avatar_fallback: identity.avatar_fallback,
         }
     }
 }
@@ -59,8 +54,6 @@ pub struct Person {
     pub urn: Urn,
     /// Bundle of user provided data.
     pub metadata: Metadata,
-    /// Generated fallback avatar to be used if actual avatar url is missing or can't be loaded.
-    pub avatar_fallback: avatar::Avatar,
     /// The user's PeerIds.
     pub peer_ids: Vec<PeerId>,
 }
@@ -83,7 +76,6 @@ impl From<DaemonPerson> for Person {
             },
         };
         Self {
-            avatar_fallback: avatar::Avatar::from(&urn.to_string(), avatar::Usage::Identity),
             urn,
             peer_ids,
             metadata: Metadata { handle, ethereum },

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -75,14 +75,6 @@ export const fetch = (urn: string): Promise<Identity> => {
 
 // MOCK
 export const fallback: Identity = {
-  avatarFallback: {
-    background: {
-      r: 122,
-      g: 112,
-      b: 90,
-    },
-    emoji: "💡",
-  },
   metadata: {
     handle: "cloudhead",
     ethereum: null,

--- a/ui/src/proxy/identity.ts
+++ b/ui/src/proxy/identity.ts
@@ -6,33 +6,13 @@
 
 import * as zod from "zod";
 
-export interface Avatar {
-  background: {
-    r: number;
-    g: number;
-    b: number;
-  };
-  emoji: string;
-}
-
-const avatarSchema: zod.ZodSchema<Avatar> = zod.object({
-  background: zod.object({
-    r: zod.number(),
-    g: zod.number(),
-    b: zod.number(),
-  }),
-  emoji: zod.string(),
-});
-
 export interface RemoteIdentity {
-  avatarFallback: Avatar;
   metadata: Metadata;
   urn: string;
   peerIds: string[];
 }
 
 export interface Identity {
-  avatarFallback: Avatar;
   metadata: Metadata;
   urn: string;
   peerId: string;
@@ -51,7 +31,6 @@ export interface Ethereum {
 }
 
 export const remoteIdentitySchema = zod.object({
-  avatarFallback: avatarSchema,
   metadata: zod.object({
     handle: zod.string(),
     ethereum: zod
@@ -66,7 +45,6 @@ export const remoteIdentitySchema = zod.object({
 });
 
 export const identitySchema = zod.object({
-  avatarFallback: avatarSchema,
   metadata: zod.object({
     handle: zod.string(),
     ethereum: zod


### PR DESCRIPTION
As of https://github.com/radicle-dev/radicle-upstream/pull/2332 we do it all in the UI.

Closes: https://github.com/radicle-dev/radicle-upstream/issues/1927.