### PR TITLE
proxy: add option to override seeds

### DIFF
--- a/proxy/api/src/cli.rs
+++ b/proxy/api/src/cli.rs
@@ -27,9 +27,20 @@ pub struct Args {
     #[structopt(long, env = "RADICLE_PROXY_PEER_LISTEN", default_value = "0.0.0.0:0")]
     pub peer_listen: std::net::SocketAddr,
 
-    /// Add one or more default seed addresses to initialise the settings store
-    #[structopt(long, env = "RADICLE_PROXY_DEFAULT_SEED", long = "default-seed")]
+    /// Populate the seed configuration with these seeds when the app is started for the first
+    /// time.
+    #[structopt(
+        long,
+        env = "RADICLE_PROXY_DEFAULT_SEEDS",
+        long = "default-seed",
+        use_delimiter = true
+    )]
     pub default_seeds: Vec<String>,
+
+    /// Connect to the given seeds and not to those previously set and stored through the API. Does
+    /// not override the stored seeds.
+    #[structopt(long, env = "RADICLE_PROXY_SEEDS", long = "seed", use_delimiter = true)]
+    pub seeds: Option<Vec<String>>,
 
     /// Don’t install the git-remote-rad binary
     #[structopt(long)]

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -173,6 +173,7 @@ pub struct Sealed {
     pub insecure_http_api: bool,
     /// Default seeds that will be written to the settings kv store.
     pub default_seeds: Vec<String>,
+    pub seeds: Option<Vec<String>>,
     /// Handle to control the service configuration.
     pub service_handle: service::Handle,
     /// Cookie set on unsealing the key store.
@@ -236,6 +237,7 @@ impl Unsealed {
                     test: false,
                     insecure_http_api: true,
                     default_seeds: vec![],
+                    seeds: None,
                     service_handle: service::Handle::dummy(),
                     auth_token: Arc::new(RwLock::new(None)),
                     keystore: Arc::new(keystore::memory()),

--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -43,14 +43,6 @@ impl Context {
         }
     }
 
-    /// Returns the default seeds that will be written to the settings kv store.
-    pub const fn default_seeds(&self) -> &Vec<String> {
-        match self {
-            Self::Sealed(sealed) => &sealed.default_seeds,
-            Self::Unsealed(unsealed) => &unsealed.rest.default_seeds,
-        }
-    }
-
     /// Returns the [`kv::Store`] for persistent storage.
     pub const fn store(&self) -> &kv::Store {
         match self {

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -35,13 +35,8 @@ pub struct Session {
 /// # Errors
 ///
 /// Errors if we cannot read data from the store.
-pub fn seeds(store: &kv::Store, default_seeds: &[String]) -> Result<Vec<String>, error::Error> {
-    let settings = get_current(store)?.map(|session| session.settings);
-
-    match settings {
-        Some(settings) => Ok(settings.coco.seeds),
-        None => Ok(default_seeds.to_vec()),
-    }
+pub fn seeds(store: &kv::Store) -> Result<Option<Vec<String>>, error::Error> {
+    Ok(get_current(store)?.map(|session| session.settings.coco.seeds))
 }
 
 /// Get the current session if present


### PR DESCRIPTION
Consists of two commits, the first one is preparing the change.

proxy: improve seed handling for discovery

* Don’t pass the default seeds down to `session::seeds()`. Instead, return an `Option` that can later be combined with `unwrap_or_default()`.
* Use an empty list of seeds as the default if nothing is set. This alleviates the need to pass the default seeds to the discovery task. The configured default seeds will still be used when the session is initialized and the seed value set to the default seeds.
* Query the configured seeds more frequently (every 0.4s instead of every 5s). Querying is cheap and this results and updates being propagated more quickly.
* Update the discovery list even if the peer status is offline. Not sure why this was there but I seems wrong.

proxy: add option to override seeds

Add a `--seed` option and environment variable that forces the proxy to use the provided seeds instead of those stored in the configuration. Using this option will make the seed API read-only and return the seeds provided on the command line.

We also adjust the environment variable for specifying the default seed. It now uses the plural `RADICLE_PROXY_DEFAULT_SEEDS` and multiple seeds can be given by separating them with a comma.

Fixes #2562