### PR TITLE
chore: remove unused feature flagging code

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -13,7 +13,7 @@ Cypress.on("window:before:load", appWindow => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (appWindow as any).isCypressTestEnv = true;
 
-  // Stub electron preloader to always enable `isDev` and `isExperimental` before executing tests.
+  // Stub electron preloader to always enable `isDev` before executing tests.
   ipcStub.setup(appWindow);
 });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -86,25 +86,6 @@ linting and formatting are enforced locally on a pre-commit basis with
 Additionally we run the same checks as separate build steps on our CI, just to
 make sure only properly formatted and lint-free code lands into master.
 
-### Feature flagging
-
-UI features that are experimental or under construction that find their way
-into the main branch must be placed behind the feature flag, to make them
-inaccessible for the general public.
-
-We do that by using `native > ipc.ts > isExperimental` as a feature flag to
-enable or disable said features accordingly to the mode in which we are running
-the app.
-
-To start the app with experimental features enabled run:
-
-    RADICLE_UPSTREAM_EXPERIMENTAL=true yarn start
-
-The feature flag is only available in development mode. It is always disabled
-in production.
-
-
-
 ### Running tests
 
 Before running UI end-to-end tests locally you'll need to check out the latest

--- a/docs/ethereum.md
+++ b/docs/ethereum.md
@@ -102,7 +102,7 @@ tabs:
 
 - `npm run start` within `walletconnect-test-wallet`
 - `./scripts/ethereum-dev-node.ts` in `radicle-upstream`
-- `RADICLE_UPSTREAM_EXPERIMENTAL=true yarn start` within `radicle-upstream`
+- `yarn start` within `radicle-upstream`
 
 
 

--- a/native/index.ts
+++ b/native/index.ts
@@ -352,9 +352,6 @@ function buildConfig(): Partial<Config> {
   if (process.env.RADICLE_UPSTREAM_UI_PROXY_ADDRESS) {
     config.proxyAddress = process.env.RADICLE_UPSTREAM_UI_PROXY_ADDRESS;
   }
-  if (["1", "true"].includes(process.env.RADICLE_UPSTREAM_EXPERIMENTAL || "")) {
-    config.experimentalFeaturesEnabled = true;
-  }
   if (process.env.RADICLE_UPSTREAM_TEST_WALLET_MNEMONIC) {
     config.testWalletMnemonic =
       process.env.RADICLE_UPSTREAM_TEST_WALLET_MNEMONIC;

--- a/ui/App/ProjectScreen/Source/SourceBrowser/RevisionSelector.svelte
+++ b/ui/App/ProjectScreen/Source/SourceBrowser/RevisionSelector.svelte
@@ -9,7 +9,7 @@
   import { createEventDispatcher } from "svelte";
 
   import type { Branch, Tag } from "ui/src/source";
-  import { config } from "ui/src/config";
+  import * as config from "ui/src/config";
 
   import Icon from "ui/DesignSystem/Icon";
   import Overlay from "ui/DesignSystem/Overlay.svelte";
@@ -30,8 +30,11 @@
         // Don’t show the selected revision again
         return false;
       } else if (rev.type === "tag") {
-        // Show tags only if in experimental mode
-        return config.experimentalFeaturesEnabled;
+        // Tags behave differently in radicle-link than people are used to in
+        // normal git workflows, hence we're not showing them in the UI.
+        // Because some old integration test cases still depend on tags, we
+        // only show them when run in Cypress.
+        return config.isCypressTestEnv;
       } else {
         return true;
       }

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -15,10 +15,6 @@ export const INFURA_API_KEY_MAINNET = "7a19a4bf0af84fcc86ffb693a257fad4";
 export interface Config {
   // The address of the proxy in `host:port` format.
   proxyAddress: string;
-  // `true` if experimental features should be enabled.
-  //
-  // This is `true` in the cypress and node test environments.
-  experimentalFeaturesEnabled: boolean;
   // If set, a test wallet is used to automatically sign Ethereum
   // transactions. The value is the mnemonic from which the private key
   // is derived.
@@ -28,7 +24,6 @@ export interface Config {
 
 const partialConfigSchema: zod.Schema<Partial<Config>> = zod.object({
   proxyAddress: zod.string().optional(),
-  experimentalFeaturesEnabled: zod.boolean().optional(),
   testWalletMnemonic: zod.string().optional(),
   isDev: zod.boolean().optional(),
 });
@@ -53,7 +48,6 @@ export const config = getConfig();
 function getConfig(): Config {
   const config = loadPartialConfig();
   return {
-    experimentalFeaturesEnabled: isNodeTestEnv || isCypressTestEnv,
     isDev: isNodeTestEnv || isCypressTestEnv,
     proxyAddress: "127.0.0.1:17246",
     ...config,


### PR DESCRIPTION
This was introduced together with the funding feature which didn't get released and is not useful anymore.