### PR TITLE
seed: reduce logging noise and log gossip puts

### DIFF
--- a/upstream-seed/src/peer.rs
+++ b/upstream-seed/src/peer.rs
@@ -309,7 +309,7 @@ impl Peer {
     /// stream are not processed in time events may be skipped.
     ///
     /// The stream will never end.
-    fn events(
+    pub fn events(
         &self,
     ) -> impl Stream<Item = librad::net::peer::ProtocolEvent> + Unpin + Send + 'static {
         self.librad_peer


### PR DESCRIPTION
* Reduce the logging noise coming from `librad` by default. We set the `librad` log level to `info` and silence some of the `info` logs.
* Log gossip put events so that we see what arrives over the wire.