### PR TITLE
optimize build cache by removing large files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
             ./target/*/deps
             ./target/*/build
             ./target/*/.fingerprint
-          key: build-${{ runner.os }}-rust-v4-${{ hashFiles('Cargo.lock') }}
+          key: build-${{ runner.os }}-rust-v5-${{ hashFiles('Cargo.lock') }}
       - run: ci/build.sh
       - uses: actions/upload-artifact@v2
         if: always()
@@ -65,7 +65,7 @@ jobs:
             ./target/*/deps
             ./target/*/build
             ./target/*/.fingerprint
-          key: build-${{ runner.os }}-rust-v4-${{ hashFiles('Cargo.lock') }}
+          key: build-${{ runner.os }}-rust-v5-${{ hashFiles('Cargo.lock') }}
       - run: ci/build.sh
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -34,7 +34,7 @@ jobs:
             ./target/*/deps
             ./target/*/build
             ./target/*/.fingerprint
-          key: ${{ github.job }}-${{ runner.os }}-rust-v3-${{ hashFiles('Cargo.lock') }}
+          key: ${{ github.job }}-${{ runner.os }}-rust-v4-${{ hashFiles('Cargo.lock') }}
       - run: ci/dist.sh
       - name: publish artifacts by commit
         uses: google-github-actions/upload-cloud-storage@v0.4.0

--- a/.github/workflows/p2p-network-tests.yaml
+++ b/.github/workflows/p2p-network-tests.yaml
@@ -20,13 +20,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            /usr/local/bin/cargo-deny
-            ~/.cargo/advisory-db/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git
             ./target/*/deps
             ./target/*/build
             ./target/*/.fingerprint
-          key: build-${{ runner.os }}-rust-v4-${{ hashFiles('Cargo.lock') }}
+          key: build-${{ runner.os }}-rust-v5-${{ hashFiles('Cargo.lock') }}
       - run: ci/p2p-network-tests.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -92,3 +92,5 @@ time FORCE_COLOR=1 ELECTRON_ENABLE_LOGGING=1 yarn test |
     s/^.*Run Finished.*/$(log-group-end)\n$(log-group-start)Run Finished/
   "
 log-group-end
+
+clean-cargo-build-artifacts

--- a/ci/dist.sh
+++ b/ci/dist.sh
@@ -21,6 +21,8 @@ log-group-start "Building and packaging binaries"
 time yarn dist
 log-group-end
 
+clean-cargo-build-artifacts
+
 echo "Collect artifacts"
 mkdir artifacts
 shopt -s nullglob

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -23,6 +23,20 @@ else
   exit 1
 fi
 
+# Remove cargo build artifacts that are large and become stale on every
+# build.
+function clean-cargo-build-artifacts () {
+  if [[ ${RUNNER_OS} == "macOS" ]]; then
+    echo "skipping build artifacts clean-up on macOS"
+  else
+    echo "clean up cargo build artifacts"
+    find target/*/deps -type f -perm -a=x -not -name "*.so" -exec rm {} \;
+    rm \
+      target/*/deps/libapi-* \
+      target/*/deps/libupstream_seed-*
+  fi
+}
+
 export YARN_CACHE_FOLDER="$CACHE_FOLDER/yarn"
 export CARGO_HOME="$HOME/.cargo"
 export CYPRESS_CACHE_FOLDER="$CACHE_FOLDER/cypress"

--- a/ci/p2p-network-tests.sh
+++ b/ci/p2p-network-tests.sh
@@ -41,3 +41,5 @@ log-group-end
 log-group-start "contributor-fork-replication-2-test.ts"
 time sudo -E FORCE_COLOR=1 ./p2p-tests/contributor-fork-replication-2-test.ts
 log-group-end
+
+clean-cargo-build-artifacts


### PR DESCRIPTION
The new cache is 800MB instead of 1000MB which makes the builds faster and reduces the number of times our build cache gets cleared because we run out of space.