### PR TITLE
test: multiple project replication

### DIFF
--- a/ci/p2p-network-tests.sh
+++ b/ci/p2p-network-tests.sh
@@ -50,4 +50,8 @@ log-group-start "contributor-fork-replication-2-test.ts"
 run-test ./p2p-tests/contributor-fork-replication-2-test.ts
 log-group-end
 
+log-group-start "multiple-project-replication-test.ts"
+run-test ./p2p-tests/multiple-project-replication-test.ts
+log-group-end
+
 clean-cargo-build-artifacts

--- a/p2p-tests/multiple-project-replication-test.ts
+++ b/p2p-tests/multiple-project-replication-test.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env -S node --require ts-node/register/transpile-only --require tsconfig-paths/register
+
+// Copyright © 2021 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+import * as path from "path";
+import { strict as strictAssert } from "assert";
+
+import { sleep } from "ui/src/sleep";
+import {
+  RadicleProxy,
+  UpstreamSeed,
+  radCli,
+  runTestcase,
+  withRetry,
+} from "./lib/p2p";
+
+async function testcase(dataPath: string) {
+  const project1 = {
+    name: "project1",
+    urn: "rad:git:hnrkn4pax4rsgyxqrioxi9sypj8w8rwnz6tky",
+  };
+
+  const project2 = {
+    name: "project2",
+    urn: "rad:git:hnrkgr1yb8wkfhmd3sucz9zj77ji6ubospd9y",
+  };
+
+  const seed = new UpstreamSeed({
+    name: "seed",
+    ipAddress: "10.0.0.1",
+    project: `${project1.urn},${project2.urn}`,
+    dataPath,
+  });
+
+  const maintainer = new RadicleProxy({
+    name: "maintainer",
+    ipAddress: "10.0.0.101",
+    seed: seed.seedAddress,
+    dataPath,
+  });
+
+  const contributor = new RadicleProxy({
+    name: "contributor",
+    ipAddress: "10.0.0.102",
+    seed: seed.seedAddress,
+    dataPath,
+  });
+
+  seed.start();
+  maintainer.start();
+
+  // Maintainer creates first project.
+  await withRetry(async () => {
+    await maintainer.proxyClient.project.create({
+      repo: {
+        type: "new",
+        path: maintainer.checkoutPath,
+        name: project1.name,
+      },
+      description: "",
+      defaultBranch: "main",
+    });
+  });
+
+  // Maintainer creates second project.
+  await withRetry(async () => {
+    await maintainer.proxyClient.project.create({
+      repo: {
+        type: "new",
+        path: maintainer.checkoutPath,
+        name: project2.name,
+      },
+      description: "",
+      defaultBranch: "main",
+    });
+  });
+
+  // Assert that the seed received the first project.
+  await withRetry(async () => {
+    const result = radCli({
+      radHome: seed.radHome,
+      args: ["identities", "project", "get", "--urn", project1.urn],
+    });
+
+    strictAssert.deepStrictEqual(result, {
+      urn: project1.urn,
+      payload: {
+        "https://radicle.xyz/link/identities/project/v1": {
+          name: project1.name,
+          description: "",
+          default_branch: "main",
+        },
+      },
+    });
+  });
+
+  // Assert that the seed received the second project.
+  await withRetry(async () => {
+    const result = radCli({
+      radHome: seed.radHome,
+      args: ["identities", "project", "get", "--urn", project2.urn],
+    });
+
+    strictAssert.deepStrictEqual(result, {
+      urn: project2.urn,
+      payload: {
+        "https://radicle.xyz/link/identities/project/v1": {
+          name: project2.name,
+          description: "",
+          default_branch: "main",
+        },
+      },
+    });
+  });
+
+  // Without this the test fails, not sure why.
+  await sleep(1000);
+
+  await maintainer.stop();
+  contributor.start();
+
+  // Contributor follows the first project.
+  await withRetry(async () => {
+    await contributor.proxyClient.project.requestSubmit(project1.urn);
+  });
+
+  // Without this the test fails, not sure why.
+  await sleep(3000);
+
+  // Contributor follows the second project.
+  await withRetry(async () => {
+    await contributor.proxyClient.project.requestSubmit(project2.urn);
+  });
+
+  // Assert that the contributor received the first project.
+  await withRetry(async () => {
+    const result = await contributor.proxyClient.project.get(project1.urn);
+    strictAssert.deepStrictEqual(result.urn, project1.urn);
+  });
+
+  // Assert that the contributor received the second project.
+  await withRetry(async () => {
+    const result = await contributor.proxyClient.project.get(project2.urn);
+    strictAssert.deepStrictEqual(result.urn, project2.urn);
+  });
+}
+
+runTestcase({
+  testcase,
+  networkScript: "star-topology.sh",
+  dataDirName: path.basename(__filename).replace(".ts", ""),
+});


### PR DESCRIPTION
Reproduces replication failure from https://github.com/radicle-dev/radicle-upstream/issues/2703.

The contributor node doesn't replicate the maintainer's default branch:
```
contributor  |   2022-01-06T14:10:37.364875Z ERROR api::http::error: internal server error, we could not find a default branch for 'project2@rad:git:hnrkgr1yb8wkfhmd3sucz9zj77ji6ubospd9y', variant: INTERNAL_SERVER_ERROR, err: Rejection(State(NoDefaultBranch { name: "project2", urn: Urn { id: Oid(6248013d145e2c79b4d97fdd3dea6be9861668fe), path: None } }))
contributor  |     at proxy/api/src/http/error.rs:101
```

Contributor's monorepo tree of the first project:
```
vagrant@ubuntu-focal:/vagrant/p2p-tests/workspace/multiple-project-replication-test/contributor-rad-home/f0b33c27-0053-4e89-9de4-c84b223100ec/git/refs/namespaces$ tree hnrkn4pax4rsgyxqrioxi9sypj8w8rwnz6tky
hnrkn4pax4rsgyxqrioxi9sypj8w8rwnz6tky
└── refs
    ├── rad
    │   ├── id
    │   ├── ids
    │   │   └── hnrkeiq6qo4d96m13nxud3qgfzbahmwsfmdwy
    │   ├── self
    │   └── signed_refs
    └── remotes
        ├── hybfoqx9wrdjhnr9jyb74zpduph57z99f67bjgfnsf83p1rk7z1diy
        │   └── rad
        │       └── ids
        └── hybhe78oy41yzux5d6rk8fdtek881de76wuwy7mga1imzoj7p17pnw
            ├── heads
            │   └── main
            └── rad
                ├── id
                ├── ids
                │   └── hnrkeiq6qo4d96m13nxud3qgfzbahmwsfmdwy
                ├── self
                └── signed_refs
```

Contributor's monorepo tree of the second project (note: missing `heads/main` in the `hybhe78oy41yzux5d6rk8fdtek881de76wuwy7mga1imzoj7p17pnw` remote):

```
vagrant@ubuntu-focal:/vagrant/p2p-tests/workspace/multiple-project-replication-test/contributor-rad-home/f0b33c27-0053-4e89-9de4-c84b223100ec/git/refs/namespaces$ tree hnrkgr1yb8wkfhmd3sucz9zj77ji6ubospd9y
hnrkgr1yb8wkfhmd3sucz9zj77ji6ubospd9y
└── refs
    ├── rad
    │   ├── id
    │   ├── ids
    │   │   └── hnrkeiq6qo4d96m13nxud3qgfzbahmwsfmdwy
    │   ├── self
    │   └── signed_refs
    └── remotes
        ├── hybfoqx9wrdjhnr9jyb74zpduph57z99f67bjgfnsf83p1rk7z1diy
        │   └── rad
        │       └── ids
        └── hybhe78oy41yzux5d6rk8fdtek881de76wuwy7mga1imzoj7p17pnw
            └── rad
                ├── id
                ├── ids
                │   └── hnrkeiq6qo4d96m13nxud3qgfzbahmwsfmdwy
                ├── self
                └── signed_refs
```