### PR TITLE
run app in dev mode during development

### DIFF
--- a/native/index.js
+++ b/native/index.js
@@ -4,6 +4,10 @@
 // with Radicle Linking Exception. For full terms see the included
 // LICENSE file.
 
+if (process.env.NODE_ENV === undefined) {
+  process.env.NODE_ENV = "development";
+}
+
 /* eslint-disable @typescript-eslint/no-var-requires */
-require("ts-node").register();
+require("ts-node").register({ transpileOnly: true });
 require("./index.ts");

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ds:deploy": "scripts/deploy-design-system.sh",
     "_private:test:integration": "wait-on tcp:127.0.0.1:30000 && yarn run webpack build --config-name ui && yarn run cypress run",
     "_private:test:integration:debug": "wait-on ./public/bundle.js tcp:127.0.0.1:30000 && yarn run cypress open",
-    "_private:electron:start": "wait-on ./public/bundle.js && NODE_ENV='development' electron native/index.js",
+    "_private:electron:start": "wait-on ./public/bundle.js && electron native/index.js",
     "_private:dist:clean": "rimraf ./dist && mkdir ./dist",
     "_private:prettier": "prettier \"**/*.@(js|ts|json|svelte|css|html)\" --ignore-path .gitignore",
     "_private:proxy:start:test": "cargo build --all-features --bins && cargo run --all-features -- --test --unsafe-fast-keystore --http-listen 127.0.0.1:30000",


### PR DESCRIPTION
When running the app from the command line during development with `yarn run electron ./native/index.js` we ensure that the NODE_ENV environment variable which configures the app is set to "development".

The NODE_ENV variable was properly set when running the app with `yarn start` but not when running the devnet instantces.

We also enable the `transpileOnly` flag for `ts-node`. This makes the app start quicker.