### PR TITLE
fix: add default bg color for image avatars with transparency

### DIFF
--- a/design-system/Avatar.svelte
+++ b/design-system/Avatar.svelte
@@ -139,6 +139,7 @@
     align-items: center;
     user-select: none;
     flex-shrink: 0;
+    background-color: var(--color-foreground-level-3);
   }
 
   .pulsate {


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-upstream/issues/2629.

<img width="378" alt="Screenshot 2021-12-17 at 16 10 46" src="https://user-images.githubusercontent.com/158411/146565582-eb6aa8ef-51ca-4d56-b48f-537ca984df9f.png">
<img width="464" alt="Screenshot 2021-12-17 at 16 11 02" src="https://user-images.githubusercontent.com/158411/146565586-3fe7799c-d3b3-4eda-a5f5-2c266650a0cb.png">
<img width="1440" alt="Screenshot 2021-12-17 at 16 11 18" src="https://user-images.githubusercontent.com/158411/146565590-fd65f9f3-af56-463f-b086-6de081939466.png">