### PR TITLE
feat: move attestation widget beneath wallet balance

### DIFF
--- a/ui/App/WalletScreen.svelte
+++ b/ui/App/WalletScreen.svelte
@@ -16,16 +16,11 @@
     selectedEnvironment as ethereumEnvironment,
     supportedNetwork,
   } from "ui/src/ethereum";
-  import {
-    watchAttestationStatus,
-    attestationStatus,
-    AttestationStatus,
-  } from "ui/src/attestation/status";
+  import { watchAttestationStatus } from "ui/src/attestation/status";
   import { store, Status, accountBalancesStore } from "ui/src/wallet";
 
   import TransactionsIcon from "design-system/icons/Transactions.svelte";
 
-  import EmptyState from "ui/App/SharedComponents/EmptyState.svelte";
   import ScreenLayout from "ui/App/ScreenLayout.svelte";
   import TabBar, { Tab } from "ui/App/ScreenLayout/TabBar.svelte";
 
@@ -108,28 +103,20 @@
           eth={$accountBalancesStore.eth}
           rad={$accountBalancesStore.rad}
           address={w.connected.address} />
+        <LinkAddress />
       </div>
       {#if supportedNetwork($ethereumEnvironment) === w.connected.network}
-        {#if $attestationStatus === AttestationStatus.Fetching}
-          <EmptyState
-            text="Checking whether you have attested your Ethereum address…"
-            style="height: 30rem; margin-top: 3.75rem;"
-            emoji="🧦" />
-        {:else if $attestationStatus === AttestationStatus.Valid}
-          <div class="right-column">
-            <TabBar
-              slot="left"
-              tabs={tabs(activeTab)}
-              style="padding: 0.5rem 0; margin-bottom: 1rem;" />
-            {#if activeTab === "transactions"}
-              <Transactions />
-            {:else}
-              {unreachable(activeTab)}
-            {/if}
-          </div>
-        {:else}
-          <LinkAddress />
-        {/if}
+        <div class="right-column">
+          <TabBar
+            slot="left"
+            tabs={tabs(activeTab)}
+            style="padding: 0.5rem 0; margin-bottom: 1rem;" />
+          {#if activeTab === "transactions"}
+            <Transactions />
+          {:else}
+            {unreachable(activeTab)}
+          {/if}
+        </div>
       {:else}
         <WrongNetwork
           walletNetwork={w.connected.network}

--- a/ui/App/WalletScreen/ConnectWallet.svelte
+++ b/ui/App/WalletScreen/ConnectWallet.svelte
@@ -34,7 +34,7 @@
 <div class="wrapper" class:connecting>
   <Emoji emoji="👛" size="huge" />
   <p class="typo-text">
-    In order to use Ethereum features, you need to connect a wallet.
+    To use Ethereum features, you need to connect a wallet.
   </p>
   <Button disabled={connecting} on:click={onConnect} dataCy="connect-wallet">
     Connect your wallet

--- a/ui/App/WalletScreen/LinkAddress.svelte
+++ b/ui/App/WalletScreen/LinkAddress.svelte
@@ -6,9 +6,18 @@
  LICENSE file.
 -->
 <script lang="ts">
+  import {
+    selectedEnvironment as ethereumEnvironment,
+    supportedNetwork,
+  } from "ui/src/ethereum";
+  import {
+    attestationStatus,
+    AttestationStatus,
+  } from "ui/src/attestation/status";
   import { lastClaimed } from "ui/src/attestation/lastClaimed";
   import { store as walletStore } from "ui/src/wallet";
   import * as modal from "ui/src/modal";
+  import { store, Status } from "ui/src/wallet";
 
   import Button from "design-system/Button.svelte";
   import Emoji from "design-system/Emoji.svelte";
@@ -20,6 +29,9 @@
   function onLink(): void {
     modal.toggle(LinkAddressModal);
   }
+
+  $: wallet = $store;
+  $: w = $wallet;
 </script>
 
 <style>
@@ -30,8 +42,8 @@
     align-items: center;
 
     text-align: center;
-    padding: 10vh 0;
-    margin-top: 3.75rem;
+    padding: 3rem 0;
+    margin-top: 1.5rem;
 
     border: 1px solid var(--color-foreground-level-2);
     box-sizing: border-box;
@@ -44,14 +56,11 @@
     flex-direction: column;
     justify-content: space-around;
     align-items: center;
-
-    width: 23.75rem;
     margin: 0 auto;
   }
 
   p {
-    margin-top: 1rem;
-    margin-bottom: 1.25rem;
+    margin: 1rem 1rem 1.25rem 1rem;
   }
 
   .spinner-wrapper {
@@ -61,21 +70,37 @@
   }
 </style>
 
-<div class="wrapper">
-  <div class="inner">
-    <Emoji emoji="👛" size="huge" />
-    <p class="typo-text">
-      In order to use Ethereum features, you need to link your Radicle ID and
-      Ethereum address.
-    </p>
-    {#if !$lastClaimed || $lastClaimed !== address}
-      <Button on:click={onLink} dataCy="link-button"
-        >Link your Radicle ID</Button>
-    {:else}
-      <div class="spinner-wrapper">
-        Linking your Radicle ID…
-        <Button variant="transparent" on:click={onLink}>Retry</Button>
+{#if w.status === Status.Connected}
+  {#if supportedNetwork($ethereumEnvironment) === w.connected.network}
+    <div class="wrapper">
+      <div class="inner">
+        {#if $attestationStatus === AttestationStatus.Fetching}
+          <Emoji emoji="🧦" size="huge" />
+          <p class="typo-text">
+            Checking whether your Radicle ID and Ethereum address are linked…
+          </p>
+        {:else if $attestationStatus === AttestationStatus.Valid}
+          <Emoji emoji="🧦" size="huge" />
+          <p class="typo-text">
+            Your Radicle ID and Ethereum address are linked.
+          </p>
+        {:else}
+          <Emoji emoji="👛" size="huge" />
+          <p class="typo-text">
+            To use Ethereum features, you need to link your Radicle ID and
+            Ethereum address.
+          </p>
+          {#if !$lastClaimed || $lastClaimed !== address}
+            <Button on:click={onLink} dataCy="link-button"
+              >Link your Radicle ID</Button>
+          {:else}
+            <div class="spinner-wrapper">
+              Linking your Radicle ID…
+              <Button variant="transparent" on:click={onLink}>Retry</Button>
+            </div>
+          {/if}
+        {/if}
       </div>
-    {/if}
-  </div>
-</div>
+    </div>
+  {/if}
+{/if}

--- a/ui/App/WalletScreen/Transactions.svelte
+++ b/ui/App/WalletScreen/Transactions.svelte
@@ -11,6 +11,8 @@
   import type { Tx } from "ui/src/transaction";
 
   import TransactionList from "./Transactions/TransactionList.svelte";
+  import EmptyState from "ui/App/SharedComponents/EmptyState.svelte";
+
   interface Section {
     key: string;
     title: string;
@@ -70,10 +72,19 @@
         <TransactionList title="Rejected transactions" txs={rejectedTxs} />
       </div>
     {/if}
-    <div class="list" data-cy="transactions">
-      {#each txMonthSections as section}
-        <TransactionList title={section.title} txs={section.items} />
-      {/each}
+    {#if txMonthSections.length > 0}
+      <div class="list" data-cy="transactions">
+        {#each txMonthSections as section}
+          <TransactionList title={section.title} txs={section.items} />
+        {/each}
+      </div>
+    {/if}
+  {:else}
+    <div class="list">
+      <EmptyState
+        emoji="📜"
+        text="You don't have any transactions yet."
+        style="min-height: 32rem;" />
     </div>
   {/if}
 </div>


### PR DESCRIPTION
We move attestation out of the way, so it doesn't block the user from seeing their transactions.

Refs https://github.com/radicle-dev/radicle-upstream/issues/2583 and [user testing findings](https://www.notion.so/Summary-of-friction-along-onboarding-journey-fd32a1171b52449e8014468e8e46b899).

<img width="1440" alt="Screenshot 2021-12-17 at 12 06 35" src="https://user-images.githubusercontent.com/158411/146535664-628e1a10-2d49-45d6-992f-ae5b7f3d1141.png">

<img width="1440" alt="Screenshot 2021-12-17 at 12 07 00" src="https://user-images.githubusercontent.com/158411/146535955-d0b1cc4e-3594-4b4b-80c8-2a116e9fd89c.png">


<img width="1440" alt="Screenshot 2021-12-17 at 12 07 25" src="https://user-images.githubusercontent.com/158411/146535678-046ba4bb-8c94-4734-b708-e6bd978f1015.png">
<img width="1440" alt="Screenshot 2021-12-17 at 12 07 32" src="https://user-images.githubusercontent.com/158411/146535681-654c5240-a78d-49e0-bfe8-d5fcbbd3f28f.png">
<img width="1440" alt="Screenshot 2021-12-17 at 12 07 40" src="https://user-images.githubusercontent.com/158411/146535684-35601b82-bd07-4ec8-8678-e26de512a09a.png">
<img width="1440" alt="Screenshot 2021-12-17 at 12 07 58" src="https://user-images.githubusercontent.com/158411/146535687-cc79e2f7-9aaa-4c9f-9897-243b7d587380.png">

