### PR TITLE
feat: improve keyboard shortcuts

### DIFF
--- a/ui/App/Hotkeys.svelte
+++ b/ui/App/Hotkeys.svelte
@@ -84,6 +84,13 @@
       case hotkeys.ShortcutKey.NewProjects:
         toggleModal(CreateProjectModal);
         break;
+      case hotkeys.ShortcutKey.Network:
+        modal.hide();
+        if ($activeRouteStore.type === "network") {
+          return;
+        }
+        push({ type: "network" });
+        break;
       case hotkeys.ShortcutKey.NetworkDiagnostics:
         modal.hide();
         if ($activeRouteStore.type === "networkDiagnostics") {

--- a/ui/App/ShortcutsModal.svelte
+++ b/ui/App/ShortcutsModal.svelte
@@ -6,17 +6,12 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { config } from "ui/src/config";
   import * as hotkeys from "ui/src/hotkeys";
 
   import { KeyHint } from "ui/DesignSystem";
   import Modal from "ui/App/ModalLayout/Modal.svelte";
 
-  const shortcuts = [
-    ...hotkeys.shortcuts,
-    ...(config.isDev ? hotkeys.devShortcuts : []),
-    hotkeys.escape,
-  ];
+  const shortcuts = [...hotkeys.shortcuts, hotkeys.escape];
 </script>
 
 <style>
@@ -43,16 +38,18 @@
 <Modal dataCy="hotkey-modal" emoji="⌨️" title="Keyboard shortcuts">
   <div class="shortcuts">
     {#each shortcuts as shortcut}
-      <div class="shortcut">
-        {#if shortcut.modifierKey}
-          <KeyHint style="margin-right: 0.25rem;"
-            >{hotkeys.osModifierKey}</KeyHint>
-        {/if}
-        <KeyHint>
-          {shortcut.displayKey || shortcut.key}
-        </KeyHint>
-        <p class="description">{shortcut.description}</p>
-      </div>
+      {#if !shortcut.hide}
+        <div class="shortcut">
+          {#if shortcut.modifierKey}
+            <KeyHint style="margin-right: 0.25rem;"
+              >{hotkeys.osModifierKey}</KeyHint>
+          {/if}
+          <KeyHint>
+            {shortcut.displayKey || shortcut.key}
+          </KeyHint>
+          <p class="description">{shortcut.description}</p>
+        </div>
+      {/if}
     {/each}
   </div>
 </Modal>

--- a/ui/src/hotkeys.ts
+++ b/ui/src/hotkeys.ts
@@ -27,6 +27,7 @@ export enum ShortcutKey {
   Help = "?",
   Escape = "Escape",
   NewProjects = "n",
+  Network = "b",
   Search = "p",
   Settings = ",",
   NetworkDiagnostics = "1",
@@ -34,9 +35,16 @@ export enum ShortcutKey {
 
 export interface KeyboardShortcut {
   description: string;
+  // Key code.
   key: ShortcutKey;
-  displayKey?: string; // if this is not the same as the encoded key value
+  // If set, this will be shown to the user in the ShortcutsModal instead of
+  // the `key` code. E.g. the `Escape` keycode is presented to the user as
+  // `esc`.
+  displayKey?: string;
   modifierKey?: boolean;
+  // If `true`, this hotkey won't be shown to the user in the ShortcutsModal,
+  // the hotkey itself will still work however.
+  hide?: boolean;
 }
 
 export const shortcuts: KeyboardShortcut[] = [
@@ -47,14 +55,17 @@ export const shortcuts: KeyboardShortcut[] = [
     modifierKey: true,
   },
   { description: "Search", key: ShortcutKey.Search, modifierKey: true },
+  { description: "Network", key: ShortcutKey.Network, modifierKey: true },
   { description: "Settings", key: ShortcutKey.Settings, modifierKey: true },
   {
     description: "Network diagnostics",
     key: ShortcutKey.NetworkDiagnostics,
     modifierKey: true,
+    hide: true,
   },
 ];
 
+// These are enabled in development mode, but not shown in the shortcuts modal.
 export const devShortcuts: KeyboardShortcut[] = [
   {
     description: "Design system",


### PR DESCRIPTION
- add a new shortcut for the Network screen <kbd>⌘</kbd> + <kbd>b</kbd>

- hide dev shortcuts from the shortcuts modal, because we decided that
  development mode should visually look exactly the same as
  production

- hide network diagnostics shortcut from the shortcuts modal, because
  this is only used for debugging and the diagnostics screen itself
  isn't designed properly yet

Closes: https://github.com/radicle-dev/radicle-upstream/issues/2122.
Closes: https://github.com/radicle-dev/radicle-upstream/issues/1973.

I picked the network shortcut based on [this post](https://stackoverflow.com/a/59010351).

<img width="1552" alt="Screenshot 2021-09-07 at 16 40 17" src="https://user-images.githubusercontent.com/158411/132363981-8658bfec-1f5c-4324-9510-8fa9f41dae5f.png">
