### PR TITLE
fix: ignore cargo-deny advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,7 @@ ignore = [
   #
   # https://rustsec.org/advisories/RUSTSEC-2020-0071
   "RUSTSEC-2020-0071",
+  "RUSTSEC-2020-0159",
   # "RUSTSEC-2021-0080"
 
 ]


### PR DESCRIPTION
They're all coming from radicle-link and should be fixed there. Muting
the advisories until they get fixed upstream.

Signed-off-by: Rūdolfs Ošiņš <rudolfs@osins.org>