### PR TITLE
build all branches on linux and macOS on master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: build
 on:
   push:
-    branches: [master]
+    branches: ["**"]
   pull_request:
 jobs:
   build-linux:
@@ -37,7 +37,7 @@ jobs:
             cypress/workspace/test-tmp/*/combined-node.log
   build-macos:
     runs-on: macos-11
-    if: github.event.pull_request
+    if: github.event.pull_request || github.head_ref == "refs/heads/master"
     steps:
       - run:  |
           echo "CARGO_HOME=$HOME/cache/cargo" >> $GITHUB_ENV


### PR DESCRIPTION
macOS builds are now run on master too. We build linux for all pushes, not only pull requests.