### PR TITLE
feat: allow to specify the librad key file path via CLI option

### DIFF
--- a/proxy/api/src/cli.rs
+++ b/proxy/api/src/cli.rs
@@ -37,6 +37,10 @@ pub struct Args {
     )]
     pub default_seeds: Vec<String>,
 
+    /// Path to the secret key for the identity. Uses `RAD_HOME` if not provided.
+    #[structopt(long)]
+    pub identity_key: Option<std::path::PathBuf>,
+
     /// Connect to the given seeds and not to those previously set and stored through the API. Does
     /// not override the stored seeds.
     #[structopt(long, env = "RADICLE_PROXY_SEEDS", long = "seed", use_delimiter = true)]

--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -34,6 +34,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         test_mode: args.test,
         insecure_http_api: args.insecure_http_api,
         unsafe_fast_keystore: args.unsafe_fast_keystore,
+        identity_key: args.identity_key.clone(),
     })?;
 
     if let Some(passphrase) = &args.key_passphrase {


### PR DESCRIPTION
To make manual testing and debugging easier, we add a couple of CLI options and environment variables.

Add `--identity-key <identity-key>` option to `radicle-proxy`, which allows overriding the key file path that normally gets set by `RAD_HOME`.

Also add 2 new environment variables for the `git-remote-rad` helper:
  - `IDENTITY_KEY` allows overriding the key file path (analogous to `--identity-key` option in proxy)
  - `KEY_PASSPHRASE` allows passing in the passphrase via an env variable (analogous to the `--key-passphrase` option in proxy).