### PR TITLE
Move code to proxy client

### DIFF
--- a/ui/App/OrgScreen/AnchorProjectModal.svelte
+++ b/ui/App/OrgScreen/AnchorProjectModal.svelte
@@ -96,12 +96,12 @@
   }
 
   async function loadCommitData(revisionData: RevisionData) {
-    const commits = await source.fetchCommits(
-      revisionData.project.urn,
-      revisionData.peerId,
-      revisionData.selectedRevision
-    );
-    commit = commits.history[0];
+    const commits = await proxy.client.source.commitsGet({
+      projectUrn: revisionData.project.urn,
+      peerId: revisionData.peerId,
+      revision: revisionData.selectedRevision,
+    });
+    commit = commits.headers[0];
   }
 
   async function createAnchor(): Promise<void> {

--- a/ui/src/proxy/source.ts
+++ b/ui/src/proxy/source.ts
@@ -111,6 +111,11 @@ interface BlobGetParams {
   highlight?: "dark" | "light" | "h4x0r";
 }
 
+interface RefsGetParams {
+  projectUrn: string;
+  peerId?: string;
+}
+
 export class Client {
   private fetcher: Fetcher;
 
@@ -118,7 +123,10 @@ export class Client {
     this.fetcher = fetcher;
   }
 
-  async blobGet(params: BlobGetParams, options: RequestOptions): Promise<Blob> {
+  async blobGet(
+    params: BlobGetParams,
+    options?: RequestOptions
+  ): Promise<Blob> {
     return this.fetcher.fetchOk(
       {
         method: "GET",
@@ -132,6 +140,40 @@ export class Client {
         options,
       },
       blobSchema
+    );
+  }
+
+  async branchesGet(
+    params: RefsGetParams,
+    options?: RequestOptions
+  ): Promise<string[]> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: `source/branches/${params.projectUrn}`,
+        query: {
+          peerId: params.peerId,
+        },
+        options,
+      },
+      zod.array(zod.string())
+    );
+  }
+
+  async tagsGet(
+    params: RefsGetParams,
+    options?: RequestOptions
+  ): Promise<string[]> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: `source/tags/${params.projectUrn}`,
+        query: {
+          peerId: params.peerId,
+        },
+        options,
+      },
+      zod.array(zod.string())
     );
   }
 }

--- a/ui/src/source.ts
+++ b/ui/src/source.ts
@@ -19,10 +19,18 @@ import type {
   Person,
   CommitHeader,
 } from "./proxy/source";
-import { RevisionType } from "./proxy/source";
+import { RevisionType, Stats } from "./proxy/source";
 import type * as diff from "./source/diff";
 
-export type { Blob, RevisionSelector, Branch, Tag, Person, CommitHeader };
+export type {
+  Blob,
+  RevisionSelector,
+  Branch,
+  Tag,
+  Person,
+  CommitHeader,
+  Stats,
+};
 export { RevisionType };
 
 // TYPES
@@ -38,17 +46,6 @@ export interface Commit {
   header: CommitHeader;
   stats: CommitStats;
   changeset: Record<string, unknown>;
-}
-
-export interface Stats {
-  branches: number;
-  commits: number;
-  contributors: number;
-}
-
-interface Commits {
-  headers: CommitHeader[];
-  stats: Stats;
 }
 
 export interface CommitsHistory {
@@ -125,24 +122,21 @@ export const fetchCommit = (
   return api.get<Commit>(`source/commit/${projectUrn}/${sha1}`);
 };
 
-export const fetchCommits = (
+export async function fetchCommits(
   projectUrn: string,
   peerId: PeerId,
   revision: RevisionSelector
-): Promise<CommitsHistory> => {
-  return api
-    .get<Commits>(`source/commits/${projectUrn}/`, {
-      query: {
-        revision: { ...revision, peerId },
-      },
-    })
-    .then(response => {
-      return {
-        stats: response.stats,
-        history: response.headers,
-      };
-    });
-};
+): Promise<CommitsHistory> {
+  const { headers, stats } = await proxy.client.source.commitsGet({
+    projectUrn,
+    peerId,
+    revision,
+  });
+  return {
+    stats,
+    history: headers,
+  };
+}
 
 export const fetchReadme = async (
   projectUrn: string,


### PR DESCRIPTION
While working on integrating the new Radicle CLIs (#2432) to do source browsing I realized that it would be helpful get a better understanding of the HTTP API for source browsing. Making it more type-safe will also help detecting mistakes.

Please see the individual commits for details.