### PR TITLE
build on Ubuntu 18.04 for improved GLIBC compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
       - name: Cache Yarn
@@ -29,7 +29,7 @@ jobs:
             ./target/*/deps
             ./target/*/build
             ./target/*/.fingerprint
-          key: build-${{ runner.os }}-rust-v5-${{ hashFiles('Cargo.lock') }}
+          key: build-${{ runner.os }}-rust-v6-${{ hashFiles('Cargo.lock') }}
       - run: ci/build.sh
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - "**"
     - release-candidate/**
 
 jobs:
@@ -10,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
@@ -34,7 +35,7 @@ jobs:
             ./target/*/deps
             ./target/*/build
             ./target/*/.fingerprint
-          key: ${{ github.job }}-${{ runner.os }}-rust-v4-${{ hashFiles('Cargo.lock') }}
+          key: ${{ github.job }}-${{ runner.os }}-rust-v5-${{ hashFiles('Cargo.lock') }}
       - run: ci/dist.sh
       - name: publish artifacts by commit
         uses: google-github-actions/upload-cloud-storage@v0.4.0

--- a/.github/workflows/p2p-network-tests.yaml
+++ b/.github/workflows/p2p-network-tests.yaml
@@ -4,7 +4,7 @@ on:
     branches: ["**"]
 jobs:
   p2p-network-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
       - name: Cache Yarn
@@ -26,5 +26,5 @@ jobs:
             ./target/*/deps
             ./target/*/build
             ./target/*/.fingerprint
-          key: build-${{ runner.os }}-rust-v5-${{ hashFiles('Cargo.lock') }}
+          key: build-${{ runner.os }}-rust-v6-${{ hashFiles('Cargo.lock') }}
       - run: ci/p2p-network-tests.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -36,7 +36,7 @@ cp ci/gitconfig "$HOME/.gitconfig"
 log-group-end
 
 log-group-start "License compliance"
-time ./scripts/license-header.ts check
+time node -r ts-node/register/transpile-only ./scripts/license-header.ts check
 time cargo deny check
 log-group-end
 

--- a/ci/p2p-network-tests.sh
+++ b/ci/p2p-network-tests.sh
@@ -18,28 +18,36 @@ log-group-start "cargo build"
 cargo build --all --all-features --all-targets
 log-group-end
 
+function run-test () {
+  time sudo -E FORCE_COLOR=1 \
+    node \
+      --require ts-node/register/transpile-only \
+      --require tsconfig-paths/register \
+      "$1"
+}
+
 log-group-start "maintainer-update-propagation-1-test.ts"
-time sudo -E FORCE_COLOR=1 ./p2p-tests/maintainer-update-propagation-1-test.ts
+run-test ./p2p-tests/maintainer-update-propagation-1-test.ts
 log-group-end
 
 log-group-start "maintainer-update-propagation-2-test.ts"
-time sudo -E FORCE_COLOR=1 ./p2p-tests/maintainer-update-propagation-2-test.ts
+run-test ./p2p-tests/maintainer-update-propagation-2-test.ts
 log-group-end
 
 log-group-start "maintainer-update-propagation-3-test.ts"
-time sudo -E FORCE_COLOR=1 ./p2p-tests/maintainer-update-propagation-3-test.ts
+run-test ./p2p-tests/maintainer-update-propagation-3-test.ts
 log-group-end
 
 log-group-start "active-sets-test.ts"
-time sudo -E FORCE_COLOR=1 ./p2p-tests/active-sets-test.ts
+run-test ./p2p-tests/active-sets-test.ts
 log-group-end
 
 log-group-start "contributor-fork-replication-1-test.ts"
-time sudo -E FORCE_COLOR=1 ./p2p-tests/contributor-fork-replication-1-test.ts
+run-test ./p2p-tests/contributor-fork-replication-1-test.ts
 log-group-end
 
 log-group-start "contributor-fork-replication-2-test.ts"
-time sudo -E FORCE_COLOR=1 ./p2p-tests/contributor-fork-replication-2-test.ts
+run-test ./p2p-tests/contributor-fork-replication-2-test.ts
 log-group-end
 
 clean-cargo-build-artifacts


### PR DESCRIPTION
Run builds on Ubuntu 18.04 instead of 20.04. The former has an earlier GLIBC version (v2.27) which makes the built binaries compatible with more systems.

Fixes #2732 and #2731.