### PR TITLE
seed: announce projects whenever new peer connects.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "git2",
  "librad",
  "link-identities",
+ "rad-identities",
  "rustc-hex",
  "serde",
  "serde_json",

--- a/upstream-seed/Cargo.toml
+++ b/upstream-seed/Cargo.toml
@@ -30,3 +30,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # radicle-link dependencies. These are patched in the workspace.
 librad = { version = "0" }
 link-identities = { version = "0" }
+rad-identities = { version = "0" }

--- a/upstream-seed/README.md
+++ b/upstream-seed/README.md
@@ -12,5 +12,7 @@ projects.
 * Asks for updates to tracked projects and replicates updates if they are
   available.
 * Replicates person identities associated with owners of the tracked projects.
+* Announces all projects it tracks and all peers that it tracks for these
+  projects whenever a new peer connects.
 
 [librad]: https://github.com/radicle-dev/radicle-link/tree/master/librad


### PR DESCRIPTION
Whenever a new peer is added to the active gossip set we broadcast a Have message for all projects and remotes that we replicate.

See #2564.