### PR TITLE
chore: decouple design system `unreachable` from Upstream

### DIFF
--- a/ui/DesignSystem/Avatar.svelte
+++ b/ui/DesignSystem/Avatar.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="ts">
-  import { unreachable } from "ui/src/unreachable";
+  import { unreachable } from "./lib/unreachable";
   import * as radicleAvatar from "radicle-avatar";
   import Emoji from "./Emoji.svelte";
 

--- a/ui/DesignSystem/IdentifierLink.svelte
+++ b/ui/DesignSystem/IdentifierLink.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="ts">
-  import { unreachable } from "ui/src/unreachable";
+  import { unreachable } from "./lib/unreachable";
   import * as format from "./lib/format";
   import Icon from "./Icon";
 

--- a/ui/DesignSystem/lib/unreachable.ts
+++ b/ui/DesignSystem/lib/unreachable.ts
@@ -1,0 +1,9 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+export const unreachable = (value: never): never => {
+  throw new Error(`Unreachable code: ${value}`);
+};


### PR DESCRIPTION
We want to decouple the design system from Upstream, so it can be re-used by other projects.

A step towards: https://github.com/radicle-dev/radicle-upstream/issues/1877.