### PR TITLE
chore: improve anchoring placeholder wording

### DIFF
--- a/ui/App/OrgScreen/Projects.svelte
+++ b/ui/App/OrgScreen/Projects.svelte
@@ -135,7 +135,7 @@
       text="Get started by anchoring your org’s first project."
       primaryActionText={isMultiSig
         ? "Anchor with Gnosis Safe"
-        : "Anchor Project"}
+        : "Anchor project"}
       primaryActionDisabled={disableAnchorCreation}
       primaryActionTooltipMessage="Create or follow a project first"
       on:primaryAction={() => {


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-upstream/issues/2128.

Should the tab also be all lowercase i.e. `Anchored projects`?

<img width="1552" alt="Screenshot 2021-09-09 at 19 08 35" src="https://user-images.githubusercontent.com/158411/132731161-ee23859a-5dae-4d12-84a6-1dd4f080d45c.png">
