### PR TITLE
chore: clean up routes

### DIFF
--- a/cypress/integration/routing.spec.ts
+++ b/cypress/integration/routing.spec.ts
@@ -49,7 +49,7 @@ context("routing", () => {
           it("opens the app on the profile screen", () => {
             cy.visit("./public/index.html");
             cy.location().should(loc => {
-              expect(loc.hash).to.eq("#/profile/projects");
+              expect(loc.hash).to.eq("#/profile");
             });
           });
         }

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -74,7 +74,7 @@
             $activeRouteStore.type === "lock" ||
             $activeRouteStore.type === "boot"
           ) {
-            router.push({ type: "profile", activeTab: "projects" });
+            router.push({ type: "profile" });
           }
         } else {
           unreachable(session.data);

--- a/ui/App/CreateProjectModal.svelte
+++ b/ui/App/CreateProjectModal.svelte
@@ -94,7 +94,7 @@
           message: `Project ${response.metadata.name} was created!`,
         });
       } catch (err: unknown) {
-        router.push({ type: "profile", activeTab: "projects" });
+        router.push({ type: "profile" });
         let message;
         if (err instanceof proxy.ResponseError) {
           message = `Could not create project: ${err.message}`;

--- a/ui/App/OrgScreen/UnresolvedAnchorList.svelte
+++ b/ui/App/OrgScreen/UnresolvedAnchorList.svelte
@@ -26,7 +26,7 @@
 
   const onFollow = (projectId: string) => {
     search.requestProject(projectId);
-    router.push({ type: "profile", activeTab: "following" });
+    router.push({ type: "profile" });
     notification.info({
       message: `Added ${projectId} to the queue`,
       showIcon: true,

--- a/ui/App/SearchModal.svelte
+++ b/ui/App/SearchModal.svelte
@@ -91,7 +91,7 @@
   // Fire notification when a request has been created.
   $: if ($request.status === remote.Status.Success) {
     reset();
-    router.push({ type: "profile", activeTab: "following" });
+    router.push({ type: "profile" });
     notification.info({
       message: "You’ll be notified when this project has been found.",
     });

--- a/ui/App/SharedComponents/UserIdentity.svelte
+++ b/ui/App/SharedComponents/UserIdentity.svelte
@@ -55,7 +55,7 @@
   function goToProfile(urn: string) {
     modal.hide();
     if (urn === session.unsealed().identity.urn) {
-      router.push({ type: "profile", activeTab: "projects" });
+      router.push({ type: "profile" });
     } else {
       router.push({
         type: "userProfile",

--- a/ui/App/Sidebar.svelte
+++ b/ui/App/Sidebar.svelte
@@ -72,7 +72,7 @@
         dataCy="profile"
         indicator
         active={$activeRouteStore.type === "profile"}
-        onClick={() => push({ type: "profile", activeTab: "projects" })}>
+        onClick={() => push({ type: "profile" })}>
         <Avatar
           size="regular"
           kind={{

--- a/ui/src/router/definition.ts
+++ b/ui/src/router/definition.ts
@@ -9,7 +9,6 @@ import * as projectRoute from "ui/App/ProjectScreen/route";
 import * as userProfileRoute from "ui/App/UserProfileScreen/route";
 
 export type NetworkDiagnosticsTab = "peers" | "requests";
-export type ProfileTab = "projects" | "following";
 export type WalletTab = "transactions";
 
 export type Route =
@@ -18,7 +17,7 @@ export type Route =
   | { type: "lock" }
   | { type: "onboarding" }
   | { type: "org"; params: orgRoute.Params }
-  | { type: "profile"; activeTab: ProfileTab }
+  | { type: "profile" }
   | { type: "networkDiagnostics"; activeTab: NetworkDiagnosticsTab }
   | { type: "userProfile"; params: userProfileRoute.Params }
   | {
@@ -36,7 +35,7 @@ export type LoadedRoute =
   | { type: "lock" }
   | { type: "onboarding" }
   | orgRoute.LoadedRoute
-  | { type: "profile"; activeTab: ProfileTab }
+  | { type: "profile" }
   | { type: "networkDiagnostics"; activeTab: NetworkDiagnosticsTab }
   | userProfileRoute.LoadedRoute
   | projectRoute.LoadedRoute
@@ -48,10 +47,14 @@ export type LoadedRoute =
 export function routeToPath(route: Route): string {
   let subRoute = "";
 
-  if (route.type === "profile" || route.type === "networkDiagnostics") {
+  if (route.type === "org") {
+    subRoute = `/${route.params.address}/${route.params.view}`;
+  } else if (route.type === "networkDiagnostics" || route.type === "wallet") {
     subRoute = `/${route.activeTab}`;
+  } else if (route.type === "userProfile") {
+    subRoute = `/${route.params.urn}`;
   } else if (route.type === "project") {
-    subRoute = `/${route.params.activeView.type}`;
+    subRoute = `/${route.params.urn}/${route.params.activeView.type}`;
   }
 
   return `#/${route.type}${subRoute}`;

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -89,6 +89,9 @@ const setHistory = async (history: Route[]) => {
   window.history.replaceState(
     history,
     DOCUMENT_TITLE,
+    // This sets `window.location.href`. At the moment it's not used by
+    // Upstream, but when we switch to a browser environment it'll be
+    // displayed in the URL bar.
     routeToPath(targetRoute)
   );
 };


### PR DESCRIPTION
Remove unused parameter from `ProfileScreen` route and update URL generator function.

Here's a non-exhaustive list of generated URLs as an example:
```
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/lock
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/profile
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/project/rad:git:hnrk8ueib11sen1g9n1xbt71qdns9n4gipw1o/files
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/project/rad:git:hnrk8ueib11sen1g9n1xbt71qdns9n4gipw1o/commits
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/project/rad:git:hnrk8ueib11sen1g9n1xbt71qdns9n4gipw1o/patches
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/project/rad:git:hnrk8ueib11sen1g9n1xbt71qdns9n4gipw1o/anchors
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/org/0x0d3e64c702b362afc0a4c0e750ca008a539d14f8/projects
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/org/0x0d3e64c702b362afc0a4c0e750ca008a539d14f8/members
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/userProfile/rad:git:hnrkbo46og4rgnprbi46b189hfotwamrs8quo
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/orgs
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/wallet/transactions
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/network
file:///Users/rudolfs/work/radicle-upstream/public/index.html?config=%7B%22isDev%22%3Atrue%7D#/settings
```