### PR TITLE
remove redundant @tsconfig/svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
   },
   "devDependencies": {
     "@ethersproject/cli": "^5.5.0",
-    "@tsconfig/svelte": "^2.0.1",
     "@types/big.js": "^6.1.2",
     "@types/cookie": "^0.4.1",
     "@types/copy-webpack-plugin": "^10.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "@tsconfig/svelte/tsconfig.json",
   "include": [
     "ui/**/*",
     "native/**/*",
@@ -97,7 +96,7 @@
     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "allowSyntheticDefaultImports": true,
     /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    "esModuleInterop": true
+    "esModuleInterop": true,
     /* Do not resolve the real path of symlinks. */
     // "preserveSymlinks": true,
     /* Source Map Options */
@@ -114,6 +113,7 @@
     // "experimentalDecorators": true,
     /* Enables experimental support for emitting type metadata for decorators. */
     // "emitDecoratorMetadata": true,
+    "skipLibCheck": true
   },
   "ts-node": {
     "compilerOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,13 +1503,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/svelte@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@tsconfig/svelte@npm:2.0.1"
-  checksum: b866a3e2a40eed8e4ab9f062a70086d3ab564e7b359545802bdd092f077a268ef715c58408c1b5ef0846efaf3884cc3a26fcb43df6e37195ec0d93392302c431
-  languageName: node
-  linkType: hard
-
 "@types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.14":
   version: 7.1.18
   resolution: "@types/babel__core@npm:7.1.18"
@@ -10822,7 +10815,6 @@ __metadata:
     "@gnosis.pm/safe-core-sdk": ^0.3.1
     "@gnosis.pm/safe-core-sdk-types": ^0.1.1
     "@gnosis.pm/safe-service-client": ^0.1.1
-    "@tsconfig/svelte": ^2.0.1
     "@types/big.js": ^6.1.2
     "@types/cookie": ^0.4.1
     "@types/copy-webpack-plugin": ^10.1.0


### PR DESCRIPTION
We set the `skipLibCheck` to `true` in `tsconfig`. Now extending our `tsconfig` with `@tsconfig/svelte` has no effect since we overwrite all options that set by `@tsconfig/svelte`.