### PR TITLE
refactor: decouple TextInput from Upstream

### DIFF
--- a/ui/App/CreateOrgModal.svelte
+++ b/ui/App/CreateOrgModal.svelte
@@ -7,11 +7,11 @@
 -->
 <script lang="ts">
   import type { Identity } from "ui/src/identity";
+  import type { TextInputValidationState } from "ui/DesignSystem";
 
   import * as ethereum from "ui/src/ethereum";
   import * as modal from "ui/src/modal";
   import * as org from "ui/src/org";
-  import * as validation from "ui/src/validation";
 
   import {
     Button,
@@ -28,21 +28,18 @@
   let ownerAddress: string = walletAddress;
 
   let isMultiSig: boolean | undefined = undefined;
-  let ownerValidationState: validation.ValidationState;
-  let validOwnerAddress = false;
+  let ownerValidationState: TextInputValidationState;
 
   $: {
     if (ownerAddress.match(ethereum.VALID_ADDRESS_MATCH)) {
       ownerValidationState = {
-        status: validation.ValidationStatus.Success,
+        type: "valid",
       };
-      validOwnerAddress = true;
     } else {
       ownerValidationState = {
-        status: validation.ValidationStatus.Error,
+        type: "invalid",
         message: "This does not look like a valid Ethereum address",
       };
-      validOwnerAddress = false;
     }
   }
 
@@ -103,7 +100,7 @@
         bind:value={ownerAddress}
         placeholder="Enter owner address"
         showSuccessCheck
-        validation={ownerValidationState} />
+        validationState={ownerValidationState} />
     </div>
   </RadioOption>
 
@@ -144,7 +141,8 @@
   <svelte:fragment slot="buttons">
     <Button variant="transparent" on:click={() => modal.hide()}>Cancel</Button>
     <Button
-      disabled={isMultiSig === undefined || (!isMultiSig && !validOwnerAddress)}
+      disabled={isMultiSig === undefined ||
+        (!isMultiSig && ownerValidationState.type !== "valid")}
       on:click={() => createOrg()}>
       Confirm in your wallet
     </Button>

--- a/ui/App/CreateProjectModal.svelte
+++ b/ui/App/CreateProjectModal.svelte
@@ -26,7 +26,6 @@
     repositoryPathValidationStore,
   } from "ui/src/project";
   import * as proxy from "ui/src/proxy";
-  import { ValidationStatus } from "ui/src/validation";
   import * as screen from "ui/src/screen";
 
   import {
@@ -145,18 +144,16 @@
   $: isExisting && (name = "");
 
   // The presence check is outside the validations since we don't want to show the validation error message for it.
-  $: validName =
-    name.length > 0 && $nameValidation.status === ValidationStatus.Success;
+  $: validName = name.length > 0 && $nameValidation.type === "valid";
 
   $: validDescription =
     description.length === 0 ||
-    (description.length > 0 &&
-      $descriptionValidation.status === ValidationStatus.Success);
+    (description.length > 0 && $descriptionValidation.type === "valid");
 
   $: disableSubmit =
     !validName ||
     !validDescription ||
-    $pathValidation.status !== ValidationStatus.Success ||
+    $pathValidation.type !== "valid" ||
     loading;
 
   $: localStateStore = $localState;
@@ -200,7 +197,7 @@
         <div slot="option-body">
           <DirectoryInput
             placeholder="Where to create the repository"
-            validation={$pathValidation}
+            validationState={$pathValidation}
             bind:path={newRepositoryPath}
             on:selected={() => nameInput.focus()} />
           <p
@@ -223,7 +220,7 @@
         <div slot="option-body">
           <DirectoryInput
             placeholder="Choose an existing repository"
-            validation={$pathValidation}
+            validationState={$pathValidation}
             bind:path={existingRepositoryPath} />
           <div class="default-branch-row">
             <p
@@ -269,7 +266,7 @@
         dataCy="name"
         bind:value={name}
         bind:this={nameInput}
-        validation={$nameValidation}
+        validationState={$nameValidation}
         disabled={isExisting} />
     </Tooltip>
 
@@ -277,7 +274,7 @@
       dataCy="description"
       style="margin-top: 1rem; margin-bottom: 1rem;"
       placeholder="Project description"
-      validation={$descriptionValidation}
+      validationState={$descriptionValidation}
       bind:value={description} />
   </div>
 

--- a/ui/App/DesignSystemGuideModal.svelte
+++ b/ui/App/DesignSystemGuideModal.svelte
@@ -9,7 +9,6 @@
   import * as notification from "ui/src/notification";
   import * as router from "ui/src/router";
 
-  import { ValidationStatus } from "ui/src/validation";
   import {
     theme,
     themeOptions,
@@ -462,11 +461,11 @@
 
         <div class="swatch">
           <TextInput
-            placeholder="And I'm an input with a validation error."
+            placeholder="I'm an input with a validation error."
             style="flex: 1"
-            validation={{
-              status: ValidationStatus.Error,
-              message: "Well, that didn't go well...",
+            validationState={{
+              type: "invalid",
+              message: "That doesn't look good!",
             }} />
         </div>
 
@@ -475,14 +474,14 @@
             placeholder="Enter user name"
             style="width: 100%"
             showSuccessCheck
-            validation={{ status: ValidationStatus.Success }} />
+            validationState={{ type: "valid" }} />
         </div>
 
         <div class="swatch">
           <TextInput
             placeholder="Enter user name"
             style="width: 100%"
-            validation={{ status: ValidationStatus.Loading }}
+            validationState={{ type: "pending" }}
             value="user123" />
         </div>
 
@@ -505,8 +504,8 @@
             concealed={true}
             style="width: 100%;"
             value="too short"
-            validation={{
-              status: ValidationStatus.Error,
+            validationState={{
+              type: "invalid",
               message: "Password too short.",
             }} />
         </div>

--- a/ui/App/NetworkScreen.svelte
+++ b/ui/App/NetworkScreen.svelte
@@ -11,7 +11,7 @@
   import { status } from "ui/src/localPeer";
   import * as proxy from "ui/src/proxy";
   import { indicatorState } from "ui/src/network";
-  import { createValidationStore, ValidationStatus } from "ui/src/validation";
+  import { createValidationStore } from "ui/src/validation";
   import { VALID_SEED_MATCH } from "ui/src/session";
 
   import { Button, CopyableIdentifier, Icon, TextInput } from "ui/DesignSystem";
@@ -52,7 +52,7 @@
     // We have to wait a tick so that the asynchronous validations can
     // run and update the validation status
     await Promise.resolve();
-    if (svelteStore.get(seedValidation).status === ValidationStatus.Success) {
+    if (svelteStore.get(seedValidation).type === "valid") {
       await updateSeeds(seeds => [...seeds, seedInputValue]);
       seedInputValue = "";
     }
@@ -178,7 +178,7 @@
             bind:value={seedInputValue}
             placeholder="Enter a seed address here"
             style="min-width: 14rem; width: 100%;"
-            validation={$seedValidation} />
+            validationState={$seedValidation} />
           <Button
             dataCy="add-seed"
             on:click={addSeed}

--- a/ui/App/OnboardingModal/EnterName.svelte
+++ b/ui/App/OnboardingModal/EnterName.svelte
@@ -8,7 +8,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
 
-  import { ValidationStatus } from "ui/src/validation";
   import * as onboarding from "ui/src/onboarding";
 
   import { Button, Emoji, TextInput } from "ui/DesignSystem";
@@ -22,10 +21,8 @@
 
   const validationStore = onboarding.createHandleValidationStore();
 
-  const validationPasses = () =>
-    $validationStore.status === ValidationStatus.Success;
-  const validationStarted = () =>
-    $validationStore.status !== ValidationStatus.NotStarted;
+  const validationPasses = () => $validationStore.type === "valid";
+  const validationStarted = () => $validationStore.type !== "unvalidated";
 
   $: beginValidation && validationStore.validate(handle);
   $: allowNext = (handle && validationPasses()) || !validationStarted();
@@ -113,7 +110,7 @@
       bind:value={handle}
       on:keydown={onKeydown}
       dataCy="handle-input"
-      validation={$validationStore}
+      validationState={$validationStore}
       hint="↵"
       style="margin: 1rem 0 2rem 0;" />
     <div class="buttons">

--- a/ui/App/OnboardingModal/EnterPassphrase.svelte
+++ b/ui/App/OnboardingModal/EnterPassphrase.svelte
@@ -6,12 +6,10 @@
  LICENSE file.
 -->
 <script lang="ts">
-  import type { ValidationState } from "ui/src/validation";
+  import type { TextInputValidationState } from "ui/DesignSystem";
 
   import { createEventDispatcher } from "svelte";
   import validatejs from "validate.js";
-
-  import { ValidationStatus, getValidationState } from "ui/src/validation";
 
   import { Button, Icon, TextInput } from "ui/DesignSystem";
 
@@ -54,11 +52,25 @@
     },
   };
 
-  let passphraseValidation: ValidationState = {
-    status: ValidationStatus.NotStarted,
+  let passphraseValidationState: TextInputValidationState = {
+    type: "unvalidated",
   };
-  let repeatedPassphraseValidation: ValidationState = {
-    status: ValidationStatus.NotStarted,
+  let repeatedPassphraseValidationState: TextInputValidationState = {
+    type: "unvalidated",
+  };
+
+  const getValidationState = (
+    entity: string,
+    validationErrors: { [key: string]: string[] }
+  ): TextInputValidationState => {
+    if (validationErrors && validationErrors[entity]) {
+      return {
+        type: "invalid",
+        message: validationErrors[entity][0],
+      };
+    }
+
+    return { type: "valid" };
   };
 
   // The `dummy` argument allows us to encode reactive dependencies for
@@ -77,8 +89,8 @@
     );
 
     // @ts-expect-error: `validations` is guaranteed to be a validations object
-    passphraseValidation = getValidationState("passphrase", validations);
-    repeatedPassphraseValidation = getValidationState(
+    passphraseValidationState = getValidationState("passphrase", validations);
+    repeatedPassphraseValidationState = getValidationState(
       "repeatedPassphrase",
       // @ts-expect-error: `validations` is guaranteed to be a validations object
       validations
@@ -198,7 +210,7 @@
       placeholder="Enter a secure passphrase"
       hint="↵"
       style="margin-top: 1.5rem;"
-      validation={passphraseValidation}
+      validationState={passphraseValidationState}
       bind:value={passphrase}
       concealed={isPassphraseConcealed}
       {disabled} />
@@ -217,7 +229,7 @@
         dataCy="repeat-passphrase-input"
         placeholder="Repeat the secure passphrase"
         hint="↵"
-        validation={repeatedPassphraseValidation}
+        validationState={repeatedPassphraseValidationState}
         bind:value={repeatedPassphrase}
         concealed={isPassphraseConcealed}
         {disabled} />

--- a/ui/App/OrgScreen/ConfigureEns/RegisterName.svelte
+++ b/ui/App/OrgScreen/ConfigureEns/RegisterName.svelte
@@ -14,6 +14,7 @@
 
 <script lang="ts">
   import type * as ethers from "ethers";
+  import type { TextInputValidationState } from "ui/DesignSystem";
 
   import { sleep } from "ui/src/sleep";
   import { unreachable } from "ui/src/unreachable";
@@ -26,7 +27,6 @@
   import * as notification from "ui/src/notification";
   import * as svelteStore from "ui/src/svelteStore";
   import * as transaction from "ui/src/transaction";
-  import * as validation from "ui/src/validation";
   import * as wallet from "ui/src/wallet";
 
   import { Button, TextInput } from "ui/DesignSystem";
@@ -52,8 +52,8 @@
   let nameInputValue: string = currentName || "";
   let commitInProgress: boolean = false;
   let validatedName: string;
-  let validationState: validation.ValidationState = {
-    status: validation.ValidationStatus.NotStarted,
+  let validationState: TextInputValidationState = {
+    type: "unvalidated",
   };
   let registration: ensResolver.Registration | undefined;
   let userInputStarted: boolean = nameInputValue !== "";
@@ -66,7 +66,7 @@
     name: string | undefined
   ): Promise<void> {
     validationState = {
-      status: validation.ValidationStatus.Loading,
+      type: "pending",
     };
 
     const validationResult = await validateFormExecutor.run(
@@ -75,8 +75,8 @@
           return {
             validatedName: "",
             validationState: {
-              status: validation.ValidationStatus.NotStarted,
-            } as validation.ValidationState,
+              type: "unvalidated",
+            } as TextInputValidationState,
             registration: undefined,
           };
         }
@@ -99,7 +99,7 @@
 
   async function runAsyncValidations(name: string): Promise<{
     validatedName: string;
-    validationState: validation.ValidationState;
+    validationState: TextInputValidationState;
     registration: ensResolver.Registration | undefined;
   }> {
     const available = await ensRegistrar.isAvailable(name);
@@ -112,7 +112,7 @@
         return {
           validatedName: name,
           validationState: {
-            status: validation.ValidationStatus.Error,
+            type: "invalid",
             message: `You don't have enough RAD in your wallet to register this name. Name registration costs ${ethereum.formatTokenAmount(
               fee
             )} RAD.`,
@@ -124,7 +124,7 @@
       return {
         validatedName: name,
         validationState: {
-          status: validation.ValidationStatus.Success,
+          type: "valid",
         },
         registration: undefined,
       };
@@ -140,7 +140,7 @@
       return {
         validatedName: name,
         validationState: {
-          status: validation.ValidationStatus.Success,
+          type: "valid",
         },
         registration,
       };
@@ -149,7 +149,7 @@
     return {
       validatedName: name,
       validationState: {
-        status: validation.ValidationStatus.Error,
+        type: "invalid",
         message: "Sorry, that name is already taken.",
       },
       registration: undefined,
@@ -284,7 +284,7 @@
       bind:value={nameInputValue}
       showSuccessCheck
       disabled={commitInProgress}
-      validation={validationState}
+      {validationState}
       suffix={`.${ensResolver.DOMAIN}`}
       placeholder="Your org name"
       style="margin: 16px auto; width: 352px;" />
@@ -297,8 +297,7 @@
         }}>Cancel</Button>
       <Button
         on:click={commitOrGoToUpdateMetadata}
-        disabled={validationState.status !==
-          validation.ValidationStatus.Success || commitInProgress}
+        disabled={validationState.type !== "valid" || commitInProgress}
         >Continue</Button>
     </svelte:fragment>
   </Modal>

--- a/ui/App/OrgScreen/ConfigureEns/UpdateMetadata.svelte
+++ b/ui/App/OrgScreen/ConfigureEns/UpdateMetadata.svelte
@@ -6,13 +6,14 @@
  LICENSE file.
 -->
 <script lang="ts">
+  import type { TextInputValidationState } from "ui/DesignSystem";
+
   import * as configureEns from "ui/src/org/configureEns";
   import * as ensResolver from "ui/src/org/ensResolver";
   import * as error from "ui/src/error";
   import * as modal from "ui/src/modal";
   import * as notification from "ui/src/notification";
   import * as transaction from "ui/src/transaction";
-  import * as validation from "ui/src/validation";
 
   import { Button, TextInput, Tooltip } from "ui/DesignSystem";
   import Modal from "ui/App/ModalLayout/Modal.svelte";
@@ -30,16 +31,16 @@
 
   let setRecordsInProgress = false;
 
-  let orgAddressValidationStatus: validation.ValidationState = {
-    status: validation.ValidationStatus.NotStarted,
+  let orgAddressValidationState: TextInputValidationState = {
+    type: "unvalidated",
   };
 
   if (
     registration.address &&
     registration.address.toLowerCase() !== orgAddress.toLowerCase()
   ) {
-    orgAddressValidationStatus = {
-      status: validation.ValidationStatus.Error,
+    orgAddressValidationState = {
+      type: "invalid",
       message: `This name already points to your org with the address ${registration.address}. If you change this here, it will overwrite the existing metadata associated with this ENS name.`,
     };
   }
@@ -151,7 +152,7 @@
       style="margin-bottom: 24px"
       disabled
       value={orgAddress}
-      validation={orgAddressValidationStatus} />
+      validationState={orgAddressValidationState} />
   </Tooltip>
 
   <div class="label typo-text-bold">Website URL</div>

--- a/ui/App/ProjectScreen/ManagePeersModal.svelte
+++ b/ui/App/ProjectScreen/ManagePeersModal.svelte
@@ -83,7 +83,7 @@
           dataCy="peer-input"
           bind:value={newPeer}
           placeholder="Enter a Device ID here"
-          validation={$peerValidation}
+          validationState={$peerValidation}
           style="width: 100%; margin-right: .5rem;" />
         <Button
           dataCy="follow-button"

--- a/ui/DesignSystem/DirectoryInput.svelte
+++ b/ui/DesignSystem/DirectoryInput.svelte
@@ -6,10 +6,10 @@
  LICENSE file.
 -->
 <script lang="ts">
+  import type { TextInputValidationState } from "./TextInput";
+
   import { createEventDispatcher } from "svelte";
   import { getDirectoryPath } from "ui/src/ipc";
-
-  import type { ValidationState } from "ui/src/validation";
 
   import Button from "./Button.svelte";
   import TextInput from "./TextInput.svelte";
@@ -17,7 +17,7 @@
   export let placeholder: string | undefined = undefined;
   export let style: string | undefined = undefined;
   export let path = "";
-  export let validation: ValidationState | undefined = undefined;
+  export let validationState: TextInputValidationState | undefined = undefined;
 
   const dispatch = createEventDispatcher();
 
@@ -40,9 +40,9 @@
   <TextInput
     on:click={openFileDialog}
     {placeholder}
-    {validation}
+    {validationState}
     value={path}
-    disabled
+    readonly
     style="margin-right: 0.5rem; flex: 1" />
 
   <Button dataCy="choose-path-button" on:click={openFileDialog}>Choose</Button>

--- a/ui/DesignSystem/TextInput.ts
+++ b/ui/DesignSystem/TextInput.ts
@@ -1,0 +1,18 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+// We have to keep the exported TextInput types in a separate .ts file because
+// we use them in other .ts files and tsc/webpack are not smart enough to
+// pick up type definitions exported from `context="module"` sections in
+// .svelte files yet.
+//
+// See https://github.com/sveltejs/svelte/issues/5817 for more details.
+
+export type TextInputValidationState =
+  | { type: "unvalidated" }
+  | { type: "pending" }
+  | { type: "valid" }
+  | { type: "invalid"; message: string };

--- a/ui/DesignSystem/index.ts
+++ b/ui/DesignSystem/index.ts
@@ -4,68 +4,36 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
-import Avatar from "./Avatar.svelte";
-import Badge from "./Badge.svelte";
-import Button from "./Button.svelte";
-import Checkbox from "./Checkbox.svelte";
-import Copyable from "./Copyable.svelte";
-import CopyableIdentifier from "./CopyableIdentifier.svelte";
-import DirectoryInput from "./DirectoryInput.svelte";
-import Dropdown from "./Dropdown.svelte";
-import Emoji from "./Emoji.svelte";
-import FollowToggle from "./FollowToggle.svelte";
-import Hovercard from "./Hovercard.svelte";
-import Hoverable from "./Hoverable.svelte";
-import Icon from "./Icon";
-import IdentifierLink from "./IdentifierLink.svelte";
-import KeyHint from "./KeyHint.svelte";
-import List from "./List.svelte";
-import Loading from "./Loading.svelte";
-import Markdown from "./Markdown.svelte";
-import Notification from "./Notification.svelte";
-import Overlay from "./Overlay.svelte";
-import RadicleLogo from "./RadicleLogo.svelte";
-import RadioOption from "./RadioOption.svelte";
-import SegmentedControl from "./SegmentedControl.svelte";
-import SegmentedColorPicker from "./SegmentedColorPicker.svelte";
-import Spinner from "./Spinner.svelte";
-import SupportButton from "./SupportButton.svelte";
-import TextInput from "./TextInput.svelte";
-import ThreeDotsMenu from "./ThreeDotsMenu.svelte";
-import Tooltip from "./Tooltip.svelte";
+export type { TextInputValidationState } from "./TextInput";
 
-import * as format from "./lib/format";
+export * as format from "./lib/format";
 
-export {
-  Avatar,
-  Badge,
-  Button,
-  Checkbox,
-  Copyable,
-  CopyableIdentifier,
-  DirectoryInput,
-  Dropdown,
-  Emoji,
-  FollowToggle,
-  Hovercard,
-  Hoverable,
-  Icon,
-  IdentifierLink,
-  KeyHint,
-  List,
-  Loading,
-  Markdown,
-  Notification,
-  Overlay,
-  RadicleLogo,
-  RadioOption,
-  SegmentedControl,
-  SegmentedColorPicker,
-  Spinner,
-  SupportButton,
-  TextInput,
-  ThreeDotsMenu,
-  Tooltip,
-};
-
-export { format };
+export { default as Avatar } from "./Avatar.svelte";
+export { default as Badge } from "./Badge.svelte";
+export { default as Button } from "./Button.svelte";
+export { default as Checkbox } from "./Checkbox.svelte";
+export { default as Copyable } from "./Copyable.svelte";
+export { default as CopyableIdentifier } from "./CopyableIdentifier.svelte";
+export { default as DirectoryInput } from "./DirectoryInput.svelte";
+export { default as Dropdown } from "./Dropdown.svelte";
+export { default as Emoji } from "./Emoji.svelte";
+export { default as FollowToggle } from "./FollowToggle.svelte";
+export { default as Hoverable } from "./Hoverable.svelte";
+export { default as Hovercard } from "./Hovercard.svelte";
+export { default as Icon } from "./Icon";
+export { default as IdentifierLink } from "./IdentifierLink.svelte";
+export { default as KeyHint } from "./KeyHint.svelte";
+export { default as List } from "./List.svelte";
+export { default as Loading } from "./Loading.svelte";
+export { default as Markdown } from "./Markdown.svelte";
+export { default as Notification } from "./Notification.svelte";
+export { default as Overlay } from "./Overlay.svelte";
+export { default as RadicleLogo } from "./RadicleLogo.svelte";
+export { default as RadioOption } from "./RadioOption.svelte";
+export { default as SegmentedColorPicker } from "./SegmentedColorPicker.svelte";
+export { default as SegmentedControl } from "./SegmentedControl.svelte";
+export { default as Spinner } from "./Spinner.svelte";
+export { default as SupportButton } from "./SupportButton.svelte";
+export { default as TextInput } from "./TextInput.svelte";
+export { default as ThreeDotsMenu } from "./ThreeDotsMenu.svelte";
+export { default as Tooltip } from "./Tooltip.svelte";

--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -162,7 +162,7 @@ export const addPeer = async (
   // async then the seed input form will have to be submitted twice to take any
   // effect.
   await peerValidation.validate(newRemote);
-  if (get(peerValidation).status !== validation.ValidationStatus.Success) {
+  if (get(peerValidation).type !== "valid") {
     return false;
   }
 


### PR DESCRIPTION
We remove the import from `validation.ts`. See individual commits for more details.

Refs https://github.com/radicle-dev/radicle-upstream/issues/1877.