### PR TITLE
fix: make DirectoryInput text field open the file dialog

### DIFF
--- a/ui/DesignSystem/DirectoryInput.svelte
+++ b/ui/DesignSystem/DirectoryInput.svelte
@@ -38,6 +38,7 @@
 
 <div class="wrapper" {style}>
   <TextInput
+    on:click={openFileDialog}
     {placeholder}
     {validation}
     value={path}

--- a/ui/DesignSystem/TextInput.svelte
+++ b/ui/DesignSystem/TextInput.svelte
@@ -137,7 +137,7 @@
 </style>
 
 <div {style} class="wrapper">
-  <div bind:clientHeight={inputHeight}>
+  <div bind:clientHeight={inputHeight} on:click>
     <input
       data-cy={dataCy}
       class:invalid={validation && validation.status === Status.Error}


### PR DESCRIPTION
This is how it's done in other UIs and users expect to be able to click on the text input field.

Closes: https://github.com/radicle-dev/radicle-upstream/issues/1165.

https://user-images.githubusercontent.com/158411/132455855-2f17777c-9d00-4ec8-a40c-14b104adcf65.mov

