### PR TITLE
refactor: deduplicate common fields in context

### DIFF
--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -110,7 +110,7 @@ fn with_owner_guard(ctx: context::Context) -> BoxedFilter<(radicle_daemon::Local
         .and(with_context_unsealed(ctx))
         .and_then(|ctx: context::Unsealed| async move {
             let session =
-                crate::session::get_current(&ctx.store)?.ok_or(error::Routing::NoSession)?;
+                crate::session::get_current(&ctx.rest.store)?.ok_or(error::Routing::NoSession)?;
 
             let user = radicle_daemon::state::get_local(&ctx.peer, session.identity.urn)
                 .await

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -67,7 +67,7 @@ mod handler {
         ctx: context::Unsealed,
         metadata: identity::Metadata,
     ) -> Result<impl Reply, Rejection> {
-        if session::get_current(&ctx.store)?.is_some() {
+        if session::get_current(&ctx.rest.store)?.is_some() {
             return Err(http::error::Response {
                 status_code: StatusCode::BAD_REQUEST,
                 variant: "SESSION_IN_USE",
@@ -78,7 +78,7 @@ mod handler {
 
         let id = identity::create(&ctx.peer, metadata).await?;
 
-        session::initialize(&ctx.store, id.clone(), &ctx.default_seeds)?;
+        session::initialize(&ctx.rest.store, id.clone(), &ctx.rest.default_seeds)?;
 
         Ok(reply::with_status(reply::json(&id), StatusCode::CREATED))
     }
@@ -88,9 +88,9 @@ mod handler {
         ctx: context::Unsealed,
         metadata: identity::Metadata,
     ) -> Result<impl Reply, Rejection> {
-        session::get_current(&ctx.store)?.ok_or(http::error::Routing::NoSession)?;
+        session::get_current(&ctx.rest.store)?.ok_or(http::error::Routing::NoSession)?;
         let id = identity::update(&ctx.peer, metadata).await?;
-        session::update_identity(&ctx.store, id.clone())?;
+        session::update_identity(&ctx.rest.store, id.clone())?;
 
         Ok(reply::with_status(reply::json(&id), StatusCode::OK))
     }
@@ -146,7 +146,7 @@ mod test {
             .await;
 
         let urn = {
-            let session = session::get_current(&ctx.store)?.expect("no session exists");
+            let session = session::get_current(&ctx.rest.store)?.expect("no session exists");
             session.identity.urn
         };
 
@@ -222,7 +222,7 @@ mod test {
             .await;
 
         let urn = {
-            let session = session::get_current(&ctx.store)?.expect("no session exists");
+            let session = session::get_current(&ctx.rest.store)?.expect("no session exists");
             session.identity.urn
         };
 
@@ -298,7 +298,7 @@ mod test {
             .await;
 
         let urn = {
-            let session = session::get_current(&ctx.store)?.expect("no session exists");
+            let session = session::get_current(&ctx.rest.store)?.expect("no session exists");
             session.identity.urn
         };
 

--- a/proxy/api/src/http/project.rs
+++ b/proxy/api/src/http/project.rs
@@ -372,9 +372,9 @@ mod test {
             )
             .await?;
             session::initialize(
-                &ctx.store,
+                &ctx.rest.store,
                 (ctx.peer.peer_id(), owner.clone().into_inner().into_inner()).into(),
-                &ctx.default_seeds,
+                &ctx.rest.default_seeds,
             )?;
 
             let platinum_project = crate::control::replicate_platinum(
@@ -461,7 +461,7 @@ mod test {
             };
             let id = identity::create(&ctx.peer, metadata).await?;
 
-            session::initialize(&ctx.store, id, &ctx.default_seeds)?;
+            session::initialize(&ctx.rest.store, id, &ctx.rest.default_seeds)?;
         };
 
         let project = radicle_daemon::project::Create {
@@ -523,7 +523,7 @@ mod test {
                 ethereum: None,
             };
             let id = identity::create(&ctx.peer, metadata).await?;
-            session::initialize(&ctx.store, id, &ctx.default_seeds)?;
+            session::initialize(&ctx.rest.store, id, &ctx.rest.default_seeds)?;
         };
 
         let project = radicle_daemon::project::Create {

--- a/proxy/api/src/http/session.rs
+++ b/proxy/api/src/http/session.rs
@@ -70,7 +70,7 @@ mod handler {
 
     #[allow(clippy::unused_async)]
     pub async fn get_seeds(ctx: context::Unsealed) -> Result<impl Reply, Rejection> {
-        let seeds = match session::get_current(&ctx.store)? {
+        let seeds = match session::get_current(&ctx.rest.store)? {
             None => vec![],
             Some(session) => session.settings.coco.seeds,
         };
@@ -83,7 +83,7 @@ mod handler {
         ctx: context::Unsealed,
         seeds: Vec<String>,
     ) -> Result<impl Reply, Rejection> {
-        session::update_seeds(&ctx.store, seeds)?;
+        session::update_seeds(&ctx.rest.store, seeds)?;
 
         Ok(warp::reply::with_status(reply(), StatusCode::NO_CONTENT))
     }

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -118,7 +118,8 @@ pub async fn initialize_test(ctx: &crate::context::Unsealed, owner_handle: &str)
     .await
     .expect("cannot init owner identity");
     let identity = (ctx.peer.peer_id(), owner.into_inner().into_inner()).into();
-    initialize(&ctx.store, identity, &ctx.default_seeds).expect("failed to initialize session")
+    initialize(&ctx.rest.store, identity, &ctx.rest.default_seeds)
+        .expect("failed to initialize session")
 }
 
 /// Stores the session as the current session


### PR DESCRIPTION
We deduplicate common fields in `Context`.