### PR TITLE
feat: view org when not connected to a wallet

### DIFF
--- a/ui/src/attestation/contract.ts
+++ b/ui/src/attestation/contract.ts
@@ -5,6 +5,8 @@
 // LICENSE file.
 
 import type { Signer } from "ethers";
+import type * as wallet from "ui/src/wallet";
+
 import LruCache from "lru-cache";
 import * as ethers from "ethers";
 
@@ -50,8 +52,8 @@ const claimsContractCache = new LruCache<string, ClaimsContractCacheEntry>({
 export class ClaimsContract {
   contract: Claims;
 
-  constructor(signer: Signer, address: string) {
-    this.contract = ClaimsFactory.connect(address, signer);
+  constructor(signerOrProvider: Signer | wallet.Provider, address: string) {
+    this.contract = ClaimsFactory.connect(address, signerOrProvider);
   }
 
   async claim(urn: string): Promise<void> {

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -434,7 +434,7 @@ export async function fetchMembers(
   );
 
   const contract = new ClaimsContract(
-    wallet.signer,
+    wallet.provider,
     claimsAddress(wallet.environment)
   );
 

--- a/ui/src/org/ensResolver.ts
+++ b/ui/src/org/ensResolver.ts
@@ -165,7 +165,7 @@ async function getOwner(domain: string): Promise<string> {
   const wallet = svelteStore.get(Wallet.store);
   const ensAddr = ethereum.ensAddress(wallet.environment);
 
-  const registry = EnsRegistryFactory.connect(ensAddr, wallet.signer);
+  const registry = EnsRegistryFactory.connect(ensAddr, wallet.provider);
   const owner = await registry.owner(ethers.utils.namehash(domain));
 
   return owner;


### PR DESCRIPTION
Make functions that depend on an Ethereum gateway not depend on a connected wallet.

Required by https://github.com/radicle-dev/radicle-upstream/pull/2450.