### PR TITLE
style: format all external links consistently

### DIFF
--- a/public/typography.css
+++ b/public/typography.css
@@ -169,6 +169,7 @@ p,
   color: var(--color-primary);
   cursor: pointer;
   text-decoration: underline;
+  text-underline-offset: 0.25rem;
 }
 
 .typo-link:hover,

--- a/ui/App/ExternalLink.svelte
+++ b/ui/App/ExternalLink.svelte
@@ -1,0 +1,33 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import * as ipc from "ui/src/ipc";
+
+  export let url: string;
+</script>
+
+<style>
+  .title {
+    text-decoration: underline;
+    margin-right: 0.1rem;
+  }
+
+  .arrow {
+    vertical-align: text-top;
+  }
+</style>
+
+<span
+  class="typo-link"
+  style="text-decoration: none;"
+  on:click={() => {
+    ipc.openUrl(url);
+  }}>
+  <span class="title"
+    >{#if $$slots.default}<slot />{:else}{url}{/if}</span
+  ><span class="arrow">↗</span></span>

--- a/ui/App/NetworkScreen.svelte
+++ b/ui/App/NetworkScreen.svelte
@@ -18,6 +18,7 @@
   } from "../src/session";
 
   import { Button, Icon, Identifier, TextInput } from "ui/DesignSystem";
+  import ExternalLink from "ui/App/ExternalLink.svelte";
 
   import ScreenLayout from "ui/App/ScreenLayout.svelte";
 
@@ -122,11 +123,9 @@
         </p>
         <p style="color: var(--color-foreground-level-6);">
           Enter seed addresses that you’d like to connect to here.
-          <a
-            style="color: var(--color-foreground-level-5);"
-            class="typo-link"
-            href="https://docs.radicle.xyz/docs/understanding-radicle/glossary#seed"
-            >Learn more</a>
+          <ExternalLink
+            url="https://docs.radicle.xyz/docs/understanding-radicle/glossary#seed"
+            >Learn more</ExternalLink>
         </p>
       </div>
       <form

--- a/ui/App/OrgScreen/ConfigureEns/Intro.svelte
+++ b/ui/App/OrgScreen/ConfigureEns/Intro.svelte
@@ -9,10 +9,10 @@
   import type * as ethers from "ethers";
 
   import * as ethereum from "ui/src/ethereum";
-  import * as ipc from "ui/src/ipc";
   import * as modal from "ui/src/modal";
 
   import { Button } from "ui/DesignSystem";
+  import ExternalLink from "ui/App/ExternalLink.svelte";
   import Modal from "ui/App/ModalLayout/Modal.svelte";
 
   export let fee: ethers.BigNumber;
@@ -24,16 +24,9 @@
     Your ENS name allows linking your org with a name, logo, URL and social
     media profiles. The registration costs {ethereum.formatTokenAmount(fee)}
     RAD, and you'll also need sufficient ETH to cover transaction costs.
-    <!-- svelte-ignore a11y-missing-attribute -->
-    <a
-      class="typo-link"
-      on:click={() => {
-        ipc.openUrl(
-          "https://docs.radicle.xyz/docs/connecting-to-ethereum/obtaining-rad"
-        );
-      }}>
-      Buy RAD
-    </a>
+    <ExternalLink
+      url="https://docs.radicle.xyz/docs/connecting-to-ethereum/obtaining-rad"
+      >Buy RAD</ExternalLink>
   </svelte:fragment>
 
   <svelte:fragment slot="buttons">

--- a/ui/App/OrgScreen/Projects.svelte
+++ b/ui/App/OrgScreen/Projects.svelte
@@ -13,6 +13,7 @@
   import * as org from "ui/src/org";
 
   import EmptyState from "ui/App/ScreenLayout/EmptyState.svelte";
+  import ExternalLink from "ui/App/ExternalLink.svelte";
   import ProjectList from "ui/App/ProfileScreen/ProjectList.svelte";
   import UnresolvedAnchorList from "./UnresolvedAnchorList.svelte";
 
@@ -83,17 +84,15 @@
         <p class="typo-text-bold">Pending</p>
         <p style="margin-left: .5rem; color: var(--color-foreground-level-6);">
           {#if isWaitingForExecution(anchors)}
-            Waiting for a member to execute this anchor transaction. <span
-              class="typo-link"
-              on:click={() =>
-                org.openOnGnosisSafe(ownerAddress, "transactions")}>
-              Execute transaction</span>
+            Waiting for a member to execute this anchor transaction.
+            <ExternalLink
+              url={org.gnosisSafeWebAppUrl(ownerAddress, "transactions")}
+              >Execute transaction</ExternalLink>
           {:else}
-            Not enough members have confirmed this anchor transaction. <span
-              class="typo-link"
-              on:click={() =>
-                org.openOnGnosisSafe(ownerAddress, "transactions")}>
-              Confirm transaction</span>
+            Not enough members have confirmed this anchor transaction.
+            <ExternalLink
+              url={org.gnosisSafeWebAppUrl(ownerAddress, "transactions")}
+              >Confirm transaction</ExternalLink>
           {/if}
         </p>
       </div>

--- a/ui/App/ProjectScreen/RemoteHelperHint.svelte
+++ b/ui/App/ProjectScreen/RemoteHelperHint.svelte
@@ -8,6 +8,7 @@
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
   import { Copyable, Hoverable, Icon } from "ui/DesignSystem";
+  import ExternalLink from "ui/App/ExternalLink.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -48,12 +49,10 @@
   <p class="description">
     To publish code to Radicle, you need to add this to your shell configuration
     file. Not sure how?
-    <a
-      style="color: var(--color-foreground-level-5);"
-      class="typo-link"
-      href="https://docs.radicle.xyz/docs/getting-started#configuring-your-system">
+    <ExternalLink
+      url="https://docs.radicle.xyz/docs/getting-started#configuring-your-system">
       Read more
-    </a>
+    </ExternalLink>
   </p>
   <Hoverable bind:hovering={hover}>
     <Copyable name="shell configuration">

--- a/ui/App/SettingsScreen.svelte
+++ b/ui/App/SettingsScreen.svelte
@@ -25,6 +25,7 @@
   import { Button, Identifier, SegmentedControl } from "ui/DesignSystem";
   import ShortcutsModal from "ui/App/ShortcutsModal.svelte";
   import ScreenLayout from "ui/App/ScreenLayout.svelte";
+  import ExternalLink from "ui/App/ExternalLink.svelte";
 
   const updateTheme = (event: CustomEvent) =>
     Session.updateAppearance({
@@ -162,11 +163,10 @@
         <div class="section-item">
           <p>
             Share your Device ID with others to be added as a remote.
-            <br /><a
-              style="color: var(--color-foreground-level-5);"
-              class="typo-link"
-              href="https://docs.radicle.xyz/docs/understanding-radicle/faq#can-i-use-radicle-with-multiple-devices"
-              >Learn more about managing devices</a>
+            <br />
+            <ExternalLink
+              url="https://docs.radicle.xyz/docs/understanding-radicle/faq#can-i-use-radicle-with-multiple-devices"
+              >Learn more about managing devices</ExternalLink>
           </p>
           <div class="action">
             <Identifier value={session.identity.peerId} kind="deviceId" />
@@ -247,19 +247,15 @@
         <div class="section-item">
           <p class="typo-text-bold">Get in touch directly</p>
           <div class="action">
-            <a
-              class="typo-link"
-              href="https://radicle.community/c/site-feedback/2">
-              radicle.community
-            </a>
+            <ExternalLink url="https://radicle.community/c/site-feedback/2"
+              >radicle.community</ExternalLink>
           </div>
         </div>
         <div class="section-item">
           <p class="typo-text-bold">Join the community chat</p>
           <div class="action">
-            <a class="typo-link" href="https://matrix.radicle.community">
-              matrix.radicle.community
-            </a>
+            <ExternalLink url="https://matrix.radicle.community"
+              >matrix.radicle.community</ExternalLink>
           </div>
         </div>
       </section>

--- a/ui/App/WalletScreen/QrCodeModal.svelte
+++ b/ui/App/WalletScreen/QrCodeModal.svelte
@@ -11,6 +11,7 @@
   import * as format from "ui/src/format";
   import { Copyable } from "ui/DesignSystem";
   import Modal from "ui/App/ModalLayout/Modal.svelte";
+  import ExternalLink from "ui/App/ExternalLink.svelte";
 
   export let uri: string;
 
@@ -45,9 +46,8 @@
 <Modal emoji="👛" title="Connect your wallet">
   <p style="text-align: center;">
     Scan this code with your wallet. Not working? <br />
-    <a href="https://walletconnect.org/wallets" class="typo-link">
-      View compatible wallets
-    </a>
+    <ExternalLink url="https://walletconnect.org/wallets"
+      >View compatible wallets</ExternalLink>
   </p>
 
   <div class="qrcode-wrapper">

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -121,12 +121,17 @@ export function openOnGnosisSafe(
   gnosisSafeAddress: string,
   view: "transactions" | "settings"
 ): void {
-  ipc.openUrl(
-    Safe.appUrl(
-      svelteStore.get(wallet.store).environment,
-      gnosisSafeAddress,
-      view
-    )
+  ipc.openUrl(gnosisSafeWebAppUrl(gnosisSafeAddress, view));
+}
+
+export function gnosisSafeWebAppUrl(
+  gnosisSafeAddress: string,
+  view: "transactions" | "settings"
+): string {
+  return Safe.appUrl(
+    svelteStore.get(wallet.store).environment,
+    gnosisSafeAddress,
+    view
   );
 }
 


### PR DESCRIPTION
This is only about links that open outside of Upstream.

Closes: https://github.com/radicle-dev/radicle-upstream/issues/1967.

<img width="1552" alt="Screenshot 2021-09-09 at 09 15 57" src="https://user-images.githubusercontent.com/158411/132640350-a4b8a68d-8684-4abe-9190-876f67b3c18c.png">
