### PR TITLE
style: use different org avatar image example

### DIFF
--- a/design-system/Showcase.svelte
+++ b/design-system/Showcase.svelte
@@ -477,7 +477,7 @@
             size="small"
             kind={{
               type: "orgImage",
-              url: "https://app.radicle.network/images/alt-clients.png",
+              url: "https://pbs.twimg.com/profile_images/1372563232850870274/aREQff_C_400x400.jpg",
             }} />
           <Avatar
             style="margin-right: 16px"
@@ -512,7 +512,7 @@
             size="regular"
             kind={{
               type: "orgImage",
-              url: "https://app.radicle.network/images/alt-clients.png",
+              url: "https://pbs.twimg.com/profile_images/1372563232850870274/aREQff_C_400x400.jpg",
             }} />
           <Avatar
             style="margin-right: 16px"
@@ -547,7 +547,7 @@
             size="large"
             kind={{
               type: "orgImage",
-              url: "https://app.radicle.network/images/alt-clients.png",
+              url: "https://pbs.twimg.com/profile_images/1372563232850870274/aREQff_C_400x400.jpg",
             }} />
           <Avatar
             style="margin-right: 16px"
@@ -582,7 +582,7 @@
             size="huge"
             kind={{
               type: "orgImage",
-              url: "https://app.radicle.network/images/alt-clients.png",
+              url: "https://pbs.twimg.com/profile_images/1372563232850870274/aREQff_C_400x400.jpg",
             }} />
           <Avatar
             style="margin-right: 16px"


### PR DESCRIPTION
Use an org avatar image with a background so that the shape is visible in the example.

![Screenshot_2021-10-29_at_10 39 43](https://user-images.githubusercontent.com/158411/139404932-48833bbf-9943-4dab-929e-91d2700039b4.png)


