### PR TITLE
refactor: remove endpoint for getting local identities

### DIFF
--- a/proxy/api/src/identity.rs
+++ b/proxy/api/src/identity.rs
@@ -182,29 +182,12 @@ pub async fn update(
     Ok((peer.peer_id(), user.into_inner().into_inner()).into())
 }
 
-/// Retrieve an identity by id. We assume the `Identity` is owned by this peer.
-///
-/// # Errors
-///
-/// Errors if access to coco state on the filesystem fails, or the id is malformed.
-pub async fn get(
-    peer: &radicle_daemon::net::peer::Peer<BoxedSigner>,
-    id: Urn,
-) -> Result<Option<Identity>, error::Error> {
-    match radicle_daemon::state::get_local(peer, id).await? {
-        Some(user) => Ok(Some(
-            (peer.peer_id(), user.into_inner().into_inner()).into(),
-        )),
-        None => Ok(None),
-    }
-}
-
 /// Retrieve an identity by id.
 ///
 /// # Errors
 ///
 /// Errors if access to coco state on the filesystem fails, or the id is malformed.
-pub async fn get_remote(
+pub async fn get(
     peer: &radicle_daemon::net::peer::Peer<BoxedSigner>,
     id: Urn,
 ) -> Result<Option<Person>, error::Error> {

--- a/ui/src/proxy/identity.ts
+++ b/ui/src/proxy/identity.ts
@@ -80,17 +80,6 @@ export class Client {
     );
   }
 
-  async get(urn: string, options?: RequestOptions): Promise<Identity> {
-    return this.fetcher.fetchOk(
-      {
-        method: "GET",
-        path: `identities/${urn}`,
-        options,
-      },
-      identitySchema
-    );
-  }
-
   async update(params: Metadata, options?: RequestOptions): Promise<Identity> {
     return this.fetcher.fetchOk(
       {


### PR DESCRIPTION
We remove the proxy endpoint for getting local identities since it was unused.