### PR TITLE
use `git ls-files` to get paths for license check

### DIFF
--- a/.lintstagedrc.yaml
+++ b/.lintstagedrc.yaml
@@ -2,4 +2,5 @@
 - prettier --write
 "*.{js,ts,svelte}":
 - eslint --fix --max-warnings=0
+"*":
 - ./scripts/license-header.ts check

--- a/docs/development.md
+++ b/docs/development.md
@@ -406,7 +406,6 @@ build times. If you need to update this image, proceed as follows:
      we don’t support ES modules yet. See [#2227](https://github.com/radicle-dev/radicle-upstream/issues/2227).
      If possible, do a minor version upgrade.
      * `node-fetch` and `@types/node`
-     * `globby`
      * `exit-hook`
      * `strip-ansi`
    * Don’t update `radicle-contracts`.

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "eslint-plugin-svelte3": "^3.2.1",
     "exit-hook": "^2.2.1",
     "ganache-cli": "^6.12.2",
-    "globby": "^11.0.4",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^7.0.4",
     "jest": "^27.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10907,7 +10907,6 @@ __metadata:
     execa: ^5.1.1
     exit-hook: ^2.2.1
     ganache-cli: ^6.12.2
-    globby: ^11.0.4
     graphql: ^15.7.0
     html-webpack-plugin: ^5.5.0
     husky: ^7.0.4


### PR DESCRIPTION
Use `git ls-files` to get paths to check for the license headers. This is simpler and does not require adjustments when directories are added or changed.