### PR TITLE
feat: improve diagnostics screen

### DIFF
--- a/cypress/support/ipc-stub.ts
+++ b/cypress/support/ipc-stub.ts
@@ -38,6 +38,7 @@ export function setup(window: Window): void {
   let clipboard = "";
 
   const electronStubs: ElectronStubs = {
+    getProxyLogs: sinon.stub().returns(Promise.resolve("Dummy log line")),
     getVersion: sinon.stub().returns(Promise.resolve("v1.2.3")),
     selectDirectory: sinon.stub().throws(new Error("not implemented")),
     openPath: sinon.stub().throws(new Error("not implemented")),

--- a/native/index.ts
+++ b/native/index.ts
@@ -170,6 +170,9 @@ function installMainProcessHandler(handler: MainProcess) {
 }
 
 installMainProcessHandler({
+  async getProxyLogs(): Promise<string> {
+    return proxyProcessManager.getOutputBuffer();
+  },
   async clipboardWriteText(text: string): Promise<void> {
     clipboard.writeText(text);
   },

--- a/native/ipc-types.ts
+++ b/native/ipc-types.ts
@@ -36,6 +36,7 @@ export interface CustomProtocolInvocation {
 export interface MainProcess {
   clipboardWriteText(text: string): Promise<void>;
   getVersion(): Promise<string>;
+  getProxyLogs(): Promise<string>;
   openPath(path: string): Promise<void>;
   openUrl(path: string): Promise<void>;
   // Open a system dialog to select a directory and returns the
@@ -48,6 +49,7 @@ export interface MainProcess {
 export const mainProcessMethods: Array<keyof MainProcess> = [
   "clipboardWriteText",
   "getVersion",
+  "getProxyLogs",
   "openPath",
   "openUrl",
   "selectDirectory",

--- a/ui/App/DiagnosticsScreen/Connections.svelte
+++ b/ui/App/DiagnosticsScreen/Connections.svelte
@@ -24,8 +24,8 @@
 
 <div class="container">
   <Json title="Your identity" data={session.identity} />
+  <Json title="Connection status" data={$localPeerState} />
   {#await proxy.client.diagnosticsGet() then result}
     <Json title="Your peer" data={result.peer} />
   {/await}
-  <Json title="Connection status" data={$localPeerState} />
 </div>

--- a/ui/App/DiagnosticsScreen/ProxyLogs.svelte
+++ b/ui/App/DiagnosticsScreen/ProxyLogs.svelte
@@ -1,0 +1,27 @@
+<!--
+ Copyright © 2021 The Radicle Upstream Contributors
+
+ This file is part of radicle-upstream, distributed under the GPLv3
+ with Radicle Linking Exception. For full terms see the included
+ LICENSE file.
+-->
+<script lang="ts">
+  import * as ipc from "ui/src/ipc";
+</script>
+
+<style>
+  pre {
+    font-family: var(--typeface-mono-regular);
+    font-size: 14px;
+    background-color: var(--color-foreground-level-1);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    overflow: scroll;
+  }
+</style>
+
+{#await ipc.getProxyLogs() then result}
+  <pre>
+    {result}
+  </pre>
+{/await}

--- a/ui/App/DiagnosticsScreen/Storage.svelte
+++ b/ui/App/DiagnosticsScreen/Storage.svelte
@@ -11,5 +11,5 @@
 </script>
 
 {#await proxy.client.diagnosticsGet() then result}
-  <Json title="Storage locations" data={result} />
+  <Json title="Storage locations" data={result.storage} />
 {/await}

--- a/ui/src/ipc.ts
+++ b/ui/src/ipc.ts
@@ -29,6 +29,8 @@ export const getDirectoryPath = mainProcess.selectDirectory;
 
 export const getVersion = mainProcess.getVersion;
 
+export const getProxyLogs = mainProcess.getProxyLogs;
+
 export const copyToClipboard = mainProcess.clipboardWriteText;
 
 export const openPath = mainProcess.openPath;

--- a/ui/src/router/definition.ts
+++ b/ui/src/router/definition.ts
@@ -11,6 +11,7 @@ import * as userProfileRoute from "ui/App/UserProfileScreen/route";
 export type DiagnosticsTab =
   | "connections"
   | "notificationHistory"
+  | "proxyLogs"
   | "storage"
   | "waitingRoom";
 export type WalletTab = "transactions";


### PR DESCRIPTION
Adding the proxy logs to the diagnostics info screen should help with debugging in case the app was not started from the terminal and we still want to get to the logs.

- show Upstream version in header and add it to copy-to-clipboard button
- don't show redundant peer information in storage tab
- align copy-to-clipboard data shape to what we see on the screen
- use a different icon for notification history tab
- add proxy logs tab and add it to copy-to-clipboard button

<img width="1440" alt="Screenshot 2021-12-16 at 11 01 39" src="https://user-images.githubusercontent.com/158411/146351063-7a594de3-8dfe-45ea-9b4a-9fa3b48b84f3.png">

