### PR TITLE
add contribution notes for designers to `contributing.md`

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,11 +19,11 @@ We are currently accepting [PR's through GitHub][pr] while we make our own
 infrastructure more robust. If it's your first time using GitHub Pull Requests,
 learn more about it [here][gh].
 
-We also accept contributions through [Upstream Patches][up] -- our first
-version of Pull Requests in Upstream. Learn more about the contribution flow
-[here][cb]. For us to see you've contributed a Patch, we need to
-[add your Device ID as a remote][ar] to our repo. You can either add it to the
-[Remotes to track issue][rt] or post it in [#upstream on Discord][di].
+We also accept contributions through [Upstream Patches][up] -- our first version
+of Pull Requests in Upstream. Learn more about the contribution flow [here][cb].
+For us to see you've contributed a Patch, we need to [add your Device ID as a
+remote][ar] to our repo. You can either add it to the [Remotes to track
+issue][rt] or post it in [#upstream on Discord][dc].
 
 ## Creating a commit
 
@@ -47,31 +47,53 @@ feat(proxy): improve session (#380)
 
 ### Certificate of Origin
 
-We require commits to be signed off to show your agreement to the
-[Developer Certificate of Origin (DCO)][do]. This means that the messages of
-all your commits must include the following line at the end.
+We require commits to be signed off to show your agreement to the [Developer
+Certificate of Origin (DCO)][do]. This means that the messages of all your
+commits must include the following line at the end.
 
     Signed-off-by: John Doe <john.doe@example.com>
 
 You can create commits with this line by running `git commit -s`.
 
-The DCO was created by the Linux Kernel community and is a simple statement
-that you, as a contributor, have the legal right to make the contribution.
+The DCO was created by the Linux Kernel community and is a simple statement that
+you, as a contributor, have the legal right to make the contribution.
 
 ## Documentation
 
 We're writing documentation as we are developing new features. If you find
-something that is confusing or not covered at all, feel free to
-[open a bug][ob] or [contribute][cd]
+something that is confusing or not covered at all, feel free to [open a bug][ob]
+or [contribute][cd]
 
+## Contributing to the Design
+
+Since Radicle is an open source project, anyone can contribute. This is normal
+in open source development, but we do it for design too! Here's how you can get
+started:
+
+- I’d suggest starting by joining our [Discord server][dc] to chat with me or
+  anyone on the team and ask any questions you have. It’s all public and open
+  for anyone to join and chat in. We even have our “internal” chats public on
+  there where we chat all day about features. The #Upstream channel is an
+  example of that.
+- There are also a lot of issues on our GitHub marked as “Design needed” which
+  are open for anyone to grab and submit a solution for. You can find them
+  [here][dn]. Some are easier than others. Feel free to read through those and
+  ask any questions you have directly on the GitHub issue.
+- You can also reach out directly on Discord with any questions you have. If you
+  need any help getting set up with our [Figma file][ff] just ask one of the
+  core designer on the team ([@brandonhaslegs][bo] and [@juliendonck][jd])!
+  You’ll need to duplicate the file and make changes in your own private file.
+  If we accept them, we’ll integrate them into the official file.
+- If you want to submit a design solution on GitHub, just post screenshots of
+  your solution and a description on the issue (see here for an example of this
+  in action)
 
 
 [ar]: http://docs.radicle.xyz/docs/using-radicle/tracking-and-viewing#adding-remotes
 [cb]: https://docs.radicle.xyz/docs/using-radicle/overview
 [cc]: https://www.conventionalcommits.org/en/v1.0.0
 [cd]: https://github.com/radicle-dev/radicle-docs#readme
-[dc]: https://discord.gg/HRdnwAwGbG
-[di]: https://discord.com/channels/841318878125490186/843873418205331506
+[dc]: https://discord.com/channels/841318878125490186/843873418205331506
 [dm]: development.md
 [do]: ../DCO
 [gh]: https://guides.github.com/introduction/flow/
@@ -82,3 +104,7 @@ something that is confusing or not covered at all, feel free to
 [rd]: https://docs.radicle.xyz
 [rt]: https://github.com/radicle-dev/radicle-upstream/issues/1958
 [up]: http://docs.radicle.xyz/docs/using-radicle/creating-patches
+[dn]: https://github.com/radicle-dev/radicle-upstream/issues?q=is%3Aopen+is%3Aissu+label%3Adesign-needed
+[ff]: https://www.figma.com/file/owmgsbs6lnUt8R1bixstCA/Radicle-Upstream?node-id=4147%3A7246
+[bo]: https://github.com/brandonhaslegs
+[jd]: https://github.com/juliendonck


### PR DESCRIPTION
Just adding some notes for how to contribute as a designer. Open to any suggestions to make this more clear or specific. We haven't actually accepted any open source design contributions yet so it's a totally new process.