### PR TITLE
refactor: remove URN type alias

### DIFF
--- a/ui/src/localPeer.ts
+++ b/ui/src/localPeer.ts
@@ -15,7 +15,6 @@ import { config } from "./config";
 import * as notifiation from "./notification";
 import * as remote from "./remote";
 import * as session from "./session";
-import type * as urn from "./urn";
 import * as error from "./error";
 import * as bacon from "./bacon";
 import type { Event as RoomEvent, RoomState } from "./waitingRoom";
@@ -87,28 +86,28 @@ enum EventType {
 interface ProjectUpdated {
   type: EventType.ProjectUpdated;
   provider: identity.PeerId;
-  urn: urn.Urn;
+  urn: string;
 }
 
 interface RequestCreated {
   type: EventType.RequestCreated;
-  urn: urn.Urn;
+  urn: string;
 }
 
 interface RequestCloned {
   type: EventType.RequestCloned;
   peer: identity.PeerId;
-  urn: urn.Urn;
+  urn: string;
 }
 
 interface RequestQueried {
   type: EventType.RequestQueried;
-  urn: urn.Urn;
+  urn: string;
 }
 
 interface RequestTimedOut {
   type: EventType.RequestTimedOut;
-  urn: urn.Urn;
+  urn: string;
 }
 
 export interface WaitingRoomTransition {

--- a/ui/src/urn.ts
+++ b/ui/src/urn.ts
@@ -7,9 +7,6 @@
 import multibase from "multibase";
 import * as error from "ui/src/error";
 
-// FIXME(xla): Improve type safety of it, this is a placeholder to avoid using strings everywhere.
-export type Urn = string;
-
 const VALID_URN_MATCH = /^rad:git:([1-9A-HJ-NP-Za-km-z]+)(?:\/.*)?/;
 
 export function extractSha1FromUrn(


### PR DESCRIPTION
We don't gain any additional type safety and have to import them everywhere.