### PR TITLE
feat: show loading animation on project screen

### DIFF
--- a/ui/App/LoadingScreen.svelte
+++ b/ui/App/LoadingScreen.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="ts">
-  import EmptyState from "ui/App/ScreenLayout/EmptyState.svelte";
+  import { Loading } from "ui/DesignSystem";
 </script>
 
 <style>
@@ -21,5 +21,5 @@
 </style>
 
 <div class="container">
-  <EmptyState headerText="Loading…" emoji="🕵️" />
+  <Loading />
 </div>

--- a/ui/App/OnboardingModal/EnterName.svelte
+++ b/ui/App/OnboardingModal/EnterName.svelte
@@ -99,7 +99,7 @@
   <div>
     <h1>
       Hey
-      <Emoji emoji="👋 " size="big" style="display: inline;" />
+      <Emoji emoji="👋 " size="large" style="display: inline;" />
       what should we call you?
     </h1>
     <p>

--- a/ui/App/ProjectScreen/Source.svelte
+++ b/ui/App/ProjectScreen/Source.svelte
@@ -30,7 +30,7 @@
   import * as screen from "ui/src/screen";
   import * as wallet from "ui/src/wallet";
 
-  import { Icon } from "ui/DesignSystem";
+  import { Icon, Loading } from "ui/DesignSystem";
 
   import ActionBar from "ui/App/ScreenLayout/ActionBar.svelte";
   import TabBar from "ui/App/ScreenLayout/TabBar.svelte";
@@ -186,6 +186,15 @@
   }
 </script>
 
+<style>
+  .loading-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: calc(100vh - var(--bigheader-height));
+  }
+</style>
+
 {#if $store.status === remote.Status.Success}
   <ActionBar>
     <div slot="left">
@@ -239,4 +248,8 @@
   {:else}
     {unreachable(activeView)}
   {/if}
+{:else if $store.status === remote.Status.Loading}
+  <div class="loading-container">
+    <Loading />
+  </div>
 {/if}

--- a/ui/DesignSystem/Emoji.svelte
+++ b/ui/DesignSystem/Emoji.svelte
@@ -10,7 +10,7 @@
 
   export let emoji: string;
 
-  type EmojiSize = "small" | "regular" | "medium" | "big" | "huge";
+  type EmojiSize = "small" | "regular" | "large" | "huge";
   export let size: EmojiSize = "regular";
 
   export let style: string | undefined = undefined;
@@ -33,14 +33,9 @@
     width: 1rem;
   }
 
-  :global(.emoji.medium) {
-    height: 1.125rem;
-    width: 1.125rem;
-  }
-
-  :global(.emoji.big) {
-    height: 2.25rem;
-    width: 2.25rem;
+  :global(.emoji.large) {
+    height: 2rem;
+    width: 2rem;
   }
 
   :global(.emoji.huge) {

--- a/ui/DesignSystem/Loading.svelte
+++ b/ui/DesignSystem/Loading.svelte
@@ -1,0 +1,35 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="typescript">
+  import Emoji from "./Emoji.svelte";
+</script>
+
+<style>
+  .animation {
+    animation: rotate, rotate-back;
+    animation-iteration-count: infinite;
+    animation-timing-function: cubic-bezier(0.45, 1.45, 0.8, 1);
+    animation-duration: 1400ms;
+  }
+  @keyframes rotate {
+    0%,
+    15%,
+    85%,
+    100% {
+      transform: rotate(0deg);
+    }
+    35%,
+    65% {
+      transform: rotate(180deg);
+    }
+  }
+</style>
+
+<div class="animation">
+  <Emoji emoji="⏳" size="large" />
+</div>

--- a/ui/DesignSystem/index.ts
+++ b/ui/DesignSystem/index.ts
@@ -19,6 +19,7 @@ import Icon from "./Icon";
 import IdentifierLink from "./IdentifierLink.svelte";
 import KeyHint from "./KeyHint.svelte";
 import List from "./List.svelte";
+import Loading from "./Loading.svelte";
 import Markdown from "./Markdown.svelte";
 import Notification from "./Notification.svelte";
 import Overlay from "./Overlay.svelte";
@@ -51,6 +52,7 @@ export {
   IdentifierLink,
   KeyHint,
   List,
+  Loading,
   Markdown,
   Notification,
   Overlay,


### PR DESCRIPTION
Extract the loading component from https://github.com/radicle-dev/radicle-upstream/pull/2450.
Closes: https://github.com/radicle-dev/radicle-upstream/issues/2477.

https://user-images.githubusercontent.com/158411/136974373-0c77ba0c-4bd6-4d87-8c52-97c8fa27edac.mov



https://user-images.githubusercontent.com/158411/136978612-b05567e6-acd9-4dfc-94e0-55037c765d26.mov


<img width="1440" alt="Screenshot 2021-10-12 at 16 28 53" src="https://user-images.githubusercontent.com/158411/136975403-26356a42-8f89-4eba-beca-db5c89b2adda.png">


