### PR TITLE
Better caching on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/cache/cargo
-            ~/cache/proxy-target
-          key: build-${{ runner.os }}-rust-v1-${{ hashFiles('Cargo.lock') }}
+            ~/.cargo/advisory-db/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git
+            ./target/*/deps
+            ./target/*/build
+            ./target/*/.fingerprint
+          key: build-${{ runner.os }}-rust-v3-${{ hashFiles('Cargo.lock') }}
       - run: ci/build.sh
       - uses: actions/upload-artifact@v2
         if: always()
@@ -39,9 +44,6 @@ jobs:
     runs-on: macos-11
     if: github.event.pull_request || github.ref == 'refs/heads/master'
     steps:
-      - run:  |
-          echo "CARGO_HOME=$HOME/cache/cargo" >> $GITHUB_ENV
-          echo "PATH=$HOME/cache/cargo/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Cache Yarn
         uses: actions/cache@v2
@@ -56,13 +58,19 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/cache/cargo
-            ~/cache/proxy-target
-          key: build-${{ runner.os }}-rust-v2-${{ hashFiles('Cargo.lock') }}
+            ~/.cargo/bin/cargo-deny
+            ~/.cargo/advisory-db/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git
+            ./target/*/deps
+            ./target/*/build
+            ./target/*/.fingerprint
+          key: build-${{ runner.os }}-rust-v3-${{ hashFiles('Cargo.lock') }}
       - name: Install toolchain
         run: |
           rustup component add clippy rustfmt
-          test -f $CARGO_HOME/bin/cargo-deny || cargo install cargo-deny
+          test -f ~/.cargo/bin/cargo-deny || cargo install cargo-deny
       - run: ci/build.sh
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -26,9 +26,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/cache/cargo
-            ./target
-          key: ${{ github.job }}-rust-v2-${{ hashFiles('Cargo.lock') }}
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git
+            ./target/*/deps
+            ./target/*/build
+            ./target/*/.fingerprint
+          key: ${{ github.job }}-rust-v3-${{ hashFiles('Cargo.lock') }}
       - run: ci/dist.sh
       - uses: actions/upload-artifact@v2
         with:
@@ -39,9 +43,6 @@ jobs:
   build-dist-macos:
     runs-on: macos-11
     steps:
-      - run:  |
-          echo "CARGO_HOME=$HOME/cache/cargo" >> $GITHUB_ENV
-          echo "PATH=$HOME/cache/cargo/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Cache Yarn
         uses: actions/cache@v2
@@ -57,9 +58,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/cache/cargo
-            ./target
-          key: ${{ github.job }}-rust-v2-${{ hashFiles('Cargo.lock') }}
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git
+            ./target/*/deps
+            ./target/*/build
+            ./target/*/.fingerprint
+          key: ${{ github.job }}-rust-v3-${{ hashFiles('Cargo.lock') }}
       - run: ci/dist.sh
       - uses: actions/upload-artifact@v2
         with:

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -13,17 +13,6 @@ yarn install --immutable
 yarn dedupe --check
 log-group-end
 
-log-group-start "Linking cache"
-declare -r rust_target_cache="$CACHE_FOLDER/proxy-target"
-mkdir -p "$rust_target_cache"
-ln -s "${rust_target_cache}" ./target
-
-declare -r cargo_deny_cache="$CACHE_FOLDER/cargo-deny"
-mkdir -p "$cargo_deny_cache"
-mkdir -p ~/.cargo
-ln -sf "$cargo_deny_cache" ~/.cargo/advisory-db
-log-group-end
-
 log-group-start "Test setup"
 ./scripts/test-setup.sh
 cp ci/gitconfig "$HOME/.gitconfig"

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -24,8 +24,8 @@ else
 fi
 
 export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
-export CARGO_HOME="$CACHE_FOLDER/cargo"
+export CARGO_HOME="$HOME/.cargo"
 export CYPRESS_CACHE_FOLDER="$CACHE_FOLDER/cypress"
-export PATH="$HOME/.cargo/bin:$CARGO_HOME/bin:$PATH"
+export PATH="$CARGO_HOME/bin:$PATH"
 
 export TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'

--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
     "_private:electron:start": "wait-on ./public/bundle.js && NODE_ENV=development electron native/index.js",
     "_private:dist:clean": "rimraf ./dist && mkdir ./dist",
     "_private:prettier": "prettier \"**/*.@(js|ts|json|svelte|css|html)\" --ignore-path .gitignore",
-    "_private:proxy:start:test": "cargo build --features unsafe-fast-keystore --bins && cargo run --features unsafe-fast-keystore -- --test --unsafe-fast-keystore",
-    "_private:proxy:start:test:watch": "cargo build --features unsafe-fast-keystore --bins && cargo watch -x 'run --features unsafe-fast-keystore -- --test --unsafe-fast-keystore'",
+    "_private:proxy:start:test": "cargo build --all-features --bins && cargo run --all-features -- --test --unsafe-fast-keystore",
+    "_private:proxy:start:test:watch": "cargo build --all-features --bins && cargo watch -x 'run --all-features -- --test --unsafe-fast-keystore'",
     "_private:webpack:ui:watch": "webpack build --watch --config-name ui",
     "postinstall": "patch-package && scripts/install-twemoji-assets.sh && husky install"
   },


### PR DESCRIPTION
Improvements and cleanup to CI regarding caching

50dd2a40 clean up CI build script

* Align the logs more closely with the command they run
* Remove `time` whenever the command prints the time itself.
* Add `cargo build` step. Before this was implicitly called by `yarn test:ingeration` and the output was hard to find.
* Group cargo steps together

https://github.com/radicle-dev/radicle-upstream/pull/2584/commits/533bd12bb58d7aa8d5c5c060f8cac471912303cb cache more efficiently on CI

* Be more selective about which directories to cache on CI to reduce the cache size from 1.5GB to 1.3GB.
* Avoid symlinks for target directory and use standard CARGO_HOME to for reduced complexity.