### PR TITLE
proxy: improved peer events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-broadcast",
  "bytes 1.1.0",
  "chrono",
  "data-encoding",
@@ -128,6 +129,17 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "async-broadcast"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90622698a1218e0b2fb846c97b5f19a0831f6baddee73d9454156365ccfa473b"
+dependencies = [
+ "easy-parallel",
+ "event-listener",
+ "futures-core",
+]
 
 [[package]]
 name = "async-channel"
@@ -952,6 +964,12 @@ name = "dyn-clone"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
+name = "easy-parallel"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd4afd79212583ff429b913ad6605242ed7eec277e950b1438f300748f948f4"
 
 [[package]]
 name = "ed25519-zebra"

--- a/proxy/api/Cargo.toml
+++ b/proxy/api/Cargo.toml
@@ -13,6 +13,7 @@ default-run = "radicle-proxy"
 
 [dependencies]
 anyhow = "1.0"
+async-broadcast = "0.3.4"
 chrono = { version = "0.4.19", features = [ "serde" ] }
 data-encoding = "2.3"
 directories = "4.0"

--- a/proxy/api/src/http/notification.rs
+++ b/proxy/api/src/http/notification.rs
@@ -40,10 +40,14 @@ mod handler {
             new: current_status,
         }]);
 
+        let notifications = ctx
+            .peer_events()
+            .filter_map(|event| future::ready(crate::notification::from_peer_event(event)));
+
         Ok(sse::reply(
             sse::keep_alive().stream(
                 initial
-                    .chain(ctx.notifications())
+                    .chain(notifications)
                     .map(|event| sse::Event::default().json_data(event)),
             ),
         ))


### PR DESCRIPTION
* We replace `tokio` broadcast channels with `async_broadcast` channels. The latter has `InactiveReceivers` that can be cloned. This allows contexts to contain a receiver instead of a sender.

* We can now separate the logging of events from the forwarding to another broadcast receiver.

* We move the conversion to `Notification` out of the `process` module since this is not part of its responsibility.

* We don’t need to use the shutdown runner because the tasks automatically finish when the peer shuts down.