### PR TITLE
refactor: introduce Response struct for easier error conversion

### DIFF
--- a/proxy/api/src/error.rs
+++ b/proxy/api/src/error.rs
@@ -8,8 +8,6 @@
 
 use std::io;
 
-use link_identities::git::Urn;
-
 use crate::keystore;
 
 /// All error variants the API will return.
@@ -32,9 +30,6 @@ pub enum Error {
     /// An I/O error occurred.
     #[error(transparent)]
     Io(#[from] io::Error),
-
-    #[error("the current session is in use by `{0}`")]
-    SessionInUse(Urn),
 
     /// Issues when access persistent storage.
     #[error(transparent)]

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -289,11 +289,6 @@ impl From<&error::Error> for Response {
                 variant: "FORBIDDEN",
                 message: err.to_string(),
             },
-            error::Error::SessionInUse(_) => Self {
-                status_code: StatusCode::BAD_REQUEST,
-                variant: "SESSION_IN_USE",
-                message: err.to_string(),
-            },
             _ => Self {
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
                 variant: "INTERNAL_SERVER_ERROR",

--- a/proxy/api/src/http/error.rs
+++ b/proxy/api/src/http/error.rs
@@ -7,9 +7,9 @@
 //! Recovery and conversion of [`error::Error`] to proper JSON responses, which expose variants
 //! for API consumers to act on.
 
-use serde::Serialize;
 use std::convert::Infallible;
-use warp::{http::StatusCode, reject, reply, Rejection, Reply};
+
+use warp::http::StatusCode;
 
 use crate::error;
 
@@ -38,297 +38,267 @@ pub enum Routing {
     QueryMissing,
 }
 
-impl reject::Reject for Routing {}
+impl warp::reject::Reject for Routing {}
 
-impl reject::Reject for error::Error {}
+impl warp::reject::Reject for error::Error {}
 
-/// Error type to carry context for failed requests.
-#[derive(Serialize)]
-pub struct Error {
+#[derive(Debug, Clone)]
+pub struct Response {
+    pub status_code: StatusCode,
+    /// The triggered error variant.
+    pub variant: &'static str,
     /// Human readable message to convery error case.
     pub message: String,
-    /// The triggered error variant.
-    pub variant: String,
 }
 
-fn recover_source(err: &radicle_source::error::Error) -> (StatusCode, &'static str, String) {
-    match err {
-        radicle_source::error::Error::Git(git_error) => (
-            StatusCode::BAD_REQUEST,
-            "GIT_ERROR",
-            format!("Internal Git error: {}", git_error),
-        ),
-        radicle_source::error::Error::NoBranches => (
-            StatusCode::BAD_REQUEST,
-            "GIT_ERROR",
-            radicle_source::error::Error::NoBranches.to_string(),
-        ),
-        radicle_source::error::Error::PathNotFound(path) => {
-            (StatusCode::NOT_FOUND, "NOT_FOUND", path.to_string())
-        },
-        _ => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_SERVER_ERROR",
-            err.to_string(),
-        ),
-    }
-}
+impl warp::reject::Reject for Response {}
 
-/// Handler to convert [`error::Error`] to [`Error`] response.
-#[allow(clippy::too_many_lines, clippy::unused_async)]
-pub async fn recover(err: Rejection) -> Result<impl Reply, Infallible> {
+#[allow(clippy::unused_async)]
+pub async fn recover(err: warp::Rejection) -> Result<impl warp::Reply, Infallible> {
     tracing::error!(?err, "request error");
 
-    let (code, variant, message) = {
-        if err.is_not_found() {
-            (
-                StatusCode::NOT_FOUND,
-                "NOT_FOUND",
-                "Resource not found".to_string(),
-            )
-        } else if let Some(err) = err.find::<Routing>() {
-            match err {
-                Routing::NoSession => (StatusCode::NOT_FOUND, "NOT_FOUND", err.to_string()),
-                Routing::InvalidQuery { .. } => {
-                    (StatusCode::BAD_REQUEST, "INVALID_QUERY", err.to_string())
-                },
-                Routing::QueryMissing { .. } => {
-                    (StatusCode::BAD_REQUEST, "QUERY_MISSING", err.to_string())
-                },
-            }
-        } else if let Some(err) = err.find::<error::Error>() {
-            match err {
-                error::Error::State(err) => match err {
-                    radicle_daemon::state::Error::Checkout(checkout_error) => {
-                        match checkout_error {
-                            radicle_daemon::project::checkout::Error::AlreadExists(_) => (
-                                StatusCode::CONFLICT,
-                                "PATH_EXISTS",
-                                checkout_error.to_string(),
-                            ),
-                            radicle_daemon::project::checkout::Error::Git(git_error) => (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "GIT_ERROR",
-                                git_error.message().to_string(),
-                            ),
-                            radicle_daemon::project::checkout::Error::Include(include_error) => (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "INTERNAL_ERROR",
-                                include_error.to_string(),
-                            ),
-                            radicle_daemon::project::checkout::Error::Io(io) => (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "INTERNAL_ERROR",
-                                io.to_string(),
-                            ),
-                            radicle_daemon::project::checkout::Error::Transport(err) => (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "TRANSPORT_ERROR",
-                                err.to_string(),
-                            ),
-                            radicle_daemon::project::checkout::Error::Prefix(err) => (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "PREFIX_ERROR",
-                                err.to_string(),
-                            ),
-                        }
-                    },
-                    radicle_daemon::state::Error::Create(
-                        radicle_daemon::project::create::Error::Validation(err),
-                    ) => match err {
-                        radicle_daemon::project::create::validation::Error::AlreadExists(_) => {
-                            (StatusCode::CONFLICT, "PATH_EXISTS", err.to_string())
-                        },
-                        radicle_daemon::project::create::validation::Error::EmptyExistingPath(_) => {
-                            (StatusCode::BAD_REQUEST, "EMPTY_PATH", err.to_string())
-                        },
-                        radicle_daemon::project::create::validation::Error::Git(_) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "GIT_ERROR",
-                            err.to_string(),
-                        ),
-                        radicle_daemon::project::create::validation::Error::MissingAuthorEmail => (
-                            StatusCode::BAD_REQUEST,
-                            "MISSING_AUTHOR_EMAIL",
-                            err.to_string(),
-                        ),
-                        radicle_daemon::project::create::validation::Error::MissingGitConfig => (
-                            StatusCode::BAD_REQUEST,
-                            "MISSING_GIT_CONFIG",
-                            err.to_string(),
-                        ),
-                        radicle_daemon::project::create::validation::Error::MissingAuthorName => (
-                            StatusCode::BAD_REQUEST,
-                            "MISSING_AUTHOR_NAME",
-                            err.to_string(),
-                        ),
-                        radicle_daemon::project::create::validation::Error::MissingDefaultBranch { .. } => (
-                            StatusCode::BAD_REQUEST,
-                            "MISSING_DEFAULT_BRANCH",
-                            err.to_string(),
-                        ),
-                        radicle_daemon::project::create::validation::Error::MissingUrl => {
-                            (StatusCode::BAD_REQUEST, "MISSING_URL", err.to_string())
-                        },
-                        radicle_daemon::project::create::validation::Error::PathDoesNotExist(_) => (
-                            StatusCode::NOT_FOUND,
-                            "PATH_DOES_NOT_EXIST",
-                            err.to_string(),
-                        ),
-                        radicle_daemon::project::create::validation::Error::NotARepo(_) => {
-                            (StatusCode::BAD_REQUEST, "NOT_A_REPO", err.to_string())
-                        },
-                        radicle_daemon::project::create::validation::Error::Io(err) => {
-                            (StatusCode::BAD_REQUEST, "IO_ERROR", err.to_string())
-                        },
-                        radicle_daemon::project::create::validation::Error::UrlMismatch { .. } => {
-                            (StatusCode::BAD_REQUEST, "URL_MISMATCH", err.to_string())
-                        },
-
-                        radicle_daemon::project::create::validation::Error::Transport(_) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "TRANSPORT_ERROR",
-                            err.to_string(),
-                        ),
-                        radicle_daemon::project::create::validation::Error::Remote(_) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "MISSING_REMOTE",
-                            err.to_string(),
-                        ),
-                    },
-                    radicle_daemon::state::Error::Git(git_error) => (
-                        StatusCode::BAD_REQUEST,
-                        "GIT_ERROR",
-                        format!("Internal Git error: {:?}", git_error),
-                    ),
-                    radicle_daemon::state::Error::MissingOwner => {
-                        (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", err.to_string())
-                    },
-                    radicle_daemon::state::Error::Storage(
-                        radicle_daemon::state::error::storage::Error::Blob(
-                            radicle_daemon::state::error::blob::Error::NotFound(_),
-                        ),
-                    ) => (
-                        StatusCode::NOT_FOUND,
-                        "NOT_FOUND",
-                        "entity not found".to_string(),
-                    ),
-                    radicle_daemon::state::Error::IdentityExists(_) => {
-                        (StatusCode::CONFLICT, "IDENTITY_EXISTS", err.to_string())
-                    },
-                    _ => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "INTERNAL_SERVER_ERROR",
-                        err.to_string(),
-                    ),
-                },
-                error::Error::Source(err) => recover_source(err),
-                error::Error::Keystore(keystore_err) => {
-                    if keystore_err.is_invalid_passphrase() {
-                        (
-                            StatusCode::FORBIDDEN,
-                            "INCORRECT_PASSPHRASE",
-                            "That\u{2019}s the wrong passphrase.".to_string(),
-                        )
-                    } else if keystore_err.is_key_exists() {
-                        (
-                            StatusCode::CONFLICT,
-                            "KEY_EXISTS",
-                            "A key already exists".to_string(),
-                        )
-                    } else {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "INTERNAL_SERVER_ERROR",
-                            err.to_string(),
-                        )
-                    }
-                },
-                error::Error::KeystoreSealed | error::Error::InvalidAuthCookie => {
-                    (StatusCode::FORBIDDEN, "FORBIDDEN", err.to_string())
-                },
-                error::Error::SessionInUse(_) => {
-                    (StatusCode::BAD_REQUEST, "SESSION_IN_USE", err.to_string())
-                },
-                _ => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "INTERNAL_SERVER_ERROR",
-                    err.to_string(),
-                ),
-            }
-        } else {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "INTERNAL_ERROR",
-                "Something went wrong".to_string(),
-            )
+    let error_response = if err.is_not_found() {
+        Response {
+            status_code: StatusCode::NOT_FOUND,
+            variant: "NOT_FOUND",
+            message: "Resource not found".to_string(),
+        }
+    } else if let Some(err) = err.find::<error::Error>() {
+        Response::from(err)
+    } else if let Some(err) = err.find::<Routing>() {
+        Response::from(err)
+    } else if let Some(err) = err.find::<Response>() {
+        err.clone()
+    } else {
+        Response {
+            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            variant: "INTERNAL_SERVER_ERROR",
+            message: "Something went wrong".to_string(),
         }
     };
-    let res = reply::json(&Error {
-        message,
-        variant: variant.to_string(),
+
+    let body = serde_json::json!({
+        "message": error_response.message,
+        "variant": error_response.variant,
     });
 
-    Ok(reply::with_header(
-        reply::with_status(res, code),
-        "content-type",
-        "application/json",
+    Ok(warp::reply::with_status(
+        warp::reply::json(&body),
+        error_response.status_code,
     ))
 }
 
-#[allow(clippy::unwrap_used)]
-#[cfg(test)]
-mod tests {
-    use std::convert::TryFrom;
-
-    use futures::stream::TryStreamExt;
-    use pretty_assertions::assert_eq;
-    use serde_json::{json, Value};
-    use warp::{reply::Reply as _, Rejection};
-
-    use link_identities::git::Urn;
-
-    #[tokio::test]
-    async fn recover_custom() {
-        let urn = Urn::new(
-            radicle_git_ext::Oid::try_from("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")
-                .expect("failed to parse Oid"),
-        );
-        let message = format!("the current session is in use by `{}`", urn);
-        let have: Value =
-            response(warp::reject::custom(crate::error::Error::SessionInUse(urn))).await;
-        let want = json!({
-            "message": message,
-            "variant": "SESSION_IN_USE"
-        });
-
-        assert_eq!(have, want);
+impl From<&Routing> for Response {
+    fn from(err: &Routing) -> Self {
+        let (status_code, variant) = match err {
+            Routing::NoSession => (StatusCode::NOT_FOUND, "NOT_FOUND"),
+            Routing::InvalidQuery { .. } => (StatusCode::BAD_REQUEST, "INVALID_QUERY"),
+            Routing::QueryMissing { .. } => (StatusCode::BAD_REQUEST, "QUERY_MISSING"),
+        };
+        Self {
+            status_code,
+            variant,
+            message: err.to_string(),
+        }
     }
+}
 
-    #[tokio::test]
-    async fn recover_not_found() {
-        let have: Value = response(warp::reject::not_found()).await;
-        let want = json!({
-            "message": "Resource not found",
-            "variant": "NOT_FOUND",
-        });
-
-        assert_eq!(have, want);
+impl From<&crate::keystore::Error> for Response {
+    fn from(err: &crate::keystore::Error) -> Self {
+        if err.is_invalid_passphrase() {
+            Self {
+                status_code: StatusCode::FORBIDDEN,
+                variant: "INCORRECT_PASSPHRASE",
+                message: "That\u{2019}s the wrong passphrase.".to_string(),
+            }
+        } else if err.is_key_exists() {
+            Self {
+                status_code: StatusCode::CONFLICT,
+                variant: "KEY_EXISTS",
+                message: "A key already exists".to_string(),
+            }
+        } else {
+            Self {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                variant: "INTERNAL_SERVER_ERROR",
+                message: err.to_string(),
+            }
+        }
     }
+}
 
-    async fn response(err: Rejection) -> Value {
-        let res = super::recover(err).await.unwrap();
+impl From<&radicle_source::error::Error> for Response {
+    fn from(err: &radicle_source::error::Error) -> Self {
+        let (status_code, variant) = match err {
+            radicle_source::error::Error::Git(_) => (StatusCode::BAD_REQUEST, "GIT_ERROR"),
+            radicle_source::error::Error::NoBranches => (StatusCode::BAD_REQUEST, "NO_BRANCHES"),
+            radicle_source::error::Error::PathNotFound(_) => (StatusCode::NOT_FOUND, "NOT_FOUND"),
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"),
+        };
+        Self {
+            status_code,
+            variant,
+            message: err.to_string(),
+        }
+    }
+}
 
-        let body = res
-            .into_response()
-            .body_mut()
-            .try_fold(Vec::new(), |mut data, chunk| async move {
-                data.extend_from_slice(&chunk);
-                Ok(data)
-            })
-            .await
-            .unwrap();
+impl From<&radicle_daemon::state::Error> for Response {
+    #[allow(clippy::too_many_lines)]
+    fn from(err: &radicle_daemon::state::Error) -> Self {
+        let (status_code, variant, message) = match err {
+            radicle_daemon::state::Error::Checkout(checkout_error) => match checkout_error {
+                radicle_daemon::project::checkout::Error::AlreadExists(_) => (
+                    StatusCode::CONFLICT,
+                    "PATH_EXISTS",
+                    checkout_error.to_string(),
+                ),
+                radicle_daemon::project::checkout::Error::Git(git_error) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "GIT_ERROR",
+                    git_error.message().to_string(),
+                ),
+                radicle_daemon::project::checkout::Error::Include(include_error) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "INTERNAL_ERROR",
+                    include_error.to_string(),
+                ),
+                radicle_daemon::project::checkout::Error::Io(io) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "INTERNAL_ERROR",
+                    io.to_string(),
+                ),
+                radicle_daemon::project::checkout::Error::Transport(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "TRANSPORT_ERROR",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::checkout::Error::Prefix(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "PREFIX_ERROR",
+                    err.to_string(),
+                ),
+            },
+            radicle_daemon::state::Error::Create(
+                radicle_daemon::project::create::Error::Validation(err),
+            ) => match err {
+                radicle_daemon::project::create::validation::Error::AlreadExists(_) => {
+                    (StatusCode::CONFLICT, "PATH_EXISTS", err.to_string())
+                },
+                radicle_daemon::project::create::validation::Error::EmptyExistingPath(_) => {
+                    (StatusCode::BAD_REQUEST, "EMPTY_PATH", err.to_string())
+                },
+                radicle_daemon::project::create::validation::Error::Git(_) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "GIT_ERROR",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::create::validation::Error::MissingAuthorEmail => (
+                    StatusCode::BAD_REQUEST,
+                    "MISSING_AUTHOR_EMAIL",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::create::validation::Error::MissingGitConfig => (
+                    StatusCode::BAD_REQUEST,
+                    "MISSING_GIT_CONFIG",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::create::validation::Error::MissingAuthorName => (
+                    StatusCode::BAD_REQUEST,
+                    "MISSING_AUTHOR_NAME",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::create::validation::Error::MissingDefaultBranch {
+                    ..
+                } => (
+                    StatusCode::BAD_REQUEST,
+                    "MISSING_DEFAULT_BRANCH",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::create::validation::Error::MissingUrl => {
+                    (StatusCode::BAD_REQUEST, "MISSING_URL", err.to_string())
+                },
+                radicle_daemon::project::create::validation::Error::PathDoesNotExist(_) => (
+                    StatusCode::NOT_FOUND,
+                    "PATH_DOES_NOT_EXIST",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::create::validation::Error::NotARepo(_) => {
+                    (StatusCode::BAD_REQUEST, "NOT_A_REPO", err.to_string())
+                },
+                radicle_daemon::project::create::validation::Error::Io(err) => {
+                    (StatusCode::BAD_REQUEST, "IO_ERROR", err.to_string())
+                },
+                radicle_daemon::project::create::validation::Error::UrlMismatch { .. } => {
+                    (StatusCode::BAD_REQUEST, "URL_MISMATCH", err.to_string())
+                },
 
-        serde_json::from_slice(&body).unwrap()
+                radicle_daemon::project::create::validation::Error::Transport(_) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "TRANSPORT_ERROR",
+                    err.to_string(),
+                ),
+                radicle_daemon::project::create::validation::Error::Remote(_) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "MISSING_REMOTE",
+                    err.to_string(),
+                ),
+            },
+            radicle_daemon::state::Error::Git(git_error) => (
+                StatusCode::BAD_REQUEST,
+                "GIT_ERROR",
+                format!("Internal Git error: {:?}", git_error),
+            ),
+            radicle_daemon::state::Error::MissingOwner => {
+                (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", err.to_string())
+            },
+            radicle_daemon::state::Error::Storage(
+                radicle_daemon::state::error::storage::Error::Blob(
+                    radicle_daemon::state::error::blob::Error::NotFound(_),
+                ),
+            ) => (
+                StatusCode::NOT_FOUND,
+                "NOT_FOUND",
+                "entity not found".to_string(),
+            ),
+            radicle_daemon::state::Error::IdentityExists(_) => {
+                (StatusCode::CONFLICT, "IDENTITY_EXISTS", err.to_string())
+            },
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_SERVER_ERROR",
+                err.to_string(),
+            ),
+        };
+        Self {
+            status_code,
+            variant,
+            message,
+        }
+    }
+}
+
+impl From<&error::Error> for Response {
+    fn from(err: &error::Error) -> Self {
+        match err {
+            error::Error::State(err) => Self::from(err),
+            error::Error::Source(err) => Self::from(err),
+            error::Error::Keystore(keystore_err) => Self::from(keystore_err),
+            error::Error::KeystoreSealed | error::Error::InvalidAuthCookie => Self {
+                status_code: StatusCode::FORBIDDEN,
+                variant: "FORBIDDEN",
+                message: err.to_string(),
+            },
+            error::Error::SessionInUse(_) => Self {
+                status_code: StatusCode::BAD_REQUEST,
+                variant: "SESSION_IN_USE",
+                message: err.to_string(),
+            },
+            _ => Self {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                variant: "INTERNAL_SERVER_ERROR",
+                message: err.to_string(),
+            },
+        }
     }
 }


### PR DESCRIPTION
* Eliminate `Error` struct which was only used as the payload and replace it with the `Response` struct which also includes the status code.
* Separate responsibilities for converting an error into an HTTP response and actually replying. The former is implemented via `From` traits.
* Remove globally defined SessionInUse error to demonstrate new design