### PR TITLE
feat: enable CI builds for macOS on Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,46 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-artifacts
+          name: test-artifacts-linux
           path: |
             dist/*.AppImage
+            cypress/screenshots/**/*.png
+            cypress/workspace/test-tmp/*/node-*/*.log
+            cypress/workspace/test-tmp/*/combined-node.log
+  build-macos:
+    runs-on: macos-11
+    steps:
+      - run:  |
+          echo "CARGO_HOME=$HOME/cache/cargo" >> $GITHUB_ENV
+          echo "PATH=$HOME/cache/cargo/bin:$PATH" >> $GITHUB_ENV
+      - uses: actions/checkout@master
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/cache/yarn
+            ~/cache/cypress
+          key: build-${{ runner.os }}-yarn-v3-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            build-${{ runner.os }}-yarn-v3-
+      - name: Cache Rust
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/cache/cargo
+            ~/cache/proxy-target
+          key: build-${{ runner.os }}-rust-v2-${{ hashFiles('Cargo.lock') }}
+      - name: Install toolchain
+        run: |
+          rustup component add clippy rustfmt
+          test -f $CARGO_HOME/bin/cargo-deny || cargo install cargo-deny
+      - run: ci/run.sh
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-artifacts-macos
+          path: |
+            dist/*.dmg
             cypress/screenshots/**/*.png
             cypress/workspace/test-tmp/*/node-*/*.log
             cypress/workspace/test-tmp/*/combined-node.log

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -39,7 +39,7 @@ mkdir -p "$cargo_deny_cache"
 mkdir -p ~/.cargo
 ln -sf "$cargo_deny_cache" ~/.cargo/advisory-db
 
-if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" != "macos" ]]; then
+if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" != "macos" && "${RUNNER_OS:-}" != "macOS" ]]; then
   free_cache_space_kb=$(df --output=avail /cache | sed -n 2p)
   min_free_cache_kb=$(( 2 * 1024 * 1024 )) # 2GiB is 25%
   echo "$(( free_cache_space_kb / 1024 )) MiB free space on /cache"
@@ -98,7 +98,7 @@ log-group-start "Run proxy tests"
 (
   export RUST_TEST_TIME_UNIT=2000,4000
   export RUST_TEST_TIME_INTEGRATION=2000,8000
-  timeout 6m cargo test --all --all-features --all-targets -- -Z unstable-options --report-time
+  cargo test --all --all-features --all-targets -- -Z unstable-options --report-time
 )
 log-group-end
 


### PR DESCRIPTION
We only run macOS builds on master and not every PR to avoid draining our free quota on GH actions. See [this build](https://github.com/radicle-dev/radicle-upstream/actions/runs/1307010052)) for a proof that it works.