### PR TITLE
fix: network page scroll and button alignment

### DIFF
--- a/ui/App/NetworkScreen.svelte
+++ b/ui/App/NetworkScreen.svelte
@@ -79,9 +79,8 @@
 <style>
   .container {
     max-width: var(--content-max-width);
-    margin: 64px auto;
     min-width: var(--content-min-width);
-    padding: 0 var(--content-padding);
+    padding: 4rem var(--content-padding);
   }
 
   section {
@@ -98,7 +97,7 @@
   .seed-entry-field {
     width: 100%;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.5rem;
   }
 


### PR DESCRIPTION
Fixes #242 (the unnecessary scrolling on the networking page) and the misaligned seed input button.

![before](https://user-images.githubusercontent.com/3919579/135229467-46f26f94-b89c-4e58-a937-ea192abaf79f.png)

![after](https://user-images.githubusercontent.com/3919579/135229474-f9c06203-ec5d-4462-922a-bf2abccc1344.png)
