### PR TITLE
feat: add proxy CLI option to unseal key for development

### DIFF
--- a/proxy/api/src/bin/radicle-proxy.rs
+++ b/proxy/api/src/bin/radicle-proxy.rs
@@ -5,7 +5,7 @@
 // LICENSE file.
 
 #[tokio::main]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn main() -> Result<(), anyhow::Error> {
     api::env::set_if_unset("RUST_BACKTRACE", "full");
     api::env::set_if_unset("RUST_LOG", "info,quinn=warn");
 

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -38,6 +38,11 @@ pub struct Args {
     /// don’t install the git-remote-rad binary
     #[argh(switch)]
     pub skip_remote_helper_install: bool,
+    #[argh(option)]
+    /// passphrase to unlock the keystore
+    ///
+    /// If not provided the keystore must be unlocked via the HTTP API.
+    pub key_passphrase: Option<String>,
     #[cfg(feature = "unsafe-fast-keystore")]
     /// enables fast but unsafe encryption of the keystore for development builds
     #[argh(switch)]
@@ -61,7 +66,7 @@ struct Rigging {
 /// # Errors
 ///
 /// Errors when the setup or any of the services fatally fails.
-pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     let proxy_path = config::proxy_path()?;
     let bin_dir = config::bin_dir()?;
     if !args.skip_remote_helper_install {
@@ -73,6 +78,13 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(feature = "unsafe-fast-keystore")]
         unsafe_fast_keystore: args.unsafe_fast_keystore,
     })?;
+
+    if let Some(passphrase) = &args.key_passphrase {
+        service_manager.unseal_keystore(radicle_keystore::pinentry::SecUtf8::from(
+            passphrase.clone(),
+        ))?;
+    }
+
     #[cfg(unix)]
     {
         use tokio::signal::unix::{signal, SignalKind};
@@ -317,7 +329,7 @@ async fn rig(
     environment: &service::Environment,
     auth_token: Arc<RwLock<Option<String>>>,
     args: Args,
-) -> Result<Rigging, Box<dyn std::error::Error>> {
+) -> Result<Rigging, anyhow::Error> {
     let store_path = if let Some(temp_dir) = &environment.temp_dir {
         temp_dir.path().join("store")
     } else {
@@ -384,7 +396,7 @@ async fn rig(
 async fn session_seeds(
     store: &kv::Store,
     default_seeds: &[String],
-) -> Result<Vec<radicle_daemon::seed::Seed>, Box<dyn std::error::Error>> {
+) -> Result<Vec<radicle_daemon::seed::Seed>, anyhow::Error> {
     let seeds = session::seeds(store, default_seeds)?;
     Ok(radicle_daemon::seed::resolve(&seeds)
         .await


### PR DESCRIPTION
We add an option to the proxy CLI arguments that allows us to unseal the
key on startup. This should make manual testing much easier.