### PR TITLE
Migrate to host/id based seed node records

### DIFF
--- a/ui/App/OrgScreen/ConfigureEns/UpdateMetadata.svelte
+++ b/ui/App/OrgScreen/ConfigureEns/UpdateMetadata.svelte
@@ -26,7 +26,7 @@
   let twitterValue: string | undefined = registration.twitter || undefined;
   let githubValue: string | undefined = registration.github || undefined;
   let seedIdValue: string | undefined = registration.seedId || undefined;
-  let seedApiValue: string | undefined = registration.seedApi || undefined;
+  let seedHostValue: string | undefined = registration.seedHost || undefined;
 
   let setRecordsInProgress = false;
 
@@ -57,7 +57,7 @@
       { name: "twitter", value: twitterValue },
       { name: "github", value: githubValue },
       { name: "seedId", value: seedIdValue },
-      { name: "seedApi", value: seedApiValue },
+      { name: "seedHost", value: seedHostValue },
     ];
 
     // Filter out unchanged records.
@@ -186,15 +186,15 @@
   <TextInput
     disabled={setRecordsInProgress}
     style="margin-bottom: 24px"
-    placeholder="The Radicle Link node ID that hosts your org’s entities"
+    placeholder="The Device ID of the seed"
     bind:value={seedIdValue} />
 
-  <div class="label typo-text-bold">Seed API</div>
+  <div class="label typo-text-bold">Seed Host</div>
   <TextInput
     disabled={setRecordsInProgress}
     style="margin-bottom: 24px"
-    placeholder="The HTTP address of a node that serves Radicle entities"
-    bind:value={seedApiValue} />
+    placeholder="The seed host name"
+    bind:value={seedHostValue} />
 
   <svelte:fragment slot="buttons">
     <Button

--- a/ui/App/OrgScreen/OrgHeader.svelte
+++ b/ui/App/OrgScreen/OrgHeader.svelte
@@ -30,7 +30,7 @@
     registration?.twitter &&
     `https://twitter.com/${registration.twitter.replace("@", "")}`;
   $: seedId = registration?.seedId;
-  $: seedApi = registration?.seedApi;
+  $: seedHost = registration?.seedHost;
 </script>
 
 <style>
@@ -102,7 +102,7 @@
           </div>
         {/if}
       </div>
-      {#if websiteUrl || githubUrl || twitterUrl || seedId || seedApi}
+      {#if websiteUrl || githubUrl || twitterUrl || (seedId && seedHost)}
         <div>
           {#if websiteUrl}
             <div class="row">
@@ -139,20 +139,11 @@
           {/if}
         </div>
         <div>
-          {#if seedId}
+          {#if seedId && seedHost}
             <div class="row">
-              <CopyableIdentifier value={seedId} kind="seedAddress" />
-            </div>
-          {/if}
-          {#if seedApi}
-            <div class="row">
-              <Icon.Globe />
-              <div class="url">
-                <span
-                  on:click={() => {
-                    seedApi && ipc.openUrl(seedApi);
-                  }}>{seedApi}</span>
-              </div>
+              <CopyableIdentifier
+                value={`${seedId}@${seedHost}:8776`}
+                kind="seedAddress" />
             </div>
           {/if}
         </div>

--- a/ui/src/org/ensResolver.ts
+++ b/ui/src/org/ensResolver.ts
@@ -36,7 +36,7 @@ export interface Registration {
   twitter: string | null;
   github: string | null;
   seedId: string | null;
-  seedApi: string | null;
+  seedHost: string | null;
 }
 
 export async function setRecords(
@@ -98,11 +98,11 @@ export async function setRecords(
           ])
         );
         break;
-      case "seedApi":
+      case "seedHost":
         calls.push(
           iface.encodeFunctionData("setText", [
             node,
-            "eth.radicle.seed.api",
+            "eth.radicle.seed.host",
             record.value,
           ])
         );
@@ -140,10 +140,10 @@ export async function getRegistration(
     resolver.getText("com.twitter"),
     resolver.getText("com.github"),
     resolver.getText("eth.radicle.seed.id"),
-    resolver.getText("eth.radicle.seed.api"),
+    resolver.getText("eth.radicle.seed.host"),
   ]);
 
-  const [address, avatar, url, twitter, github, seedId, seedApi] = meta.map(
+  const [address, avatar, url, twitter, github, seedId, seedHost] = meta.map(
     (value: PromiseSettledResult<string>) =>
       value.status === "fulfilled" ? value.value : null
   );
@@ -157,7 +157,7 @@ export async function getRegistration(
     twitter,
     github,
     seedId,
-    seedApi,
+    seedHost,
   };
 }
 


### PR DESCRIPTION
This PR changes the ENS records to start working with `seed.host` instead of `seed.api`

It is based on the changes introduced in https://github.com/radicle-dev/radicle-interface/commit/75983dc98ee0654f9af2aed7e08119527cfa4a3a

One thing I wasn't quite sure about, is the `OrgHeader` where we now show the `seedHost` it seems to me that it should be a `CopyableIdentifier` but I didn't found a good way to shorten it without losing important information.
Let me know what you think.

Feel free to provide feedback.
