### PR TITLE
refactor: format all hashes consistently

### DIFF
--- a/cypress/integration/project/source_browsing.spec.ts
+++ b/cypress/integration/project/source_browsing.spec.ts
@@ -51,7 +51,7 @@ context("project source browsing", () => {
         commands.pick("commit-page").should("exist");
         commands
           .pick("commit-header")
-          .contains("Commit 223aaf87d6ea62eef0014857640fd7c8dd0f80b5")
+          .contains("Commit 223aaf8")
           .should("exist");
         commands.pick("commit-branch").should("contain", "master");
       });
@@ -76,10 +76,7 @@ context("project source browsing", () => {
           .pickWithContent(["commit-teaser"], "Commit on the dev branch")
           .click();
         commands
-          .pickWithContent(
-            ["commit-header"],
-            "Commit 27acd68c7504755aa11023300890bb85bbd69d45"
-          )
+          .pickWithContent(["commit-header"], "Commit 27acd68")
           .should("exist");
 
         commands.pick("commit-branch").should("contain", "dev");

--- a/public/global.css
+++ b/public/global.css
@@ -24,12 +24,6 @@ body {
   display: none;
 }
 
-a {
-  color: var(--color-foreground);
-  cursor: pointer;
-  text-decoration: none;
-}
-
 :root {
   --sidebar-width: 4rem;
   --topbar-height: 4rem;

--- a/public/typography.css
+++ b/public/typography.css
@@ -181,6 +181,17 @@ p,
   opacity: 0.5;
 }
 
+a {
+  visibility: hidden;
+}
+
+a:after {
+  background-color: red;
+  color: white;
+  visibility: visible;
+  content: 'Don\'t use the <a> tag. Use <span class="typo-link"> for internal links or the <ExternalLink> component for extenal links.';
+}
+
 /* Modifiers */
 
 .typo-regular {

--- a/ui/App/DesignSystemGuideModal.svelte
+++ b/ui/App/DesignSystemGuideModal.svelte
@@ -290,8 +290,8 @@
           <p class="typo-text-small-bold">0123456789</p>
         </TypographySwatch>
 
-        <TypographySwatch title={`<a href="/" class="typo-link">`}>
-          <a href="/" class="typo-link">Radicle Upstream</a>
+        <TypographySwatch title={`<span class="typo-link">`}>
+          <span class="typo-link">Radicle Upstream</span>
         </TypographySwatch>
 
         <TypographySwatch title={`<p class="typo-all-caps">`}>

--- a/ui/App/OrgScreen.svelte
+++ b/ui/App/OrgScreen.svelte
@@ -11,7 +11,6 @@
 
   import * as router from "ui/src/router";
   import * as ipc from "ui/src/ipc";
-  import * as notification from "ui/src/notification";
   import * as org from "ui/src/org";
   import { unreachable } from "ui/src/unreachable";
 
@@ -60,11 +59,10 @@
   const menuItems = (address: string, gnosisSafeAddress: string) => {
     return [
       {
-        title: "Copy Org ID",
+        title: "View on Etherscan",
         icon: Icon.At,
         event: () => {
-          ipc.copyToClipboard(address.trim());
-          notification.info({ message: "Copied to your clipboard" });
+          org.openOnEtherscan(address);
         },
       },
       {

--- a/ui/App/OrgScreen/OrgHeader.svelte
+++ b/ui/App/OrgScreen/OrgHeader.svelte
@@ -6,10 +6,11 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Avatar, Icon, Identifier } from "ui/DesignSystem";
+  import { Avatar, Copyable, Icon, Identifier } from "ui/DesignSystem";
 
   import * as ensResolver from "ui/src/org/ensResolver";
   import * as format from "ui/src/format";
+  import * as ipc from "ui/src/ipc";
 
   export let orgAddress: string;
   export let ownerAddress: string;
@@ -48,6 +49,9 @@
   .domain {
     color: var(--color-foreground-level-4);
   }
+  .url {
+    cursor: pointer;
+  }
 </style>
 
 <div style="display: flex">
@@ -59,13 +63,18 @@
       : { type: "orgEmoji", uniqueIdentifier: orgAddress }} />
 
   <div class="metadata">
-    <h1 data-cy="entity-name" class="typo-overflow-ellipsis name">
-      {#if name}
-        {name}.<span class="domain">{ensResolver.DOMAIN}</span>
-      {:else}
-        {format.shortEthAddress(orgAddress)}
-      {/if}
-    </h1>
+    <Copyable
+      name="org address"
+      clipboardContent={orgAddress}
+      tooltipStyle="width: fit-content">
+      <h1 data-cy="entity-name" class="typo-overflow-ellipsis name">
+        {#if name}
+          {name}<span class="domain">.{ensResolver.DOMAIN}</span>
+        {:else}
+          {format.shortEthAddress(orgAddress)}
+        {/if}
+      </h1>
+    </Copyable>
     <div style="display: flex; gap: 1rem;">
       <div>
         <div class="row">
@@ -77,7 +86,7 @@
           <Identifier
             value={ownerAddress}
             kind="ethAddress"
-            name="org owner address"
+            name="owner address"
             showIcon={false} />
         </div>
         {#if threshold}
@@ -93,19 +102,34 @@
           {#if websiteUrl}
             <div class="row">
               <Icon.Globe />
-              <a href={websiteUrl}>{websiteUrl}</a>
+              <div class="url">
+                <span
+                  on:click={() => {
+                    websiteUrl && ipc.openUrl(websiteUrl);
+                  }}>{websiteUrl}</span>
+              </div>
             </div>
           {/if}
           {#if githubUrl}
             <div class="row">
               <Icon.Github />
-              <a href={githubUrl}>{githubUrl}</a>
+              <div class="url">
+                <span
+                  on:click={() => {
+                    githubUrl && ipc.openUrl(githubUrl);
+                  }}>{githubUrl}</span>
+              </div>
             </div>
           {/if}
           {#if twitterUrl}
             <div class="row">
               <Icon.Twitter />
-              <a href={twitterUrl}>{twitterUrl}</a>
+              <div class="url">
+                <span
+                  on:click={() => {
+                    twitterUrl && ipc.openUrl(twitterUrl);
+                  }}>{twitterUrl}</span>
+              </div>
             </div>
           {/if}
         </div>
@@ -118,7 +142,12 @@
           {#if seedApi}
             <div class="row">
               <Icon.Globe />
-              <a href={seedApi}>{seedApi}</a>
+              <div class="url">
+                <span
+                  on:click={() => {
+                    seedApi && ipc.openUrl(seedApi);
+                  }}>{seedApi}</span>
+              </div>
             </div>
           {/if}
         </div>

--- a/ui/App/OrgScreen/ProjectAnchorPopover.svelte
+++ b/ui/App/OrgScreen/ProjectAnchorPopover.svelte
@@ -10,11 +10,11 @@
 
   import type * as project from "ui/src/project";
 
-  import * as org from "ui/src/org";
   import * as router from "ui/src/router";
   import * as format from "ui/src/format";
 
-  import { Avatar, Hoverable, Icon } from "ui/DesignSystem";
+  import { Avatar, Hoverable, Icon, Identifier } from "ui/DesignSystem";
+  import TransactionHash from "ui/App/TransactionHash.svelte";
 
   export let anchor: project.Anchor;
   export let replicated: boolean = false;
@@ -27,10 +27,6 @@
       activeView: { type: "commit", commitHash: anchor.commitHash },
       urn: anchor.projectId,
     });
-  };
-
-  const bindOpenEtherscan = (txId: string) => () => {
-    org.openOnEtherscan(txId);
   };
 
   $: anchorColor =
@@ -50,7 +46,7 @@
   }
   .modal {
     position: absolute;
-    width: 354px;
+    max-width: 23rem;
     border-radius: 0.5rem;
     background: var(--color-background);
     box-shadow: var(--color-shadows);
@@ -63,16 +59,20 @@
     height: 3.5rem;
     align-items: center;
     display: flex;
-    padding: 0 46px 0 1rem;
     color: var(--color-primary);
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
   .meta {
     display: flex;
     color: var(--color-foreground-level-6);
-    margin: 1rem;
+    padding: 1rem 1rem 0 1rem;
     align-items: center;
   }
-  .org {
+  .meta:last-of-type {
+    padding-bottom: 1rem;
+  }
+  .org-domain {
     color: var(--color-foreground-level-6);
     text-overflow: ellipsis;
     overflow: hidden;
@@ -103,17 +103,22 @@
               kind={anchor.registration?.avatar
                 ? { type: "orgImage", url: anchor.registration.avatar }
                 : { type: "orgEmoji", uniqueIdentifier: anchor.orgAddress }} />
-            <p
-              class="typo-text-bold org"
-              style="color: var(--color-foreground-level-6);overflow: ellipsed">
-              {anchor.registration?.domain || anchor.orgAddress}
-            </p>
+            {#if anchor.registration?.domain}
+              <p class="typo-text-bold org-domain">
+                {anchor.registration?.domain}
+              </p>
+            {:else}
+              <Identifier
+                kind="ethAddress"
+                value={anchor.orgAddress}
+                showIcon={false} />
+            {/if}
           {/if}
         </div>
         {#if anchor.type === "pending"}
           <div class="meta">
             <Icon.Pen style="margin-right: 0.5rem;" />
-            <p class="typo-text-small-bold" style="margin-right: 0.5rem;">
+            <p class="typo-text-bold" style="margin-right: 0.5rem;">
               Signed by {anchor.confirmations} of {anchor.threshold}
             </p>
           </div>
@@ -122,27 +127,26 @@
         {#if anchor.type === "confirmed"}
           <div class="meta">
             <Icon.Ethereum style="margin-right: 0.5rem;" />
-            <p class="typo-text-small-bold" style="margin-right: 0.5rem;">
+            <p class="typo-text-bold" style="margin-right: 0.5rem;">
               Transaction hash
             </p>
-            <p
-              class="typo-text-small typo-link"
-              on:click={bindOpenEtherscan(anchor.transactionId)}>
-              {format.shortEthTx(anchor.transactionId)}↗
-            </p>
+            <TransactionHash hash={anchor.transactionId} />
           </div>
         {/if}
         <div class="meta">
           <Icon.Commit style="margin-right: 0.5rem;" />
-          <p class="typo-text-small-bold" style="margin-right: 0.5rem;">
+          <p class="typo-text-bold" style="margin-right: 0.5rem;">
             Commit hash
           </p>
           {#if replicated}
-            <p class="typo-text-small typo-link" on:click={openCommit}>
-              {anchor.commitHash.slice(0, 7)}↗
-            </p>
+            <span class="typo-link" on:click={openCommit}>
+              {format.shortCommitHash(anchor.commitHash)}
+            </span>
           {:else}
-            <p class="typo-text-small">{anchor.commitHash.slice(0, 7)}</p>
+            <Identifier
+              style="display: inline-block;"
+              kind="commitHash"
+              value={anchor.commitHash} />
           {/if}
         </div>
       </div>

--- a/ui/App/ProjectScreen/Source/Commit.svelte
+++ b/ui/App/ProjectScreen/Source/Commit.svelte
@@ -6,13 +6,13 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import * as error from "ui/src/error";
-  import { formatCommitTime } from "ui/src/source";
   import { commit, fetchCommit } from "ui/src/screen/project/source";
+  import { formatCommitTime } from "ui/src/source";
+  import * as error from "ui/src/error";
   import * as remote from "ui/src/remote";
   import * as router from "ui/src/router";
 
-  import { Icon } from "ui/DesignSystem";
+  import { Icon, Identifier } from "ui/DesignSystem";
 
   import BackButton from "../BackButton.svelte";
   import Changeset from "./SourceBrowser/Changeset.svelte";
@@ -87,8 +87,10 @@
             it differently. -->
           <span>{$commit.data.header.author.name}</span>
           <span>committed</span>
-          <span class="typo-mono"
-            >{$commit.data.header.sha1.substring(0, 7)}</span>
+          <Identifier
+            style="display: inline-block;"
+            kind="commitHash"
+            value={$commit.data.header.sha1} />
           {#if $commit.data.branches.length > 0}
             <span style="margin-right: -1ch">to</span>
             <span class="branch typo-semi-bold">
@@ -142,7 +144,11 @@
         <!-- TODO(cloudhead): Commit parents when dealing with merge commit -->
         <p class="field">
           Commit
-          <span class="hash">{$commit.data.header.sha1}</span>
+          <Identifier
+            tooltipPosition="left"
+            style="display: inline-block;"
+            kind="commitHash"
+            value={$commit.data.header.sha1} />
         </p>
       </div>
     </div>

--- a/ui/App/ProjectScreen/Source/SourceBrowser/CommitTeaser.svelte
+++ b/ui/App/ProjectScreen/Source/SourceBrowser/CommitTeaser.svelte
@@ -10,6 +10,7 @@
 
   import { formatCommitTime } from "ui/src/source";
   import type { CommitHeader } from "ui/src/source";
+  import * as format from "ui/src/format";
 
   import Icon from "ui/DesignSystem/Icon";
 
@@ -56,16 +57,16 @@
   .commit-sha {
     padding: 0 8px 0 4px;
     color: var(--commit-sha-color, var(--color-primary));
+    cursor: pointer;
   }
 </style>
 
 <div class="container" {style} data-cy="commit-teaser">
   <div class="align-left">
     <Icon.Commit style="fill: var(--color-primary)" />
-    <!-- svelte-ignore a11y-missing-attribute -->
-    <a class="commit-sha typo-text-small-mono" on:click={onSelect}>
-      {commit.sha1.substring(0, 7)}
-    </a>
+    <span class="commit-sha typo-text-small-mono" on:click={onSelect}>
+      {format.shortCommitHash(commit.sha1)}
+    </span>
     <p class="commit-message typo-text-small">{commit.summary}</p>
   </div>
 

--- a/ui/App/Sidebar/OrgList.svelte
+++ b/ui/App/Sidebar/OrgList.svelte
@@ -12,9 +12,10 @@
   import { activeRouteStore, push } from "ui/src/router";
 
   import { orgSidebarStore, pendingOrgs } from "ui/src/org";
+  import * as ethereum from "ui/src/ethereum";
+  import * as format from "ui/src/format";
   import * as modal from "ui/src/modal";
   import * as Wallet from "ui/src/wallet";
-  import * as ethereum from "ui/src/ethereum";
 
   const ethereumEnvironment = ethereum.selectedEnvironment;
   const walletStore = Wallet.store;
@@ -31,7 +32,7 @@
 
 {#if $wallet.status === Wallet.Status.Connected && ethereum.supportedNetwork($ethereumEnvironment) === $wallet.connected.network}
   {#each $orgSidebarStore as org (org.id)}
-    <Tooltip value={org.registration?.domain || org.id}>
+    <Tooltip value={org.registration?.domain || format.shortEthAddress(org.id)}>
       <SidebarItem
         indicator={true}
         onClick={() =>

--- a/ui/App/SingleSigOrgScreen.svelte
+++ b/ui/App/SingleSigOrgScreen.svelte
@@ -9,7 +9,6 @@
   import type { Registration } from "ui/src/org/ensResolver";
 
   import * as ipc from "ui/src/ipc";
-  import * as notification from "ui/src/notification";
   import * as router from "ui/src/router";
   import * as org from "ui/src/org";
 
@@ -49,11 +48,10 @@
   const menuItems = (address: string) => {
     return [
       {
-        title: "Copy Org ID",
+        title: "View on Etherscan",
         icon: Icon.At,
         event: () => {
-          ipc.copyToClipboard(address.trim());
-          notification.info({ message: "Copied to your clipboard" });
+          org.openOnEtherscan(address);
         },
       },
       {

--- a/ui/App/TransactionHash.svelte
+++ b/ui/App/TransactionHash.svelte
@@ -1,0 +1,19 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import * as org from "ui/src/org";
+  import * as format from "ui/src/format";
+
+  export let hash: string;
+
+  import ExternalLink from "ui/App/ExternalLink.svelte";
+</script>
+
+<ExternalLink url={org.etherscanUrl(hash)}>
+  {format.shortEthTx(hash)}
+</ExternalLink>

--- a/ui/App/WalletScreen/Pool/Outgoing/Support.svelte
+++ b/ui/App/WalletScreen/Pool/Outgoing/Support.svelte
@@ -204,15 +204,14 @@
           {/if}
           <span style="margin-left: 0.4375rem;"> per week</span>
         </span>
-        <!-- svelte-ignore a11y-missing-attribute -->
-        <a
+        <span
           hidden={editing}
           class="typo-link"
           disabled={ongoingSupportUpdate}
           on:click={enterEditMode}
           style="margin-left: 0.75rem;">
           Edit
-        </a>
+        </span>
       </div>
       <div class="row">
         <p>Remaining</p>
@@ -245,15 +244,14 @@
             Add receivers to your outgoing support by clicking the “Support”
             button on someone’s profile. You can also add any Ethereum address
             to your Stream.
-            <!-- svelte-ignore a11y-missing-attribute -->
-            <a
+            <span
               hidden={editing}
               class="typo-link"
               disabled={ongoingSupportUpdate}
               style="margin-left: 0.3125rem;"
               on:click={enterEditMode}>
               Edit
-            </a>
+            </span>
           </p>
         {:else}
           <div style="display: flex; align-items: center">
@@ -263,15 +261,14 @@
             <strong>{poolData.receivers.size} </strong>
             receivers you're supporting.
 
-            <!-- svelte-ignore a11y-missing-attribute -->
-            <a
+            <span
               hidden={editing}
               class="typo-link"
               disabled={ongoingSupportUpdate}
               style="margin-left: 0.3125rem;"
               on:click={enterEditMode}>
               Edit
-            </a>
+            </span>
           </div>
         {/if}
       </div>

--- a/ui/App/WalletScreen/Pool/Receiver.svelte
+++ b/ui/App/WalletScreen/Pool/Receiver.svelte
@@ -51,9 +51,9 @@
       {disabled}
       variant="embedded"
       icon={Icon.Cross}
-      style="padding: 0" />
+      style="padding: 0; margin-right: 0.5rem;" />
   {/if}
-  <p class="content typo-text-bold">
+  <p class="content">
     <Identifier value={address} kind="ethAddress" showIcon={false} />
   </p>
 </span>

--- a/ui/App/WalletScreen/Pool/WithdrawModal.svelte
+++ b/ui/App/WalletScreen/Pool/WithdrawModal.svelte
@@ -95,9 +95,8 @@
     <p>
       Enter the amount you’d like to transfer to your linked Ethereum account
       below.
-      <!-- svelte-ignore a11y-missing-attribute -->
-      <a class="typo-link" on:click={() => (mode = Mode.CashoutAll)}
-        >Want to stop support completely</a
+      <span class="typo-link" on:click={() => (mode = Mode.CashoutAll)}
+        >Want to stop support completely</span
       >?
     </p>
     <div class="input">

--- a/ui/App/WalletScreen/TransactionModal.svelte
+++ b/ui/App/WalletScreen/TransactionModal.svelte
@@ -11,15 +11,15 @@
 
   import * as modal from "ui/src/modal";
 
-  import { Copyable, Icon } from "ui/DesignSystem";
+  import { Icon, Identifier } from "ui/DesignSystem";
 
   import Modal from "ui/App/ModalLayout/Modal.svelte";
   import Identity from "./TransactionModal/Identity.svelte";
   import TxSpinner from "./TransactionModal/TransactionSpinner.svelte";
   import Summary from "./TransactionModal/TransactionSummary.svelte";
+  import TransactionHash from "ui/App/TransactionHash.svelte";
 
   import type { Tx } from "ui/src/transaction";
-  import * as format from "ui/src/format";
   import * as error from "ui/src/error";
   import { TxKind, colorForStatus, store as txs } from "ui/src/transaction";
 
@@ -70,6 +70,7 @@
       kind === TxKind.CreateOrg ||
       kind === TxKind.LinkEnsNameToOrg ||
       kind === TxKind.RegisterEnsName ||
+      kind === TxKind.TopUp ||
       kind === TxKind.UpdateEnsMetadata
     );
   }
@@ -153,10 +154,6 @@
     padding: 0.5rem 0;
   }
 
-  .from-to .address {
-    color: var(--color-foreground-level-6);
-  }
-
   .section {
     display: flex;
     flex-direction: column;
@@ -197,9 +194,9 @@
           <p class="typo-text-bold" style="margin-bottom: 0.5rem">
             Radicle Pool
           </p>
-          <Copyable name="pool address" clipboardContent={tx.to}>
-            <p class="address typo-text">{tx.to || "n/a"}</p>
-          </Copyable>
+          {#if tx.to}
+            <Identifier kind="ethAddress" value={tx.to} />
+          {/if}
         </div>
 
         <div class="arrow">
@@ -230,11 +227,7 @@
     <div class="section">
       <div class="row">
         <p>Transaction ID</p>
-        <p class="typo-text-small-mono">
-          <Copyable name="transaction hash" clipboardContent={tx.hash}>
-            {format.shortEthTx(tx.hash)}
-          </Copyable>
-        </p>
+        <TransactionHash hash={tx.hash} />
       </div>
       <div class="row">
         <p>Status</p>

--- a/ui/App/WalletScreen/TransactionModal/Identity.svelte
+++ b/ui/App/WalletScreen/TransactionModal/Identity.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import { Avatar } from "ui/DesignSystem";
+  import { Avatar, Identifier } from "ui/DesignSystem";
   import Remote from "ui/App/Remote.svelte";
 
   import { session } from "ui/src/session";
@@ -38,7 +38,7 @@
       <p class="typo-text-bold">{it.identity.metadata.handle}</p>
     </div>
     {#if address}
-      <p>{address}</p>
+      <Identifier kind="ethAddress" value={address} />
     {/if}
   </div>
 </Remote>

--- a/ui/DesignSystem/Identifier.svelte
+++ b/ui/DesignSystem/Identifier.svelte
@@ -6,7 +6,12 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  type Kind = "radicleId" | "deviceId" | "seedAddress" | "ethAddress";
+  type Kind =
+    | "radicleId"
+    | "deviceId"
+    | "seedAddress"
+    | "ethAddress"
+    | "commitHash";
 
   import type { SvelteComponent } from "svelte";
   import type { Position } from "./Tooltip.svelte";
@@ -32,10 +37,12 @@
         return "Seed address";
       case "ethAddress":
         return "Ethereum address";
+      case "commitHash":
+        return "commit hash";
     }
   }
 
-  function kindToIcon(kind: Kind): typeof SvelteComponent {
+  function kindToIcon(kind: Kind): typeof SvelteComponent | undefined {
     switch (kind) {
       case "radicleId":
         return Icon.At;
@@ -45,6 +52,8 @@
         return Icon.Server;
       case "ethAddress":
         return Icon.Ethereum;
+      case "commitHash":
+        return undefined;
     }
   }
 
@@ -58,6 +67,8 @@
         return format.shortSeedAddress(value);
       case "ethAddress":
         return format.shortEthAddress(value);
+      case "commitHash":
+        return format.shortCommitHash(value);
     }
   }
 
@@ -83,7 +94,7 @@
     {tooltipPosition}
     clipboardContent={value}
     style="color: var(--color-foreground-level-6)">
-    {#if showIcon}
+    {#if showIcon && kindToIcon(kind)}
       <div class="icon">
         <svelte:component this={kindToIcon(kind)} />
       </div>

--- a/ui/src/ethereum/index.ts
+++ b/ui/src/ethereum/index.ts
@@ -84,10 +84,10 @@ export const VALID_ADDRESS_MATCH = /^0x[a-fA-F0-9]{40}$/;
 export function etherscanUrl(ethEnv: Environment, query: string): string {
   switch (ethEnv) {
     case Environment.Local:
-      throw new error.Error({
-        code: error.Code.FeatureNotAvailableForGivenNetwork,
-        message: "Etherscan links are not supported on the Local environment",
-      });
+      console.error(
+        "Etherscan links are not supported on the Local environment"
+      );
+      return "";
     case Environment.Rinkeby:
       return `https://rinkeby.etherscan.io/search?f=0&q=${query}`;
     case Environment.Mainnet:

--- a/ui/src/format.ts
+++ b/ui/src/format.ts
@@ -45,3 +45,9 @@ export function shortSeedAddress(value: string): string {
 
   return value;
 }
+
+// 07e57974a3b0aa77a92c2a605c72523c6f996215 ->
+// 07e5797
+export function shortCommitHash(value: string): string {
+  return value.slice(0, 7);
+}

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -141,6 +141,13 @@ export const openOnEtherscan = (query: string): void => {
   );
 };
 
+export const etherscanUrl = (query: string): string => {
+  return ethereum.etherscanUrl(
+    svelteStore.get(wallet.store).environment,
+    query
+  );
+};
+
 export async function anchorProjectWithGnosis(
   orgAddress: string,
   safeAddress: string,


### PR DESCRIPTION
- style Ethereum address properly in transaction modal
- ban <a> tags
- format pool receiver button Ethereum addresse
- add component for displaying Ethereum transaction links to Etherscan
- make org address copyable
- truncate org address in sidebar
- replace copy owner address to clipboard with "View on Etherscan"
- restyle anchor popover
- show commit hashes consistently

Closes: https://github.com/radicle-dev/radicle-upstream/issues/2231.

<img width="1552" alt="Screenshot 2021-09-09 at 17 21 57" src="https://user-images.githubusercontent.com/158411/132715819-fc5b3678-4f66-4781-85f1-6d03a3cabf77.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 23 31" src="https://user-images.githubusercontent.com/158411/132715823-2d8b1723-5ac0-4891-92da-efe4e448158e.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 23 42" src="https://user-images.githubusercontent.com/158411/132715829-dc085e6f-808a-4e92-b095-947035d67dde.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 24 12" src="https://user-images.githubusercontent.com/158411/132715832-ab5002cb-9779-4e82-bcaf-7ca2bda3d5be.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 24 22" src="https://user-images.githubusercontent.com/158411/132715837-a1afde19-28c0-4000-bb5b-98cf19842761.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 24 43" src="https://user-images.githubusercontent.com/158411/132715842-99f7f378-d17b-4050-bb6b-5b55acf0d060.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 24 47" src="https://user-images.githubusercontent.com/158411/132715848-ce8344fe-db9d-4508-a05b-2572fb753217.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 26 13" src="https://user-images.githubusercontent.com/158411/132715851-c4f4a684-44b1-46d7-8f67-a89d7992ff94.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 26 16" src="https://user-images.githubusercontent.com/158411/132715856-9b2b0c6c-8155-4918-877d-902ae79385bc.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 27 01" src="https://user-images.githubusercontent.com/158411/132715862-b0bde348-3f62-4f44-9099-de4476c3035c.png">
<img width="1552" alt="Screenshot 2021-09-09 at 17 27 42" src="https://user-images.githubusercontent.com/158411/132715865-0e2744eb-911c-427e-9035-2b5c688bdc46.png">

This is what the UI would look like _if_ a developer would use the `<a>` tag. It is an "UI error" and formatted like this on purpose.
<img width="1552" alt="Screenshot 2021-09-09 at 17 21 35" src="https://user-images.githubusercontent.com/158411/132715797-e5df9635-e827-450a-8b18-787bbf98f310.png">
