### PR TITLE
chore: update macOS notarization release steps

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
@@ -53,10 +53,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: dist-Linux
-          path: dist
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-macOS
           path: dist
       - name: publish artifacts by commit
         uses: google-github-actions/upload-cloud-storage@v0.4.0

--- a/ci/dist.sh
+++ b/ci/dist.sh
@@ -18,15 +18,6 @@ env -u GITHUB_ACTIONS yarn install --immutable
 log-group-end
 
 log-group-start "Building and packaging binaries"
-if [[ "${RUNNER_OS:-}" == "macOS" ]]; then
-  :
-  # TODO setup notarization
-  # export NOTARIZE=true
-  # export APPLE_ID="rudolfs@monadic.xyz"
-  # export APPLE_ID_PASSWORD="@keychain:AC_PASSWORD"
-  # export CSC_NAME="Monadic GmbH (35C27H9VL2)"
-fi
-
 time yarn dist
 target="$(uname -m)-$(uname -s | tr "[:upper:]" "[:lower:]")"
 mkdir "dist/${target}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -175,13 +175,12 @@ However, if the build host is not available, it is possible to set up and
 perform notarization locally on Apple hardware.
 
 For this we need:
-  - a paid Apple developer account registered to Monadic
+  - a paid Apple developer account
   - an Apple ID token for allowing the notarization script to run on behalf of
     our developer account
     - [Account Manage][ma] -> APP-SPECIFIC PASSWORDS -> Generate password…
   - a valid "Developer ID Application" certificate
     - [Certificates Add][ca] -> Developer ID Application
-      **Note:** this can only be created via the company account holder
 
 Once you've created the _Developer ID Application_ certificate, download it
 locally and add it to your keychain by double clicking on the file.

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -152,16 +152,16 @@ const publishRcBinaries: yargs.CommandModule<unknown, unknown> = {
       `gs://${releaseBucket}/${linuxBinaryPath}`,
     ]);
 
-    const macosBinaryPath = `radicle-upstream-${version}-rc.dmg`;
-    await runVerbose("gsutil", [
-      "cp",
-      `${buildArtifactPrefix}.dmg`,
-      `gs://${releaseBucket}/${macosBinaryPath}`,
-    ]);
-
-    console.log("Release candidate binaries published as");
+    console.log("Linux release candidate binary published as");
     console.log(`  https://releases.radicle.xyz/${linuxBinaryPath}`);
-    console.log(`  https://releases.radicle.xyz/${macosBinaryPath}`);
+
+    console.log("Build and publish macOS release candidate binaries manually:");
+    console.log(
+      `  CSC_NAME="..." APPLE_ID="..." APPLE_ID_PASSWORD="..." NOTARIZE=true yarn dist`
+    );
+    console.log(
+      `  gsutil cp dist/radicle-upstream-${version}.dmg gs://${releaseBucket}/radicle-upstream-${version}-rc.dmg`
+    );
   },
 };
 


### PR DESCRIPTION
We perform macOS notarization manually from now on.

Closes: https://github.com/radicle-dev/radicle-upstream/issues/2556.