### PR TITLE
fix: relative positioning for tooltips

### DIFF
--- a/ui/App/DesignSystemGuideModal.svelte
+++ b/ui/App/DesignSystemGuideModal.svelte
@@ -732,7 +732,7 @@
         </div>
 
         <div class="swatch">
-          <Tooltip value="Bottom" position="bottom">
+          <Tooltip value="A very long text" position="bottom">
             <Button variant="outline">Hover me!</Button>
           </Tooltip>
         </div>

--- a/ui/DesignSystem/Tooltip.svelte
+++ b/ui/DesignSystem/Tooltip.svelte
@@ -19,14 +19,16 @@
   let container: Element | null = null;
   let message: Element | null = null;
 
-  let visibility: "hidden" | "visible" = "hidden";
+  let visible: boolean;
   let offset: Offset = {
     top: 0,
     left: 0,
   };
 
+  const TOOLTIP_MARGIN = 8;
+
   function hide() {
-    visibility = "hidden";
+    visible = false;
   }
 
   function show() {
@@ -39,7 +41,7 @@
     const containerRect = container.getBoundingClientRect();
     const messageRect = message.getBoundingClientRect();
 
-    visibility = "visible";
+    visible = true;
     offset = calculateOffset(position, containerRect, messageRect);
   }
 
@@ -51,54 +53,58 @@
     switch (position) {
       case "top":
         return {
-          top: container.top - 40,
-          left: container.left + container.width / 2,
+          top: -(TOOLTIP_MARGIN + message.height),
+          left: (container.width - message.width) / 2,
         };
 
       case "right":
         return {
-          top: container.top + container.height / 2 - 16,
-          left: container.right + 8,
+          top: (container.height - message.height) / 2,
+          left: container.width + TOOLTIP_MARGIN,
         };
 
       case "bottom":
         return {
-          top: container.bottom + 8,
-          left: container.left + container.width / 2,
+          top: container.height + TOOLTIP_MARGIN,
+          left: (container.width - message.width) / 2,
         };
 
       case "left":
         return {
-          top: container.top + container.height / 2 - 16,
-          left: container.left - message.width - 8,
+          top: (container.height - message.height) / 2,
+          left: -(message.width + TOOLTIP_MARGIN),
         };
     }
   }
 </script>
 
 <style>
+  .container {
+    position: relative;
+  }
+
   .tooltip {
     white-space: nowrap;
     user-select: none;
     background-color: var(--color-foreground);
     color: var(--color-background);
-    text-align: center;
     border-radius: 0.5rem;
     padding: 4px 8px;
-    position: fixed;
+    position: absolute;
     pointer-events: none;
     z-index: 100;
+    visibility: hidden;
   }
 
-  .tooltip.bottom,
-  .tooltip.top {
-    transform: translateX(-50%);
+  .visible {
+    visibility: visible;
   }
 </style>
 
 {#if value}
   <div
     {style}
+    class="container"
     bind:this={container}
     data-cy="tooltip"
     on:mouseenter={show}
@@ -106,9 +112,10 @@
     <slot />
     <div
       bind:this={message}
-      class={`tooltip ${position}`}
-      style={`top: ${offset.top}px; left: ${offset.left}px; visibility: ${visibility}`}>
-      <p>{value}</p>
+      class="tooltip"
+      class:visible
+      style={`top: ${offset.top}px; left: ${offset.left}px`}>
+      {value}
     </div>
   </div>
 {:else}


### PR DESCRIPTION
We position tooltips relative to their container.

Using `position: fixed` (i.e. relative to the viewport) does not work when a containing element has the `transform` property set [1]. In that case the tooltip would be positioned relative to that element.

This example is from #2433.

![Peek 2021-09-30 11-55](https://user-images.githubusercontent.com/3919579/135432952-1bd43af2-132f-4f16-b700-59bddb071f5f.gif)


[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/position#values