### PR TITLE
cypress: connect nodes client side

### DIFF
--- a/cypress/plugins/nodeManager/shared.ts
+++ b/cypress/plugins/nodeManager/shared.ts
@@ -28,10 +28,6 @@ export interface OnboardNodeOptions {
   passphrase: string;
 }
 
-export interface ConnectNodeOptions {
-  nodeIds: NodeId[];
-}
-
 // We us `Promise<null>` because Cypress complains if we use
 // `Promise<void>` or `Promise<undefined>`.
 //
@@ -44,7 +40,6 @@ export interface NodeManagerPlugin {
   // related data.
   startNode: (dataDir: string) => Promise<number>;
   onboardNode: (options: OnboardNodeOptions) => Promise<NodeSession>;
-  connectNodes: (options: ConnectNodeOptions) => Promise<null>;
   stopAllNodes: () => Promise<null>;
 }
 
@@ -52,5 +47,4 @@ export const pluginMethods: Array<keyof NodeManagerPlugin> = [
   "startNode",
   "onboardNode",
   "stopAllNodes",
-  "connectNodes",
 ];

--- a/cypress/support/nodeManager.ts
+++ b/cypress/support/nodeManager.ts
@@ -64,13 +64,14 @@ interface WithTwoOnboardedNodesOptions {
   node2User: OnboardedUser;
 }
 
-export const connectTwoNodes = (
-  node1: NodeSession,
-  node2: NodeSession
-): void => {
+export function connectTwoNodes(node1: NodeHandle, node2: NodeHandle): void {
   cy.log(`adding node ${node2.id} as seed to node ${node1.id}`);
-  nodeManagerPlugin.connectNodes({ nodeIds: [node1.id, node2.id] });
-};
+  cy.then(async () => {
+    await node1.client.seedsPut([
+      `${node2.peerId}@127.0.0.1:${node2.httpPort}`,
+    ]);
+  });
+}
 
 // Executes a shell command in the context of a node session.
 //


### PR DESCRIPTION
Issue the request to connect two nodes in the tests on the client instead of the cypress plugin. This allows us to remove a lot of code.