### PR TITLE
consistent Rust lint settings

### DIFF
--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -209,7 +209,7 @@ where
 {
     with_qs_opt()
         .and_then(|opt_query: Option<T>| async move {
-            opt_query.ok_or(warp::reject::Rejection::from(error::Routing::QueryMissing))
+            opt_query.ok_or_else(|| warp::reject::Rejection::from(error::Routing::QueryMissing))
         })
         .boxed()
 }

--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -9,30 +9,11 @@
 #![warn(
     clippy::all,
     clippy::cargo,
-    clippy::nursery,
-    clippy::pedantic,
     unused_import_braces,
     unused_qualifications
 )]
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
-// TODO(xla): Handle all Results properly and never panic outside of main.
-// TODO(xla): Remove exception for or_fun_call lint.
-#![allow(
-    // This lint yields false positives
-    // https://github.com/rust-lang/rust-clippy/issues/7438
-    clippy::semicolon_if_nothing_returned,
-    clippy::clone_on_ref_ptr,
-    clippy::expect_used,
-    clippy::implicit_return,
-    clippy::integer_arithmetic,
-    clippy::missing_inline_in_public_items,
-    clippy::multiple_crate_versions,
-    clippy::or_fun_call,
-    clippy::shadow_reuse,
-    clippy::option_if_let_else,
-    clippy::similar_names,
-    clippy::large_types_passed_by_value
-)]
+#![allow(clippy::multiple_crate_versions)]
 
 mod browser;
 mod cli;

--- a/proxy/api/src/service.rs
+++ b/proxy/api/src/service.rs
@@ -155,7 +155,7 @@ impl Manager {
         let env = self
             .environment()
             .context("failed to load environment")?
-            .ok_or(anyhow::anyhow!("service has been shut down"))?;
+            .ok_or_else(|| anyhow::anyhow!("service has been shut down"))?;
         let key = env
             .keystore
             .get(passphrase)

--- a/upstream-seed/src/peer.rs
+++ b/upstream-seed/src/peer.rs
@@ -78,7 +78,8 @@ impl Peer {
         shutdown_signal: impl Future<Output = ()>,
     ) -> anyhow::Result<()> {
         let librad_peer = self.librad_peer.clone();
-        let static_discovery = discovery::Static::resolve(bootstrap).unwrap();
+        let static_discovery = discovery::Static::resolve(bootstrap)
+            .context("failed to resolve bootstrap addresses")?;
         let shutdown_signal = shutdown_signal.shared();
 
         let bound = librad_peer


### PR DESCRIPTION
* Align the lint settings between both crates.
* Remove clippy’s pedantic and nursery lints. They lead to a lot of false postivies that require manual tweaking.
* Don’t allow `clippy::or_fun_call` and fix all instances. This lint is sensible and we wan to limit the tweaking.