### PR TITLE
fix: disable yarn log grouping on CI

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -25,8 +25,9 @@ fi
 log-group-end
 
 log-group-start "yarn install"
-yarn install --immutable
-yarn dedupe --check
+# Unsetting GITHUB_ACTIONS because yarn tries to add log groups in a buggy way.
+env -u GITHUB_ACTIONS yarn install --immutable
+env -u GITHUB_ACTIONS yarn dedupe --check
 log-group-end
 
 log-group-start "Test setup"

--- a/ci/dist.sh
+++ b/ci/dist.sh
@@ -13,7 +13,8 @@ time rustup show active-toolchain
 log-group-start "install toolcahin"
 
 log-group-start "yarn install"
-yarn install --immutable
+# Unsetting GITHUB_ACTIONS because yarn tries to add log groups in a buggy way.
+env -u GITHUB_ACTIONS yarn install --immutable
 log-group-end
 
 log-group-start "Building and packaging binaries"


### PR DESCRIPTION
Yarn is trying to be clever and inserts its own log groups when run on Github actions, but the implementation seems buggy, because there are stray logs interleaved with the log groups making the output harder to read.

I tried removing the outer log group wrapper, but that didn't help either, in the end settled on disabling the fancy log output entirely.

If anyone's curious, here's the implementation:
https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/StreamReport.ts#L31

Before:

<img width="476" alt="Screenshot 2021-11-25 at 08 23 19" src="https://user-images.githubusercontent.com/158411/143397485-b47b0a58-e32d-4928-b78f-85cb0d30d0d8.png">

After:

<img width="345" alt="Screenshot 2021-11-25 at 08 23 43" src="https://user-images.githubusercontent.com/158411/143397496-7f7d0e04-9799-45e1-b437-0171a24c6fd0.png">
<img width="930" alt="Screenshot 2021-11-25 at 08 24 03" src="https://user-images.githubusercontent.com/158411/143397498-a9f4509a-0b53-4f4d-b2b6-1acd66a09cbb.png">

