### PR TITLE
refactor: fetch single commits through proxy client

### DIFF
--- a/ui/App/ProjectScreen/Source/Code.svelte
+++ b/ui/App/ProjectScreen/Source/Code.svelte
@@ -6,7 +6,6 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import type { Sha1 } from "ui/src/source";
   import * as router from "ui/src/router";
 
   import { fetchTree } from "ui/src/source";
@@ -16,7 +15,7 @@
   import Remote from "ui/App/Remote.svelte";
   import Tree from "./SourceBrowser/Tree.svelte";
 
-  const onSelectCommit = (projectUrn: string, sha1: Sha1) => {
+  const onSelectCommit = (projectUrn: string, sha1: string) => {
     router.push({
       type: "project",
       params: {

--- a/ui/App/ProjectScreen/Source/SourceBrowser/Changeset.svelte
+++ b/ui/App/ProjectScreen/Source/SourceBrowser/Changeset.svelte
@@ -6,8 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import type { CommitStats } from "ui/src/source";
-  import type { Diff } from "ui/src/source/diff";
+  import type { Diff, CommitStats } from "ui/src/proxy/commit";
 
   import Icon from "ui/DesignSystem/Icon";
 

--- a/ui/App/ProjectScreen/Source/SourceBrowser/FileDiff.svelte
+++ b/ui/App/ProjectScreen/Source/SourceBrowser/FileDiff.svelte
@@ -6,12 +6,7 @@
  LICENSE file.
 -->
 <script lang="typescript">
-  import {
-    lineNumberL,
-    lineNumberR,
-    lineSign,
-    FileDiffType,
-  } from "ui/src/source/diff";
+  import { lineNumberL, lineNumberR, lineSign } from "ui/src/source/diff";
   import type { ModifiedFile } from "ui/src/source/diff";
 
   import Icon from "ui/DesignSystem/Icon";
@@ -113,7 +108,7 @@
     <p class="typo-text-bold">{file.path}</p>
   </header>
   <main>
-    {#if file.diff.type === FileDiffType.Plain && file.diff.hunks.length > 0}
+    {#if file.diff.type === "plain" && file.diff.hunks.length > 0}
       <table class="diff">
         {#each file.diff.hunks as hunk}
           <tr class="diff-line">

--- a/ui/src/proxy/commit.ts
+++ b/ui/src/proxy/commit.ts
@@ -1,0 +1,172 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as zod from "zod";
+
+export enum LineDiffType {
+  Addition = "addition",
+  Context = "context",
+  Deletion = "deletion",
+}
+
+export interface Addition {
+  type: LineDiffType.Addition;
+  line: string;
+  lineNum: number;
+}
+
+export interface Context {
+  type: LineDiffType.Context;
+  line: string;
+  lineNumNew: number;
+  lineNumOld: number;
+}
+
+export interface Deletion {
+  type: LineDiffType.Deletion;
+  line: string;
+  lineNum: number;
+}
+
+export type LineDiff = Addition | Deletion | Context;
+
+const lineDiffSchema: zod.Schema<LineDiff> = zod.union([
+  zod.object({
+    type: zod.literal(LineDiffType.Addition),
+    line: zod.string(),
+    lineNum: zod.number(),
+  }),
+  zod.object({
+    type: zod.literal(LineDiffType.Context),
+    line: zod.string(),
+    lineNumNew: zod.number(),
+    lineNumOld: zod.number(),
+  }),
+  zod.object({
+    type: zod.literal(LineDiffType.Deletion),
+    line: zod.string(),
+    lineNum: zod.number(),
+  }),
+]);
+
+export interface Binary {
+  type: "binary";
+}
+
+export interface Plain {
+  type: "plain";
+  hunks: Array<{
+    header: string;
+    lines: LineDiff[];
+  }>;
+}
+
+export type FileDiff = Binary | Plain;
+
+const fileDiffSchema: zod.Schema<FileDiff> = zod.union([
+  zod.object({ type: zod.literal("binary") }),
+  zod.object({
+    type: zod.literal("plain"),
+    hunks: zod.array(
+      zod.object({ header: zod.string(), lines: zod.array(lineDiffSchema) })
+    ),
+  }),
+]);
+
+export interface CopiedFile {
+  newPath: string;
+  oldPath: string;
+}
+
+export interface ModifiedFile {
+  diff: FileDiff;
+  path: string;
+}
+
+export interface MovedFile {
+  newPath: string;
+  oldPath: string;
+}
+
+export interface Diff {
+  copied: CopiedFile[];
+  created: string[];
+  deleted: string[];
+  modified: ModifiedFile[];
+  moved: MovedFile[];
+}
+
+const diffSchema: zod.Schema<Diff> = zod.object({
+  copied: zod.array(
+    zod.object({
+      newPath: zod.string(),
+      oldPath: zod.string(),
+    })
+  ),
+  created: zod.array(zod.string()),
+  deleted: zod.array(zod.string()),
+  modified: zod.array(
+    zod.object({
+      path: zod.string(),
+      diff: fileDiffSchema,
+    })
+  ),
+  moved: zod.array(
+    zod.object({
+      newPath: zod.string(),
+      oldPath: zod.string(),
+    })
+  ),
+});
+
+export interface CommitHeader {
+  author: Person;
+  committer: Person;
+  committerTime: number;
+  description: string;
+  sha1: string;
+  summary: string;
+}
+
+export interface Person {
+  email: string;
+  name: string;
+}
+const personSchema: zod.Schema<Person> = zod.object({
+  email: zod.string(),
+  name: zod.string(),
+});
+
+export const commitHeaderSchema: zod.Schema<CommitHeader> = zod.object({
+  author: personSchema,
+  committer: personSchema,
+  committerTime: zod.number(),
+  description: zod.string(),
+  sha1: zod.string(),
+  summary: zod.string(),
+});
+
+export interface CommitStats {
+  additions: number;
+  deletions: number;
+}
+
+export interface Commit {
+  branches: string[];
+  diff: Diff;
+  header: CommitHeader;
+  stats: CommitStats;
+}
+
+export const commitSchema: zod.Schema<Commit> = zod.object({
+  branches: zod.array(zod.string()),
+  diff: diffSchema,
+  header: commitHeaderSchema,
+  stats: zod.object({
+    additions: zod.number(),
+    deletions: zod.number(),
+  }),
+});

--- a/ui/src/proxy/source.ts
+++ b/ui/src/proxy/source.ts
@@ -6,33 +6,15 @@
 
 import * as zod from "zod";
 import type { Fetcher, RequestOptions } from "./fetcher";
+import {
+  Commit,
+  CommitHeader,
+  Person,
+  commitHeaderSchema,
+  commitSchema,
+} from "./commit";
 
-export interface Person {
-  email: string;
-  name: string;
-}
-const personSchema: zod.Schema<Person> = zod.object({
-  email: zod.string(),
-  name: zod.string(),
-});
-
-export interface CommitHeader {
-  author: Person;
-  committer: Person;
-  committerTime: number;
-  description: string;
-  sha1: string;
-  summary: string;
-}
-
-const commitHeaderSchema: zod.Schema<CommitHeader> = zod.object({
-  author: personSchema,
-  committer: personSchema,
-  committerTime: zod.number(),
-  description: zod.string(),
-  sha1: zod.string(),
-  summary: zod.string(),
-});
+export type { CommitHeader, Person };
 
 export interface Stats {
   branches: number;
@@ -146,6 +128,11 @@ interface CommitsGetParams {
   revision: RevisionSelector;
 }
 
+interface CommitGetParams {
+  projectUrn: string;
+  sha1?: string;
+}
+
 export class Client {
   private fetcher: Fetcher;
 
@@ -224,6 +211,20 @@ export class Client {
         options,
       },
       commitSummarySchema
+    );
+  }
+
+  async commitGet(
+    params: CommitGetParams,
+    options?: RequestOptions
+  ): Promise<Commit> {
+    return this.fetcher.fetchOk(
+      {
+        method: "GET",
+        path: `source/commit/${params.projectUrn}/${params.sha1}`,
+        options,
+      },
+      commitSchema
     );
   }
 }

--- a/ui/src/screen/project/source.ts
+++ b/ui/src/screen/project/source.ts
@@ -15,6 +15,7 @@ import * as remote from "ui/src/remote";
 import * as router from "ui/src/router";
 import * as source from "ui/src/source";
 import * as appearance from "ui/src/appearance";
+import * as proxy from "ui/src/proxy";
 
 export enum ViewKind {
   Aborted = "ABORTED",
@@ -282,7 +283,9 @@ export const fetchCommit = async (sha1: string): Promise<void> => {
     } = screen;
 
     try {
-      commitStore.success(await source.fetchCommit(project.urn, sha1));
+      commitStore.success(
+        await proxy.client.source.commitGet({ projectUrn: project.urn, sha1 })
+      );
     } catch (err: unknown) {
       const e = error.fromUnknown(err);
       if (e.message.match("object not found")) {

--- a/ui/src/source.ts
+++ b/ui/src/source.ts
@@ -16,11 +16,9 @@ import type {
   Branch,
   Tag,
   SourceObject,
-  Person,
-  CommitHeader,
 } from "./proxy/source";
+import type { Person, CommitHeader, Commit } from "./proxy/commit";
 import { RevisionType, Stats } from "./proxy/source";
-import type * as diff from "./source/diff";
 
 export type {
   Blob,
@@ -29,24 +27,10 @@ export type {
   Tag,
   Person,
   CommitHeader,
+  Commit,
   Stats,
 };
 export { RevisionType };
-
-// TYPES
-export type Sha1 = string;
-export interface CommitStats {
-  additions: number;
-  deletions: number;
-}
-
-export interface Commit {
-  branches: string[];
-  diff: diff.Diff;
-  header: CommitHeader;
-  stats: CommitStats;
-  changeset: Record<string, unknown>;
-}
 
 export interface CommitsHistory {
   history: CommitHeader[];
@@ -113,13 +97,6 @@ export const fetchBlob = async (
     },
     { abort: signal }
   );
-};
-
-export const fetchCommit = (
-  projectUrn: string,
-  sha1: Sha1
-): Promise<Commit> => {
-  return api.get<Commit>(`source/commit/${projectUrn}/${sha1}`);
 };
 
 export async function fetchCommits(

--- a/ui/src/source/diff.ts
+++ b/ui/src/source/diff.ts
@@ -4,34 +4,14 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
-export type Line = string;
+import {
+  LineDiff,
+  LineDiffType,
+  ModifiedFile,
+  Diff,
+} from "ui/src/proxy/commit";
 
-export enum LineDiffType {
-  Addition = "addition",
-  Context = "context",
-  Deletion = "deletion",
-}
-
-export interface Addition {
-  type: LineDiffType.Addition;
-  line: Line;
-  lineNum: number;
-}
-
-export interface Context {
-  type: LineDiffType.Context;
-  line: Line;
-  lineNumNew: number;
-  lineNumOld: number;
-}
-
-export interface Deletion {
-  type: LineDiffType.Deletion;
-  line: Line;
-  lineNum: number;
-}
-
-export type LineDiff = Addition | Deletion | Context;
+export type { ModifiedFile, Diff };
 
 export const lineNumberR = (line: LineDiff): string | number => {
   switch (line.type) {
@@ -74,50 +54,3 @@ export const lineSign = (line: LineDiff): string => {
     }
   }
 };
-
-export interface Hunk {
-  header: Line;
-  lines: LineDiff[];
-}
-
-export enum FileDiffType {
-  Binary = "binary",
-  Plain = "plain",
-}
-
-export interface Binary {
-  type: FileDiffType.Binary;
-}
-
-export interface Plain {
-  type: FileDiffType.Plain;
-  hunks: Hunk[];
-}
-
-export type FileDiff = Binary | Plain;
-
-export interface CopiedFile {
-  newPath: string;
-  oldPath: string;
-}
-
-export type CreatedFile = string;
-export type DeletedFile = string;
-
-export interface ModifiedFile {
-  diff: FileDiff;
-  path: string;
-}
-
-export interface MovedFile {
-  newPath: string;
-  oldPath: string;
-}
-
-export interface Diff {
-  copied: CopiedFile[];
-  created: CreatedFile[];
-  deleted: DeletedFile[];
-  modified: ModifiedFile[];
-  moved: MovedFile[];
-}


### PR DESCRIPTION
We add `commitGet` to the proxy client and use this function exclusively to get commit data.

This requires us to move the type definitions for commits and diffs to the proxy (`ui/src/proxy/commit`) and also implement schemas for these types.

We also eliminate some type definitions and inline them.

We also remove the `changeset` field from `Commit`. It is not used in the client and not provided by the proxy.