### PR TITLE
patch `radicle-link` crates at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,46 @@ members = [
   "proxy/api",
 ]
 
+[patch.crates-io.librad]
+git = "https://github.com/radicle-dev/radicle-link.git"
+tag = "cycle/2021-10-26"
+
+[patch.crates-io.link-crypto]
+git = "https://github.com/radicle-dev/radicle-link.git"
+tag = "cycle/2021-10-26"
+
+[patch.crates-io.link-identities]
+git = "https://github.com/radicle-dev/radicle-link.git"
+tag = "cycle/2021-10-26"
+
+[patch.crates-io.rad-identities]
+git = "https://github.com/radicle-dev/radicle-link.git"
+tag = "cycle/2021-10-26"
+
+[patch.crates-io.radicle-daemon]
+git = "https://github.com/radicle-dev/radicle-link.git"
+tag = "cycle/2021-10-26"
+
+[patch.crates-io.radicle-git-ext]
+git = "https://github.com/radicle-dev/radicle-link.git"
+tag = "cycle/2021-10-26"
+
+[patch.crates-io.radicle-git-helpers]
+git = "https://github.com/radicle-dev/radicle-link.git"
+tag = "cycle/2021-10-26"
+
+# Uncomment the following lines and comment out the radicle-link patches above
+# to develop against a local copy of `radicle-link`.
+
+# [patch.crates-io]
+# librad = { path = "../radicle-link/librad" }
+# link-crypto = { path = "../radicle-link/link-crypto" }
+# link-identities = { path = "../radicle-link/link-identities" }
+# radicle-daemon = { path = "../radicle-link/daemon" }
+# rad-identities = { path = "../radicle-link/rad-identities" }
+# radicle-git-ext = { path = "../radicle-link/git-ext" }
+# radicle-git-helpers = { path = "../radicle-link/git-helpers" }
+
 # These patches are the same as those listed in
 # https://github.com/radicle-dev/radicle-link/blob/master/Cargo.toml
 
@@ -24,14 +64,3 @@ branch = "generic-agent"
 git = "https://github.com/radicle-dev/radicle-keystore"
 rev = "00f8fb6135f8e4cd097a48e6f0700e08ce4abb04"
 features = [ "ssh-agent" ]
-
-# Uncomment the following lines to develop against a local copy of
-# `radicle-link`.
-
-# [patch.'https://github.com/radicle-dev/radicle-link']
-# librad = { path = "../radicle-link/librad" }
-# link-crypto = { path = "../radicle-link/link-crypto" }
-# link-identities = { path = "../radicle-link/link-identities" }
-# radicle-daemon = { path = "../radicle-link/daemon" }
-# radicle-git-ext = { path = "../radicle-link/git-ext" }
-# radicle-git-helpers = { path = "../radicle-link/git-helpers" }

--- a/proxy/api/Cargo.toml
+++ b/proxy/api/Cargo.toml
@@ -45,33 +45,14 @@ tokio = { version = "1.2", features = [ "macros", "process", "signal", "time" ] 
 url = "2.1"
 warp = { version = "0.3", default-features = false }
 
-[dependencies.librad]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2021-10-26"
-
-[dependencies.link-crypto]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2021-10-26"
-
-[dependencies.link-identities]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2021-10-26"
-
-[dependencies.rad-identities]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2021-10-26"
-
-[dependencies.radicle-daemon]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2021-10-26"
-
-[dependencies.radicle-git-ext]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2021-10-26"
-
-[dependencies.radicle-git-helpers]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2021-10-26"
+# radicle-link dependencies. These are patched in the workspace
+librad = "0.1"
+link-crypto = "0.1"
+link-identities = "0.1"
+rad-identities = "0.1"
+radicle-daemon = "0.1"
+radicle-git-ext = "0.1"
+radicle-git-helpers = "0.1"
 
 [dev-dependencies]
 bytes = "1.0"


### PR DESCRIPTION
We patch the `radicle-link` crates at the workspace level instead of the
crate `Cargo.toml`. If we add our seed peer as a Rust crate to the repo.
Having the patches in the workspace file guarantees that everything uses
the same version of `radicle-link`.