### PR TITLE
fix: reduce spec flakiness

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,7 @@
 {
   "video": false,
   "viewportWidth": 1200,
-  "viewportHeight": 600
+  "viewportHeight": 600,
+  "defaultCommandTimeout": 8000,
+  "retries": { "runMode": 1, "openMode": 0 }
 }

--- a/cypress/integration/networking.spec.ts
+++ b/cypress/integration/networking.spec.ts
@@ -15,35 +15,30 @@ const validSeedAddress =
 
 context("p2p networking", () => {
   context("network status indicator", () => {
-    it(
-      "reacts to network state changes",
-      { defaultCommandTimeout: 8000 },
-      () => {
-        commands.withTempDir(tempDirPath => {
-          nodeManager.withTwoOnboardedNodes(
-            { dataDir: tempDirPath, node1User: {}, node2User: {} },
-            (node1, node2) => {
-              nodeManager.asNode(node1);
-              commands.pick("connection-status-offline").should("exist");
-              nodeManager.connectTwoNodes(node1, node2);
-              commands.pick("connection-status-online").should("exist");
-              nodeManager.asNode(node2);
-              commands.pick("connection-status-online").should("exist");
-            }
-          );
-        });
-      }
-    );
+    it("reacts to network state changes", () => {
+      commands.withTempDir(tempDirPath => {
+        nodeManager.withTwoOnboardedNodes(
+          { dataDir: tempDirPath, node1User: {}, node2User: {} },
+          (node1, node2) => {
+            nodeManager.asNode(node1);
+            commands.pick("connection-status-offline").should("exist");
+            nodeManager.connectTwoNodes(node1, node2);
+            commands.pick("connection-status-online").should("exist");
+            nodeManager.asNode(node2);
+            commands.pick("connection-status-online").should("exist");
+          }
+        );
+      });
+    });
   });
 
   it(
     "replicates a project from one node to another",
     {
-      defaultCommandTimeout: 8000,
       // Tests involving two nodes are extremely flaky
       retries: {
         runMode: 3,
-        openMode: 1,
+        openMode: 0,
       },
     },
     () => {


### PR DESCRIPTION
The Github CI instances are slower than the previous Buildkite instances and some tests now take longer and occasionally fail. We raise the global command timeout to 8 seconds for all tests and retry failing tests once.