### PR TITLE
proxy: less noisy logging

### DIFF
--- a/proxy/api/src/process.rs
+++ b/proxy/api/src/process.rs
@@ -365,22 +365,16 @@ fn setup_logging(args: &Args) {
     } else {
         let mut env_filter = tracing_subscriber::EnvFilter::default();
 
-        let mut directives = vec!["info", "quinn=warn"];
+        let mut directives = vec![
+            "info",
+            "quinn=warn",
+            // Silence some noisy debug statements.
+            "librad::net::protocol::io::streams=warn",
+            "librad::net::protocol::io::recv::git=warn",
+        ];
 
         if args.dev_log {
-            directives.extend([
-                "api=debug",
-                "radicle_daemon=debug",
-                "librad=debug",
-                // Silence some noisy debug statements
-                "librad::git::refs=info",
-                "librad::git::include=info",
-                "librad::git::identities::person=info",
-                "librad::git::identities::local=info",
-                "librad::net::protocol::membership::periodic=info",
-                "librad::git::tracking=info",
-                "librad::net::protocol::io::recv::git=warn",
-            ])
+            directives.extend(["api=debug", "radicle_daemon=debug"])
         }
 
         for directive in directives {


### PR DESCRIPTION
Make the log output from the proxy less noisy by raising the level of `librad` to `info` and filtering unnecessary info logs. Thew new configuration is roughly the same as the one for `upstream-seed`.