### PR TITLE
refactor: deduplicate and annotate identity schemas

### DIFF
--- a/ui/src/proxy/identity.ts
+++ b/ui/src/proxy/identity.ts
@@ -7,36 +7,32 @@
 import * as zod from "zod";
 import type { Fetcher, RequestOptions } from "./fetcher";
 
-export interface RemoteIdentity {
-  metadata: Metadata;
-  urn: string;
-  peerIds: string[];
-}
-
-export interface Identity {
-  metadata: Metadata;
-  urn: string;
-  peerId: string;
-}
-
-export const identitySchema = zod.object({
-  metadata: zod.object({
-    handle: zod.string(),
-    ethereum: zod
-      .object({
-        address: zod.string(),
-        expiration: zod.string(),
-      })
-      .nullable(),
-  }),
-  urn: zod.string(),
-  peerId: zod.string(),
-});
-
 export interface Metadata {
   handle: string;
   ethereum: Ethereum | null;
 }
+
+const metadataSchema: zod.Schema<Metadata> = zod.object({
+  handle: zod.string(),
+  ethereum: zod
+    .object({
+      address: zod.string(),
+      expiration: zod.string(),
+    })
+    .nullable(),
+});
+
+export interface Identity {
+  urn: string;
+  peerId: string;
+  metadata: Metadata;
+}
+
+export const identitySchema: zod.Schema<Identity> = zod.object({
+  urn: zod.string(),
+  peerId: zod.string(),
+  metadata: metadataSchema,
+});
 
 // A claim over an Ethereum Address
 export interface Ethereum {
@@ -44,18 +40,16 @@ export interface Ethereum {
   expiration: string;
 }
 
+export interface RemoteIdentity {
+  urn: string;
+  peerIds: string[];
+  metadata: Metadata;
+}
+
 export const remoteIdentitySchema = zod.object({
-  metadata: zod.object({
-    handle: zod.string(),
-    ethereum: zod
-      .object({
-        address: zod.string(),
-        expiration: zod.string(),
-      })
-      .nullable(),
-  }),
   urn: zod.string(),
   peerIds: zod.array(zod.string()),
+  metadata: metadataSchema,
 });
 
 export class Client {


### PR DESCRIPTION
* We deduplicate the schema for `Metadata`
* We put type annotations on the schema to ensure that they are schemas for the given types.