### PR TITLE
feat: properly shutdown proxy when app is closed

### DIFF
--- a/native/proxy-process-manager.test.ts
+++ b/native/proxy-process-manager.test.ts
@@ -60,7 +60,8 @@ it("returns the signal", async () => {
     lineLimit: 1,
   });
   const resultPromise = manager.run();
-  manager.kill();
+  const shutdownResult = await manager.shutdown().catch(e => e);
+  expect(shutdownResult.signal).toBe("SIGTERM");
   const result = await resultPromise;
   expect(result.signal).toBe("SIGTERM");
 });


### PR DESCRIPTION
With this change the `radicle-proxy` now shuts downs properly when it receives SIGINT or SIGTERM. In addition, Electron waits for `radicle-proxy` to shutdown properly before it quits.