### PR TITLE
feat: add validated browser storage abstraction

### DIFF
--- a/ui/src/browserStore.test.ts
+++ b/ui/src/browserStore.test.ts
@@ -1,0 +1,80 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as zod from "zod";
+import * as error from "ui/src/error";
+import * as svelteStore from "svelte/store";
+
+import * as browserStore from "./browserStore";
+
+jest.mock("ui/src/error", () => {
+  const original = jest.requireActual("ui/src/error");
+  return {
+    __esModule: true,
+    ...original,
+    show: jest.fn(),
+  };
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  window.localStorage.clear();
+});
+
+test("persist value in storage", () => {
+  const store = browserStore.create("radicle.foo", false, zod.boolean());
+
+  expect(window.localStorage.getItem("radicle.foo")).toBe(
+    JSON.stringify(false)
+  );
+  expect(svelteStore.get(store)).toBe(false);
+
+  store.set(true);
+
+  expect(window.localStorage.getItem("radicle.foo")).toBe(JSON.stringify(true));
+  expect(svelteStore.get(store)).toBe(true);
+});
+
+test("update value", () => {
+  const store = browserStore.create("radicle.foo", false, zod.boolean());
+
+  expect(window.localStorage.getItem("radicle.foo")).toBe(
+    JSON.stringify(false)
+  );
+  expect(svelteStore.get(store)).toBe(false);
+
+  const updater = jest.fn((x: boolean) => !x);
+  store.update(updater);
+
+  expect(window.localStorage.getItem("radicle.foo")).toBe(JSON.stringify(true));
+  expect(svelteStore.get(store)).toBe(true);
+  expect(updater).toHaveBeenLastCalledWith(false);
+});
+
+test("invalid value returns initial value and shows error", () => {
+  window.localStorage.setItem("radicle.foo", "0");
+  const store = browserStore.create("radicle.foo", false, zod.boolean());
+
+  expect(svelteStore.get(store)).toBe(false);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const showMock: any = (error.show as any).mock;
+  expect(showMock.calls[0][0].message).toBe(
+    "Stored data does not match schema"
+  );
+});
+
+test("invalid value shows error only once", () => {
+  window.localStorage.setItem("radicle.foo", "0");
+  const store = browserStore.create("radicle.foo", false, zod.boolean());
+
+  expect(svelteStore.get(store)).toBe(false);
+  expect(svelteStore.get(store)).toBe(false);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const showMock: any = (error.show as any).mock;
+  expect(showMock.calls.length).toBe(1);
+});

--- a/ui/src/browserStore.ts
+++ b/ui/src/browserStore.ts
@@ -1,0 +1,71 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import type * as zod from "zod";
+import persistentStore from "svelte-persistent-store/dist";
+
+import * as svelteStore from "ui/src/svelteStore";
+import * as error from "ui/src/error";
+
+const VALID_STORAGE_KEY_RE = /radicle(\.[a-zA-Z])+/;
+
+// Create a store that is backed by the browsers local storage.
+//
+// The raw storage value must conform to `schema`. If the value does
+// not parse, `initialValue` is returned and an error is shown to the
+// user.
+//
+// `key` must be a dot-separated list letters that starts with
+// "radicle". For example "radicle.foo.bar".
+//
+// `initialValue` is the value assigned to the storage if it is not
+// set.
+export function create<T>(
+  key: string,
+  initialValue: T,
+  schema: zod.Schema<T>
+): svelteStore.Writable<T> {
+  let errorShown = false;
+  if (!VALID_STORAGE_KEY_RE.test(key)) {
+    throw new Error(
+      `invalid storage key ${key}. Must match ${VALID_STORAGE_KEY_RE}`
+    );
+  }
+
+  function parseOrInitial(value: unknown): T {
+    const result = schema.safeParse(value);
+    if (result.success) {
+      return result.data;
+    } else {
+      if (!errorShown) {
+        errorShown = true;
+        error.show(
+          new error.Error({
+            message: "Stored data does not match schema",
+            details: {
+              key,
+              value,
+              zodIssues: result.error.issues,
+            },
+          })
+        );
+      }
+      return initialValue;
+    }
+  }
+
+  const raw = persistentStore.local.writable<unknown>(key, initialValue);
+  const parsed = svelteStore.derived(raw, parseOrInitial);
+  return {
+    set: raw.set,
+    update: (updater: svelteStore.Updater<T>) => {
+      raw.update(value => {
+        return updater(parseOrInitial(value));
+      });
+    },
+    subscribe: parsed.subscribe,
+  };
+}

--- a/ui/src/ethereum/index.ts
+++ b/ui/src/ethereum/index.ts
@@ -4,10 +4,10 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
-import * as svelteStore from "svelte/store";
+import * as zod from "zod";
 import Big from "big.js";
 import * as ethers from "ethers";
-import persistentStore from "svelte-persistent-store/dist";
+import * as browserStore from "ui/src/browserStore";
 import { config, isCypressTestEnv } from "ui/src/config";
 import * as error from "ui/src/error";
 
@@ -16,21 +16,15 @@ import * as contractAddresses from "./contractAddresses";
 
 export { Environment, supportedNetwork, Network, contractAddresses };
 
-// The store where the selected Ethereum environment is persisted.
-export const selectedEnvironment = persistentStore.local.writable<Environment>(
-  "ethereum-environment-v0",
-  config.isDev ? Environment.Rinkeby : Environment.Mainnet
+export const selectedEnvironment = browserStore.create<Environment>(
+  "radicle.ethereum.environment",
+  config.isDev ? Environment.Rinkeby : Environment.Mainnet,
+  zod.union([
+    zod.literal(Environment.Mainnet),
+    zod.literal(Environment.Rinkeby),
+    zod.literal(Environment.Local),
+  ])
 );
-
-if (
-  ![Environment.Mainnet, Environment.Rinkeby, Environment.Local].includes(
-    svelteStore.get(selectedEnvironment)
-  )
-) {
-  selectedEnvironment.set(
-    config.isDev ? Environment.Rinkeby : Environment.Mainnet
-  );
-}
 
 if (isCypressTestEnv) {
   selectedEnvironment.set(Environment.Local);

--- a/ui/src/updateChecker.ts
+++ b/ui/src/updateChecker.ts
@@ -4,10 +4,11 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
+import * as zod from "zod";
 import * as svelteStore from "svelte/store";
-import persistentStore from "svelte-persistent-store/dist";
 import * as semver from "semver";
 import * as router from "ui/src/router";
+import * as browserStore from "ui/src/browserStore";
 
 import * as ipc from "./ipc";
 import * as modal from "./modal";
@@ -36,14 +37,16 @@ const VERSION_NOTIFY_SILENCE_INTERVAL = config.isCypressTestEnv
   ? 5000
   : 14 * 24 * 60 * 60 * 1000;
 
-const lastNotifiedStore = persistentStore.local.writable<number | null>(
+const lastNotifiedStore = browserStore.create<number | null>(
   "radicle.settings.updateChecker.lastNotified",
-  null
+  null,
+  zod.number().nullable()
 );
 
-const isEnabledStore = persistentStore.local.writable<boolean | null>(
+const isEnabledStore = browserStore.create<boolean | null>(
   "radicle.settings.updateChecker.isEnabled",
-  null
+  null,
+  zod.boolean().nullable()
 );
 
 class UpdateChecker {


### PR DESCRIPTION
We add a svelte store abstraction that uses the browser storage for
persistence and validates the values.