### PR TITLE
feat: add dedicated endpoint for network seeds

### DIFF
--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -11,7 +11,6 @@
     clippy::cargo,
     clippy::nursery,
     clippy::pedantic,
-    missing_docs,
     unused_import_braces,
     unused_qualifications
 )]

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -94,6 +94,14 @@ pub fn update_identity(
     Ok(())
 }
 
+pub fn update_seeds(store: &kv::Store, seeds: Vec<String>) -> Result<(), error::Error> {
+    if let Some(mut session) = get_current(store)? {
+        session.settings.coco.seeds = seeds;
+        set_current(store, session)?;
+    }
+    Ok(())
+}
+
 /// Update the session settings. Does nothing if there is no session yet.
 ///
 /// # Errors

--- a/ui/src/proxy/index.ts
+++ b/ui/src/proxy/index.ts
@@ -111,6 +111,26 @@ export class Client {
       options,
     });
   }
+
+  async seedsGet(options?: RequestOptions): Promise<string[]> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: "session/seeds",
+        options,
+      },
+      zod.array(zod.string())
+    );
+  }
+
+  async seedsPut(seeds: string[], options?: RequestOptions): Promise<void> {
+    return this.fetcher.fetchOkNoContent({
+      method: "PUT",
+      path: "session/seeds",
+      body: seeds,
+      options,
+    });
+  }
 }
 
 export const client = new Client(`http://${config.proxyAddress}`);

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -12,10 +12,8 @@ import * as proxy from "./proxy";
 import * as error from "./error";
 import type * as identity from "./identity";
 import * as remote from "./remote";
-import { Appearance, CoCo, Settings, defaultSetttings } from "./settings";
+import { Appearance, Settings, defaultSetttings } from "./settings";
 import * as svelteStore from "ui/src/svelteStore";
-
-import { createValidationStore, ValidationStatus } from "./validation";
 
 // TYPES
 export enum Status {
@@ -200,51 +198,7 @@ export const updateAppearance = async (
   await updateSettings(s => ({ ...s, appearance }));
 };
 
-const updateCoCo = async (coco: CoCo): Promise<void> => {
-  await updateSettings(s => ({ ...s, coco }));
-};
-
-const VALID_SEED_MATCH = /^[\w\d]{54}@([\w\d-]+\.)*[\w\d-]+:[\d]{1,5}$/;
-
-const checkSeedUniqueness = (seed: string): Promise<boolean> => {
-  return Promise.resolve(!get(settings).coco.seeds.includes(seed));
-};
-
-export const seedValidation = createValidationStore(
-  {
-    format: {
-      pattern: VALID_SEED_MATCH,
-      message: "This is not a valid seed address",
-    },
-  },
-  [
-    {
-      promise: checkSeedUniqueness,
-      validationMessage: "This seed already exists",
-    },
-  ]
-);
-
-export const addSeed = async (seed: string): Promise<boolean> => {
-  // This has to be awaited contrary to what tslint suggests, because we're
-  // running async remote validations in in the background. If we remove the
-  // async then the seed input form will have to be submitted twice to take any
-  // effect.
-  await seedValidation.validate(seed);
-  if (get(seedValidation).status !== ValidationStatus.Success) {
-    return false;
-  }
-
-  updateCoCo({ seeds: [...get(settings).coco.seeds, seed] });
-  return true;
-};
-
-export const removeSeed = (seed: string): void => {
-  updateCoCo({
-    seeds: get(settings).coco.seeds.filter((x: string) => x !== seed),
-  });
-  seedValidation.reset();
-};
+export const VALID_SEED_MATCH = /^[\w\d]{54}@([\w\d-]+\.)*[\w\d-]+:[\d]{1,5}$/;
 
 export const __test__ = {
   sessionStore,


### PR DESCRIPTION
We add a dedicated endpoint for getting and updating seed addresses for the proxy. This decouples the seeds from the session and will allow us to eliminate the settings in the future. See #1137