### PR TITLE
seed: log info about connections and gossip membership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4055,6 +4055,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]

--- a/upstream-seed/Cargo.toml
+++ b/upstream-seed/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { version = "1" }
 structopt = "0.3"
 thiserror = { version = "1" }
 tokio = { version = "1", features = ["macros", "time", "rt", "rt-multi-thread", "signal"] }
+tokio-stream = { version = "0.1.8", features = ["time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 

--- a/upstream-seed/src/peer.rs
+++ b/upstream-seed/src/peer.rs
@@ -4,7 +4,7 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
-use std::{net::SocketAddr, time::Duration};
+use std::{collections::HashSet, iter::FromIterator, net::SocketAddr, time::Duration};
 
 use anyhow::Context as _;
 use futures::prelude::*;
@@ -173,10 +173,83 @@ impl Peer {
         Ok(())
     }
 
+    /// Returns stream that emits an item whenever the membership of the gossip layer changes.
+    ///
+    /// The stream never ends.
+    pub fn membership(&self) -> impl Stream<Item = librad::net::peer::MembershipInfo> + 'static {
+        self.events().filter_map({
+            let librad_peer = self.librad_peer.clone();
+
+            move |event| match event {
+                librad::net::peer::ProtocolEvent::Membership(_) => {
+                    let librad_peer = librad_peer.clone();
+                    async move { Some(librad_peer.membership().await) }.left_future()
+                }
+                _ => futures::future::ready(None).right_future(),
+            }
+        })
+    }
+
+    /// Returns stream that emits the set of connected peers whenever it changes.
+    ///
+    /// The stream never ends.
+    pub fn connected_peers(&self) -> impl Stream<Item = HashSet<PeerId>> + 'static {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        tokio_stream::wrappers::IntervalStream::new(interval)
+            .then({
+                let librad_peer = self.librad_peer.clone();
+
+                move |_| {
+                    let librad_peer = librad_peer.clone();
+                    async move { HashSet::from_iter(librad_peer.connected_peers().await) }
+                }
+            })
+            .filter_map({
+                let mut prev = HashSet::new();
+                move |connected| {
+                    futures::future::ready(if connected == prev {
+                        None
+                    } else {
+                        prev = connected.clone();
+                        Some(connected)
+                    })
+                }
+            })
+    }
+
     async fn get_project(&self, urn: Urn) -> anyhow::Result<Option<link_identities::git::Project>> {
         Ok(self
             .librad_peer
             .using_storage(move |storage| identities::project::get(&storage, &urn))
             .await??)
+    }
+
+    /// Stream of events from [`LibradPeer`].
+    ///
+    /// It’s not guaranteed that all peer events are delivered to the stream. If items from the
+    /// stream are not processed in time events may be skipped.
+    ///
+    /// The stream will never end.
+    fn events(
+        &self,
+    ) -> impl Stream<Item = librad::net::peer::ProtocolEvent> + Unpin + Send + 'static {
+        self.librad_peer
+            .subscribe()
+            .scan((), |(), res| async move {
+                use tokio::sync::broadcast::error::RecvError;
+                match res {
+                    Ok(item) => Some(Some(item)),
+                    Err(err) => match err {
+                        RecvError::Closed => None,
+                        RecvError::Lagged(_) => {
+                            tracing::warn!("skipped peer events");
+                            Some(None)
+                        }
+                    },
+                }
+            })
+            .filter_map(futures::future::ready)
+            .boxed()
     }
 }


### PR DESCRIPTION
The seed now logs information about the active and passive gossip membership and the list of connections whenever these change.