### PR TITLE
style: render external links in markdown with appropriate style

### DIFF
--- a/cypress/integration/project/source_browsing.spec.ts
+++ b/cypress/integration/project/source_browsing.spec.ts
@@ -191,7 +191,7 @@ context("project source browsing", () => {
             commands
               .pickWithContent(
                 ["project-screen", "file-view"],
-                "This repository is a data source for the Upstream front-end tests and the radicle-surf unit tests."
+                "This repository is a data source for the Upstream front-end tests"
               )
               .should("exist");
 

--- a/public/typography.css
+++ b/public/typography.css
@@ -181,17 +181,6 @@ p,
   opacity: 0.5;
 }
 
-a {
-  visibility: hidden;
-}
-
-a:after {
-  background-color: red;
-  color: white;
-  visibility: visible;
-  content: 'Don\'t use the <a> tag. Use <span class="typo-link"> for internal links or the <ExternalLink> component for extenal links.';
-}
-
 /* Modifiers */
 
 .typo-regular {

--- a/ui/DesignSystem/Markdown.svelte
+++ b/ui/DesignSystem/Markdown.svelte
@@ -9,6 +9,26 @@
   import marked from "marked";
 
   export let content: string;
+
+  const renderer = {
+    link(href: string, _title: string, text: string) {
+      if (
+        href.toLowerCase().startsWith("http://") ||
+        href.toLowerCase().startsWith("https://")
+      ) {
+        if (text.includes("<img")) {
+          return `<a href="${href}">${text}</a>`;
+        } else {
+          return `<a class="typo-link" style="text-decoration: none;" href="${href}"><span style="text-decoration: underline; margin-right: 0.1rem;">${text}</span><span style="vertical-align: text-top">↗</span></a>`;
+        }
+      } else {
+        // Internal links don't work yet, so we disable user-interaction.
+        return `<span style="text-decoration: underline; text-underline-offset: 0.25rem;">${text}</span>`;
+      }
+    },
+  };
+
+  marked.use({ renderer });
 </script>
 
 <style>
@@ -101,15 +121,6 @@
   .markdown :global(p) {
     margin-top: 0;
     margin-bottom: 0.625rem;
-  }
-
-  .markdown :global(a) {
-    background-color: initial;
-    color: var(--color-primary);
-    text-decoration: none;
-  }
-  .markdown :global(a:hover) {
-    text-decoration: underline;
   }
 
   .markdown :global(strong) {


### PR DESCRIPTION
Fixes a regression introduced with https://github.com/radicle-dev/radicle-upstream/pull/2352. Links in rendered markdown had a wrong styling due to the CSS warning that I added. Wasn't a good idea in hindsight.

We also apply a different style to relative links and prevent user interaction.
Closes https://github.com/radicle-dev/radicle-upstream/issues/1347.

Note: making relative links work properly would require a substantial change to the source browsing code.

Regression:
<img width="1552" alt="Screenshot 2021-09-15 at 16 29 11" src="https://user-images.githubusercontent.com/158411/133452631-98a8b988-2f00-4487-9081-b886bc8e2ad4.png">

Fix:
<img width="1552" alt="Screenshot 2021-09-15 at 16 30 20" src="https://user-images.githubusercontent.com/158411/133452829-23384e09-fc87-4155-b643-4e3f2fca2dd5.png">

Disabled relative links:
<img width="1552" alt="Screenshot 2021-09-15 at 16 30 41" src="https://user-images.githubusercontent.com/158411/133453748-a78cbe91-33dc-4772-8550-ff2df499d21a.png">

We don't apply the styling if the `<a>` tag contains images:
<img width="1552" alt="Screenshot 2021-09-15 at 16 48 48" src="https://user-images.githubusercontent.com/158411/133456138-60cf7449-6de5-4c96-bcc4-f28c3b88e254.png">

