### PR TITLE
refactor: eliminate custom proxy API calls in tests

### DIFF
--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -76,9 +76,9 @@ context("p2p networking", () => {
             const projectName = "new-fancy-project.xyz";
             cy.log("Create a project via API");
             commands.createEmptyProject(
+              maintainerNode.client,
               projectName,
-              maintainerProjectsDir,
-              maintainerNode.httpPort
+              maintainerProjectsDir
             );
 
             cy.log("refresh the UI for the project to show up");

--- a/cypress/integration/project/patches.spec.ts
+++ b/cypress/integration/project/patches.spec.ts
@@ -41,10 +41,16 @@ context("patches", () => {
         { dataDir: tempDirPath, handle: "rudolfs" },
         node => {
           nodeManager.asNode(node);
-          commands.createEmptyProject(
-            "new-project",
-            tempDirPath,
-            node.httpPort
+          cy.then(() =>
+            node.client.project.create({
+              repo: {
+                type: "new",
+                path: tempDirPath,
+                name: "new-project",
+              },
+              description: "",
+              defaultBranch: "main",
+            })
           );
           commands.pick("sidebar", "settings").click();
           commands.pick("sidebar", "profile").click();
@@ -133,11 +139,7 @@ context("patches", () => {
         { dataDir: tempDirPath, handle: "rudolfs" },
         node => {
           nodeManager.asNode(node);
-          commands.createEmptyProject(
-            "new-project",
-            tempDirPath,
-            node.httpPort
-          );
+          commands.createEmptyProject(node.client, "new-project", tempDirPath);
           commands.pick("sidebar", "settings").click();
           commands.pick("sidebar", "profile").click();
           commands.pick("project-list-entry-new-project").should("exist");
@@ -207,9 +209,9 @@ context("patches", () => {
             const projectName = "new-fancy-project.xyz";
             cy.log("Create a project via API");
             commands.createEmptyProject(
+              maintainerNode.client,
               projectName,
-              maintainerProjectsDir,
-              maintainerNode.httpPort
+              maintainerProjectsDir
             );
 
             cy.log("refresh the UI for the project to show up");
@@ -238,7 +240,7 @@ context("patches", () => {
               nodeManager.asNode(contributorNode);
 
               cy.log("contributor follows the project");
-              commands.followProject(urn, contributorNode.httpPort);
+              cy.then(() => contributorNode.client.project.requestSubmit(urn));
               commands.pick("following-tab").click();
               commands
                 .pick(
@@ -249,11 +251,11 @@ context("patches", () => {
 
               cy.log("contributor checks out the project");
               cy.exec(`mkdir -p "${contributorProjectsDir}"`);
-              commands.checkoutProject(
-                urn,
-                contributorProjectsDir,
-                maintainerNode.peerId,
-                contributorNode.httpPort
+              cy.then(() =>
+                contributorNode.client.project.checkout(urn, {
+                  path: contributorProjectsDir,
+                  peerId: maintainerNode.peerId,
+                })
               );
             });
 
@@ -304,10 +306,11 @@ context("patches", () => {
                 throw new Error("Could not find URN");
               }
 
-              commands.trackPeer(
-                urn,
-                contributorNode.peerId,
-                maintainerNode.httpPort
+              cy.then(() =>
+                maintainerNode.client.project.peerTrack(
+                  urn,
+                  contributorNode.peerId
+                )
               );
             });
 
@@ -374,9 +377,9 @@ context("patches", () => {
             cy.log("Create a project via API");
             commands
               .createEmptyProject(
+                maintainerNode.client,
                 projectName,
-                maintainerProjectsDir,
-                maintainerNode.httpPort
+                maintainerProjectsDir
               )
               .as("projectUrn");
 
@@ -400,7 +403,7 @@ context("patches", () => {
             nodeManager.asNode(contributorNode);
             cy.get<string>("@projectUrn").then(urn => {
               cy.log("contributor checks out the project");
-              commands.followProject(urn, contributorNode.httpPort);
+              cy.then(() => contributorNode.client.project.requestSubmit(urn));
               commands.pick("following-tab").click();
               commands
                 .pick(
@@ -410,21 +413,22 @@ context("patches", () => {
                 .should("exist");
 
               cy.exec(`mkdir -p "${contributorProjectsDir}"`);
-              commands.checkoutProject(
-                urn,
-                contributorProjectsDir,
-                maintainerNode.peerId,
-                contributorNode.httpPort
+              cy.then(() =>
+                contributorNode.client.project.checkout(urn, {
+                  path: contributorProjectsDir,
+                  peerId: maintainerNode.peerId,
+                })
               );
             });
 
             cy.log("maintainer tracks peer");
             nodeManager.asNode(maintainerNode);
             cy.get<string>("@projectUrn").then(urn => {
-              commands.trackPeer(
-                urn,
-                contributorNode.peerId,
-                maintainerNode.httpPort
+              cy.then(() =>
+                maintainerNode.client.project.peerTrack(
+                  urn,
+                  contributorNode.peerId
+                )
               );
             });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -97,18 +97,13 @@ export const createProjectWithFixture = (
   });
 };
 
-export const createEmptyProject = (
-  name: string = "new-project",
-  path: string,
-  port: number = 17246
-): Cypress.Chainable<string> =>
-  requestOk({
-    url: `http://localhost:${port}/v1/projects`,
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
+export function createEmptyProject(
+  client: proxy.Client,
+  name: string,
+  path: string
+): Cypress.Chainable<string> {
+  return cy.then(async () => {
+    const project = await client.project.create({
       repo: {
         type: "new",
         path,
@@ -116,51 +111,10 @@ export const createEmptyProject = (
       },
       description: "This is the description.",
       defaultBranch: "main",
-    }),
-  }).then(response => response.urn as string);
-
-export const followProject = (
-  urn: string,
-  port: number = 17246
-): Cypress.Chainable<void> =>
-  requestOk({
-    url: `http://localhost:${port}/v1/projects/requests/${urn}`,
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    });
+    return project.urn;
   });
-
-export const checkoutProject = (
-  urn: string,
-  path: string,
-  peerId: string,
-  localhost: number = 17246
-): Cypress.Chainable<void> =>
-  requestOk({
-    url: `http://localhost:${localhost}/v1/projects/${urn}/checkout`,
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      path,
-      peerId,
-    }),
-  });
-
-export const trackPeer = (
-  urn: string,
-  peerId: string,
-  localhost: number = 17246
-): Cypress.Chainable<void> =>
-  requestOk({
-    url: `http://localhost:${localhost}/v1/projects/${urn}/track/${peerId}`,
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
+}
 
 export const onboardUser = (
   handle = "secretariat"
@@ -179,19 +133,6 @@ export const ethereumDevNode = createPlugin<ethereumDevNodeApi.Plugin>(
   "ethereumDevNode",
   ethereumDevNodeApi.methods
 );
-
-/**
- * Invokes `cy.request` and assert that the response status code is 2xx.
- */
-function requestOk(
-  opts: Partial<Cypress.RequestOptions> & { url: string }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Cypress.Chainable<any> {
-  return cy.request(opts).then(response => {
-    expect(response.status).to.be.within(200, 299, "Failed response");
-    return response.body;
-  });
-}
 
 function getCurrentTestName() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
We eliminate all custom HTTP API calls in the tests and replace them with calls to the proxy client.