### PR TITLE
fix: show handle from metadata if none is passed via props

### DIFF
--- a/ui/App/SharedComponents/UserIdentity.svelte
+++ b/ui/App/SharedComponents/UserIdentity.svelte
@@ -140,7 +140,9 @@
       <div class="metadata">
         {#if user}
           <div class="handle-wrapper">
-            <h2 class="typo-overflow-ellipsis">{handle}</h2>
+            <h2 class="typo-overflow-ellipsis">
+              {handle || user.metadata.handle}
+            </h2>
           </div>
           {#if user.metadata.ethereum}
             <CopyableIdentifier


### PR DESCRIPTION
Fixes a bug where the user handle was "undefined" in the `UserIdentity` hovercard.

Before:
<img width="1552" alt="Screenshot 2021-11-10 at 14 58 43" src="https://user-images.githubusercontent.com/158411/141126378-0f48ac2e-7167-4821-858d-d3c87ba80ba7.png">

After:
<img width="1552" alt="Screenshot 2021-11-10 at 14 57 48" src="https://user-images.githubusercontent.com/158411/141126215-9481f17f-4b5c-4d9b-ba3a-85db9216f388.png">