### PR TITLE
feat: add experimental windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 Upstream is a cross-platform desktop client for the radicle code collaboration
 protocol.
 
-At the moment we support Linux and macOS. Later on we'll provide ready-made
-packages for both platforms, however for now a good way to explore the project
-is to read the documentation and have a go at building it locally.
+At the moment we support Linux and macOS. Latest packages for these platforms
+are available on the [Radicle website][rw].
+
+Windows support is considered experimental at this stage -- we don't provide
+packages for this platform, so you'll have to build it from source.
 
 The [UI][ui] is written in JavaScript using [Svelte][sv] and Electron and the
 node [proxy][pr] logic is implemented in [Rust][ru].
@@ -53,6 +55,7 @@ Upstream uses:
 [ra]: https://rsms.me/inter
 [rc]: https://radicle.community
 [ru]: https://www.rust-lang.org
+[rw]: https://radicle.xyz/downloads.html
 [so]: https://adobe-fonts.github.io/source-code-pro
 [st]: https://buildkite.com/monadic/radicle-upstream
 [sv]: https://svelte.dev

--- a/docs/development.md
+++ b/docs/development.md
@@ -140,11 +140,24 @@ then you can use `RAD_PROFILE` instead of `RAD_HOME`, but be aware that
 Electron state will be shared by all instances.
 
 
+### Running on Windows (experimental)
+
+Windows have [some shortcomings on the directory depth](https://github.com/libgit2/libgit2/issues/3053)
+created by Radicle, even if long paths are enabled on the system.
+To prevent errors, set `RAD_HOME` to a root folder (eg: `$env:RAD_HOME="C:\rad"`). You may download a [free VM](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/) from Microsoft to test it out.
+
+
+Start Upstream in development mode: `yarn start` (or `yarn run start:dev:win` for Windows).
+
 ### Building an Upstream package for your platform
 
 You can build and package Upstream with: `yarn dist`. The generated package
-will be in: `dist/` as `radicle-upstream-X.X.X.{dmg|AppImage}`.
+will be in: `dist/` as `radicle-upstream-X.X.X.{dmg|AppImage|exe}`.
 
+For windows, there is `yarn run dist:win:static` to
+[pre-compile](https://rust-lang.github.io/rfcs/1721-crt-static.html)
+`vcruntime140.dll` to avoid the need to install `Visual C++ Redistributable`
+on the target computer.
 
 #### Apple notarization
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,22 +142,24 @@ Electron state will be shared by all instances.
 
 ### Running on Windows (experimental)
 
-Windows have [some shortcomings on the directory depth](https://github.com/libgit2/libgit2/issues/3053)
-created by Radicle, even if long paths are enabled on the system.
-To prevent errors, set `RAD_HOME` to a root folder (eg: `$env:RAD_HOME="C:\rad"`). You may download a [free VM](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/) from Microsoft to test it out.
+There might be [issues due to long file paths on windows][lf]. A workaround
+for this is to set `RAD_HOME` to a root folder, for example:
 
+`$env:RAD_HOME="C:\rad"`.
 
-Start Upstream in development mode: `yarn start` (or `yarn run start:dev:win` for Windows).
+To try out Upstream on Windows, you can use a [free VM][fv] provided by
+Microsoft.
+
 
 ### Building an Upstream package for your platform
 
 You can build and package Upstream with: `yarn dist`. The generated package
 will be in: `dist/` as `radicle-upstream-X.X.X.{dmg|AppImage|exe}`.
 
-For windows, there is `yarn run dist:win:static` to
-[pre-compile](https://rust-lang.github.io/rfcs/1721-crt-static.html)
-`vcruntime140.dll` to avoid the need to install `Visual C++ Redistributable`
-on the target computer.
+On Windows you can do `yarn run dist:win:static` to [pre-compile][pc]
+`vcruntime140.dll` to avoid the need to install Visual C++ Redistributable on
+the target computer.
+
 
 #### Apple notarization
 
@@ -509,6 +511,7 @@ All Github access tokens _must_ have the `public_repo` scope.
 [eb]: https://github.com/electron-userland/electron-builder
 [el]: https://www.electronjs.org
 [es]: https://eslint.org
+[fv]: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines
 [ga]: https://docs.github.com/en/actions
 [gc]: https://cloud.google.com/sdk/docs/quickstart-macos
 [gg]: https://cloud.google.com/storage/docs/gsutil_install
@@ -517,10 +520,12 @@ All Github access tokens _must_ have the `public_repo` scope.
 [hb]: https://github.com/github/hub
 [hub-config]: https://hub.github.com/hub.1.html#configuration
 [hu]: https://github.com/typicode/husky
+[lf]: https://github.com/libgit2/libgit2/issues/3053
 [ls]: https://github.com/okonet/lint-staged
 [ma]: https://appleid.apple.com/account/manage
 [merging-prs]: https://github.com/radicle-dev/radicle-decisions/blob/master/proposals/0003.md#merging-pull-requests
 [on]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Excluding-and-Including-Tests
+[pc]: https://github.com/libgit2/libgit2/issues/3053
 [pr]: https://prettier.io
 [qa]: qa.md
 [rd]: https://github.com/radicle-dev/radicle.xyz/blob/master/pages/downloads.html.mustache

--- a/native/index.ts
+++ b/native/index.ts
@@ -27,6 +27,7 @@ import { parseRadicleUrl, throttled } from "./nativeCustomProtocolHandler";
 import type { Config } from "ui/src/config";
 
 const isDev = process.env.NODE_ENV === "development";
+const isWindows = process.platform === "win32";
 
 let proxyPath;
 let proxyArgs: string[] = [];
@@ -46,7 +47,11 @@ if (isDev) {
   proxyArgs.push("--unsafe-fast-keystore");
 } else {
   // Packaged app, i.e. production.
-  proxyPath = path.join(__dirname, "../../radicle-proxy");
+  if (isWindows) {
+    proxyPath = path.join(__dirname, "../../radicle-proxy.exe");
+  } else {
+    proxyPath = path.join(__dirname, "../../radicle-proxy");
+  }
   proxyArgs = [
     "--default-seed",
     "hynkyndc6w3p8urucakobzna7sxwgcqny7xxtw88dtx3pkf7m3nrzc@sprout.radicle.xyz:12345",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,14 @@
         "to": "./"
       },
       {
+        "from": "target/release/radicle-proxy.exe",
+        "to": "./"
+      },
+      {
+        "from": "target/release/git-remote-rad.exe",
+        "to": "./"
+      },
+      {
         "from": "proxy/assets",
         "to": "assets"
       }
@@ -68,12 +76,13 @@
   "main": "./native/bundle.js",
   "scripts": {
     "start": "cargo build --all-features --all-targets && yarn run-p --race _private:webpack:ui:watch _private:electron:start",
-    "test": "TZ='UTC' yarn test:unit && TZ='UTC' yarn test:integration",
-    "test:integration": "TZ='UTC' run-p --race _private:proxy:start:test _private:test:integration",
-    "test:integration:debug": "TZ='UTC' run-p --race _private:webpack:ui:watch _private:proxy:start:test:watch _private:test:integration:debug",
+    "test": "cross-env TZ='UTC' yarn test:unit && TZ='UTC' yarn test:integration",
+    "test:integration": "cross-env TZ='UTC' run-p --race _private:proxy:start:test _private:test:integration",
+    "test:integration:debug": "cross-env TZ='UTC' run-p --race _private:webpack:ui:watch _private:proxy:start:test:watch _private:test:integration:debug",
     "test:unit": "jest",
     "test:unit:watch": "jest --watchAll",
     "dist": "yarn _private:dist:clean && webpack build --mode production && cargo build --release && electron-builder --publish never",
+    "dist:win:static": "cross-env RUSTFLAGS='-C target-feature=+crt-static' yarn dist",
     "release": "scripts/release.ts",
     "typescript:check": "tsc --noEmit && tsc --noEmit --project cypress && svelte-check",
     "prettier:check": "yarn _private:prettier --check",
@@ -83,7 +92,7 @@
     "_private:test:integration": "wait-on tcp:17246 && yarn run webpack build --config-name ui && yarn run cypress run",
     "_private:test:integration:debug": "wait-on ./public/bundle.js tcp:17246 && yarn run cypress open",
     "_private:electron:start": "wait-on ./public/bundle.js && NODE_ENV=development electron native/index.js",
-    "_private:dist:clean": "rm -rf ./dist && mkdir ./dist",
+    "_private:dist:clean": "rimraf ./dist && mkdir ./dist",
     "_private:prettier": "prettier \"**/*.@(js|ts|json|svelte|css|html)\" --ignore-path .gitignore",
     "_private:proxy:start:test": "cargo build --features unsafe-fast-keystore --bins && cargo run --features unsafe-fast-keystore -- --test --unsafe-fast-keystore",
     "_private:proxy:start:test:watch": "cargo build --features unsafe-fast-keystore --bins && cargo watch -x 'run --features unsafe-fast-keystore -- --test --unsafe-fast-keystore'",
@@ -147,6 +156,7 @@
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "chokidar": "^3.5.2",
+    "cross-env": "^7.0.3",
     "cypress": "^8.3.1",
     "electron": "^14.0.0",
     "electron-builder": "^22.13.1",
@@ -171,6 +181,7 @@
     "prettier": "^2.3.2",
     "prettier-plugin-svelte": "^2.4.0",
     "prompts": "^2.4.1",
+    "rimraf": "^3.0.2",
     "sinon": "^11.1.2",
     "spdx-expression-parse": "^3.0.1",
     "spdx-whitelisted": "^1.0.0",

--- a/proxy/api/src/config.rs
+++ b/proxy/api/src/config.rs
@@ -53,10 +53,15 @@ pub fn store_dir(profile_id: &ProfileId) -> path::PathBuf {
 ///
 ///   * Could not get the user home path from the HOME env variable
 pub fn bin_dir() -> Result<path::PathBuf, Error> {
-    let home_dir = std::env::var("HOME").or_else(|_| {
-        // Windows don't have HOME by default
-        std::env::var("USERPROFILE")
-    })?;
+    let home_dir;
+    #[cfg(windows)]
+    {
+        home_dir = std::env::var("USERPROFILE")?;
+    }
+    #[cfg(unix)]
+    {
+        home_dir = std::env::var("HOME")?;
+    }
 
     Ok(path::Path::new(&home_dir).join(".radicle/bin"))
 }

--- a/proxy/api/src/config.rs
+++ b/proxy/api/src/config.rs
@@ -53,7 +53,10 @@ pub fn store_dir(profile_id: &ProfileId) -> path::PathBuf {
 ///
 ///   * Could not get the user home path from the HOME env variable
 pub fn bin_dir() -> Result<path::PathBuf, Error> {
-    let home_dir = std::env::var("HOME")?;
+    let home_dir = std::env::var("HOME").or_else(|_| {
+        // Windows don't have HOME by default
+        std::env::var("USERPROFILE")
+    })?;
 
     Ok(path::Path::new(&home_dir).join(".radicle/bin"))
 }

--- a/proxy/api/src/git_helper.rs
+++ b/proxy/api/src/git_helper.rs
@@ -6,7 +6,7 @@
 
 //! git-remote-rad git helper related functionality.
 
-use std::{fs, io, os::unix::fs::PermissionsExt as _, path};
+use std::{fs, io, path};
 
 /// Git helper errors.
 #[derive(Debug, thiserror::Error)]
@@ -17,7 +17,12 @@ pub enum Error {
 }
 
 /// Filename of the git helper binary.
+#[cfg(unix)]
 pub const GIT_REMOTE_RAD: &str = "git-remote-rad";
+
+/// Filename of the git helper binary.
+#[cfg(windows)]
+pub const GIT_REMOTE_RAD: &str = "git-remote-rad.exe";
 
 /// Checks if the git-remote-rad helper is in a stable location and has the
 /// executable flag, if not copies the executable to the right place.
@@ -34,9 +39,14 @@ pub fn setup(src_dir: &path::Path, dst_dir: &path::Path) -> Result<(), Error> {
 
     fs::create_dir_all(dst_dir)?;
     fs::copy(helper_bin_src, helper_bin_dst.clone())?;
-    let mut permissions = helper_bin_dst.metadata()?.permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&helper_bin_dst, permissions)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut permissions = helper_bin_dst.metadata()?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&helper_bin_dst, permissions)?;
+    }
 
     tracing::info!(destination = ?helper_bin_dst, "copied git remote helper binary");
 
@@ -45,7 +55,10 @@ pub fn setup(src_dir: &path::Path, dst_dir: &path::Path) -> Result<(), Error> {
 
 #[cfg(test)]
 mod test {
-    use std::{fs, os::unix::fs::PermissionsExt as _};
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use std::fs;
 
     use super::Error;
 
@@ -53,22 +66,32 @@ mod test {
     async fn ensure_setup_sets_up_remote_helper() -> Result<(), Error> {
         let tmp_src_dir = tempfile::tempdir().expect("failed to create source tempdir");
         let src_git_helper_bin_path = tmp_src_dir.path().join(super::GIT_REMOTE_RAD);
-        let file = fs::File::create(src_git_helper_bin_path.clone())
+        let _file = fs::File::create(src_git_helper_bin_path.clone())
             .expect("failed to create mock binary");
-        let mut src_permissions = file.metadata()?.permissions();
-        src_permissions.set_mode(0o644);
 
-        fs::set_permissions(src_git_helper_bin_path, src_permissions)?;
+        #[cfg(unix)]
+        {
+            let mut src_permissions = _file.metadata()?.permissions();
+            src_permissions.set_mode(0o644);
+            fs::set_permissions(src_git_helper_bin_path, src_permissions)?;
+        }
 
         let tmp_dst_dir = tempfile::tempdir().expect("failed to create destination tempdir");
         let dst_full_path = tmp_dst_dir.path().join(".radicle/bin");
         super::setup(&tmp_src_dir.path().to_path_buf(), &dst_full_path)?;
 
         let dst_git_helper_bin_path = dst_full_path.join(super::GIT_REMOTE_RAD);
+        assert!(
+            dst_git_helper_bin_path.exists(),
+            "destination helper exists"
+        );
 
-        let dst_metadata = dst_git_helper_bin_path.metadata()?;
-        let dst_permissions = dst_metadata.permissions();
-        assert_eq!(dst_permissions.mode(), 0o100_755);
+        #[cfg(unix)]
+        {
+            let dst_metadata = dst_git_helper_bin_path.metadata()?;
+            let dst_permissions = dst_metadata.permissions();
+            assert_eq!(dst_permissions.mode(), 0o100_755);
+        }
 
         Ok(())
     }

--- a/proxy/api/src/git_helper.rs
+++ b/proxy/api/src/git_helper.rs
@@ -66,12 +66,17 @@ mod test {
     async fn ensure_setup_sets_up_remote_helper() -> Result<(), Error> {
         let tmp_src_dir = tempfile::tempdir().expect("failed to create source tempdir");
         let src_git_helper_bin_path = tmp_src_dir.path().join(super::GIT_REMOTE_RAD);
-        let _file = fs::File::create(src_git_helper_bin_path.clone())
-            .expect("failed to create mock binary");
+        #[cfg(windows)]
+        {
+            fs::File::create(src_git_helper_bin_path.clone())
+                .expect("failed to create mock binary");
+        }
 
         #[cfg(unix)]
         {
-            let mut src_permissions = _file.metadata()?.permissions();
+            let file = fs::File::create(src_git_helper_bin_path.clone())
+                .expect("failed to create mock binary");
+            let mut src_permissions = file.metadata()?.permissions();
             src_permissions.set_mode(0o644);
             fs::set_permissions(src_git_helper_bin_path, src_permissions)?;
         }

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -9,7 +9,6 @@ import { derived, Readable } from "svelte/store";
 import * as error from "./error";
 import * as localPeer from "./localPeer";
 import * as project from "./project";
-import { Status } from "./remote";
 import * as remote from "./remote";
 import * as proxy from "./proxy";
 
@@ -35,24 +34,24 @@ export const following: Readable<remote.Data<Following | null>> = derived(
   ([follows, requests]): remote.Data<Following | null> => {
     // Transition to loading.
     if (
-      follows.status === Status.Loading ||
-      requests.status === Status.Loading
+      follows.status === remote.Status.Loading ||
+      requests.status === remote.Status.Loading
     ) {
-      return { status: Status.Loading as const };
+      return { status: remote.Status.Loading };
     }
 
     // Return errors.
-    if (follows.status === Status.Error) {
+    if (follows.status === remote.Status.Error) {
       return follows;
     }
-    if (requests.status === Status.Error) {
+    if (requests.status === remote.Status.Error) {
       return requests;
     }
 
     // Data loaded.
     if (
-      follows.status === Status.Success &&
-      requests.status === Status.Success
+      follows.status === remote.Status.Success &&
+      requests.status === remote.Status.Success
     ) {
       let data = null;
       const reqs = requests.data.filter(
@@ -67,10 +66,10 @@ export const following: Readable<remote.Data<Following | null>> = derived(
           requests: reqs,
         };
       }
-      return { status: Status.Success as const, data };
+      return { status: remote.Status.Success, data };
     }
 
-    return { status: Status.NotAsked as const };
+    return { status: remote.Status.NotAsked };
   }
 );
 

--- a/ui/src/profile.ts
+++ b/ui/src/profile.ts
@@ -9,6 +9,7 @@ import { derived, Readable } from "svelte/store";
 import * as error from "./error";
 import * as localPeer from "./localPeer";
 import * as project from "./project";
+import { Status } from "./remote";
 import * as remote from "./remote";
 import * as proxy from "./proxy";
 
@@ -34,24 +35,24 @@ export const following: Readable<remote.Data<Following | null>> = derived(
   ([follows, requests]): remote.Data<Following | null> => {
     // Transition to loading.
     if (
-      follows.status === remote.Status.Loading ||
-      requests.status === remote.Status.Loading
+      follows.status === Status.Loading ||
+      requests.status === Status.Loading
     ) {
-      return { status: remote.Status.Loading };
+      return { status: Status.Loading as const };
     }
 
     // Return errors.
-    if (follows.status === remote.Status.Error) {
+    if (follows.status === Status.Error) {
       return follows;
     }
-    if (requests.status === remote.Status.Error) {
+    if (requests.status === Status.Error) {
       return requests;
     }
 
     // Data loaded.
     if (
-      follows.status === remote.Status.Success &&
-      requests.status === remote.Status.Success
+      follows.status === Status.Success &&
+      requests.status === Status.Success
     ) {
       let data = null;
       const reqs = requests.data.filter(
@@ -66,10 +67,10 @@ export const following: Readable<remote.Data<Following | null>> = derived(
           requests: reqs,
         };
       }
-      return { status: remote.Status.Success, data };
+      return { status: Status.Success as const, data };
     }
 
-    return { status: remote.Status.NotAsked };
+    return { status: Status.NotAsked as const };
   }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4267,6 +4267,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: ^7.0.1
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -9805,6 +9817,7 @@ __metadata:
     big.js: ^6.1.1
     buffer: ^6.0.3
     chokidar: ^3.5.2
+    cross-env: ^7.0.3
     crypto-browserify: ^3.12.0
     cypress: ^8.3.1
     electron: ^14.0.0
@@ -9842,6 +9855,7 @@ __metadata:
     qs: ^6.10.1
     radicle-avatar: "https://github.com/radicle-dev/radicle-avatar.git#commit=28033ef5a562aeb52c2e77c008021d27c3b24f4e"
     radicle-contracts: "github:radicle-dev/radicle-contracts#commit=157a5b59df94704702623765198deb4ba70ace84"
+    rimraf: ^3.0.2
     semver: ^7.3.5
     sinon: ^11.1.2
     spdx-expression-parse: ^3.0.1


### PR DESCRIPTION
Finishing the work that @bltavares started in https://github.com/radicle-dev/radicle-upstream/pull/1623. I squashed all of the existing commits, rebased it on top of the current master, fixed merge conflicts and cleaned up any outstanding code review comments.

So far only tested that everything still works on macOS both in dev mode and release build.

I tried testing it on Windows, but my machine is too weak to build it in a VM.
@bltavares could you please try it on Windows and let us know whether it still works?

Note that we're planning two major changes to the architecture of Upstream this year: moving away from Electron and migrating to a stand-alone Radicle daemon. Both of these changes might require re-thinking Windows support again.