### PR TITLE
refactor: cleanup identity endpoints

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -167,7 +167,7 @@ export const onboardUser = (
 ): Cypress.Chainable<void> => {
   return cy.then(async () => {
     await proxyClient.keyStoreCreate({ passphrase: "radicle-upstream" });
-    await proxyClient.identityCreate({ handle });
+    await proxyClient.identity.create({ handle });
   });
 };
 

--- a/ui/App/OnboardingModal.svelte
+++ b/ui/App/OnboardingModal.svelte
@@ -10,7 +10,7 @@
 
   import { retryFetch } from "ui/src/retryOnError";
   import { State } from "ui/src/onboarding";
-  import { createIdentity } from "ui/src/identity";
+  import * as proxy from "ui/src/proxy";
   import * as error from "ui/src/error";
   import * as router from "ui/src/router";
   import * as screen from "ui/src/screen";
@@ -59,7 +59,7 @@
         await session.createKeystore(passphrase);
         // Retry until the API is up
         const identity = await retryFetch(
-          () => createIdentity({ handle }),
+          () => proxy.client.identity.create({ handle }),
           100,
           50
         );

--- a/ui/src/identity.ts
+++ b/ui/src/identity.ts
@@ -5,7 +5,6 @@
 // LICENSE file.
 
 import * as error from "./error";
-import * as remote from "./remote";
 import * as proxy from "./proxy";
 import * as session from "./session";
 import type { Ethereum, Identity } from "./proxy/identity";
@@ -14,15 +13,6 @@ export type { Identity };
 
 // FIXME(xla): Improve type safety of it, this is a placeholder to avoid using strings everywhere.
 export type PeerId = string;
-
-const creationStore = remote.createStore<Identity>();
-export const store = creationStore.readable;
-
-export const createIdentity = (
-  params: proxy.IdentityCreateParams
-): Promise<Identity> => {
-  return proxy.client.identityCreate(params);
-};
 
 // Claim the ownership of an Ethereum address, stored on the user's Radicle Identity.
 export const claimEthAddress = async (address: string): Promise<void> =>
@@ -44,7 +34,7 @@ const updateEthereumClaim = async (
       throw new Error("Session is not unsealed");
     }
     const { metadata } = unsealed.identity;
-    await proxy.client.identityUpdate({
+    await proxy.client.identity.update({
       ...metadata,
       ethereum,
     });
@@ -68,10 +58,6 @@ function getExpirationDate(): Date {
   result.setDate(result.getDate() + days);
   return result;
 }
-
-export const fetch = (urn: string): Promise<Identity> => {
-  return proxy.client.identityGet(urn);
-};
 
 // MOCK
 export const fallback: Identity = {

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -631,7 +631,7 @@ async function getClaimedIdentity(
   const urn = identitySha1Urn(radicleIdBytes);
   let identity;
   try {
-    identity = await proxy.client.remoteIdentityGet(urn);
+    identity = await proxy.client.personGet(urn);
   } catch (error: unknown) {
     if (error instanceof proxy.ResponseError && error.response.status === 404) {
       return undefined;

--- a/ui/src/proxy/index.ts
+++ b/ui/src/proxy/index.ts
@@ -27,10 +27,6 @@ export const sessionSchema: zod.ZodSchema<Session> = zod.object({
   settings: settings.settingsSchema,
 });
 
-export interface IdentityCreateParams {
-  handle: string;
-}
-
 interface KeyStoreUnsealParams {
   passphrase: string;
 }
@@ -45,12 +41,14 @@ export class Client {
   public control: control.Control;
   public project: project.Client;
   public source: source.Client;
+  public identity: identity.Client;
 
   constructor(baseUrl: string) {
     this.fetcher = new Fetcher(baseUrl);
     this.control = new control.Control(this.fetcher);
     this.project = new project.Client(this.fetcher);
     this.source = new source.Client(this.fetcher);
+    this.identity = new identity.Client(this.fetcher);
   }
 
   async sessionGet(options?: RequestOptions): Promise<Session> {
@@ -76,36 +74,7 @@ export class Client {
     });
   }
 
-  async identityCreate(
-    params: IdentityCreateParams,
-    options?: RequestOptions
-  ): Promise<identity.Identity> {
-    return this.fetcher.fetchOk(
-      {
-        method: "POST",
-        path: "identities",
-        body: params,
-        options,
-      },
-      identity.identitySchema
-    );
-  }
-
-  async identityGet(
-    urn: string,
-    options?: RequestOptions
-  ): Promise<identity.Identity> {
-    return this.fetcher.fetchOk(
-      {
-        method: "GET",
-        path: `identities/${urn}`,
-        options,
-      },
-      identity.identitySchema
-    );
-  }
-
-  async remoteIdentityGet(
+  async personGet(
     urn: string,
     options?: RequestOptions
   ): Promise<identity.RemoteIdentity> {
@@ -116,21 +85,6 @@ export class Client {
         options,
       },
       identity.remoteIdentitySchema
-    );
-  }
-
-  async identityUpdate(
-    params: identity.Metadata,
-    options?: RequestOptions
-  ): Promise<identity.Identity> {
-    return this.fetcher.fetchOk(
-      {
-        method: "PUT",
-        path: "identities",
-        body: params,
-        options,
-      },
-      identity.identitySchema
     );
   }
 

--- a/ui/src/userProfile.ts
+++ b/ui/src/userProfile.ts
@@ -28,7 +28,7 @@ export const fetchProjects = (urn: string): void => {
 
 export const fetchUser = (urn: string): void => {
   proxy.client
-    .remoteIdentityGet(urn)
+    .personGet(urn)
     .then(userStore.success)
     .catch(err => userStore.error(error.fromUnknown(err)));
 };


### PR DESCRIPTION
* We follow the pattern outlined for other endpoints and move all the methods into a separate identity client class.
* We rename `remoteIdentityGet` to `personGet` as this is terminology used by the identities CLI.
* We eliminate some unused code and indirections.