### PR TITLE
Add devnet shell command to act as devnet peer

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -37,13 +37,14 @@ Make sure to source the script from the repository root.
 ## Run and connect multiple instances
 
 We provide the `scripts/devnet.ts` tool for running, connecting and managing
-multiple Upstream instances and a seed peer on a local machine.
+multiple Upstream instances and a seed peer on a local machine. Run `yarn run
+devent --help` for a list of all commands.
 
 The devnet tool uses numbers from 1 to 100 to identify and reference Upstream
 instances.
 
 ```bash
-scripts/devnet.ts upstream 1
+yarn run devnet upstream 1
 ```
 
 This command will start an Upstream instance. The instance will be fully
@@ -53,7 +54,7 @@ initialized with user name `1`. The `RAD_HOME` for the instance is
 To connect a second instance to the first one run
 
 ```bash
-scripts/devnet.ts upstream 2 --bootstrap 1
+yarn run devnet upstream 2 --bootstrap 1
 ```
 
 Make sure you rebuild the project before running instances
@@ -66,7 +67,7 @@ yarn run webpack --config-name ui
 You can also run a seed peer that tracks a certain project.
 
 ```bash
-scripts/devnet.ts seed --project <urn>
+yarn run devnet seed --project <urn>
 ```
 
 By default, all Upstream instances include the seed address as a bootstrap peer.

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "reset:state": "scripts/reset-state.sh",
     "ds:start": "webpack serve --open --config-name design-system",
     "ds:deploy": "scripts/deploy-design-system.sh",
+    "devnet": "scripts/devnet.ts",
     "_private:test:integration": "wait-on tcp:127.0.0.1:30000 && yarn run webpack build --config-name ui && yarn run cypress run",
     "_private:test:integration:debug": "wait-on ./public/bundle.js tcp:127.0.0.1:30000 && yarn run cypress open",
     "_private:electron:start": "wait-on ./public/bundle.js && electron native/index.js",


### PR DESCRIPTION
We add a command to the devnet script that allows us to use the radicle tools in the context of a devnet peer when run as `eval $(yarn run devnet shell 1)`. We also at an alias for the devnet script to `package.json` so that we can call it from any directory inside the repository.