### PR TITLE
style: move primary color switcher in design system guide

### DIFF
--- a/ui/App/DesignSystemGuideModal.svelte
+++ b/ui/App/DesignSystemGuideModal.svelte
@@ -194,6 +194,13 @@
             options={themeOptions}
             on:select={ev => theme.set(ev.detail)} />
         </Tooltip>
+        <Tooltip value="Primary color" position="bottom">
+          <SegmentedControl
+            style="background-color: var(--color-background); margin-right: 2rem;"
+            active={$primaryColor}
+            options={primaryColorOptions}
+            on:select={ev => primaryColor.set(ev.detail)} />
+        </Tooltip>
         <Tooltip value="UI font" position="bottom">
           <SegmentedControl
             style="background-color: var(--color-background); margin-right: 2rem;"
@@ -203,17 +210,10 @@
         </Tooltip>
         <Tooltip value="Code font" position="bottom">
           <SegmentedControl
-            style="background-color: var(--color-background); margin-right: 2rem;"
+            style="background-color: var(--color-background);"
             active={$codeFont}
             options={codeFontOptions}
             on:select={ev => codeFont.set(ev.detail)} />
-        </Tooltip>
-        <Tooltip value="Font color" position="bottom">
-          <SegmentedControl
-            style="background-color: var(--color-background);"
-            active={$primaryColor}
-            options={primaryColorOptions}
-            on:select={ev => primaryColor.set(ev.detail)} />
         </Tooltip>
       </div>
       <h1 style="margin-bottom: 92px">Primitives</h1>


### PR DESCRIPTION
- rename tooltip "Font color" -> "Primary color"
- move primary color switcher next to theme switcher

<img width="1552" alt="Screenshot 2021-09-24 at 15 00 07" src="https://user-images.githubusercontent.com/158411/134678289-d627a84c-08a5-4049-8d6c-8e5036c6de5f.png">

