### PR TITLE
proxy: encapsulate peer

### DIFF
--- a/proxy/api/src/browser.rs
+++ b/proxy/api/src/browser.rs
@@ -7,7 +7,6 @@
 use std::convert::TryFrom as _;
 
 use librad::git::types::{Reference, Single};
-use link_crypto::BoxedSigner;
 use radicle_source::{error, surf::vcs::git};
 
 use crate::error::Error;
@@ -24,7 +23,7 @@ use crate::error::Error;
 ///   * If we could not initialise the `Browser`.
 ///   * If the callback provided returned an error.
 pub fn using<T, F>(
-    peer: &radicle_daemon::net::peer::Peer<BoxedSigner>,
+    peer: &crate::peer::Peer,
     reference: Reference<Single>,
     callback: F,
 ) -> Result<T, Error>
@@ -48,7 +47,7 @@ where
         ),
     };
 
-    let monorepo = radicle_daemon::state::monorepo(peer);
+    let monorepo = radicle_daemon::state::monorepo(peer.librad_peer());
     let repo = git::Repository::new(monorepo).map_err(error::Error::from)?;
     let mut browser =
         git::Browser::new_with_namespace(&repo, &namespace, branch).map_err(error::Error::from)?;

--- a/proxy/api/src/control.rs
+++ b/proxy/api/src/control.rs
@@ -12,7 +12,6 @@ use nonempty::NonEmpty;
 
 use radicle_source::surf::vcs::git::git2;
 
-use link_crypto::BoxedSigner;
 use radicle_daemon::{
     librad::{
         git::{
@@ -25,7 +24,6 @@ use radicle_daemon::{
         },
         git_ext::OneLevel,
         identities::Project,
-        net::peer::Peer,
         refspec_pattern,
     },
     project,
@@ -43,12 +41,13 @@ pub use test::*;
 /// Will return [`Error`] if any of the git interaction fail, or the initialisation of
 /// the coco project.
 pub async fn replicate_platinum(
-    peer: &Peer<BoxedSigner>,
+    peer: &crate::peer::Peer,
     owner: &LocalIdentity,
     name: &str,
     description: &str,
     default_branch: OneLevel,
 ) -> Result<Project, Error> {
+    let peer = peer.librad_peer();
     // Construct path for fixtures to clone into.
     let monorepo = state::monorepo(peer);
     let workspace = monorepo.join("../workspace");
@@ -183,8 +182,8 @@ pub fn clone_platinum(platinum_into: impl AsRef<path::Path>) -> Result<(), Error
 mod test {
     use radicle_daemon::{
         librad::{
-            git::identities::local::LocalIdentity, git_ext::OneLevel, identities::Project,
-            net::peer::Peer, reflike, PeerId,
+            git::identities::local::LocalIdentity, git_ext::OneLevel, identities::Project, reflike,
+            PeerId,
         },
         state::Error,
     };
@@ -210,7 +209,7 @@ mod test {
     /// Will error if filesystem access is not granted or broken for the configured
     /// [`librad::paths::Paths`].
     pub async fn setup_fixtures(
-        peer: &Peer<link_crypto::BoxedSigner>,
+        peer: &crate::peer::Peer,
         owner: &LocalIdentity,
     ) -> Result<Vec<Project>, Error> {
         let infos = vec![

--- a/proxy/api/src/http/control.rs
+++ b/proxy/api/src/http/control.rs
@@ -76,9 +76,10 @@ mod handler {
         .await
         .map_err(error::Error::from)?;
 
-        let branch = radicle_daemon::state::get_branch(&ctx.peer, meta.urn(), None, None)
-            .await
-            .map_err(error::Error::from)?;
+        let branch =
+            radicle_daemon::state::get_branch(ctx.peer.librad_peer(), meta.urn(), None, None)
+                .await
+                .map_err(error::Error::from)?;
         let stats = browser::using(&ctx.peer, branch, |browser| Ok(browser.get_stats()?))
             .map_err(error::Error::from)?;
         let project = project::Full::try_from((meta, stats))?;

--- a/proxy/api/src/http/diagnostics.rs
+++ b/proxy/api/src/http/diagnostics.rs
@@ -37,9 +37,9 @@ mod handler {
     /// Get diagnostics information.
     #[allow(clippy::unused_async)]
     pub async fn get(mut ctx: context::Unsealed) -> Result<impl Reply, Rejection> {
-        let listen_addrs = ctx.peer_control.listen_addrs().await;
-        let protocol_config = ctx.peer.protocol_config();
-        let membership = ctx.peer.membership().await;
+        let listen_addrs = ctx.peer.daemon_control().listen_addrs().await;
+        let protocol_config = ctx.peer.librad_peer().protocol_config();
+        let membership = ctx.peer.librad_peer().membership().await;
         let git_dir = ctx.rest.paths.git_dir();
         let refs_tree = WalkDir::new(git_dir.join("refs"))
             .into_iter()

--- a/proxy/api/src/http/identity.rs
+++ b/proxy/api/src/http/identity.rs
@@ -76,7 +76,7 @@ mod handler {
             .into());
         }
 
-        let id = identity::create(&ctx.peer, metadata).await?;
+        let id = identity::create(ctx.peer.librad_peer(), metadata).await?;
 
         session::initialize(&ctx.rest.store, id.clone(), &ctx.rest.default_seeds)?;
 
@@ -89,7 +89,7 @@ mod handler {
         metadata: identity::Metadata,
     ) -> Result<impl Reply, Rejection> {
         session::get_current(&ctx.rest.store)?.ok_or(http::error::Routing::NoSession)?;
-        let id = identity::update(&ctx.peer, metadata).await?;
+        let id = identity::update(ctx.peer.librad_peer(), metadata).await?;
         session::update_identity(&ctx.rest.store, id.clone())?;
 
         Ok(reply::with_status(reply::json(&id), StatusCode::OK))
@@ -150,17 +150,17 @@ mod test {
             session.identity.urn
         };
 
-        let peer_id = ctx.peer.peer_id();
+        let peer_id = ctx.peer.librad_peer().peer_id();
 
         // Assert that we set the default owner and it's the same one as the session
         {
             assert_eq!(
-                radicle_daemon::state::default_owner(&ctx.peer)
+                radicle_daemon::state::default_owner(ctx.peer.librad_peer())
                     .await?
                     .unwrap()
                     .into_inner()
                     .into_inner(),
-                radicle_daemon::state::get_local(&ctx.peer, urn.clone())
+                radicle_daemon::state::get_local(ctx.peer.librad_peer(), urn.clone())
                     .await?
                     .unwrap()
                     .into_inner()
@@ -226,17 +226,17 @@ mod test {
             session.identity.urn
         };
 
-        let peer_id = ctx.peer.peer_id();
+        let peer_id = ctx.peer.librad_peer().peer_id();
 
         // Assert that we set the default owner and it's the same one as the session
         {
             assert_eq!(
-                radicle_daemon::state::default_owner(&ctx.peer)
+                radicle_daemon::state::default_owner(ctx.peer.librad_peer())
                     .await?
                     .unwrap()
                     .into_inner()
                     .into_inner(),
-                radicle_daemon::state::get_local(&ctx.peer, urn.clone())
+                radicle_daemon::state::get_local(ctx.peer.librad_peer(), urn.clone())
                     .await?
                     .unwrap()
                     .into_inner()
@@ -302,17 +302,17 @@ mod test {
             session.identity.urn
         };
 
-        let peer_id = ctx.peer.peer_id();
+        let peer_id = ctx.peer.librad_peer().peer_id();
 
         // Assert that we set the default owner and it's the same one as the session
         {
             assert_eq!(
-                radicle_daemon::state::default_owner(&ctx.peer)
+                radicle_daemon::state::default_owner(ctx.peer.librad_peer())
                     .await?
                     .unwrap()
                     .into_inner()
                     .into_inner(),
-                radicle_daemon::state::get_local(&ctx.peer, urn.clone())
+                radicle_daemon::state::get_local(ctx.peer.librad_peer(), urn.clone())
                     .await?
                     .unwrap()
                     .into_inner()

--- a/proxy/api/src/http/notification.rs
+++ b/proxy/api/src/http/notification.rs
@@ -33,7 +33,7 @@ mod handler {
 
     /// Sets up local peer events notification stream.
     pub async fn local_peer_events(mut ctx: context::Unsealed) -> Result<impl Reply, Rejection> {
-        let current_status = ctx.peer_control.current_status().await;
+        let current_status = ctx.peer.daemon_control().current_status().await;
 
         let initial = futures::stream::iter([Notification::StatusChanged {
             old: current_status.clone(),

--- a/proxy/api/src/http/source.rs
+++ b/proxy/api/src/http/source.rs
@@ -141,9 +141,10 @@ mod handler {
             super::HighlightTheme::H4x0r => "base16-ocean.h4x0r",
         });
 
-        let branch = radicle_daemon::state::get_branch(&ctx.peer, project_urn, peer_id, None)
-            .await
-            .map_err(error::Error::from)?;
+        let branch =
+            radicle_daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
+                .await
+                .map_err(error::Error::from)?;
         let blob = browser::using(&ctx.peer, branch, |browser| {
             radicle_source::blob::highlighting::blob(browser, revision, &path, theme)
         })
@@ -160,7 +161,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let peer_id = super::http::guard_self_peer_id(&ctx.peer, peer_id);
         let default_branch =
-            radicle_daemon::state::get_branch(&ctx.peer, project_urn, peer_id, None)
+            radicle_daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
                 .await
                 .map_err(error::Error::from)?;
         let branches = browser::using(&ctx.peer, default_branch, |browser| {
@@ -177,9 +178,10 @@ mod handler {
         sha1: Oid,
         ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, project_urn)
-            .await
-            .map_err(error::Error::from)?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
+                .await
+                .map_err(error::Error::from)?;
         let commit = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::commit(browser, *sha1)
         })
@@ -196,9 +198,10 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let revision = super::http::guard_self_revision(&ctx.peer, revision);
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, project_urn)
-            .await
-            .map_err(error::Error::from)?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
+                .await
+                .map_err(error::Error::from)?;
         let commits = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::commits(browser, revision)
         })
@@ -224,9 +227,10 @@ mod handler {
         _query: super::TagQuery,
         ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
-        let branch = radicle_daemon::state::find_default_branch(&ctx.peer, project_urn)
-            .await
-            .map_err(error::Error::from)?;
+        let branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
+                .await
+                .map_err(error::Error::from)?;
         let tags = browser::using(&ctx.peer, branch, |browser| radicle_source::tags(browser))
             .map_err(error::Error::from)?;
 
@@ -245,9 +249,10 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let peer_id = super::http::guard_self_peer_id(&ctx.peer, peer_id);
         let revision = super::http::guard_self_revision(&ctx.peer, revision);
-        let branch = radicle_daemon::state::get_branch(&ctx.peer, project_urn, peer_id, None)
-            .await
-            .map_err(error::Error::from)?;
+        let branch =
+            radicle_daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
+                .await
+                .map_err(error::Error::from)?;
         let tree = browser::using(&ctx.peer, branch, |browser| {
             radicle_source::tree(browser, revision, prefix)
         })
@@ -355,7 +360,7 @@ mod test {
         };
         let arrows = "text/arrows.txt";
         let default_branch =
-            radicle_daemon::state::find_default_branch(&ctx.peer, urn.clone()).await?;
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn.clone()).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::blob(browser, Some(revision.clone()), arrows)
         })?;
@@ -413,7 +418,7 @@ mod test {
         // Get binary blob.
         let ls = "bin/ls";
         let default_branch =
-            radicle_daemon::state::find_default_branch(&ctx.peer, urn.clone()).await?;
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn.clone()).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::blob(browser, Some(revision.clone()), ls)
         })?;
@@ -493,7 +498,8 @@ mod test {
             .reply(&api)
             .await;
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, urn).await?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::blob(browser, Some(revision), path)
         })?;
@@ -518,7 +524,8 @@ mod test {
             .reply(&api)
             .await;
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, urn).await?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::branches(browser, RefScope::All)
         })?;
@@ -547,7 +554,8 @@ mod test {
             .reply(&api)
             .await;
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, urn).await?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::commit::header(browser, *sha1)
         })?;
@@ -602,7 +610,8 @@ mod test {
             .reply(&api)
             .await;
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, urn).await?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::commits(browser, Some(revision.clone()))
         })?;
@@ -667,7 +676,8 @@ mod test {
             .reply(&api)
             .await;
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, urn).await?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::tags(browser)
         })?;
@@ -702,7 +712,8 @@ mod test {
         let path = format!("/tree/{}?{}", urn, serde_qs::to_string(&query).unwrap());
         let res = request().method("GET").path(&path).reply(&api).await;
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, urn).await?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::tree(browser, Some(revision), Some(prefix.to_string()))
         })?;
@@ -773,7 +784,8 @@ mod test {
         );
         let res = request().method("GET").path(&path).reply(&api).await;
 
-        let default_branch = radicle_daemon::state::find_default_branch(&ctx.peer, urn).await?;
+        let default_branch =
+            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::tree(browser, Some(revision), None)
         })?;
@@ -787,7 +799,7 @@ mod test {
 
     async fn replicate_platinum(ctx: &context::Unsealed) -> Result<Urn, error::Error> {
         let owner = radicle_daemon::state::init_owner(
-            &ctx.peer,
+            ctx.peer.librad_peer(),
             link_identities::payload::Person {
                 name: "cloudhead".into(),
             },

--- a/proxy/api/src/lib.rs
+++ b/proxy/api/src/lib.rs
@@ -22,6 +22,7 @@ mod context;
 mod control;
 pub mod env;
 mod error;
+mod peer;
 mod shutdown_runner;
 mod ethereum {
     pub mod address;

--- a/proxy/api/src/peer.rs
+++ b/proxy/api/src/peer.rs
@@ -1,0 +1,128 @@
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+use anyhow::Context as _;
+use futures::prelude::*;
+
+#[derive(Clone)]
+pub struct Peer {
+    daemon_control: radicle_daemon::PeerControl,
+    librad_peer: librad::net::peer::Peer<link_crypto::BoxedSigner>,
+    events: async_broadcast::InactiveReceiver<radicle_daemon::PeerEvent>,
+}
+
+impl Peer {
+    pub fn daemon_control(&mut self) -> &mut radicle_daemon::PeerControl {
+        &mut self.daemon_control
+    }
+
+    pub fn librad_peer(&self) -> &librad::net::peer::Peer<link_crypto::BoxedSigner> {
+        &self.librad_peer
+    }
+
+    /// Stream that emits [`radicle_daemon::PeerEvent`] and stops when the peer is shutdown.
+    pub fn events(&self) -> async_broadcast::Receiver<radicle_daemon::PeerEvent> {
+        self.events.activate_cloned()
+    }
+}
+
+pub struct Config {
+    pub key: link_crypto::SecretKey,
+    pub paths: librad::paths::Paths,
+    pub listen: std::net::SocketAddr,
+    pub discovery: radicle_daemon::config::StreamDiscovery,
+    pub store: kv::Store,
+}
+
+pub struct Runner {
+    daemon_peer:
+        radicle_daemon::Peer<link_crypto::BoxedSigner, radicle_daemon::config::StreamDiscovery>,
+}
+
+impl Runner {
+    /// Run the peer. Stops the peer when `shutdown_signal` is ready and then returns.
+    pub async fn run(
+        self,
+        shutdown_signal: future::BoxFuture<'static, ()>,
+    ) -> Result<(), radicle_daemon::peer::Error> {
+        let (peer_shutdown, peer_run) = self.daemon_peer.start();
+        let mut shutdown_signal = shutdown_signal.fuse();
+        let peer_run = peer_run.fuse();
+        futures::pin_mut!(peer_run);
+        futures::select! {
+            _ = shutdown_signal => {
+                drop(peer_shutdown);
+                peer_run.await
+            }
+            result = peer_run => {
+                result
+            }
+        }
+    }
+}
+
+pub fn create(config: Config) -> anyhow::Result<(Peer, Runner)> {
+    let signer = link_crypto::BoxedSigner::new(link_crypto::SomeSigner { signer: config.key });
+    let daemon_config = radicle_daemon::config::configure(config.paths, signer, config.listen);
+    let daemon_peer = radicle_daemon::Peer::new(
+        daemon_config,
+        config.discovery,
+        config.store,
+        radicle_daemon::RunConfig::default(),
+    )
+    .context("failed to initialize radicle_daemon peer")?;
+
+    let daemon_control = daemon_peer.control();
+    let librad_peer = daemon_peer.peer.clone();
+
+    let (peer_events_tx, peer_events) = async_broadcast::broadcast(32);
+    tokio::task::spawn(forward_broadcast(daemon_peer.subscribe(), peer_events_tx));
+
+    let peer = Peer {
+        daemon_control,
+        librad_peer,
+        events: peer_events.deactivate(),
+    };
+
+    let runner = Runner { daemon_peer };
+
+    Ok((peer, runner))
+}
+
+/// Forward messages from a `tokio` broadcast receiver to an `async_broadcast` sender with message
+/// overflow enabled.
+///
+/// The future is done and stops forwarding when either channel is closed.
+async fn forward_broadcast<T: Clone>(
+    mut tokio_receiver: tokio::sync::broadcast::Receiver<T>,
+    mut async_sender: async_broadcast::Sender<T>,
+) {
+    async_sender.set_overflow(true);
+    loop {
+        use tokio::sync::broadcast::error::RecvError;
+        match tokio_receiver.recv().await {
+            Ok(item) => {
+                if let Err(err) = async_sender.try_broadcast(item) {
+                    match err {
+                        async_broadcast::TrySendError::Full(_) => {
+                            panic!("broadcast channel in overflow mode cannot be full")
+                        },
+                        async_broadcast::TrySendError::Closed(_) => {
+                            break;
+                        },
+                        async_broadcast::TrySendError::Inactive(_) => {},
+                    }
+                }
+            },
+            Err(err) => match err {
+                RecvError::Closed => {
+                    break;
+                },
+                RecvError::Lagged(_) => {},
+            },
+        }
+    }
+}

--- a/proxy/api/src/session.rs
+++ b/proxy/api/src/session.rs
@@ -105,14 +105,18 @@ pub fn update_seeds(store: &kv::Store, seeds: Vec<String>) -> Result<(), error::
 #[cfg(test)]
 pub async fn initialize_test(ctx: &crate::context::Unsealed, owner_handle: &str) -> Session {
     let owner = radicle_daemon::state::init_owner(
-        &ctx.peer,
+        ctx.peer.librad_peer(),
         link_identities::payload::Person {
             name: owner_handle.into(),
         },
     )
     .await
     .expect("cannot init owner identity");
-    let identity = (ctx.peer.peer_id(), owner.into_inner().into_inner()).into();
+    let identity = (
+        ctx.peer.librad_peer().peer_id(),
+        owner.into_inner().into_inner(),
+    )
+        .into();
     initialize(&ctx.rest.store, identity, &ctx.rest.default_seeds)
         .expect("failed to initialize session")
 }


### PR DESCRIPTION
We encapsulate peer related logic (from `librad` and `radicle_daemon`) into a `peer` module to enforce simpler boundaries.

This change tackles the following code issues
* `context::Unsealed` held three fields related to peers which didn’t provide proper encapsulation.
* Configuring a peer was done as part of the session setup in `process`.
* Callers of peer related functionality had to decide whether to access the `librad` peer or the `daemon` peer.