### PR TITLE
Log more verbosly in proxy during development

### DIFF
--- a/native/index.ts
+++ b/native/index.ts
@@ -39,12 +39,13 @@ if (isDev) {
     proxyArgs =
       process.env.RADICLE_UPSTREAM_PROXY_ARGS.split(/[, ]/).filter(Boolean);
   }
-  proxyArgs.push("--default-seed");
   proxyArgs.push(
-    "hybz9gfgtd9d4pd14a6r66j5hz6f77fed4jdu7pana4fxaxbt369kg@setzling.radicle.xyz:12345"
+    "--default-seed",
+    "hybz9gfgtd9d4pd14a6r66j5hz6f77fed4jdu7pana4fxaxbt369kg@setzling.radicle.xyz:12345",
+    "--skip-remote-helper-install",
+    "--unsafe-fast-keystore",
+    "--dev-log"
   );
-  proxyArgs.push("--skip-remote-helper-install");
-  proxyArgs.push("--unsafe-fast-keystore");
 } else {
   // Packaged app, i.e. production.
   if (isWindows) {

--- a/proxy/api/src/bin/radicle-proxy.rs
+++ b/proxy/api/src/bin/radicle-proxy.rs
@@ -6,19 +6,5 @@
 
 #[tokio::main]
 pub async fn main() -> Result<(), anyhow::Error> {
-    api::env::set_if_unset("RUST_BACKTRACE", "full");
-    api::env::set_if_unset("RUST_LOG", "info,quinn=warn");
-
-    let builder = tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env());
-
-    match std::env::var("TRACING_FMT").as_deref() {
-        Ok("pretty") => builder.pretty().init(),
-        Ok("compact") => builder.compact().init(),
-        Ok("json") => builder.json().init(),
-        _ => builder.init(),
-    };
-
     api::run(argh::from_env()).await
 }


### PR DESCRIPTION
Add a flag that to the proxy that enables more verbose logging and enable this by default during development.

We prefer this over specifying it in the electron process because the flag can also be used when running the proxy standalone.