### PR TITLE
prevent pushing fixup commits to master with git hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# A pre-push hook based on the git template. This will verify that no WIP or
+# autosquash commits are present. If such a commit is present, pushing will not
+# be possible.
+
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+
+IFS=' '
+while read local_ref local_sha remote_ref remote_sha
+do
+  if [ "$remote_ref" != "refs/heads/master" ]
+  then
+    continue
+  fi
+
+  # Check for WIP commits
+  commit=$(git rev-list -n 1 --grep '^\(fixup\|squash\)!' "${remote_sha}..${local_sha}")
+  if [ -n "$commit" ]
+  then
+    echo "Push rejected: fixup or autosquash commit detected"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Add a Git pre-push hook that prevents pushing commits with messages that start with “fixup!”, “squash!” or “ammend!” to master.

How to test this:

1. Install the hooks with `yarn run husky install`.
2. Create a new branch `git checkout -b fixup-test` based on this commit.
3. Push the branch with `git push origin` or similar.
4. Replace the target ref in the pre-push hook with `sed -i 's/master/fixup-test/' .husky/pre-push`.
5. Commit this as a fixup commit with `git commit -a --fixup HEAD -m wip`.
6. Push the changes with `git push origin` or similar.
7. The push should fail.