### PR TITLE
simplify proxy notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,6 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-stream",
  "bytes 1.1.0",
  "chrono",
  "data-encoding",
@@ -106,6 +105,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-test",
  "tracing",
  "tracing-subscriber",
@@ -4155,6 +4155,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/proxy/api/Cargo.toml
+++ b/proxy/api/Cargo.toml
@@ -13,7 +13,6 @@ default-run = "radicle-proxy"
 
 [dependencies]
 anyhow = "1.0"
-async-stream = "0.3"
 chrono = { version = "0.4.19", features = [ "serde" ] }
 data-encoding = "2.3"
 directories = "4.0"
@@ -38,6 +37,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "1.0"
 tokio = { version = "1.2", features = [ "macros", "process", "signal", "time" ] }
+tokio-stream = { version = "0.1.8", features = ["sync"] }
 url = "2.1"
 walkdir = "2"
 warp = { version = "0.3", default-features = false }

--- a/proxy/api/src/http.rs
+++ b/proxy/api/src/http.rs
@@ -11,7 +11,7 @@ use warp::{filters::BoxedFilter, path, reject, Filter, Rejection, Reply};
 
 use link_crypto::{BoxedSigner, PeerId};
 
-use crate::{context, notification::Notification};
+use crate::context;
 
 mod control;
 mod diagnostics;
@@ -41,10 +41,7 @@ macro_rules! combine {
 }
 
 /// Main entry point for HTTP API.
-pub fn api(
-    ctx: context::Context,
-    notifications: tokio::sync::broadcast::Sender<Notification>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn api(ctx: context::Context) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let test = ctx.test();
 
     let control_filter = path("control")
@@ -59,8 +56,7 @@ pub fn api(
         .untuple_one()
         .and(control::filters(ctx.clone()));
     let identity_filter = path("identities").and(identity::filters(ctx.clone()));
-    let notification_filter =
-        path("notifications").and(notification::filters(ctx.clone(), notifications));
+    let notification_filter = path("notifications").and(notification::filters(ctx.clone()));
     let project_filter = path("projects").and(project::filters(ctx.clone()));
     let session_filter = path("session").and(session::filters(ctx.clone()));
     let keystore_filter = path("keystore").and(keystore::filters(ctx.clone()));


### PR DESCRIPTION
* Eliminate the single variant enum `Notification`
* Use `tokio-stream` to wrap the peer events receiever
* Add `notifications` to context instead of passing it separately to `api`.