### PR TITLE
allow unauthenticated access after unseal

### DIFF
--- a/proxy/api/src/context.rs
+++ b/proxy/api/src/context.rs
@@ -134,8 +134,8 @@ impl Context {
     }
 
     /// Returns `true` if `token` matches the stored authentication token.
-    pub async fn check_auth_token(&self, token: Option<String>) -> bool {
-        token == *self.auth_token().read().await
+    pub async fn check_auth_token(&self, token: String) -> bool {
+        Some(token) == *self.auth_token().read().await
     }
 }
 


### PR DESCRIPTION
We check the authentication logic so that it allows unauthenticated access when both the `--insecure-http-api` option is specified and the `/keystore/unseal` endpoint was called.