### PR TITLE
don’t buffer output for long running subprocesses

### DIFF
--- a/cypress/plugins/nodeManager/plugin.ts
+++ b/cypress/plugins/nodeManager/plugin.ts
@@ -147,8 +147,8 @@ class Node {
         "--unsafe-fast-keystore",
       ],
       {
+        buffer: false,
         env: {
-          ...global.process.env,
           RAD_HOME: this.radHome,
           RUST_LOG: [
             "info",
@@ -202,7 +202,7 @@ class Node {
 
     const gitConfigSet = (name: string, value: string) =>
       execa("git", ["config", "--global", name, value], {
-        env: { ...global.process.env, HOME: this.radHome },
+        env: { HOME: this.radHome },
       });
 
     await gitConfigSet(

--- a/native/proxy-process-manager.ts
+++ b/native/proxy-process-manager.ts
@@ -53,6 +53,7 @@ export class ProxyProcessManager {
 
     const childProcess = execa(this.options.proxyPath, this.options.proxyArgs, {
       stdio: ["ignore", "pipe", "pipe"],
+      buffer: false,
     });
 
     this.childProcess = childProcess;


### PR DESCRIPTION
We prevent `execa()` from collecting stdout and stderr for processes that may print a lot of data, in particular the proxy. Otherwise we run the risk of the Node process to run out of memory.

We also remove the parent process environment from the `env` option. This is the default behavior for `execa()`.