### PR TITLE
feat: add switch to disable HTTP API auth token check

### DIFF
--- a/proxy/api/src/cli.rs
+++ b/proxy/api/src/cli.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[structopt(long)]
     pub unsafe_fast_keystore: bool,
 
+    /// If `true`, the HTTP api will accept any request without checking the auth token.
+    #[structopt(long)]
+    pub insecure_http_api: bool,
+
     /// Enables more verbose logging for development
     #[structopt(long)]
     pub dev_log: bool,

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -35,6 +35,14 @@ impl Context {
         }
     }
 
+    /// Returns `true` if the HTTP api will accept any request without checking the auth token.
+    pub const fn insecure_http_api(&self) -> bool {
+        match self {
+            Self::Sealed(sealed) => sealed.insecure_http_api,
+            Self::Unsealed(unsealed) => unsealed.rest.insecure_http_api,
+        }
+    }
+
     /// Returns the [`SocketAddr`] where the HTTP API is bound to.
     pub const fn http_listen(&self) -> SocketAddr {
         match self {
@@ -179,6 +187,8 @@ pub struct Sealed {
     pub store: kv::Store,
     /// Flag to control if the stack is set up in test mode.
     pub test: bool,
+    /// If `true`, the HTTP api will accept any request without checking the auth token.
+    pub insecure_http_api: bool,
     /// Flag to run the HTTP API on the specified address:port.
     pub http_listen: SocketAddr,
     /// Default seeds that will be written to the settings kv store.
@@ -244,6 +254,7 @@ impl Unsealed {
                 rest: Sealed {
                     store,
                     test: false,
+                    insecure_http_api: true,
                     http_listen: "127.0.0.1:17246".parse().expect("Couln't parse address"),
                     default_seeds: vec![],
                     service_handle: service::Handle::dummy(),

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -138,7 +138,7 @@ fn with_context_unsealed(ctx: context::Context) -> BoxedFilter<(context::Unseale
     with_context(ctx)
         .and(warp::filters::cookie::optional("auth-token"))
         .and_then(|ctx: context::Context, token: Option<String>| async move {
-            if !ctx.check_auth_token(token).await {
+            if !ctx.insecure_http_api() && token == None || !ctx.check_auth_token(token).await {
                 return Err(Rejection::from(crate::error::Error::InvalidAuthCookie));
             }
 

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -31,6 +31,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let mut service_manager = service::Manager::new(service::EnvironmentConfig {
         test_mode: args.test,
+        insecure_http_api: args.insecure_http_api,
         #[cfg(feature = "unsafe-fast-keystore")]
         unsafe_fast_keystore: args.unsafe_fast_keystore,
     })?;
@@ -129,6 +130,7 @@ async fn run_session(
 
     let sealed = context::Sealed {
         store: store.clone(),
+        insecure_http_api: environment.insecure_http_api,
         test: environment.test_mode,
         http_listen: args.http_listen,
         default_seeds: args.default_seeds,

--- a/proxy/api/src/service.rs
+++ b/proxy/api/src/service.rs
@@ -27,6 +27,8 @@ pub struct Environment {
     pub keystore: Arc<dyn crate::keystore::Keystore + Send + Sync>,
     /// If true, we are running the service in test mode.
     pub test_mode: bool,
+    /// If `true`, the HTTP api will accept any request without checking the auth token.
+    pub insecure_http_api: bool,
 }
 
 /// Configuration for initializing [`Environment`].
@@ -39,6 +41,9 @@ pub struct EnvironmentConfig {
     /// If `true`, then fast but unsafe encryption parameters are used for the keystore.
     #[cfg(feature = "unsafe-fast-keystore")]
     pub unsafe_fast_keystore: bool,
+
+    /// If `true`, the HTTP api will accept any request without checking the auth token.
+    pub insecure_http_api: bool,
 }
 
 /// Error returned when creating a new [`Environment`].
@@ -76,12 +81,14 @@ impl Environment {
         } else {
             Arc::new(keystore::file(coco_profile.paths().clone()))
         };
+
         Ok(Self {
             key: None,
             temp_dir,
             coco_profile,
             keystore,
             test_mode: config.test_mode,
+            insecure_http_api: config.insecure_http_api,
         })
     }
 }


### PR DESCRIPTION
We need this for our automated network tests.

To test this:
```sh
cargo run --all-features -- --insecure-http-api --key-passphrase 1111
curl -s -X GET http://127.0.0.1:17246/v1/projects/tracked |jq
[]
```