### PR TITLE
fix: show newly created org only after Gnosis API picks it up

### DIFF
--- a/ui/src/org.ts
+++ b/ui/src/org.ts
@@ -292,7 +292,7 @@ export async function createOrg(
   });
 
   const receipt = await walletStore.provider.waitForTransaction(response.hash);
-  const orgAddress = Contract.parseOrgCreatedReceipt(receipt);
+  const { orgAddress, safeAddress } = Contract.parseOrgCreatedReceipt(receipt);
 
   await svelteStore.waitUntil(orgSidebarStore, store => {
     if (store.type === "initial") {
@@ -303,6 +303,10 @@ export async function createOrg(
       return undefined;
     }
   });
+
+  // Wait for Gnosis Safe API to pick up the newly created safe.
+  await Safe.waitUntilSafeIsReady(safeAddress, walletStore.environment);
+
   creationNotification.remove();
   pendingOrgs.update(x => x - 1);
   // Reset org list polling to default interval.

--- a/ui/src/org/safe.ts
+++ b/ui/src/org/safe.ts
@@ -10,10 +10,31 @@ import SafeServiceClient, {
   SafeMultisigTransactionResponse,
 } from "@gnosis.pm/safe-service-client";
 
+import { sleep } from "ui/src/sleep";
 import * as Ethereum from "ui/src/ethereum";
 import * as error from "ui/src/error";
 import type { Wallet } from "ui/src/wallet";
 import type { OperationType } from "@gnosis.pm/safe-core-sdk-types";
+
+export async function waitUntilSafeIsReady(
+  safeAddress: string,
+  ethEnv: Ethereum.Environment
+): Promise<void> {
+  safeAddress = ethers.utils.getAddress(safeAddress);
+  const safeServiceClient = createSafeServiceClient(ethEnv);
+  let tries = 360; // 30 min
+
+  while (tries > 0) {
+    try {
+      await safeServiceClient.getSafeInfo(safeAddress);
+      return;
+    } catch {
+      // Ignore exception.
+    }
+    tries -= 1;
+    await sleep(5000);
+  }
+}
 
 export async function getPendingTransactions(
   ethEnv: Ethereum.Environment,


### PR DESCRIPTION
After creating an org we need to wait for the Gnosis API to pick it up before we can let the user navigate to the org. 
Otherwise we get an error when querying for anchors:

```
{
  "stack": "Error: Not Found\n    at Object.sendRequest (webpack-internal:///./node_modules/@gnosis.pm/safe-service-client/dist/src/utils/httpRequests.js:27:23)\n    at async SafeServiceClient.getPendingTransactions (webpack-internal:///./node_modules/@gnosis.pm/safe-service-client/dist/src/SafeServiceClient.js:281:52)\n    at async Module.getPendingTransactions (webpack-internal:///./ui/src/org/safe.ts:28:22)\n    at async fetchPendingAnchors (webpack-internal:///./ui/src/org.ts:359:17)\n    at async Module.resolveProjectAnchors (webpack-internal:///./ui/src/org.ts:395:26)\n    at async Module.load (webpack-internal:///./ui/App/OrgScreen/route.ts:38:34)\n    at async eval (webpack-internal:///./ui/src/router/index.ts:78:20)\n    at async setHistory (webpack-internal:///./ui/src/router/index.ts:48:25)\n    at async push (webpack-internal:///./ui/src/router/index.ts:104:5)",
  "message": "Not Found",
  "code": "UnhandledRejection",
  "details": {
    "name": "Error"
  }
}
```

<img width="1440" alt="Screenshot 2021-12-17 at 15 11 37" src="https://user-images.githubusercontent.com/158411/146557263-eb165c6a-5300-4596-aa6f-92e6a7fe5e41.png">

