### PR TITLE
run macOS builds only for PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,7 @@ jobs:
             cypress/workspace/test-tmp/*/combined-node.log
   build-macos:
     runs-on: macos-11
+    if: github.event.pull_request
     steps:
       - run:  |
           echo "CARGO_HOME=$HOME/cache/cargo" >> $GITHUB_ENV


### PR DESCRIPTION
We only run macOS builds for pushes that have a corresponding PR. This should decrease the number of concurrent macOS builds which is limited by Github to 5.