### PR TITLE
test: add test for implicitly tracked peer branches

### DIFF
--- a/ci/p2p-network-tests.sh
+++ b/ci/p2p-network-tests.sh
@@ -42,4 +42,8 @@ log-group-start "contributor-fork-replication-2-test.ts"
 time sudo -E FORCE_COLOR=1 ./p2p-tests/contributor-fork-replication-2-test.ts
 log-group-end
 
+log-group-start "implicitly-tracked-peer-branches-test.ts"
+time sudo -E FORCE_COLOR=1 ./p2p-tests/implicitly-tracked-peer-branches-test.ts
+log-group-end
+
 clean-cargo-build-artifacts

--- a/p2p-tests/contributor-fork-replication-2-test.ts
+++ b/p2p-tests/contributor-fork-replication-2-test.ts
@@ -170,7 +170,7 @@ async function testcase(dataPath: string) {
     );
   });
 
-  // Assert that the contributor found the remote.
+  // Assert that the maintainer found the remote.
   await withRetry(async () => {
     const result = await maintainer.proxyClient.project.listPeers(project.urn);
 

--- a/p2p-tests/implicitly-tracked-peer-branches-test.ts
+++ b/p2p-tests/implicitly-tracked-peer-branches-test.ts
@@ -171,6 +171,21 @@ async function testcase(dataPath: string) {
     strictAssert.deepStrictEqual(result.urn, project.urn);
   });
 
+  // Assert that contributor is in contributor2's remote list.
+  await withRetry(async () => {
+    const peers = await contributor2.proxyClient.project.listPeers(project.urn);
+
+    console.log("maint: ", maintainer.peerId);
+    console.log("cont2: ", contributor2.peerId);
+    console.log("cont: ", contributor.peerId);
+    console.log(peers);
+    console.log(peers.find(x => x.peerId === contributor.peerId)?.status.type);
+    strictAssert.deepStrictEqual(
+      peers.find(x => x.peerId === contributor.peerId)?.status.type,
+      "replicated"
+    );
+  });
+
   // Assert that contributor2 can view contributor's branch.
   await withRetry(async () => {
     const branches = await contributor2.proxyClient.source.branchesGet({

--- a/p2p-tests/star-topology.sh
+++ b/p2p-tests/star-topology.sh
@@ -10,19 +10,23 @@ set -euo pipefail
 source "$(dirname "$0")/lib/topology.sh"
 
 function setup_network {
-  echo "setting up network: maintainer <==> seed <==> contributor"
+  echo "setting up network: nodes can only communicate via the seed"
 
   create_bridge
 
   create_peer seed 10.0.0.1/24
   create_peer maintainer 10.0.0.101/32
   create_peer contributor 10.0.0.102/32
+  create_peer contributor2 10.0.0.103/32
 
   ip netns exec upstream-test-maintainer ip route add 10.0.0.1/32 dev macv
   ip netns exec upstream-test-maintainer ip route add 10.0.0.254/32 dev macv
 
   ip netns exec upstream-test-contributor ip route add 10.0.0.1/32 dev macv
   ip netns exec upstream-test-contributor ip route add 10.0.0.254/32 dev macv
+
+  ip netns exec upstream-test-contributor2 ip route add 10.0.0.1/32 dev macv
+  ip netns exec upstream-test-contributor2 ip route add 10.0.0.254/32 dev macv
 }
 
 function clean_up_network {
@@ -30,6 +34,7 @@ function clean_up_network {
   ip netns delete upstream-test-maintainer > /dev/null 2>&1
   ip netns delete upstream-test-seed > /dev/null 2>&1
   ip netns delete upstream-test-contributor > /dev/null 2>&1
+  ip netns delete upstream-test-contributor2 > /dev/null 2>&1
   set -e
 
   clean_up_bridge


### PR DESCRIPTION
Refs: https://github.com/radicle-dev/radicle-upstream/issues/2691.

This test fails with:
```
  variant: 'INTERNAL_SERVER_ERROR',
  body: {
    message: "we could not find the 'refs/namespaces/hnrkrhhs1goaawo7db1gpyct8hd7mif5q8c3o/refs/remotes/hydkjndj7zhq98wg15akseowbtykjpym15oc613jq8frbpoisgi4pn/heads/main'",
    variant: 'INTERNAL_SERVER_ERROR'
  },
```

And we see this in the logs:
```
contributor2 |   2022-01-11T14:54:47.161534Z ERROR api::http::error: internal server error, we could not find the 'refs/namespaces/hnrkrhhs1goaawo7db1gpyct8hd7mif5q8c3o/refs/remotes/hydkjndj7zhq98wg15akseowbtykjpym15oc613jq8frbpoisgi4pn/heads/main', variant: INTERNAL_SERVER_ERROR, err: Rejection(State(MissingRef { reference: Reference { remote: Some(hydkjndj7zhq98wg15akseowbtykjpym15oc613jq8frbpoisgi4pn), category: Heads, name: RefLike("main"), namespace: Some(Namespace(Urn { id: Oid(4e72d234318a43a30c8cd03227e0faba976e3b33), path: None })) } }))
```