### PR TITLE
enforce explicit module boundary types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,6 +69,7 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-implicit-any-catch": "error",
     "@typescript-eslint/explicit-member-accessibility": "error",
+    "@typescript-eslint/explicit-module-boundary-types": "error",
   },
   settings: {
     "svelte3/typescript": true,

--- a/design-system/ThreeDotsMenu.svelte
+++ b/design-system/ThreeDotsMenu.svelte
@@ -5,6 +5,17 @@
  with Radicle Linking Exception. For full terms see the included
  LICENSE file.
 -->
+<script lang="ts" context="module">
+  export interface MenuItem {
+    title: string;
+    icon: typeof SvelteComponent;
+    event: () => void;
+    tooltip?: string;
+    dataCy?: string;
+    disabled?: boolean;
+  }
+</script>
+
 <script lang="ts">
   import type { SvelteComponent } from "svelte";
   import { fade } from "svelte/transition";
@@ -16,15 +27,6 @@
   export let menuItems: MenuItem[];
   export let dataCy: string | undefined = undefined;
   export let style: string | undefined = undefined;
-
-  interface MenuItem {
-    title: string;
-    icon: typeof SvelteComponent;
-    event: () => void;
-    tooltip?: string;
-    dataCy?: string;
-    disabled?: boolean;
-  }
 
   let expanded = false;
 </script>

--- a/p2p-tests/lib/p2p.ts
+++ b/p2p-tests/lib/p2p.ts
@@ -85,7 +85,7 @@ export class LinePrefix extends stream.Transform {
     super();
   }
 
-  public _transform(data: Buffer, _encoding: string, next: () => void) {
+  public _transform(data: Buffer, _encoding: string, next: () => void): void {
     const str = this.buffer + this.stringDecoder.write(data);
     const lines = str.split(/\r?\n/);
     this.buffer = lines.pop() || "";
@@ -99,7 +99,7 @@ export class LinePrefix extends stream.Transform {
     next();
   }
 
-  public _flush(done: () => void) {
+  public _flush(done: () => void): void {
     this.push(`${this.prefix}${this.buffer}${this.stringDecoder.end()}\n`);
     done();
   }
@@ -218,6 +218,8 @@ export function pushRad(
   });
 }
 
-export async function withRetry(action: () => Promise<unknown>) {
+export async function withRetry(
+  action: () => Promise<unknown>
+): Promise<unknown> {
   return await retryOnError(action, () => true, 1000, 10);
 }

--- a/ui/App/ProfileScreen.svelte
+++ b/ui/App/ProfileScreen.svelte
@@ -116,7 +116,7 @@
     }
   };
 
-  function openProject({ detail: project }: { detail: Project }) {
+  function openProject({ detail: project }: { detail: Project }): void {
     router.push({
       type: "project",
       params: {
@@ -130,7 +130,7 @@
     proxy.client.project.requestCancel(urn).then(fetchProfileProjects);
   }
 
-  function projectCountText(storeLength: number) {
+  function projectCountText(storeLength: number): string {
     return `${storeLength} project${storeLength > 1 ? "s" : ""}`;
   }
 

--- a/ui/App/ProfileScreen/ProjectList.svelte
+++ b/ui/App/ProfileScreen/ProjectList.svelte
@@ -16,13 +16,6 @@
 
   export let projects: Project[];
   export let userUrn: string;
-
-  const projectCardProps = (project: Project) => ({
-    title: project.metadata.name,
-    description: project.metadata.description || "",
-    showMaintainerBadge: isMaintainer(userUrn, project),
-    anchor: project.anchor,
-  });
 </script>
 
 <style>
@@ -45,7 +38,11 @@
   <div
     class="list-item"
     data-cy={`project-list-entry-${project.metadata.name}`}>
-    <ProjectCard {...projectCardProps(project)} />
+    <ProjectCard
+      title={project.metadata.name}
+      description={project.metadata.description || ""}
+      showMaintainerBadge={isMaintainer(userUrn, project)}
+      anchor={project.anchor} />
 
     {#if project.stats}
       <ProjectStats

--- a/ui/App/ProjectScreen.svelte
+++ b/ui/App/ProjectScreen.svelte
@@ -31,7 +31,7 @@
   import * as format from "design-system/lib/format";
 
   import Button from "design-system/Button.svelte";
-  import ThreeDotsMenu from "design-system/ThreeDotsMenu.svelte";
+  import ThreeDotsMenu, { MenuItem } from "design-system/ThreeDotsMenu.svelte";
 
   import ScreenLayout from "ui/App/ScreenLayout.svelte";
 
@@ -46,10 +46,10 @@
   export let activeView: projectRoute.ProjectView = { type: "files" };
   let hoverstyle: string = "";
 
-  const mouseenter = () => {
+  const mouseenter = (): void => {
     hoverstyle = "background-color: var(--color-foreground-level-2)";
   };
-  const mouseleave = () => {
+  const mouseleave = (): void => {
     hoverstyle = "";
   };
 
@@ -57,7 +57,7 @@
   const trackTooltipMaintainer = "You can't unfollow your own project";
   const trackTooltip = "Unfollowing is not yet supported";
 
-  const menuItems = (project: Project) => {
+  function menuItems(project: Project): MenuItem[] {
     return [
       {
         title: "Copy Radicle ID",
@@ -81,13 +81,13 @@
           : trackTooltip,
       },
     ];
-  };
+  }
 
-  const onPeerModal = () => {
+  const onPeerModal = (): void => {
     modal.toggle(ManagePeersModal);
   };
 
-  const onSelectPeer = ({ detail: peer }: { detail: User }) => {
+  const onSelectPeer = ({ detail: peer }: { detail: User }): void => {
     selectPeer(peer);
   };
 

--- a/ui/App/ProjectScreen/BackButton.svelte
+++ b/ui/App/ProjectScreen/BackButton.svelte
@@ -11,7 +11,7 @@
   import ArrowLeftIcon from "design-system/icons/ArrowLeft.svelte";
 
   const dispatch = createEventDispatcher();
-  const onArrowClick = () => {
+  const onArrowClick = (): void => {
     dispatch("arrowClick");
   };
 

--- a/ui/App/ProjectScreen/ManagePeersModal.svelte
+++ b/ui/App/ProjectScreen/ManagePeersModal.svelte
@@ -36,28 +36,28 @@
     peerValidation.reset();
   }
 
-  const submitPeer = async (projectUrn: string) => {
+  const submitPeer = async (projectUrn: string): Promise<void> => {
     if (await addPeer(projectUrn, newPeer)) {
       newPeer = "";
     }
   };
 
-  const cancelFollowRequest = (projectUrn: string, peerId: PeerId) => {
+  const cancelFollowRequest = (projectUrn: string, peerId: PeerId): void => {
     removePeer(projectUrn, peerId);
     peerValidation.reset();
   };
 
-  const unfollowPeer = (projectUrn: string, peerId: PeerId) => {
+  const unfollowPeer = (projectUrn: string, peerId: PeerId): void => {
     removePeer(projectUrn, peerId);
     peerValidation.reset();
   };
 
   // Don't show our own peer in the list unless we have published something.
-  const filteredPeers = (peers: User[]) => {
+  function filteredPeers(peers: User[]): User[] {
     return peers.filter(peer => {
       return !(peer.type === PeerType.Local && peer.role === PeerRole.Tracker);
     });
-  };
+  }
 
   const pendingPeers = svelteStore.derived(store, remoteData => {
     if (remoteData.status === remote.Status.Success) {

--- a/ui/App/ProjectScreen/Source.svelte
+++ b/ui/App/ProjectScreen/Source.svelte
@@ -39,7 +39,7 @@
 
   import ActionBar from "ui/App/ScreenLayout/ActionBar.svelte";
   import RevisionSelector from "ui/App/SharedComponents/RevisionSelector.svelte";
-  import TabBar from "ui/App/ScreenLayout/TabBar.svelte";
+  import TabBar, { Tab } from "ui/App/ScreenLayout/TabBar.svelte";
 
   import CheckoutButton from "./Source/CheckoutButton.svelte";
   import PatchButton from "./Source/PatchButton.svelte";
@@ -58,7 +58,7 @@
 
   export let activeView: projectRoute.ProjectView;
 
-  const tabs = (active: projectRoute.ProjectView, screen: Screen) => {
+  const tabs = (active: projectRoute.ProjectView, screen: Screen): Tab[] => {
     const items = [
       {
         title: "Files",
@@ -140,7 +140,7 @@
     { detail: { checkoutPath } }: { detail: { checkoutPath: string } },
     project: Project,
     peer: User
-  ) => {
+  ): Promise<void> => {
     await screen.withLock(async () => {
       try {
         const path = await proxy.client.project.checkout(project.urn, {
@@ -178,7 +178,11 @@
     });
   };
 
-  const onSelectRevision = ({ detail: revision }: { detail: Branch | Tag }) => {
+  const onSelectRevision = ({
+    detail: revision,
+  }: {
+    detail: Branch | Tag;
+  }): void => {
     selectRevision(revision);
   };
 

--- a/ui/App/ProjectScreen/Source/AcceptPatchButton.svelte
+++ b/ui/App/ProjectScreen/Source/AcceptPatchButton.svelte
@@ -20,11 +20,13 @@
 
   let expanded = false;
   let copyable: Copyable;
-  const hide = () => (expanded = false);
-  const toggleDropdown = () => {
+  const hide = (): void => {
+    expanded = false;
+  };
+  const toggleDropdown = (): void => {
     expanded = !expanded;
   };
-  const copy = () => {
+  const copy = (): void => {
     copyable.copy();
     toggleDropdown();
   };

--- a/ui/App/ProjectScreen/Source/AnchorCard.svelte
+++ b/ui/App/ProjectScreen/Source/AnchorCard.svelte
@@ -27,7 +27,7 @@
   export let showCommitHash: boolean = true;
   export let style: string | undefined = undefined;
 
-  const openCommit = (commitHash: string, projectId: string) => {
+  function openCommit(commitHash: string, projectId: string): void {
     router.push({
       type: "project",
       params: {
@@ -35,7 +35,7 @@
         urn: projectId,
       },
     });
-  };
+  }
 </script>
 
 <style>

--- a/ui/App/ProjectScreen/Source/Anchors.svelte
+++ b/ui/App/ProjectScreen/Source/Anchors.svelte
@@ -28,7 +28,7 @@
   $: latest = anchors.slice(-1)[0];
   $: oldAnchors = anchors.slice(0, -1).reverse();
 
-  const openCommit = (commitHash: string, projectId: string) => {
+  function openCommit(commitHash: string, projectId: string): void {
     router.push({
       type: "project",
       params: {
@@ -36,7 +36,7 @@
         urn: projectId,
       },
     });
-  };
+  }
 
   const isAnchorHintVisible = browserStore.create<boolean>(
     "radicle.isAnchorHintVisible",

--- a/ui/App/ProjectScreen/Source/CheckoutButton.svelte
+++ b/ui/App/ProjectScreen/Source/CheckoutButton.svelte
@@ -30,8 +30,8 @@
     : "Checkout a working copy to your local disk.";
 
   const dispatch = createEventDispatcher();
-  const hide = () => (expanded = false);
-  const toggleDropdown = () => {
+  const hide = (): boolean => (expanded = false);
+  const toggleDropdown = (): void => {
     expanded = !expanded;
   };
 </script>

--- a/ui/App/ProjectScreen/Source/CheckoutPatchButton.svelte
+++ b/ui/App/ProjectScreen/Source/CheckoutPatchButton.svelte
@@ -20,11 +20,13 @@
 
   let expanded = false;
   let copyable: Copyable;
-  const hide = () => (expanded = false);
-  const toggleDropdown = () => {
+  const hide = (): void => {
+    expanded = false;
+  };
+  const toggleDropdown = (): void => {
     expanded = !expanded;
   };
-  const copy = () => {
+  const copy = (): void => {
     copyable.copy();
     toggleDropdown();
   };

--- a/ui/App/ProjectScreen/Source/Code.svelte
+++ b/ui/App/ProjectScreen/Source/Code.svelte
@@ -14,7 +14,7 @@
   import Remote from "ui/App/SharedComponents/Remote.svelte";
   import Tree from "./SourceBrowser/Tree.svelte";
 
-  const onSelectCommit = (projectUrn: string, sha1: string) => {
+  const onSelectCommit = (projectUrn: string, sha1: string): void => {
     router.push({
       type: "project",
       params: {
@@ -24,10 +24,12 @@
     });
   };
 
-  const onSelectPath = ({ detail: path }: { detail: string }) => {
+  const onSelectPath = ({ detail: path }: { detail: string }): void => {
     selectPath(path);
   };
-  const onSelectRoot = () => selectPath("");
+  const onSelectRoot = (): void => {
+    selectPath("");
+  };
 </script>
 
 <style>

--- a/ui/App/ProjectScreen/Source/PatchButton.svelte
+++ b/ui/App/ProjectScreen/Source/PatchButton.svelte
@@ -15,8 +15,10 @@
   import Copyable from "ui/App/SharedComponents/Copyable.svelte";
 
   export let expanded = false;
-  const hide = () => (expanded = false);
-  const toggleDropdown = () => {
+  const hide = (): void => {
+    expanded = false;
+  };
+  const toggleDropdown = (): void => {
     expanded = !expanded;
   };
   const caption = "New Patch";

--- a/ui/App/ProjectScreen/Source/PatchList.svelte
+++ b/ui/App/ProjectScreen/Source/PatchList.svelte
@@ -24,7 +24,7 @@
 
   const defaultBranch = project.metadata.defaultBranch;
 
-  const selectPatch = ({ detail: patch }: { detail: Patch }) => {
+  const selectPatch = ({ detail: patch }: { detail: Patch }): void => {
     router.push({
       type: "project",
       params: {

--- a/ui/App/ProjectScreen/Source/SourceBrowser/FileView.svelte
+++ b/ui/App/ProjectScreen/Source/SourceBrowser/FileView.svelte
@@ -22,9 +22,9 @@
   export let tree: Readable<Tree>;
 
   const dispatch = createEventDispatcher();
-  const onSelectCommit = ({ detail: sha1 }: { detail: string }) =>
+  const onSelectCommit = ({ detail: sha1 }: { detail: string }): void =>
     dispatch("commit", sha1);
-  const onSelectRoot = () => dispatch("root");
+  const onSelectRoot = (): void => dispatch("root");
 
   let view: View;
   $: view = $code.view;

--- a/ui/App/ProjectScreen/Source/SourceBrowser/Tree/Folder.svelte
+++ b/ui/App/ProjectScreen/Source/SourceBrowser/Tree/Folder.svelte
@@ -26,10 +26,10 @@
   let expanded = false;
 
   const dispatch = createEventDispatcher();
-  const onSelectPath = ({ detail: path }: { detail: string }) => {
+  const onSelectPath = ({ detail: path }: { detail: string }): void => {
     dispatch("select", path);
   };
-  const toggle = () => {
+  const toggle = (): void => {
     expanded = !expanded;
   };
 

--- a/ui/App/ScreenLayout/TabBar.svelte
+++ b/ui/App/ScreenLayout/TabBar.svelte
@@ -5,16 +5,18 @@
  with Radicle Linking Exception. For full terms see the included
  LICENSE file.
 -->
-<script lang="ts">
-  import type { SvelteComponent } from "svelte";
-
-  interface Tab {
+<script lang="ts" context="module">
+  export interface Tab {
     title: string;
     active: boolean;
     icon: typeof SvelteComponent;
     counter?: number;
     onClick: () => void;
   }
+</script>
+
+<script lang="ts">
+  import type { SvelteComponent } from "svelte";
 
   export let tabs: Tab[];
   export let style: string | undefined = undefined;

--- a/ui/App/SearchModal.svelte
+++ b/ui/App/SearchModal.svelte
@@ -33,7 +33,7 @@
   const projectRequestStore = remote.createStore<proxyProject.Request>();
   const projectSearchStore = remote.createStore<proxyProject.Project>();
 
-  function navigateToProject(project: project.Project) {
+  function navigateToProject(project: project.Project): void {
     reset();
     router.push({
       type: "project",
@@ -45,7 +45,7 @@
     modal.hide();
   }
 
-  function onKeydown(event: KeyboardEvent) {
+  function onKeydown(event: KeyboardEvent): void {
     switch (event.code) {
       case "Enter":
         if ($projectSearchStore.status === remote.Status.Success) {
@@ -66,7 +66,7 @@
     projectSearchStore.reset();
   }
 
-  function follow() {
+  function follow(): void {
     if (validationState.type === "valid") {
       remote.fetch(
         projectRequestStore,

--- a/ui/App/SettingsScreen.svelte
+++ b/ui/App/SettingsScreen.svelte
@@ -26,10 +26,10 @@
   import ThemeSetting from "ui/App/SharedComponents/ThemeSetting.svelte";
   import UiFontSetting from "ui/App/SharedComponents/UiFontSetting.svelte";
 
-  const updateEthereumEnvironment = (event: CustomEvent) => {
+  function updateEthereumEnvironment(event: CustomEvent): void {
     const environment = event.detail as ethereum.Environment;
     ethereum.selectedEnvironment.set(environment);
-  };
+  }
 
   let version = "";
   (async () => {
@@ -51,13 +51,13 @@
     isEnabled => (isEnabled ? "on" : "off")
   );
 
-  const setAppUpdateNotificationEnabled = (event: CustomEvent) => {
+  function setAppUpdateNotificationEnabled(event: CustomEvent): void {
     if (event.detail === "on") {
       updateChecker.enable();
     } else {
       updateChecker.disable();
     }
-  };
+  }
 
   const appUpdateNotificationEnabledOptions = [
     { value: "on", title: "Notify Me" },

--- a/ui/App/SharedComponents/CommitTeaser.svelte
+++ b/ui/App/SharedComponents/CommitTeaser.svelte
@@ -18,7 +18,7 @@
   export let style: string | undefined = undefined;
 
   const dispatch = createEventDispatcher();
-  const onSelect = () => {
+  const onSelect = (): void => {
     dispatch("select", commit.sha1);
   };
 </script>

--- a/ui/App/SharedComponents/DirectoryInput.svelte
+++ b/ui/App/SharedComponents/DirectoryInput.svelte
@@ -21,12 +21,12 @@
 
   const dispatch = createEventDispatcher();
 
-  const openFileDialog = async () => {
+  async function openFileDialog(): Promise<void> {
     path = await getDirectoryPath();
     if (path) {
       dispatch("selected");
     }
-  };
+  }
 </script>
 
 <style>

--- a/ui/App/SharedComponents/EmptyState.svelte
+++ b/ui/App/SharedComponents/EmptyState.svelte
@@ -24,13 +24,6 @@
   export let primaryActionTooltipMessage: string | undefined = undefined;
 
   $: tooltipMessage = primaryActionDisabled ? primaryActionTooltipMessage : "";
-
-  const onPrimaryAction = () => {
-    dispatch("primaryAction");
-  };
-  const onSecondaryAction = () => {
-    dispatch("secondaryAction");
-  };
 </script>
 
 <style>
@@ -69,7 +62,7 @@
       <Button
         disabled={primaryActionDisabled}
         dataCy="primary-action"
-        on:click={() => onPrimaryAction()}>
+        on:click={() => dispatch("primaryAction")}>
         {primaryActionText}
       </Button>
     </Tooltip>
@@ -78,7 +71,7 @@
     <button
       data-cy="secondary-action"
       style="margin-top: 0.5rem;"
-      on:click={() => onSecondaryAction()}>
+      on:click={() => dispatch("secondaryAction")}>
       <p class="typo-link">{secondaryActionText}</p>
     </button>
   {/if}

--- a/ui/App/SharedComponents/PeerSelector.svelte
+++ b/ui/App/SharedComponents/PeerSelector.svelte
@@ -34,15 +34,15 @@
     );
   };
 
-  const hide = () => {
+  const hide = (): void => {
     expanded = false;
   };
-  const show = () => {
+  const show = (): void => {
     expanded = true;
   };
 
   const dispatch = createEventDispatcher();
-  const onSelect = (peer: User) => {
+  const onSelect = (peer: User): void => {
     if (peer.role === PeerRole.Tracker) {
       return;
     }

--- a/ui/App/SharedComponents/ProjectAnchorHovercard.svelte
+++ b/ui/App/SharedComponents/ProjectAnchorHovercard.svelte
@@ -26,7 +26,7 @@
   export let anchor: project.Anchor;
   export let replicated: boolean = false;
 
-  const openCommit = () => {
+  function openCommit(): void {
     router.push({
       type: "project",
       params: {
@@ -34,7 +34,7 @@
         urn: anchor.projectId,
       },
     });
-  };
+  }
 
   $: anchorColor =
     anchor.type === "confirmed"

--- a/ui/App/SharedComponents/RevisionSelector.svelte
+++ b/ui/App/SharedComponents/RevisionSelector.svelte
@@ -42,20 +42,24 @@
   ];
 
   const dispatch = createEventDispatcher();
-  const hide = () => {
+
+  function hide(): void {
     expanded = false;
-  };
-  const select = (revision: Branch | Tag) => {
+  }
+
+  function select(revision: Branch | Tag): void {
     dispatch("select", revision);
     selected = revision as Branch | Tag;
     hide();
-  };
-  const toggle = () => {
+  }
+
+  function toggle(): void {
     expanded = !expanded;
-  };
-  const revisionKey = (revision: Branch | Tag): string => {
+  }
+
+  function revisionKey(revision: Branch | Tag): string {
     return `${revision.type}-${revision.name}`;
-  };
+  }
 </script>
 
 <style>

--- a/ui/App/SharedComponents/UserIdentity.svelte
+++ b/ui/App/SharedComponents/UserIdentity.svelte
@@ -29,7 +29,7 @@
 
   let user: proxyIdentity.RemoteIdentity | undefined = undefined;
 
-  async function fetchUser(urn: string) {
+  async function fetchUser(urn: string): Promise<void> {
     // Load data only the first time a user hovers a UserIdentity component and
     // make sure we show the correct data when the URN changes due to
     // reactivity.
@@ -51,7 +51,7 @@
     }
   }
 
-  function goToProfile(urn: string) {
+  function goToProfile(urn: string): void {
     modal.hide();
     if (urn === session.unsealed().identity.urn) {
       router.push({ type: "profile" });

--- a/ui/App/SingleSigOrgScreen.svelte
+++ b/ui/App/SingleSigOrgScreen.svelte
@@ -36,45 +36,41 @@
   export let registration: Registration | undefined = undefined;
   export let showWriteActions: boolean;
 
-  const tabs = (address: string) => {
-    return [
-      {
-        title: "Anchored projects",
-        icon: ChevronLeftRightIcon,
-        active: true,
-        onClick: () => {
-          router.push({
-            type: "org",
-            params: { address, view: "projects" },
-          });
-        },
+  const tabs = [
+    {
+      title: "Anchored projects",
+      icon: ChevronLeftRightIcon,
+      active: true,
+      onClick: () => {
+        router.push({
+          type: "org",
+          params: { address, view: "projects" },
+        });
       },
-    ];
-  };
+    },
+  ];
 
-  const menuItems = (address: string) => {
-    return [
-      {
-        title: "View on Etherscan",
-        icon: AtIcon,
-        event: () => {
-          org.openOnEtherscan(address);
-        },
+  const menuItems = [
+    {
+      title: "View on Etherscan",
+      icon: AtIcon,
+      event: () => {
+        org.openOnEtherscan(address);
       },
-      {
-        title: "View in browser",
-        icon: GlobeIcon,
-        event: () => {
-          ipc.openUrl(`https://app.radicle.network/orgs/${address}`);
-        },
+    },
+    {
+      title: "View in browser",
+      icon: GlobeIcon,
+      event: () => {
+        ipc.openUrl(`https://app.radicle.network/orgs/${address}`);
       },
-      {
-        title: registration ? "Edit ENS name" : "Register ENS name",
-        icon: EthereumIcon,
-        event: () => org.openEnsConfiguration(address, registration),
-      },
-    ];
-  };
+    },
+    {
+      title: registration ? "Edit ENS name" : "Register ENS name",
+      icon: EthereumIcon,
+      event: () => org.openEnsConfiguration(address, registration),
+    },
+  ];
 
   const showSidebar: boolean = !!(
     registration?.url ||
@@ -104,14 +100,14 @@
     <OrgHeader {registration} slot="left" orgAddress={address} />
     <div style="margin-left: auto; align-self: center; display: flex">
       <FollowToggle following disabled style="margin-right: 1rem;" />
-      <ThreeDotsMenu menuItems={menuItems(address)} />
+      <ThreeDotsMenu {menuItems} />
     </div>
   </div>
   <div class="sidebar-layout" class:single-column={!showSidebar}>
     <main>
       <ActionBar style="padding: 0; margin-top: 1rem;">
         <div slot="left">
-          <TabBar tabs={tabs(address)} />
+          <TabBar {tabs} />
         </div>
         <div slot="right">
           {#if showWriteActions}

--- a/ui/App/UnrecoverableErrorScreen.svelte
+++ b/ui/App/UnrecoverableErrorScreen.svelte
@@ -28,20 +28,20 @@
   let copyIcon: typeof SvelteComponent;
   $: copyIcon = copied ? CheckIcon : CopyIcon;
 
-  const copyToClipboard = (text: string) => {
+  function copyToClipboard(text: string): void {
     ipc.copyToClipboard(text);
     notification.show({ type: "info", message: "Copied to your clipboard" });
     copied = true;
     setTimeout(() => {
       copied = false;
     }, 2000);
-  };
+  }
 
-  const support = () => {
+  function support(): void {
     ipc.openUrl(
       "https://matrix.radicle.community/#/room/#support:radicle.community"
     );
-  };
+  }
 </script>
 
 <style>

--- a/ui/App/UserProfileScreen.svelte
+++ b/ui/App/UserProfileScreen.svelte
@@ -32,7 +32,8 @@
   export let projects: proxyProject.Project[];
   export let user: proxyIdentity.RemoteIdentity;
   export let ownUserUrn: string;
-  function openProject(project: Project) {
+
+  function openProject(project: Project): void {
     router.push({
       type: "project",
       params: {

--- a/ui/App/WalletScreen.svelte
+++ b/ui/App/WalletScreen.svelte
@@ -27,7 +27,7 @@
 
   import EmptyState from "ui/App/SharedComponents/EmptyState.svelte";
   import ScreenLayout from "ui/App/ScreenLayout.svelte";
-  import TabBar from "ui/App/ScreenLayout/TabBar.svelte";
+  import TabBar, { Tab } from "ui/App/ScreenLayout/TabBar.svelte";
 
   import ConnectWallet from "./WalletScreen/ConnectWallet.svelte";
   import LinkAddress from "./WalletScreen/LinkAddress.svelte";
@@ -38,8 +38,8 @@
 
   export let activeTab: router.WalletTab;
 
-  const tabs = (active: router.WalletTab) => {
-    const items = [
+  function tabs(active: router.WalletTab): Tab[] {
+    return [
       {
         title: "Transactions",
         icon: TransactionsIcon,
@@ -49,9 +49,7 @@
         },
       },
     ];
-
-    return items;
-  };
+  }
 
   watchAttestationStatus(store);
 
@@ -60,7 +58,7 @@
   // and thus be able to access its appropriate fields.
   $: w = $wallet;
 
-  async function connectWallet() {
+  async function connectWallet(): Promise<void> {
     try {
       await wallet.connect({
         show(uri: string, onClose: () => void) {

--- a/ui/App/WalletScreen/LinkAddress.svelte
+++ b/ui/App/WalletScreen/LinkAddress.svelte
@@ -17,7 +17,7 @@
 
   $: address = $walletStore.getAddress()?.toLowerCase();
 
-  function onLink() {
+  function onLink(): void {
     modal.toggle(LinkAddressModal);
   }
 </script>

--- a/ui/App/WalletScreen/LinkAddressModal.svelte
+++ b/ui/App/WalletScreen/LinkAddressModal.svelte
@@ -29,7 +29,7 @@
 
   $: address = $walletStore.getAddress() || "";
 
-  async function claim(ident: identity.Identity) {
+  async function claim(ident: identity.Identity): Promise<void> {
     $lastClaimed = address.toLowerCase();
     modal.hide();
     await identity.claimEthAddress(address);

--- a/ui/App/WalletScreen/Transactions.svelte
+++ b/ui/App/WalletScreen/Transactions.svelte
@@ -11,6 +11,11 @@
   import type { Tx } from "ui/src/transaction";
 
   import TransactionList from "./Transactions/TransactionList.svelte";
+  interface Section {
+    key: string;
+    title: string;
+    items: Tx[];
+  }
 
   $: includedTxs = $transactions.filter(tx => tx.status === TxStatus.Included);
   $: pendingTxs = $transactions.filter(
@@ -18,8 +23,8 @@
   );
   $: rejectedTxs = $transactions.filter(tx => tx.status === TxStatus.Rejected);
 
-  const groupTxs = (txs: Tx[]) => {
-    const sections: Array<{ key: string; title: string; items: Tx[] }> = [];
+  function groupTxs(txs: Tx[]): Section[] {
+    const sections: Section[] = [];
     // Sort from newest to oldest
     txs.sort((a, b) => b.date - a.date);
     for (const tx of txs) {
@@ -40,7 +45,7 @@
       }
     }
     return sections;
-  };
+  }
 
   $: txMonthSections = groupTxs(includedTxs);
 </script>

--- a/ui/App/WalletScreen/Transactions/TransactionList.svelte
+++ b/ui/App/WalletScreen/Transactions/TransactionList.svelte
@@ -15,11 +15,11 @@
   export let title: string;
   export let txs: Tx[];
 
-  const onSelect = (hash: string) => {
+  function onSelect(hash: string): void {
     modal.toggle(TransactionModal, () => {}, {
       transactionHash: hash,
     });
-  };
+  }
 </script>
 
 <style>

--- a/ui/src/attestation/contract.ts
+++ b/ui/src/attestation/contract.ts
@@ -114,7 +114,7 @@ export class ClaimsContract {
       return this.getClaimedByTx(txHash, address);
     });
 
-    const listener = async (_: unknown, event: ethers.Event) => {
+    const listener = async (_: unknown, event: ethers.Event): Promise<void> => {
       getClaim.submit(event.transactionHash);
     };
     this.#contract.on(filter, listener);
@@ -127,7 +127,7 @@ export class ClaimsContract {
     }
     const unsubOnClaimed = getClaim.output.onValue(onClaimed);
 
-    const unwatch = () => {
+    const unwatch = (): void => {
       unsubOnClaimed();
       this.#contract.off(filter, listener);
     };

--- a/ui/src/ethereum/debug.ts
+++ b/ui/src/ethereum/debug.ts
@@ -27,18 +27,18 @@ class EthereumDebug {
     this.provider = provider;
   }
 
-  public async mineBlocks(blocks = 1) {
+  public async mineBlocks(blocks = 1): Promise<void> {
     while (blocks) {
       blocks -= 1;
       await this.provider.send("evm_mine", []);
     }
   }
 
-  public async setBlockTime(seconds = 5) {
+  public async setBlockTime(seconds = 5): Promise<void> {
     await this.provider.send("evm_setTime", [seconds]);
   }
 
-  public async increaseTime(seconds = 5) {
+  public async increaseTime(seconds = 5): Promise<void> {
     await this.provider.send("evm_increaseTime", [seconds]);
   }
 }

--- a/ui/src/ethereum/walletConnect.ts
+++ b/ui/src/ethereum/walletConnect.ts
@@ -173,7 +173,7 @@ export class WalletConnectClient implements WalletConnect {
   // https://github.com/WalletConnect/walletconnect-monorepo/issues/538
   // and
   // https://github.com/WalletConnect/walletconnect-monorepo/pull/370#issuecomment-776038638
-  private reinit() {
+  private reinit(): void {
     this.connector = new Connector({
       bridge: "https://bridge.walletconnect.org",
       qrcodeModal: {
@@ -220,7 +220,7 @@ export class WalletConnectClient implements WalletConnect {
     });
   }
 
-  private setConnection(sessionStatus: ISessionStatus | undefined) {
+  private setConnection(sessionStatus: ISessionStatus | undefined): void {
     let connection;
     if (sessionStatus) {
       connection = {

--- a/ui/src/modal.ts
+++ b/ui/src/modal.ts
@@ -8,7 +8,7 @@ import { derived, get, writable } from "svelte/store";
 import type { SvelteComponent } from "svelte";
 
 type OnHide = () => void;
-const doNothing = () => {};
+const doNothing = (): void => {};
 
 type ModalLayout = {
   modalComponent: typeof SvelteComponent;

--- a/ui/src/mutexExecutor.ts
+++ b/ui/src/mutexExecutor.ts
@@ -103,7 +103,7 @@ class MutexWorker<In, Out> {
     this.output = this.outputBus.toEventStream();
   }
 
-  public async submit(x: In) {
+  public async submit(x: In): Promise<void> {
     const output = await this.executor.run(abort => this.fn(x, abort));
     if (output !== undefined) {
       this.outputBus.push(output);

--- a/ui/src/notification.ts
+++ b/ui/src/notification.ts
@@ -69,12 +69,12 @@ const closeAction: Action = {
   handler: () => {},
 };
 
-export function removeHideTimer(notification: Notification) {
+export function removeHideTimer(notification: Notification): void {
   window.clearTimeout(notification.hideTimerHandle);
   notification.hideTimerHandle = undefined;
 }
 
-export function attachHideTimer(notification: Notification) {
+export function attachHideTimer(notification: Notification): void {
   if (notification.hideTimerHandle) {
     removeHideTimer(notification);
   }

--- a/ui/src/org/ensRegistrar.ts
+++ b/ui/src/org/ensRegistrar.ts
@@ -13,7 +13,10 @@ import * as svelteStore from "ui/src/svelteStore";
 import * as Wallet from "ui/src/wallet";
 import * as browserStore from "ui/src/browserStore";
 
-import { Registrar__factory as RegistrarFactory } from "radicle-contracts/build/contract-bindings/ethers";
+import {
+  Registrar__factory as RegistrarFactory,
+  Registrar,
+} from "radicle-contracts/build/contract-bindings/ethers";
 
 function registrarAddress(network: ethereum.Environment): string {
   switch (network) {
@@ -29,7 +32,7 @@ function registrarAddress(network: ethereum.Environment): string {
   }
 }
 
-function registrar() {
+function registrar(): Registrar {
   const wallet = svelteStore.get(Wallet.store);
   return RegistrarFactory.connect(
     registrarAddress(wallet.environment),

--- a/ui/src/org/theGraphApi.ts
+++ b/ui/src/org/theGraphApi.ts
@@ -31,7 +31,7 @@ function createApolloClient(uri: string): apolloCore.ApolloClient<unknown> {
   });
 }
 
-function orgsSubgraphClient() {
+function orgsSubgraphClient(): apolloCore.ApolloClient<unknown> {
   const walletStore = svelteStore.get(wallet.store);
   let uri;
   switch (walletStore.environment) {

--- a/ui/src/project.ts
+++ b/ui/src/project.ts
@@ -100,7 +100,7 @@ export const defaultBranchForNewRepository = async (): Promise<string> => {
   return (await ipc.getGitGlobalDefaultBranch()) || UPSTREAM_DEFAULT_BRANCH;
 };
 
-const fetchBranches = async (path: string) => {
+async function fetchBranches(path: string): Promise<void> {
   fetchLocalState(path);
 
   localStateError.set("");
@@ -129,7 +129,7 @@ const fetchBranches = async (path: string) => {
   );
 
   defaultBranch.set(foundDefaultBranch || state.branches[0]);
-};
+}
 
 // Creates a sorted user list from a peer list.
 //

--- a/ui/src/remote.ts
+++ b/ui/src/remote.ts
@@ -96,7 +96,9 @@ export const createStore = <T>(): Store<T> => {
     });
   };
 
-  const resetInternalStore = () => update(() => ({ status: Status.NotAsked }));
+  function resetInternalStore(): void {
+    update(() => ({ status: Status.NotAsked }));
+  }
 
   const is = (status: Status): boolean => {
     return svelteStore.get(internalStore).status === status;

--- a/ui/src/retryOnError.test.ts
+++ b/ui/src/retryOnError.test.ts
@@ -11,7 +11,7 @@ const TRY_COUNT = 10;
 test("retries exhausted", async () => {
   const error = new Error("ERROR");
   let callCount = 0;
-  const action = async () => {
+  const action = async (): Promise<void> => {
     callCount += 1;
     throw error;
   };
@@ -28,7 +28,7 @@ test("rethrows unmatched errors", async () => {
   const retryError = new Error("RETRY");
 
   let callCount = 0;
-  const action = async () => {
+  const action = async (): Promise<void> => {
     callCount += 1;
     if (callCount < TRY_COUNT / 2) {
       throw retryError;
@@ -51,7 +51,7 @@ test("passes valid results", async () => {
   const error = new Error("ERROR");
 
   let callCount = 0;
-  const action = async () => {
+  const action = async (): Promise<string> => {
     callCount += 1;
     if (callCount < TRY_COUNT / 2) {
       throw error;

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -28,7 +28,7 @@ const historyExecutor = mutexExecutor.create();
 
 // Sets the history to the given value and navigates to the last item
 // in the history.
-const setHistory = async (history: Route[]) => {
+async function setHistory(history: Route[]): Promise<void> {
   if (history.length === 0) {
     throw new error.Error({
       code: error.Code.EmptyHistory,
@@ -43,7 +43,7 @@ const setHistory = async (history: Route[]) => {
 
     const abort = new bacon.Bus<void>();
 
-    function scheduleNotification() {
+    function scheduleNotification(): void {
       notificationTimeout = setTimeout(() => {
         notificationHandle = notification.show({
           type: "info",
@@ -95,7 +95,7 @@ const setHistory = async (history: Route[]) => {
     // displayed in the URL bar.
     routeToPath(targetRoute)
   );
-};
+}
 
 export const push = async (newRoute: Route): Promise<void> => {
   const history = svelteStore.get(historyStore);

--- a/ui/src/screen/project.ts
+++ b/ui/src/screen/project.ts
@@ -167,8 +167,11 @@ export const removePeer = (projectId: string, peerId: PeerId): void => {
   }
 };
 
-const throwUnlessPeersPresent = (peers: project.User[], projectId: string) => {
+function throwUnlessPeersPresent(
+  peers: project.User[],
+  projectId: string
+): void {
   if (peers.length === 0) {
     throw new Error(`Project ${projectId} is missing peers`);
   }
-};
+}

--- a/ui/src/transaction.ts
+++ b/ui/src/transaction.ts
@@ -177,14 +177,14 @@ export function add(tx: Tx): void {
 }
 
 // Cap the amount of managed transactions
-function cap(length = 7) {
+function cap(length = 7): void {
   store.update((txs: Tx[]) => {
     txs.length = Math.min(txs.length, length);
     return txs;
   });
 }
 
-async function updateStatuses() {
+async function updateStatuses(): Promise<void> {
   const txs = svelteStore.get(store);
   txs.forEach(tx => {
     registerTxUpdateCallback(tx);

--- a/ui/src/updateChecker.ts
+++ b/ui/src/updateChecker.ts
@@ -84,7 +84,7 @@ class UpdateChecker {
 
   // If the user has not been asked already, we show a notification
   // and ask them to enable update notifications.
-  public notifyEnable() {
+  public notifyEnable(): void {
     const isEnabled = svelteStore.get(isEnabledStore);
     if (isEnabled === null) {
       notification.show({
@@ -112,7 +112,7 @@ class UpdateChecker {
   }
 
   // Enable background udpate checking.
-  public enable() {
+  public enable(): void {
     isEnabledStore.set(true);
 
     this.checkNewVersion();
@@ -124,7 +124,7 @@ class UpdateChecker {
   }
 
   // Disable background udpate checking.
-  public disable() {
+  public disable(): void {
     isEnabledStore.set(false);
 
     if (this.checkInterval !== null) {
@@ -166,7 +166,7 @@ class UpdateChecker {
   // Fetch information about the latest version. If that version is
   // newer than the current version and the user has not been notified
   // since `VERSION_NOTIFY_SILENCE_INTERVAL` we show a notification.
-  private async checkNewVersion() {
+  private async checkNewVersion(): Promise<void> {
     let latestVersionInfo;
     try {
       latestVersionInfo = await fetchLatestVersion();

--- a/ui/src/urn.test.ts
+++ b/ui/src/urn.test.ts
@@ -18,12 +18,12 @@ import * as ethers from "ethers";
 import * as Urn from "./urn";
 
 describe("urnToSha1", () => {
-  function expectSuccess(urn: string, expectedRoot: string) {
+  function expectSuccess(urn: string, expectedRoot: string): void {
     const actual = Urn.urnToSha1(urn);
     expect(ethers.utils.hexlify(actual)).toEqual(expectedRoot);
   }
 
-  function expectFailure(urn: string, expectedError: string) {
+  function expectFailure(urn: string, expectedError: string): void {
     expect(() => Urn.urnToSha1(urn)).toThrow(expectedError);
   }
 

--- a/ui/src/validation.ts
+++ b/ui/src/validation.ts
@@ -71,7 +71,7 @@ export const createValidationStore = (
   const { subscribe, update } = internalStore;
   let inputStore: Writable<string> | undefined = undefined;
 
-  const reset = () => {
+  const reset = (): void => {
     inputStore = undefined;
     internalStore.set(initialState);
   };

--- a/ui/src/wallet.ts
+++ b/ui/src/wallet.ts
@@ -66,7 +66,7 @@ async function updateAccountBalances(
   environment: Environment,
   address: string,
   provider: ethers.providers.Provider
-) {
+): Promise<void> {
   try {
     const radTokenContract = radToken.connect(provider, environment);
 
@@ -124,7 +124,7 @@ function build(environment: Environment, provider: Provider): Wallet {
   });
 
   // Connect to a wallet using walletconnect
-  async function connect(qrDisplay: QrDisplay) {
+  async function connect(qrDisplay: QrDisplay): Promise<void> {
     if (svelteStore.get(stateStore).status !== Status.NotConnected) {
       throw new Error("A wallet is already connected");
     }


### PR DESCRIPTION
We enable the ESlint rule that checks for explicit type annotations on functions that are exported from modules. This is an intermediate step to enabling explicit return type annotations for all functions.

I’ve converted more functions than strictly necessary and occasionally converted function declarations.