### PR TITLE
fix: force kill test nodes

### DIFF
--- a/cypress/plugins/nodeManager/plugin.ts
+++ b/cypress/plugins/nodeManager/plugin.ts
@@ -272,10 +272,11 @@ class Node {
   async stop(): Promise<void> {
     if (this.state.kind !== StateKind.Configured) {
       this.logger.log("stopping node");
-      if (!this.state.process.kill()) {
+      // We don’t shutdown the process properly to make it faster. We don’t care
+      // about corrupted state because it has no impact on the test.
+      if (!this.state.process.kill("SIGKILL")) {
         this.logger.log(`could not stop process ${this.state.process.pid}`);
       }
-      await this.state.process;
     } else {
       this.logger.log("ignoring stop node command, node wasn't running");
     }


### PR DESCRIPTION
We forcibly kill the test nodes when they are stopped instead of shutting them down properly. We have seen the shutdown timing out and resulting in CI failures when sending `SIGTERM` and we want to avoid this. We don’t care about state corruption because the node data is not reused.