### PR TITLE
build distribution on Github Actions

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,6 @@
 .test-linux: &test-linux
   label: "Test and package app on Linux"
-  command: "ci/run.sh"
+  command: "ci/build.sh"
   agents:
     production: "true"
     platform: "linux"
@@ -27,7 +27,7 @@ steps:
       build.branch == 'master'
       || build.branch =~ /^release-candidate\//
       || build.tag != null
-    command: "ci/run.sh"
+    command: "ci/build.sh"
     agents:
       production: "false"
       platform: "macos"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,13 +26,12 @@ jobs:
             ~/cache/cargo
             ~/cache/proxy-target
           key: build-${{ runner.os }}-rust-v1-${{ hashFiles('Cargo.lock') }}
-      - run: ci/run.sh
+      - run: ci/build.sh
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-artifacts-linux
+          name: test-logs-linux
           path: |
-            dist/*.AppImage
             cypress/screenshots/**/*.png
             cypress/workspace/test-tmp/*/node-*/*.log
             cypress/workspace/test-tmp/*/combined-node.log
@@ -64,13 +63,12 @@ jobs:
         run: |
           rustup component add clippy rustfmt
           test -f $CARGO_HOME/bin/cargo-deny || cargo install cargo-deny
-      - run: ci/run.sh
+      - run: ci/build.sh
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-artifacts-macos
+          name: test-logs-macos
           path: |
-            dist/*.dmg
             cypress/screenshots/**/*.png
             cypress/workspace/test-tmp/*/node-*/*.log
             cypress/workspace/test-tmp/*/combined-node.log

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -1,0 +1,100 @@
+name: dist
+on:
+  push:
+    branches:
+    - master
+    - release-candidate/**
+
+jobs:
+  build-dist-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: "gcr.io/radicle-upstream/radicle-upstream-ci:14"
+    steps:
+      - uses: actions/checkout@master
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/cache/yarn
+            ~/cache/cypress
+          # Reuses cache from `build` workflow
+          key: build-linux-yarn-v3-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            build-linux-yarn-v3-
+      - name: Cache Rust
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/cache/cargo
+            ./target
+          key: ${{ github.job }}-rust-v2-${{ hashFiles('Cargo.lock') }}
+      - run: ci/dist.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-dist
+          path: |
+            dist/*.AppImage
+
+  build-dist-macos:
+    runs-on: macos-11
+    steps:
+      - run:  |
+          echo "CARGO_HOME=$HOME/cache/cargo" >> $GITHUB_ENV
+          echo "PATH=$HOME/cache/cargo/bin:$PATH" >> $GITHUB_ENV
+      - uses: actions/checkout@master
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/cache/yarn
+            ~/cache/cypress
+          # Reuses cache from `build` workflow
+          key: build-macos-yarn-v3-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            build-macos-yarn-v3-
+      - name: Cache Rust
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/cache/cargo
+            ./target
+          key: ${{ github.job }}-rust-v2-${{ hashFiles('Cargo.lock') }}
+      - run: ci/dist.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macos-dist
+          path: |
+            dist/*.dmg
+
+
+  publish-artifacts:
+    needs:
+      - build-dist-linux
+      - build-dist-macos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: linux-dist
+          path: dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: macos-dist
+          path: dist
+      - run: ls dist
+      - name: publish artifacts by commit
+        uses: google-github-actions/upload-cloud-storage@v0.4.0
+        with:
+          path: dist
+          destination: radicle-upstream-build-artifacts/v1/by-commit/${{ github.sha }}
+          credentials: ${{ secrets.GCP_SECRET_KEY }}
+          parent: false
+      - name: publish master artifacts
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: google-github-actions/upload-cloud-storage@v0.4.0
+        with:
+          path: dist
+          destination: radicle-upstream-build-artifacts/v1/master/
+          credentials: ${{ secrets.GCP_SECRET_KEY }}
+          parent: false

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,23 +6,7 @@
 # with Radicle Linking Exception. For full terms see the included
 # LICENSE file.
 
-set -Eeou pipefail
-
-TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'
-
-if [[ "${BUILDKITE:-}" = "true" ]]; then
-  source ci/setup-buildkite.sh
-elif [[ "${GITHUB_ACTIONS:-}" = "true" ]]; then
-  source ci/setup-github-actions.sh
-else
-  echo "Unknown CI platform"
-  exit 1
-fi
-
-export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
-export CARGO_HOME="$CACHE_FOLDER/cargo"
-export CYPRESS_CACHE_FOLDER="$CACHE_FOLDER/cypress"
-export PATH="$HOME/.cargo/bin:$PATH"
+source ci/env.sh
 
 log-group-start "Installing yarn dependencies"
 yarn install --immutable
@@ -116,8 +100,8 @@ time FORCE_COLOR=1 ELECTRON_ENABLE_LOGGING=1 yarn test |
   "
 log-group-end
 
-if [[ "${BUILDKITE_BRANCH:-}" == "master" || "${BUILDKITE_BRANCH:-}" == release-candidate/v* || -n "${BUILDKITE_TAG:-}" ]]; then
-  if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM:-}" == "macos" ]]; then
+if [[ "${GITHUB_REF:-}" == "refs/heads/master" || "${GITHUB_REF:-}" == refs/heads/release-candidate/v* ]]; then
+  if [[ "${RUNNER_OS:-}" == "macOS" ]]; then
     log-group-start "Packaging, notarizing and uploading app binaries"
     (
       export NOTARIZE=true

--- a/ci/dist.sh
+++ b/ci/dist.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
+source ci/env.sh
+
+log-group-start "Installing yarn dependencies"
+yarn install --immutable
+log-group-end
+
+if [[ "${RUNNER_OS:-}" == "macOS" ]]; then
+	log-group-start "Packaging, notarizing and uploading app binaries"
+	(
+    # TODO setup notarization
+		# export NOTARIZE=true
+		# export APPLE_ID="rudolfs@monadic.xyz"
+		# export APPLE_ID_PASSWORD="@keychain:AC_PASSWORD"
+		# export CSC_NAME="Monadic GmbH (35C27H9VL2)"
+		time yarn dist
+	)
+	log-group-end
+else
+	log-group-start "Packaging and uploading app binaries"
+	time yarn dist
+	log-group-end
+fi

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright © 2021 The Radicle Upstream Contributors
+#
+# This file is part of radicle-upstream, distributed under the GPLv3
+# with Radicle Linking Exception. For full terms see the included
+# LICENSE file.
+
+set -Eeou pipefail
+
+if [[ "${BUILDKITE:-}" = "true" ]]; then
+  source ci/setup-buildkite.sh
+elif [[ "${GITHUB_ACTIONS:-}" = "true" ]]; then
+  source ci/setup-github-actions.sh
+else
+  echo "Unknown CI platform"
+  exit 1
+fi
+
+export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
+export CARGO_HOME="$CACHE_FOLDER/cargo"
+export CYPRESS_CACHE_FOLDER="$CACHE_FOLDER/cypress"
+export PATH="$HOME/.cargo/bin:$CARGO_HOME/bin:$PATH"
+
+export TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -13,9 +13,26 @@ The Upstream team owns the following infrastructure.
   * Certificates for the loadbalancers are automatically provisioned by GCP.
 * Provides a container registry under `gcr.io/radicle-upstream`.
 * Provides Org Seed Node service (see below)
+* Provides infra for Github Actions Artifacts (see below)
 
+## Github Actions Artifacts
 
-### Upstream Org Seed Node
+Infrastructure for storing public build artifacts at predictable locations
+
+* GCP service account `github-actions-radicle-upstream`
+  * Credentials are exposed as build secret `GCP_SECRET_KEY` in Github Actions
+* GCP storage bucket `radicle-upstream-build-artifacts` in region
+  `europe-west1`.
+    * `github-actions-radicle-upstream` has `storage.objectAdmin` role so it can
+      upload and overwrite files to the bucket.
+    * `allUsers` have `storage.objectViewer` role. This means public read access
+      to the bucket.
+
+The storage bucket uses the following schema to store artifacts.
+* `v1/by-commit/<commit-sha>/...` for artifacts build from a certain commit.
+* `v1/master/...` for artifacts build from the `master` branch.
+
+## Upstream Org Seed Node
 
 We're running our own [Org Seed Node][os] for Upstream.
 


### PR DESCRIPTION
We build and publish distribution artifacts with Github Actions. This requires us to set up storage infrastructure which we document.

This PR has two separate commits. The first builds the artifacts on for this branch. The second commit updates the branch selectors to only build the artifacts on release candidate branches.