### PR TITLE
fix: don't show diagnostics on devtools hotkey

### DIFF
--- a/ui/App/Hotkeys.svelte
+++ b/ui/App/Hotkeys.svelte
@@ -36,7 +36,8 @@
       !hotkeys.areEnabled() ||
       screen.isLocked() ||
       hasInputTarget ||
-      event.repeat
+      event.repeat ||
+      event.altKey
     ) {
       return false;
     }


### PR DESCRIPTION
This fix makes sure that <kbd>⌘</kbd> + <kbd>i</kbd> opens the diagnostics screen and <kbd>alt</kbd> + <kbd>⌘</kbd> + <kbd>i</kbd> only opens the chromium devtools without switching to the diagnostics screen.

Fixes a regression introduced in https://github.com/radicle-dev/radicle-upstream/pull/2566.