### PR TITLE
build and publish macOS app on main branch builds

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - main
-    - "**"
     - release-candidate/**
 
 jobs:
@@ -11,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-18.04, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ yarn run dist
 This command will create an application package in the `./dist` folder which
 you can then run.
 
-### Attribution
+## Development Builds
+
+You can download the latest development build here
+
+* <https://storage.googleapis.com/radicle-upstream-build-artifacts/v1/main/radicle-upstream.AppImage>
+* <https://storage.googleapis.com/radicle-upstream-build-artifacts/v1/main/radicle-upstream.dmg>
+
+The development builds for macOS are unsigned. See [this
+article](https://support.apple.com/en-gb/guide/mac-help/mh40616/mac) on how to
+run unsigned apps on macOS.
+
+## Attribution
 
 Upstream uses:
   - [Twemoji by Twitter][tw]

--- a/ci/dist.sh
+++ b/ci/dist.sh
@@ -27,14 +27,14 @@ echo "Collect artifacts"
 mkdir artifacts
 shopt -s nullglob
 shopt -u failglob
-cp --archive \
-  --target-directory artifacts \
+cp -a \
   dist/*.dmg \
-  dist/*.AppImage
+  dist/*.AppImage \
+  artifacts
 
 target="$(uname -m)-$(uname -s | tr "[:upper:]" "[:lower:]")"
 mkdir "artifacts/${target}"
-cp \
-  --target-directory "artifacts/${target}" \
+cp -a \
   target/release/upstream-seed \
-  target/release/rad
+  target/release/rad \
+  "artifacts/${target}" \

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "build": {
     "appId": "xyz.radicle.radicle-upstream",
-    "artifactName": "${name}-${version}.${ext}",
+    "artifactName": "${name}.${ext}",
     "afterSign": "builder/notarize.js",
     "files": [
       "public/**/*",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -143,7 +143,7 @@ const publishRcBinaries: yargs.CommandModule<unknown, unknown> = {
     const version = await getReleaseCandidateVersion();
     const sha = await getCommitSha();
 
-    const buildArtifactPrefix = `gs://${buildArtifactBucket}/v1/by-commit/${sha}/radicle-upstream-${version}`;
+    const buildArtifactPrefix = `gs://${buildArtifactBucket}/v1/by-commit/${sha}/radicle-upstream`;
 
     const linuxBinaryPath = `radicle-upstream-${version}-rc.AppImage`;
     await runVerbose("gsutil", [


### PR DESCRIPTION
Also add documentation on how to find latest development builds. To make this independent of the version we remove the version from the artifact file template.

See [this successful build](https://github.com/radicle-dev/radicle-upstream/runs/5094128807?check_suite_focus=true).