### PR TITLE
chore: expose more peer debugging info in diagnostics

### DIFF
--- a/proxy-client/index.ts
+++ b/proxy-client/index.ts
@@ -35,12 +35,7 @@ export interface Diagnostics {
     gitDirPath: string;
     refsTree: string[];
   };
-  peer: {
-    membership: {
-      active: string[];
-      passive: string[];
-    };
-  };
+  peer?: unknown;
 }
 
 export const diagnosticsSchema = zod.object({
@@ -48,12 +43,7 @@ export const diagnosticsSchema = zod.object({
     gitDirPath: zod.string(),
     refsTree: zod.array(zod.string()),
   }),
-  peer: zod.object({
-    membership: zod.object({
-      active: zod.array(zod.string()),
-      passive: zod.array(zod.string()),
-    }),
-  }),
+  peer: zod.unknown(),
 });
 
 export class ProxyClient {

--- a/proxy/api/src/http/diagnostics.rs
+++ b/proxy/api/src/http/diagnostics.rs
@@ -36,7 +36,9 @@ mod handler {
 
     /// Get diagnostics information.
     #[allow(clippy::unused_async)]
-    pub async fn get(ctx: context::Unsealed) -> Result<impl Reply, Rejection> {
+    pub async fn get(mut ctx: context::Unsealed) -> Result<impl Reply, Rejection> {
+        let listen_addrs = ctx.peer_control.listen_addrs().await;
+        let protocol_config = ctx.peer.protocol_config();
         let membership = ctx.peer.membership().await;
         let git_dir = ctx.rest.paths.git_dir();
         let refs_tree = WalkDir::new(git_dir.join("refs"))
@@ -56,6 +58,28 @@ mod handler {
                 "refsTree": refs_tree,
             },
             "peer": {
+                "listenAddresses": listen_addrs,
+                "protocolConfig": {
+                    "membership": {
+                        "maxActive": protocol_config.membership.max_active,
+                        "maxPassive": protocol_config.membership.max_passive,
+                        "activeRandomWalkLength": protocol_config.membership.active_random_walk_length,
+                        "passiveRandomWalkLength": protocol_config.membership.passive_random_walk_length,
+                        "shuffleSampleSize": protocol_config.membership.shuffle_sample_size,
+                        "shuffleInterval": protocol_config.membership.shuffle_interval,
+                        "promoteInterval": protocol_config.membership.promote_interval
+                    },
+                    "network": protocol_config.network.to_string(),
+                    "replication": {
+                        "fetchLimit": {
+                            "peek": protocol_config.replication.fetch_limit.peek,
+                            "data": protocol_config.replication.fetch_limit.data
+                        }
+                    },
+                    "fetch": {
+                        "fetchSlotWaitTimeout": protocol_config.fetch.fetch_slot_wait_timeout
+                    },
+                },
                 "membership": {
                     "active": membership.active,
                     "passive": membership.passive

--- a/ui/App/DiagnosticsScreen.svelte
+++ b/ui/App/DiagnosticsScreen.svelte
@@ -68,7 +68,7 @@
           storage: diagnostics.storage,
           identity: Session.unsealed().identity,
           localPeer: {
-            membership: diagnostics.peer.membership,
+            ...diagnostics,
             state: $localPeerState,
           },
           waitingRoomState: $waitingRoomState,

--- a/ui/App/DiagnosticsScreen/Connections.svelte
+++ b/ui/App/DiagnosticsScreen/Connections.svelte
@@ -24,8 +24,8 @@
 
 <div class="container">
   <Json title="Your identity" data={session.identity} />
-  <Json title="Connection status" data={$localPeerState} />
   {#await proxy.client.diagnosticsGet() then result}
-    <Json title="Peer membership" data={result.peer.membership} />
+    <Json title="Your peer" data={result.peer} />
   {/await}
+  <Json title="Connection status" data={$localPeerState} />
 </div>


### PR DESCRIPTION
Add mode debug info.

```
{
  "listenAddresses": [
    "127.0.0.1:62227",
    "192.168.178.20:62227"
  ],
  "protocolConfig": {
    "membership": {
      "maxActive": 5,
      "maxPassive": 30,
      "activeRandomWalkLength": 6,
      "passiveRandomWalkLength": 3,
      "shuffleSampleSize": 7,
      "promoteInterval": {
        "nanos": 0,
        "secs": 30
      },
      "shuffleInterval": {
        "nanos": 0,
        "secs": 30
      }
    },
    "network": "Main",
    "replication": {
      "fetchLimit": {
        "peek": 5120000,
        "data": 5368709120
      }
    },
    "fetch": {
      "fetchSlotWaitTimeout": {
        "nanos": 0,
        "secs": 20
      }
    }
  },
  "membership": {
    "active": [
      "hynkyndc6w3p8urucakobzna7sxwgcqny7xxtw88dtx3pkf7m3nrzc"
    ],
    "passive": []
  }
}
```