### PR TITLE
set default seed via env

### DIFF
--- a/native/index.ts
+++ b/native/index.ts
@@ -36,8 +36,6 @@ if (isDev) {
   proxyPath = path.join(__dirname, "../target/debug/radicle-proxy");
 
   proxyArgs.push(
-    "--default-seed",
-    "hybz9gfgtd9d4pd14a6r66j5hz6f77fed4jdu7pana4fxaxbt369kg@setzling.radicle.xyz:12345",
     "--skip-remote-helper-install",
     "--unsafe-fast-keystore",
     "--dev-log"

--- a/proxy/api/src/cli.rs
+++ b/proxy/api/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Args {
     pub peer_listen: std::net::SocketAddr,
 
     /// Add one or more default seed addresses to initialise the settings store
-    #[structopt(long, long = "default-seed")]
+    #[structopt(long, env = "RADICLE_PROXY_DEFAULT_SEED", long = "default-seed")]
     pub default_seeds: Vec<String>,
 
     /// Don’t install the git-remote-rad binary


### PR DESCRIPTION
The default seed for the proxy can now be configured via an environment variable. We remove the default seed in the dev environment. It is not working and prevents us from using the environment variable.