### PR TITLE
fix: store remote helper hint data locally

### DIFF
--- a/ui/App/CreateProjectModal.svelte
+++ b/ui/App/CreateProjectModal.svelte
@@ -28,8 +28,6 @@
   import * as proxy from "ui/src/proxy";
   import { ValidationStatus } from "ui/src/validation";
   import * as screen from "ui/src/screen";
-  import type { Settings } from "ui/src/settings";
-  import { dismissRemoteHelperHint, settings } from "ui/src/session";
 
   import {
     Button,
@@ -164,9 +162,6 @@
     localStateStore.status === remote.Status.Success
       ? localStateStore.data.branches
       : [];
-
-  $: showRemoteHelper =
-    $settings && ($settings as Settings).appearance.hints.showRemoteHelper;
 </script>
 
 <style>
@@ -259,9 +254,7 @@
           </p>
         </div>
       </RadioOption>
-      {#if showRemoteHelper}
-        <RemoteHelperHint on:hide={dismissRemoteHelperHint} />
-      {/if}
+      <RemoteHelperHint />
     </div>
 
     <Tooltip

--- a/ui/App/ProjectScreen/RemoteHelperHint.svelte
+++ b/ui/App/ProjectScreen/RemoteHelperHint.svelte
@@ -5,13 +5,21 @@
  with Radicle Linking Exception. For full terms see the included
  LICENSE file.
 -->
+<script lang="typescript" context="module">
+  import * as zod from "zod";
+
+  import * as browserStore from "ui/src/browserStore";
+
+  const remoteHelperHintShown = browserStore.create<boolean>(
+    "radicle.remoteHelperHintShown",
+    false,
+    zod.boolean()
+  );
+</script>
+
 <script lang="typescript">
-  import { createEventDispatcher } from "svelte";
   import { Copyable, Hoverable, Icon } from "ui/DesignSystem";
 
-  const dispatch = createEventDispatcher();
-
-  export let style: string | undefined = undefined;
   let hover = false;
 </script>
 
@@ -36,31 +44,33 @@
   }
 </style>
 
-<div class="info" {style} data-cy="remote-helper-hint">
-  <div
-    data-cy="close-hint-button"
-    class="close-hint-button"
-    on:click={() => {
-      dispatch("hide");
-    }}>
-    <Icon.CrossSmall />
+{#if !$remoteHelperHintShown}
+  <div class="info" data-cy="remote-helper-hint">
+    <div
+      data-cy="close-hint-button"
+      class="close-hint-button"
+      on:click={() => {
+        remoteHelperHintShown.set(true);
+      }}>
+      <Icon.CrossSmall />
+    </div>
+    <p class="description">
+      To publish code to Radicle, you need to add this to your shell
+      configuration file. Not sure how?
+      <a
+        class="typo-link"
+        href="https://docs.radicle.xyz/docs/getting-started#configuring-your-system">
+        Read more
+      </a>
+    </p>
+    <Hoverable bind:hovering={hover}>
+      <Copyable name="shell configuration" tooltipStyle="width: fit-content;">
+        <p
+          class="typo-text-small-mono"
+          style="color: var(--color-foreground-level-6)">
+          export PATH="$HOME/.radicle/bin:$PATH"
+        </p>
+      </Copyable>
+    </Hoverable>
   </div>
-  <p class="description">
-    To publish code to Radicle, you need to add this to your shell configuration
-    file. Not sure how?
-    <a
-      class="typo-link"
-      href="https://docs.radicle.xyz/docs/getting-started#configuring-your-system">
-      Read more
-    </a>
-  </p>
-  <Hoverable bind:hovering={hover}>
-    <Copyable name="shell configuration" tooltipStyle="width: fit-content;">
-      <p
-        class="typo-text-small-mono"
-        style="color: var(--color-foreground-level-6)">
-        export PATH="$HOME/.radicle/bin:$PATH"
-      </p>
-    </Copyable>
-  </Hoverable>
-</div>
+{/if}

--- a/ui/App/ProjectScreen/Source/CheckoutButton.svelte
+++ b/ui/App/ProjectScreen/Source/CheckoutButton.svelte
@@ -7,7 +7,6 @@
 -->
 <script lang="typescript">
   import { createEventDispatcher } from "svelte";
-  import { dismissRemoteHelperHint, settings } from "ui/src/session";
 
   import {
     Button,
@@ -70,9 +69,7 @@
       </p>
     {/if}
 
-    {#if $settings.appearance.hints.showRemoteHelper}
-      <RemoteHelperHint on:hide={dismissRemoteHelperHint} />
-    {/if}
+    <RemoteHelperHint />
 
     <Tooltip
       value={!checkoutPath ? "First choose a directory for this project" : ""}

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -200,16 +200,6 @@ export const updateAppearance = async (
   await updateSettings(s => ({ ...s, appearance }));
 };
 
-export const dismissRemoteHelperHint = async (): Promise<void> => {
-  await updateSettings(s => ({
-    ...s,
-    appearance: {
-      ...s.appearance,
-      hints: { showRemoteHelper: false },
-    },
-  }));
-};
-
 const updateCoCo = async (coco: CoCo): Promise<void> => {
   await updateSettings(s => ({ ...s, coco }));
 };


### PR DESCRIPTION
We store information on whether the remote helper hint has been shown in the browser.

This is part of #1849.