### PR TITLE
style: add "large" Avatar variant

### DIFF
--- a/ui/App/DesignSystemGuideModal.svelte
+++ b/ui/App/DesignSystemGuideModal.svelte
@@ -623,6 +623,41 @@
         <div class="swatch">
           <Avatar
             style="margin-right: 16px"
+            size="large"
+            kind={{
+              type: "userImage",
+              url: "https://avatars.githubusercontent.com/u/4406983",
+            }} />
+          <Avatar
+            style="margin-right: 16px"
+            size="large"
+            kind={{
+              type: "userEmoji",
+              uniqueIdentifier: "rad:git:hnrk8cgbe4mgkubojmkdt6enka84ryfkdxhcy",
+            }} />
+          <Avatar
+            style="margin-right: 16px"
+            size="large"
+            kind={{
+              type: "orgImage",
+              url: "https://app.radicle.network/images/alt-clients.png",
+            }} />
+          <Avatar
+            style="margin-right: 16px"
+            size="large"
+            kind={{
+              type: "orgEmoji",
+              uniqueIdentifier: "0x8152237402E0f194176154c3a6eA1eB99b611482",
+            }} />
+          <Avatar
+            style="margin-right: 16px"
+            size="large"
+            kind={{ type: "pendingOrg" }} />
+        </div>
+
+        <div class="swatch">
+          <Avatar
+            style="margin-right: 16px"
             size="huge"
             kind={{
               type: "userImage",

--- a/ui/DesignSystem/Avatar.svelte
+++ b/ui/DesignSystem/Avatar.svelte
@@ -26,7 +26,7 @@
 
   export let kind: Kind;
 
-  export let size: "small" | "regular" | "huge" = "regular";
+  export let size: "small" | "regular" | "large" | "huge" = "regular";
 
   // TODO: memoize this because we call it twice for each emoji component.
   function emojiAvatar(kind: EmojiKind): {
@@ -67,38 +67,50 @@
   }
 
   .circle.small {
-    width: 24px;
-    height: 24px;
-    border-radius: 12px;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 0.75rem;
   }
 
   .circle.regular {
-    width: 32px;
-    height: 32px;
-    border-radius: 16px;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 1rem;
+  }
+
+  .circle.large {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 2rem;
   }
 
   .circle.huge {
-    width: 120px;
-    height: 120px;
-    border-radius: 60px;
+    width: 7.5rem;
+    height: 7.5rem;
+    border-radius: 3.75rem;
   }
 
   .square.small {
-    width: 24px;
-    height: 24px;
+    width: 1.5rem;
+    height: 1.5rem;
     border-radius: 0.25rem;
   }
 
   .square.regular {
-    width: 32px;
-    height: 32px;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.5rem;
+  }
+
+  .square.large {
+    width: 4rem;
+    height: 4rem;
     border-radius: 0.5rem;
   }
 
   .square.huge {
-    width: 120px;
-    height: 120px;
+    width: 7.5rem;
+    height: 7.5rem;
     border-radius: 1.5rem;
   }
 
@@ -131,6 +143,7 @@
   class="container"
   class:small={size === "small"}
   class:regular={size === "regular"}
+  class:large={size === "large"}
   class:huge={size === "huge"}
   {style}>
   {#if kind.type === "userImage"}
@@ -138,6 +151,7 @@
       class="avatar circle"
       class:small={size === "small"}
       class:regular={size === "regular"}
+      class:large={size === "large"}
       class:huge={size === "huge"}
       src={kind.url}
       alt="user-avatar" />
@@ -146,6 +160,7 @@
       class="avatar square"
       class:small={size === "small"}
       class:regular={size === "regular"}
+      class:large={size === "large"}
       class:huge={size === "huge"}
       src={kind.url}
       alt="user-avatar" />
@@ -154,6 +169,7 @@
       class="avatar circle"
       class:small={size === "small"}
       class:regular={size === "regular"}
+      class:large={size === "large"}
       class:huge={size === "huge"}
       style={`background-color: ${emojiAvatar(kind).backgroundColor}`}
       data-cy="emoji">
@@ -164,6 +180,7 @@
       class="avatar square"
       class:small={size === "small"}
       class:regular={size === "regular"}
+      class:large={size === "large"}
       class:huge={size === "huge"}
       style={`background-color: ${emojiAvatar(kind).backgroundColor}`}
       data-cy="emoji">
@@ -174,6 +191,7 @@
       class="avatar pulsate square"
       class:small={size === "small"}
       class:regular={size === "regular"}
+      class:large={size === "large"}
       class:huge={size === "huge"}
       style="background-color: var(--color-foreground-level-3);"
       data-cy="emoji" />
@@ -182,6 +200,7 @@
       class="avatar circle"
       class:small={size === "small"}
       class:regular={size === "regular"}
+      class:large={size === "large"}
       class:huge={size === "huge"}
       style="background: var(--color-foreground-level-3)" />
   {:else}


### PR DESCRIPTION
Extract `Avatar` "large" sizing from https://github.com/radicle-dev/radicle-upstream/pull/2450.
I need it for https://github.com/radicle-dev/radicle-upstream/issues/2235.

<img width="1072" alt="Screenshot 2021-10-15 at 11 24 49" src="https://user-images.githubusercontent.com/158411/137465018-645bf4d5-983c-4d04-abc6-6f91efff6c8b.png">


