### PR TITLE
wait until session is unsealed when loading user profile route

### DIFF
--- a/ui/App/UserProfileScreen/route.ts
+++ b/ui/App/UserProfileScreen/route.ts
@@ -22,7 +22,7 @@ export interface LoadedRoute {
 }
 
 export async function load(params: Params): Promise<LoadedRoute> {
-  const session = Session.unsealed();
+  const session = await Session.waitUnsealed();
   const user = await proxy.client.personGet(params.urn);
   const projects = await proxy.client.project.listForUser(params.urn);
   return {

--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -61,9 +61,8 @@ const pollOrgListForever = async (
       }
       const walletStore = svelteStore.get(wallet.store);
 
-      await svelteStore.waitUntil(
-        walletStore,
-        w => w.status === wallet.Status.Connected
+      await svelteStore.waitUntil(walletStore, w =>
+        w.status === wallet.Status.Connected ? true : undefined
       );
 
       await fetchOrgs().then(
@@ -297,9 +296,11 @@ export async function createOrg(
 
   await svelteStore.waitUntil(orgSidebarStore, store => {
     if (store.type === "initial") {
-      return false;
+      return undefined;
+    } else if (store.orgs.some(org => org.id === orgAddress)) {
+      return true;
     } else {
-      return store.orgs.some(org => org.id === orgAddress);
+      return undefined;
     }
   });
   creationNotification.remove();

--- a/ui/src/session.ts
+++ b/ui/src/session.ts
@@ -61,20 +61,20 @@ export const unsealed = (): UnsealedSession => {
 
 // Returns when the session becomes unsealed. Throws when fetching the
 // session failed.
-export const waitUnsealed = async (): Promise<void> => {
-  await svelteStore.waitUntil(sessionStore, data => {
+export function waitUnsealed(): Promise<UnsealedSession> {
+  return svelteStore.waitUntil(sessionStore, data => {
     if (
       data.status === remote.Status.Success &&
       data.data.status === Status.UnsealedSession
     ) {
-      return true;
+      return data.data;
     } else if (data.status === remote.Status.Error) {
       throw data.error;
     } else {
-      return false;
+      return undefined;
     }
   });
-};
+}
 
 // Fetches the session from the proxy and updates the session store.
 //

--- a/ui/src/svelteStore.test.ts
+++ b/ui/src/svelteStore.test.ts
@@ -12,13 +12,15 @@ import * as svelteStore from "./svelteStore";
 describe("waitUntil", () => {
   test("current value matches", async () => {
     const store = svelteStore.writable(true);
-    const value = await svelteStore.waitUntil(store, x => x);
-    expect(value).toBe(true);
+    const value = await svelteStore.waitUntil(store, x => x.toString());
+    expect(value).toBe("true");
   });
 
   test("future value matches", async () => {
     const store = svelteStore.writable(false);
-    const promise = svelteStore.waitUntil(store, x => x);
+    const promise = svelteStore.waitUntil(store, x =>
+      x ? x.toString() : undefined
+    );
     const resolved = sinon.spy();
     promise.then(resolved);
 
@@ -28,7 +30,7 @@ describe("waitUntil", () => {
     await sleep(5);
     expect(resolved.called).toBe(false);
     store.set(true);
-    expect(await promise).toBe(true);
+    expect(await promise).toBe("true");
   });
 
   test("predicate throws", async () => {
@@ -37,8 +39,6 @@ describe("waitUntil", () => {
     const promise = svelteStore.waitUntil(store, x => {
       if (x === true) {
         throw error;
-      } else {
-        return false;
       }
     });
 


### PR DESCRIPTION
We wait until the session is unsealed on app startup when loading the user profile route. Before, the code may have thrown an error if the route was loaded before the session was loaded.

To enable this we make `svelteStore.waitUntil()` more general an useful.