### PR TITLE
improve docs for org seed node

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -98,9 +98,10 @@ apt-get update
 apt-get install docker-ce docker-ce-cli containerd.io
 ```
 
-6. As `orgnode`, set up radicle-client-services:
+6. Set up radicle-client-services:
 
 ```bash
+sudo su
 apt-get install python3-pip
 
 adduser --disabled-password --disabled-login orgnode


### PR DESCRIPTION
* List resources and their IDs up front
* Mention org seed node in GCP project overview
* Add step that creates the network address
* Consolidate some of the steps to set up the VM