### PR TITLE
refactor: localise the daemon code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-broadcast"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
@@ -2009,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "iso8601"
@@ -2277,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "df2bf61678a0a521c3f7daf815d2e6717d85a272a7dcd02c9768272b32bd1e2a"
 dependencies = [
  "cc",
  "cmake",
@@ -2990,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "onig"
@@ -3377,29 +3383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "radicle-daemon"
-version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link.git?tag=cycle/2022-03-01#a5181d98b12cf5f90362a761cc0c6a7a98712fc3"
-dependencies = [
- "anyhow",
- "async-stream",
- "either",
- "futures 0.3.21",
- "git2",
- "kv",
- "lazy_static",
- "librad",
- "nonempty 0.6.0",
- "radicle-git-ext",
- "radicle-git-helpers",
- "serde",
- "serde_millis",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4669,7 +4652,9 @@ name = "upstream-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-broadcast",
+ "async-stream",
  "bytes 1.1.0",
  "chrono",
  "clap 3.1.5",
@@ -4678,6 +4663,7 @@ dependencies = [
  "eip55",
  "either",
  "futures 0.3.21",
+ "git2",
  "http",
  "kv",
  "lazy_static",
@@ -4689,7 +4675,6 @@ dependencies = [
  "nonempty 0.6.0",
  "percent-encoding",
  "pretty_assertions",
- "radicle-daemon",
  "radicle-git-ext",
  "radicle-git-helpers",
  "radicle-keystore",
@@ -4698,6 +4683,7 @@ dependencies = [
  "secstr",
  "serde",
  "serde_json",
+ "serde_millis",
  "serde_qs",
  "sha2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,6 @@ tag = "cycle/2022-03-01"
 git = "https://github.com/radicle-dev/radicle-link.git"
 tag = "cycle/2022-03-01"
 
-[patch.crates-io.radicle-daemon]
-git = "https://github.com/radicle-dev/radicle-link.git"
-tag = "cycle/2022-03-01"
-
 [patch.crates-io.radicle-git-ext]
 git = "https://github.com/radicle-dev/radicle-link.git"
 tag = "cycle/2022-03-01"
@@ -46,7 +42,6 @@ tag = "cycle/2022-03-01"
 # librad = { path = "../radicle-link/librad" }
 # link-crypto = { path = "../radicle-link/link-crypto" }
 # link-identities = { path = "../radicle-link/link-identities" }
-# radicle-daemon = { path = "../radicle-link/daemon" }
 # lnk-exe = { path = "../radicle-link/lnk-exe" }
 # lnk-identities = { path = "../radicle-link/lnk-identities" }
 # radicle-git-ext = { path = "../radicle-link/git-ext" }

--- a/upstream-proxy/Cargo.toml
+++ b/upstream-proxy/Cargo.toml
@@ -14,6 +14,7 @@ default-run = "upstream-proxy"
 [dependencies]
 anyhow = "1.0"
 async-broadcast = "0.3.4"
+async-stream = "0.3"
 chrono = { version = "0.4.19", features = [ "serde" ] }
 clap = { version =  "3.0", features = ["derive", "env"] }
 data-encoding = "2.3"
@@ -21,6 +22,7 @@ directories = "4.0"
 eip55 = "0.1.1"
 either = "1"
 futures = { version = "0.3", features = [ "compat" ] }
+git2 = { version = ">= 0.13.23", default-features = false, features = [ "vendored-libgit2" ] }
 kv = { version = "0.22", features = [ "json-value" ] }
 lazy_static = "1.4"
 nonempty = { version = "0.6", features = [ "serialize" ] }
@@ -32,6 +34,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 serde_qs = "0.8"
 secstr = { version = "0.3.2", features = [ "serde" ] }
+serde_millis = "0.1"
 sha2 = "0.9.8"
 tempfile = "3.1"
 tracing = "0.1"
@@ -49,11 +52,11 @@ link-crypto = "0.1"
 link-identities = "0.1"
 lnk-identities = "0.1"
 lnk-exe = "0.1"
-radicle-daemon = "0.1"
 radicle-git-ext = "0.1"
 radicle-git-helpers = "0.1"
 
 [dev-dependencies]
+assert_matches = "1.3"
 bytes = "1.0"
 http = "0.2"
 pretty_assertions = "1"

--- a/upstream-proxy/src/browser.rs
+++ b/upstream-proxy/src/browser.rs
@@ -14,7 +14,7 @@ use crate::error::Error;
 /// Provide a repo [`git::Browser`] where the `Browser` is initialised with the provided
 /// `reference`.
 ///
-/// See [`radicle_daemon::state::find_default_branch`] and [`radicle_daemon::state::get_branch`] for
+/// See [`crate::daemon::state::find_default_branch`] and [`crate::daemon::state::get_branch`] for
 /// obtaining a [`Reference`].
 ///
 /// # Errors
@@ -33,7 +33,7 @@ where
     let namespace = git::namespace::Namespace::try_from(
         reference
             .namespace
-            .ok_or(radicle_daemon::state::Error::MissingNamespace)?
+            .ok_or(crate::daemon::state::Error::MissingNamespace)?
             .to_string()
             .as_str(),
     )
@@ -47,7 +47,7 @@ where
         ),
     };
 
-    let monorepo = radicle_daemon::state::monorepo(peer.librad_peer());
+    let monorepo = crate::daemon::state::monorepo(peer.librad_peer());
     let repo = git::Repository::new(monorepo).map_err(error::Error::from)?;
     let mut browser =
         git::Browser::new_with_namespace(&repo, &namespace, branch).map_err(error::Error::from)?;

--- a/upstream-proxy/src/context.rs
+++ b/upstream-proxy/src/context.rs
@@ -176,7 +176,7 @@ impl Unsealed {
     /// Return a stream that emits peer events.
     ///
     /// The stream ends when API server is shut down.
-    pub fn peer_events(&self) -> impl Stream<Item = radicle_daemon::PeerEvent> + Send + 'static {
+    pub fn peer_events(&self) -> impl Stream<Item = crate::daemon::PeerEvent> + Send + 'static {
         let shutdown = self.rest.shutdown.clone();
         self.peer
             .events()
@@ -205,7 +205,7 @@ impl Unsealed {
             paths: paths.clone(),
             key,
             store: store.clone(),
-            discovery: radicle_daemon::config::StreamDiscovery::new(seeds_watch),
+            discovery: crate::daemon::config::StreamDiscovery::new(seeds_watch),
             listen: "127.0.0.1:0".parse().expect("invalid IP address"),
         })
         .unwrap();

--- a/upstream-proxy/src/control.rs
+++ b/upstream-proxy/src/control.rs
@@ -12,7 +12,7 @@ use nonempty::NonEmpty;
 
 use radicle_source::surf::vcs::git::git2;
 
-use radicle_daemon::{
+use crate::daemon::{
     librad::{
         git::{
             identities::local::LocalIdentity,
@@ -180,7 +180,7 @@ pub fn clone_platinum(platinum_into: impl AsRef<path::Path>) -> Result<(), Error
 
 #[cfg(test)]
 mod test {
-    use radicle_daemon::{
+    use crate::daemon::{
         librad::{
             git::identities::local::LocalIdentity, git_ext::OneLevel, identities::Project, reflike,
             PeerId,

--- a/upstream-proxy/src/daemon.rs
+++ b/upstream-proxy/src/daemon.rs
@@ -1,0 +1,56 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3
+// with Radicle Linking Exception. For full terms see the included
+// LICENSE file.
+
+//! Abstractions and utilities to run and interact with link and surf.
+
+#![warn(
+    clippy::all,
+    clippy::cargo,
+    clippy::nursery,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    missing_docs,
+    unused_import_braces,
+    unused_qualifications
+)]
+#![allow(
+    clippy::cargo_common_metadata,
+    clippy::clone_on_ref_ptr,
+    clippy::expect_used,
+    clippy::implicit_return,
+    clippy::integer_arithmetic,
+    clippy::missing_inline_in_public_items,
+    clippy::multiple_crate_versions,
+    clippy::multiple_inherent_impl,
+    clippy::similar_names,
+    clippy::too_many_lines
+)]
+
+#[cfg(test)]
+extern crate assert_matches;
+
+pub use librad::{
+    self, crypto,
+    git::{self, identities::local::LocalIdentity, include, local::url::LocalUrl, Urn},
+    identities::{self, Person, Project},
+    net::{self, discovery},
+    paths::Paths,
+    profile, PeerId,
+};
+
+pub use librad::git_ext;
+
+pub use radicle_git_helpers::remote_helper;
+
+pub mod config;
+pub mod convert;
+pub mod peer;
+pub use peer::{Control as PeerControl, Event as PeerEvent, Peer, RunConfig, Status as PeerStatus};
+pub mod project;
+pub mod request;
+pub mod state;
+
+pub mod seed;

--- a/upstream-proxy/src/daemon/announcement.rs
+++ b/upstream-proxy/src/daemon/announcement.rs
@@ -1,0 +1,302 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Compute, track and announce noteworthy changes to the network.
+
+use std::collections::HashSet;
+
+use librad::{
+    git::Urn,
+    git_ext::{Oid, RefLike},
+    identities::{urn, SomeIdentity},
+    net::peer::Peer,
+    Signer,
+};
+use tokio::task::spawn_blocking;
+
+use crate::{peer::gossip, state};
+
+/// Name for the bucket used in [`kv::Store`].
+const BUCKET_NAME: &str = "announcements";
+/// Key for the single value used as cache.
+const KEY_NAME: &str = "latest";
+
+/// Announcement errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failures from [`kv`].
+    #[error(transparent)]
+    Kv(#[from] kv::Error),
+
+    /// Failures parsing.
+    #[error(transparent)]
+    Parse(#[from] urn::error::FromStr<git2::Error>),
+
+    /// Error occurred when interacting with [`Peer`].
+    #[error(transparent)]
+    State(#[from] Box<state::Error>),
+
+    /// Error in spawned task.
+    #[error(transparent)]
+    Task(#[from] tokio::task::JoinError),
+}
+
+impl From<state::Error> for Error {
+    fn from(e: state::Error) -> Self {
+        Self::from(Box::new(e))
+    }
+}
+
+/// An update and all the required information that can be announced on the
+/// network.
+pub type Announcement = (Urn, Oid);
+
+/// Unique list of [`Announcement`]s.
+pub type Updates = HashSet<Announcement>;
+
+/// Announces the list of given `updates` with the [`librad::net::protocol`].
+///
+/// # Errors
+///
+/// * if the announcemnet of one of the project heads failed
+fn announce<'a, S>(peer: &Peer<S>, updates: impl Iterator<Item = &'a Announcement> + Send)
+where
+    S: Clone + Signer,
+{
+    for (urn, hash) in updates {
+        gossip::announce(peer, urn, Some(*hash));
+    }
+}
+
+/// Builds the latest list of [`Announcement`]s for the current state of the
+/// peer.
+///
+/// # Errors
+///
+/// * if listing of the projects fails
+/// * if listing of the Refs for a project fails
+async fn build<S>(peer: &Peer<S>) -> Result<Updates, Error>
+where
+    S: Clone + Signer,
+{
+    let identities = state::list_identities(peer).await?;
+    let mut updates: Updates = HashSet::new();
+    for identity in identities {
+        let urn = match identity {
+            SomeIdentity::Person(person) => person.urn(),
+            SomeIdentity::Project(project) => project.urn(),
+            _ => continue,
+        };
+        let refs = match state::load_refs(peer, urn.clone()).await? {
+            Some(refs) => refs,
+            None => continue,
+        };
+        for ((one_level, oid), category) in refs.iter_categorised() {
+            let path = RefLike::from(one_level.clone().into_qualified(category.into()));
+            let urn = urn.clone().with_path(path);
+            updates.insert((urn, *oid));
+        }
+    }
+    Ok(updates)
+}
+
+/// Computes the list of announcements based on the difference of the `new` and
+/// `old` state. An [`Announcement`] will be included if an entry in `new` can't
+/// be found in `old`.
+#[allow(clippy::implicit_hasher)]
+#[must_use]
+fn diff<'a>(old_state: &'a Updates, new_state: &'a Updates) -> Updates {
+    new_state.difference(old_state).cloned().collect()
+}
+
+/// Load the cached announcements from the [`kv::Store`].
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the access of the key in the [`kv::Bucket`] fails
+fn load(store: &kv::Store) -> Result<Updates, Error> {
+    let bucket = store.bucket::<&'static str, kv::Json<Updates>>(Some(BUCKET_NAME))?;
+    let value = bucket.get(KEY_NAME)?.map_or(HashSet::new(), |json| json.0);
+
+    Ok(value)
+}
+
+/// Runs the entire announcement procedure.
+///
+/// # Errors
+///
+/// * if it can't build the new list of updates
+/// * access to the storage fails
+pub async fn run<S>(peer: &Peer<S>, store: kv::Store) -> Result<Updates, Error>
+where
+    S: Clone + Signer,
+{
+    let old = spawn_blocking({
+        let store = store.clone();
+        move || load(&store)
+    })
+    .await??;
+    let new = build(peer).await?;
+    let updates = diff(&old, &new);
+
+    announce(peer, updates.iter());
+
+    if !updates.is_empty() {
+        spawn_blocking(move || save(&store, new.clone())).await??;
+    }
+
+    Ok(updates)
+}
+
+/// Update the cache with the latest announcements.
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the storage of the new updates fails
+#[allow(clippy::implicit_hasher)]
+fn save(store: &kv::Store, updates: Updates) -> Result<(), Error> {
+    let bucket = store.bucket::<&'static str, kv::Json<Updates>>(Some(BUCKET_NAME))?;
+    bucket.set(KEY_NAME, kv::Json(updates)).map_err(Error::from)
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashSet, convert::TryFrom as _};
+
+    use pretty_assertions::assert_eq;
+
+    use librad::{
+        crypto::{BoxedSigner, SomeSigner},
+        git::Urn,
+        net,
+        SecretKey,
+    };
+    use radicle_git_ext::{oid, RefLike};
+
+    use crate::{config, identities::payload::Person};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::unwrap_used)] // XXX: clippy sees an unwrap where there is none
+    async fn announce() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = BoxedSigner::new(SomeSigner {
+            signer: key.clone(),
+        });
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+
+        let _owner = crate::state::init_owner(
+            &peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
+
+        // TODO(xla): Build up proper testnet to assert that haves are announced.
+        let updates = super::build(&peer).await?;
+        super::announce(&peer, updates.iter());
+
+        Ok(())
+    }
+
+    #[test]
+    fn diff() -> Result<(), Box<dyn std::error::Error>> {
+        let both = vec![
+            (project0("dev"), "68986574".parse::<oid::Oid>()?),
+            (project0("master"), "c8d2ad44".parse::<oid::Oid>()?),
+            (project0("stable"), "2d2e1408".parse::<oid::Oid>()?),
+            (
+                project0("cloudhead/cool-feature"),
+                "68986574".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("fintohaps/doc-tests"),
+                "f90353ba".parse::<oid::Oid>()?,
+            ),
+            (project1("dev"), "c8d2ad44".parse::<oid::Oid>()?),
+            (project0("master"), "2d2e1408".parse::<oid::Oid>()?),
+            (project1("stable"), "a3403e2d".parse::<oid::Oid>()?),
+        ];
+        let old = vec![
+            (
+                project0("igor/zero-assertions"),
+                "72a78226".parse::<oid::Oid>()?,
+            ),
+            (project0("thoshol/remove"), "7c69d71a".parse::<oid::Oid>()?),
+            (project1("rudolfs/release"), "8c085d58".parse::<oid::Oid>()?),
+        ];
+        let new = vec![
+            (
+                project0("cloudhead/new-language"),
+                "7dec3269".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("fintohaps/notations"),
+                "b4d3276d".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("kalt/eat-my-impls"),
+                "2206e5dc".parse::<oid::Oid>()?,
+            ),
+            (project1("backport"), "869e5740".parse::<oid::Oid>()?),
+        ];
+
+        let left: HashSet<_> = [&both[..], &old[..]].concat().iter().cloned().collect();
+        let right: HashSet<_> = [&both[..], &new[..]].concat().iter().cloned().collect();
+        let announcements = super::diff(&left, &right);
+
+        assert_eq!(announcements, new.iter().cloned().collect::<HashSet<_>>());
+
+        Ok(())
+    }
+
+    #[test]
+    fn save_and_load() -> Result<(), Box<dyn std::error::Error>> {
+        let updates: HashSet<_> = vec![
+            (
+                project0("cloudead/new-language"),
+                "7dec3269".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("fintohaps/notations"),
+                "b4d3276d".parse::<oid::Oid>()?,
+            ),
+            (project0("kalt/loops"), "2206e5dc".parse::<oid::Oid>()?),
+            (project1("backport"), "869e5740".parse::<oid::Oid>()?),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        let dir = tempfile::tempdir()?;
+        let store = kv::Store::new(kv::Config::new(dir.path().join("store")))?;
+
+        super::save(&store, updates.clone())?;
+
+        assert_eq!(super::load(&store)?, updates);
+
+        Ok(())
+    }
+
+    fn project0(head: &str) -> Urn {
+        Urn {
+            id: "7ab8629dd6da14dcacde7f65b3d58cd291d7e235"
+                .parse::<radicle_git_ext::Oid>()
+                .expect("oid parse failed"),
+            path: Some(RefLike::try_from(head).expect("head was not reflike")),
+        }
+    }
+    fn project1(head: &str) -> Urn {
+        Urn {
+            id: "7ab8629dd6da14dcacde7f65b3d58cd291d7e234"
+                .parse::<radicle_git_ext::Oid>()
+                .expect("oid parse failed"),
+            path: Some(RefLike::try_from(head).expect("head was not reflike")),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/checkout.rs
+++ b/upstream-proxy/src/daemon/checkout.rs
@@ -1,0 +1,324 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    convert::TryFrom,
+    ffi,
+    io,
+    path::{self, PathBuf},
+};
+
+use librad::{
+    git::{
+        include,
+        local::{transport::CanOpenStorage, url::LocalUrl},
+        types::{
+            remote::{LocalFetchspec, LocalPushspec, Remote},
+            Flat,
+            Force,
+            GenericRef,
+            Reference,
+            Refspec,
+        },
+        Urn,
+    },
+    git_ext::{self, OneLevel, Qualified, RefLike},
+    reflike,
+    refspec_pattern,
+    PeerId,
+};
+
+/// When checking out a working copy, we can run into several I/O failures.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The path already existed when trying to checkout the project.
+    #[error("the path provided '{0}' already exists")]
+    AlreadExists(PathBuf),
+
+    /// Git error when checking out the project.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// An error occurred building include files.
+    #[error(transparent)]
+    Include(#[from] include::Error),
+
+    /// An error occurred validating the project path
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// An error occurred when attempting to strip a prefix from a reference.
+    #[error(transparent)]
+    Prefix(#[from] git_ext::name::StripPrefixError),
+
+    /// An error occurred in the local transport.
+    #[error(transparent)]
+    Transport(#[from] librad::git::local::transport::Error),
+}
+
+/// The data necessary for checking out a project.
+pub struct Checkout<P>
+where
+    P: AsRef<path::Path>,
+{
+    /// The URN identifier for the project we are checking out.
+    pub urn: Urn,
+    /// The name of the project.
+    pub name: String,
+    /// The default branch of the project.
+    pub default_branch: OneLevel,
+    /// The path on the filesystem where we're going to checkout to.
+    pub path: P,
+    /// Absolute path of the include file that will be set in the working copy
+    /// config.
+    pub include_path: PathBuf,
+}
+
+/// We want to know whether we're checking out from one of our own copies, or if
+/// we're checking out based off of a remote's branch.
+pub enum Ownership {
+    /// We're checking out our own copy of the project.
+    Local(PeerId),
+    /// We're checking out a remote's version of the project.
+    Remote {
+        /// The handle of the remote peer gives themselves via their user
+        /// profile. For example, `90s-kid` -- the name of the remote
+        /// will then be `90s-kid@<urn.id>`.
+        handle: String,
+        /// The `PeerId` of the remote.
+        remote: PeerId,
+        /// Our own `PeerId`.
+        local: PeerId,
+    },
+}
+
+/// Clone a git repository to the `path` location, based off of the `remote`
+/// provided.
+///
+/// # Errors
+///   * if initialisation of the repository fails
+///   * if branch or remote manipulation fails
+pub fn clone<F>(
+    path: &path::Path,
+    storage: F,
+    mut remote: Remote<LocalUrl>,
+) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+where
+    F: CanOpenStorage + 'static,
+{
+    let repo = git2::Repository::init(path)?;
+    remote.save(&repo)?;
+    for (reference, oid) in remote.fetch(storage, &repo, LocalFetchspec::Configured)? {
+        let msg = format!("Fetched `{}->{}`", reference, oid);
+        tracing::debug!("{}", msg);
+
+        // FIXME(finto): we should ignore refs that don't start with heads to avoid
+        // unintended side-effects.
+        let branch: RefLike = OneLevel::from(reference).into();
+        let branch = branch.strip_prefix(remote.name.clone())?;
+        let branch = branch.strip_prefix(reflike!("heads")).unwrap_or(branch);
+        let _remote_branch = repo.reference(
+            reflike!("refs/remotes")
+                .join(remote.name.clone())
+                .join(branch.clone())
+                .as_str(),
+            oid,
+            true,
+            &msg,
+        )?;
+        let _local_branch = repo.reference(Qualified::from(branch).as_str(), oid, true, &msg);
+    }
+
+    Ok((repo, remote))
+}
+
+impl Ownership {
+    /// Clone a project based off of the `Ownership` value. See
+    /// [`Checkout::run`] for more details.
+    ///
+    /// # Errors
+    ///   * If the cloning of the working copy fails.
+    ///   * In the case of a remote clone, if the pushing of the default branch
+    ///     fails.
+    pub fn clone<F>(
+        self,
+        open_storage: F,
+        urn: Urn,
+        default_branch: &OneLevel,
+        path: &path::Path,
+    ) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        match self {
+            Self::Local(_peer_id) => {
+                let url = LocalUrl::from(urn);
+                Self::local(open_storage, url, path).map_err(Error::from)
+            },
+            Self::Remote { handle, remote, .. } => {
+                let url = LocalUrl::from(urn);
+                Self::remote(open_storage, &handle, remote, url, default_branch, path)
+            },
+        }
+    }
+
+    /// See [`Checkout::run`].
+    fn local<F>(
+        open_storage: F,
+        url: LocalUrl,
+        path: &path::Path,
+    ) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+    where
+        F: CanOpenStorage + 'static,
+    {
+        let rad = Remote::rad_remote(
+            url,
+            Refspec {
+                src: refspec_pattern!("refs/heads/*"),
+                dst: refspec_pattern!("refs/remotes/rad/*"),
+                force: Force::True,
+            },
+        );
+        clone(path, open_storage, rad)
+    }
+
+    /// See [`Checkout::run`].
+    fn remote<F>(
+        open_storage: F,
+        handle: &str,
+        peer: PeerId,
+        url: LocalUrl,
+        default_branch: &OneLevel,
+        path: &path::Path,
+    ) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        let name =
+            RefLike::try_from(format!("{}@{}", handle, peer)).expect("failed to parse remote name");
+
+        let remote = Remote::new(url.clone(), name.clone()).with_fetchspecs(vec![Refspec {
+            src: Reference::heads(Flat, peer),
+            dst: GenericRef::heads(Flat, name),
+            force: Force::True,
+        }]);
+
+        let (repo, _) = clone(path, open_storage.clone(), remote)?;
+
+        // Create a rad remote and push the default branch so we can set it as the
+        // upstream.
+        let rad = {
+            // Create a fetchspec `refs/heads/*:refs/remotes/rad/*`
+            let fetchspec = Refspec {
+                src: GenericRef::<_, RefLike, _>::heads(Flat, None),
+                dst: refspec_pattern!("refs/remotes/rad/*"),
+                force: Force::True,
+            };
+            let mut rad = Remote::rad_remote(url, fetchspec);
+            rad.save(&repo)?;
+            let _refs = rad.push(
+                open_storage,
+                &repo,
+                LocalPushspec::Matching {
+                    pattern: Qualified::from(default_branch.clone()).into(),
+                    force: Force::False,
+                },
+            )?;
+            rad
+        };
+
+        Ok((repo, rad))
+    }
+}
+
+impl<P> Checkout<P>
+where
+    P: AsRef<path::Path>,
+{
+    /// Based off of the `Ownership`, clone the project using the provided
+    /// inputs.
+    ///
+    /// ## Local Clone
+    ///
+    /// If the `Ownership` is `Local` this means that we are cloning based off
+    /// the user's own project and so the `url` used to clone will be built
+    /// from the user's `PeerId`. The only remote that will be created is
+    /// `rad` remote, pointing to the `url` built from the provided `urn`
+    /// and the user's `PeerId`.
+    ///
+    /// ## Remote Clone
+    ///
+    /// If the `Ownership` is `Remote` this means that we are cloning based off
+    /// of a peer's project.
+    /// Due to this we need to point the remote to the specific remote in our
+    /// project's hierarchy. What this means is that we need to set up a
+    /// fetch refspec in the form of `refs/remotes/<peer_id>/heads/*` where
+    /// the name of the remote is given by `<user_handle>@<peer_id>` -- this
+    /// keeps in line with `librad::git::include`. To finalise the setup of
+    /// the clone, we also want to add the `rad` remote, which is the designated
+    /// remote the user pushes their own work to update their monorepo for this
+    /// project. To do this, we create a `url` that is built using the
+    /// provided `urn` and the user's `PeerId` and create the `rad` remote.
+    /// Finally, we initialise the `default_branch` of the proejct --
+    /// think upstream branch in git. We do this by pushing to the `rad` remote.
+    /// This means that the working copy will be now setup where when we
+    /// open it up we see the initial branch as being `default_branch`.
+    ///
+    /// To illustrate further, the `config` of the final repository will look
+    /// similar to:
+    ///
+    /// ```text
+    /// [remote "rad"]
+    ///     url = rad://hyymr17h1fg5zk7duikgc7xoqonqorhwnxxs98kdb63f9etnsjxxmo@hwd1yrerzpjbmtshsqw6ajokqtqrwaswty6p7kfeer3yt1n76t46iqggzcr.git
+    ///     fetch = +refs/heads/*:refs/remotes/rad/*
+    /// [remote "banana@hyy36ey56mfayah398n7w4i8hy5ywci43hbyhwf1krfwonc1ur87ch"]
+    ///     url = rad://hyymr17h1fg5zk7duikgc7xoqonqorhwnxxs98kdb63f9etnsjxxmo@hwd1yrerzpjbmtshsqw6ajokqtqrwaswty6p7kfeer3yt1n76t46iqggzcr.git
+    ///     fetch = +refs/remotes/hyy36ey56mfayah398n7w4i8hy5ywci43hbyhwf1krfwonc1ur87ch/heads/*:refs/remotes/banana@hyy36ey56mfayah398n7w4i8hy5ywci43hbyhwf1krfwonc1ur87ch/*
+    /// [branch "master"]
+    ///     remote = rad
+    ///     merge = refs/heads/master
+    /// [include]
+    ///     path = /home/user/.config/radicle/git-includes/hwd1yrerzpjbmtshsqw6ajokqtqrwaswty6p7kfeer3yt1n76t46iqggzcr.inc
+    /// ```
+    ///
+    /// # Errors
+    ///  * If the project cloning fails.
+    ///  * If we cannot set the upstream branch for the `rad` remote.
+    ///  * If we cannot set the include path for the working copy.
+    pub fn run<F>(self, open_storage: F, ownership: Ownership) -> Result<PathBuf, Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        // Check if the path provided ends in the 'directory_name' provided. If not we
+        // create the full path to that name.
+        let path = &self.path.as_ref();
+        let project_path: PathBuf =
+            path.components()
+                .next_back()
+                .map_or(path.join(&self.name), |destination| {
+                    let destination: &ffi::OsStr = destination.as_ref();
+                    let name: &ffi::OsStr = self.name.as_ref();
+                    if destination == name {
+                        path.to_path_buf()
+                    } else {
+                        path.join(name)
+                    }
+                });
+        crate::project::ensure_directory(&project_path)?
+            .ok_or_else(|| Error::AlreadExists(project_path.clone()))?;
+
+        // Clone the repository
+        let (repo, rad) =
+            ownership.clone(open_storage, self.urn, &self.default_branch, &project_path)?;
+
+        // Set configurations
+        super::set_upstream(&repo, &rad, self.default_branch.clone())?;
+        include::set_include_path(&repo, self.include_path)?;
+        repo.set_head(Qualified::from(self.default_branch).as_str())?;
+        repo.checkout_head(None)?;
+
+        Ok(project_path)
+    }
+}

--- a/upstream-proxy/src/daemon/command.rs
+++ b/upstream-proxy/src/daemon/command.rs
@@ -1,0 +1,56 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::time::{Duration, SystemTime};
+
+use librad::{git::Urn, PeerId};
+
+use crate::{peer::control, request::waiting_room::WaitingRoom};
+
+/// Instructions to issue side-effectful operations which are the results from
+/// state transitions.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum Command {
+    /// Start the announcement subroutine.
+    Announce,
+    /// Answer control requests.
+    Control(Control),
+    /// Update the include file for the provided [`Urn`].
+    Include(Urn),
+    /// Tell the subroutine to persist the [`WaitingRoom`].
+    PersistWaitingRoom(WaitingRoom<SystemTime, Duration>),
+    /// Fulfill request commands.
+    Request(Request),
+    Stats,
+    /// Emit an external event to all subscribers
+    EmitEvent(super::Event),
+}
+
+/// Reactions for incoming control requests.
+#[derive(Debug)]
+pub enum Control {
+    /// Send a response corresponding to a control request.
+    Respond(control::Response),
+}
+
+/// Commands issued when requesting an identity from the network.
+#[derive(Debug, PartialEq)]
+pub enum Request {
+    /// Tell the subroutine to attempt a clone from the given [`Urn`] and
+    /// [`PeerId`].
+    Clone(Urn, PeerId),
+    /// Tell the subroutine that we should query for the given [`Urn`] on the
+    /// network.
+    Query(Urn),
+    /// The request for [`Urn`] timed out.
+    TimedOut(Urn),
+}
+
+impl From<Request> for Command {
+    fn from(other: Request) -> Self {
+        Self::Request(other)
+    }
+}

--- a/upstream-proxy/src/daemon/config.rs
+++ b/upstream-proxy/src/daemon/config.rs
@@ -1,0 +1,107 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Crate configuration.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use async_stream::stream;
+use futures::stream::BoxStream;
+use tokio::sync::watch;
+
+use librad::{net, net::discovery, paths, PeerId, Signer};
+
+#[cfg(test)]
+use librad::crypto::BoxedSigner;
+
+use crate::daemon::seed;
+
+lazy_static::lazy_static! {
+    /// Localhost binding to any available port, i.e. `127.0.0.1:0`.
+    pub static ref LOCALHOST_ANY: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
+}
+
+#[cfg(test)]
+/// Provide the default config.
+///
+/// Address: 127.0.0.1:0
+/// No seeds.
+/// Default gossip parameters.
+///
+/// # Errors
+///
+/// Results in an error if the [`paths::Paths`] could not be created.
+pub fn default(
+    signer: BoxedSigner,
+    path: impl AsRef<std::path::Path>,
+) -> Result<net::peer::Config<BoxedSigner>, std::io::Error> {
+    let paths = paths::Paths::from_root(path)?;
+    Ok(configure(paths, signer, *LOCALHOST_ANY))
+}
+
+/// Configure a [`net::peer::Config`].
+#[allow(clippy::as_conversions)]
+#[must_use]
+pub fn configure<S>(paths: paths::Paths, signer: S, listen_addr: SocketAddr) -> net::peer::Config<S>
+where
+    S: Signer + Clone + Send + Sync + 'static,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    net::peer::Config {
+        signer,
+        protocol: net::protocol::Config {
+            paths,
+            listen_addr,
+            advertised_addrs: None,
+            membership: net::protocol::membership::Params::default(),
+            network: net::Network::default(),
+            replication: net::replication::Config::default(),
+            rate_limits: net::protocol::Quota::default(),
+        },
+        storage: net::peer::config::Storage::default(),
+    }
+}
+
+/// Stream based discovery based on a watch.
+#[derive(Clone)]
+pub struct StreamDiscovery {
+    /// Stream of new sets of seeds coming from configuration changes.
+    seeds_receiver: watch::Receiver<Vec<seed::Seed>>,
+}
+
+impl StreamDiscovery {
+    /// Returns a new streaming discovery.
+    #[must_use]
+    pub fn new(seeds_receiver: watch::Receiver<Vec<seed::Seed>>) -> Self {
+        Self { seeds_receiver }
+    }
+}
+
+impl discovery::Discovery for StreamDiscovery {
+    type Addr = SocketAddr;
+    type Stream = BoxStream<'static, (PeerId, Vec<SocketAddr>)>;
+
+    fn discover(mut self) -> Self::Stream {
+        let updates = stream! {
+            loop {
+                let seeds = self.seeds_receiver.borrow().clone();
+                for seed in seeds {
+                    yield seed.into();
+                }
+
+                match self.seeds_receiver.changed().await {
+                    Ok(_) => {},
+                    Err(_) => {
+                        tracing::warn!("Peer discovery stream dropped");
+                        break;
+                    }
+                }
+            }
+        };
+
+        Box::pin(updates)
+    }
+}

--- a/upstream-proxy/src/daemon/control.rs
+++ b/upstream-proxy/src/daemon/control.rs
@@ -1,0 +1,178 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Inspect state and perform actions on a running peer.
+
+use std::{net::SocketAddr, time::SystemTime};
+
+use either::Either;
+use tokio::sync::{mpsc, oneshot};
+
+use librad::git::Urn;
+
+use crate::{request, request::waiting_room};
+
+use super::run_state::Status;
+
+/// Requests sent to the peer.
+#[derive(Debug)]
+pub enum Request {
+    ListenAddrs(oneshot::Sender<Vec<SocketAddr>>),
+    /// Request the current peer status.
+    CurrentStatus(oneshot::Sender<Status>),
+
+    /// Cancel an ongoing project search.
+    CancelSearch(
+        Urn,
+        SystemTime,
+        oneshot::Sender<Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>>,
+    ),
+    /// Get a project search.
+    GetSearch(
+        Urn,
+        oneshot::Sender<Option<request::SomeRequest<SystemTime>>>,
+    ),
+    /// List all project searches.
+    ListSearches(oneshot::Sender<Vec<request::SomeRequest<SystemTime>>>),
+    /// Initiate a search for a project on the network.
+    StartSearch(
+        Urn,
+        SystemTime,
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
+    ),
+}
+
+/// Returned responses from the peer.
+#[derive(Debug)]
+pub enum Response {
+    ListenAddrs(oneshot::Sender<Vec<SocketAddr>>, Vec<SocketAddr>),
+    /// Response to a status request.
+    CurrentStatus(oneshot::Sender<Status>, Status),
+
+    /// Response to a cancel project search request.
+    CancelSearch(
+        oneshot::Sender<Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>>,
+        Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>,
+    ),
+    /// Response to get project search request.
+    GetSearch(
+        oneshot::Sender<Option<request::SomeRequest<SystemTime>>>,
+        Option<request::SomeRequest<SystemTime>>,
+    ),
+    /// Response to list project searches request.
+    ListSearches(
+        oneshot::Sender<Vec<request::SomeRequest<SystemTime>>>,
+        Vec<request::SomeRequest<SystemTime>>,
+    ),
+    /// Response to a start project search request.
+    StartSearch(
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
+        waiting_room::Created<SystemTime>,
+    ),
+}
+
+/// A handle to inspect state and perform actions on a running peer.
+#[derive(Clone)]
+pub struct Control {
+    /// Channel to send requests to the peer.
+    sender: mpsc::Sender<Request>,
+}
+
+impl Control {
+    /// Construct a new [`Control`] handle.
+    #[must_use = "take control"]
+    pub const fn new(sender: mpsc::Sender<Request>) -> Self {
+        Self { sender }
+    }
+
+    /// Initiate a new request for the status.
+    pub async fn current_status(&mut self) -> Status {
+        let (sender, receiver) = oneshot::channel::<Status>();
+
+        self.sender
+            .send(Request::CurrentStatus(sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// List listen addrs of the running peer.
+    pub async fn listen_addrs(&mut self) -> Vec<SocketAddr> {
+        let (sender, receiver) = oneshot::channel::<Vec<SocketAddr>>();
+
+        self.sender
+            .send(Request::ListenAddrs(sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// Cancel an ongoing search for a project.
+    ///
+    /// # Errors
+    ///
+    /// * if the waiting room returns an error
+    pub async fn cancel_project_request(
+        &mut self,
+        urn: &Urn,
+        timestamp: SystemTime,
+    ) -> Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(Request::CancelSearch(urn.clone(), timestamp, sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// Initiate a new request to fetch a project from the network.
+    pub async fn get_project_request(
+        &mut self,
+        urn: &Urn,
+    ) -> Option<request::SomeRequest<SystemTime>> {
+        let (sender, receiver) = oneshot::channel::<Option<request::SomeRequest<SystemTime>>>();
+
+        self.sender
+            .send(Request::GetSearch(urn.clone(), sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// Initiate a new reuest for the list of existing project requests.
+    pub async fn get_project_requests(&mut self) -> Vec<request::SomeRequest<SystemTime>> {
+        let (sender, receiver) = oneshot::channel::<Vec<request::SomeRequest<SystemTime>>>();
+
+        self.sender
+            .send(Request::ListSearches(sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// Initiate a new request for the `urn`.
+    pub async fn request_project(
+        &mut self,
+        urn: &Urn,
+        timestamp: SystemTime,
+    ) -> request::SomeRequest<SystemTime> {
+        let (sender, receiver) = oneshot::channel::<waiting_room::Created<SystemTime>>();
+
+        self.sender
+            .send(Request::StartSearch(urn.clone(), timestamp, sender))
+            .await
+            .expect("peer is gone");
+
+        match receiver.await.expect("receiver is gone") {
+            Either::Left(req) | Either::Right(req) => req,
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/convert.rs
+++ b/upstream-proxy/src/daemon/convert.rs
@@ -1,0 +1,20 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Traits for conversions between types.
+
+use std::convert::TryFrom;
+
+/// Used to do conversions where the input maybe maps.
+pub trait MaybeFrom<T>: Sized {
+    /// Performs the conversion.
+    fn maybe_from(_: T) -> Option<Self>;
+}
+
+impl<T, U: TryFrom<T>> MaybeFrom<T> for U {
+    fn maybe_from(t: T) -> Option<Self> {
+        Self::try_from(t).ok()
+    }
+}

--- a/upstream-proxy/src/daemon/create.rs
+++ b/upstream-proxy/src/daemon/create.rs
@@ -1,0 +1,210 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{convert::TryFrom, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use librad::{git::local::url::LocalUrl, git_ext::OneLevel};
+
+pub mod validation;
+
+/// Errors that occur when attempting to create a working copy of a project.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Internal git error while trying to create the project.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// An error occurred while validating input.
+    #[error(transparent)]
+    Validation(#[from] validation::Error),
+}
+
+/// The signature of a git author. Used internally to convert into a
+/// `git2::Signature`, which _cannot_ be shared between threads.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct Signature {
+    /// The name of the author
+    pub name: String,
+    /// The email of the author
+    pub email: String,
+}
+
+impl TryFrom<Signature> for git2::Signature<'static> {
+    type Error = git2::Error;
+
+    fn try_from(signature: Signature) -> Result<Self, Self::Error> {
+        Self::now(&signature.name, &signature.email)
+    }
+}
+
+/// The data required to either open an existing repository or create a new one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Repo {
+    /// Open an existing repository.
+    Existing {
+        /// The path to the existing project.
+        path: PathBuf,
+    },
+    /// Create a new project where the final directory path is `<path>/<name>`.
+    New {
+        /// The name of the project.
+        name: String,
+        /// The directory where we create the project.
+        path: PathBuf,
+    },
+}
+
+impl Repo {
+    /// Get the project name based off of `path` or `path` + `name`.
+    ///
+    /// # Errors
+    ///
+    ///   * The existing path provided was empty, so we could not get the
+    ///     project's name.
+    pub fn project_name(&self) -> Result<String, validation::Error> {
+        match self {
+            Self::Existing { path } => path
+                .components()
+                .next_back()
+                .and_then(|component| component.as_os_str().to_str())
+                .map(ToString::to_string)
+                .ok_or_else(|| validation::Error::EmptyExistingPath(path.clone())),
+            Self::New { name, .. } => Ok(name.to_string()),
+        }
+    }
+
+    /// Get the full path of the `Repo` creation data.
+    #[must_use]
+    pub fn full_path(&self) -> PathBuf {
+        match self {
+            Self::Existing { path } => path.clone(),
+            Self::New { name, path, .. } => path.join(name),
+        }
+    }
+}
+
+/// The data required for creating a new project.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Create {
+    /// Description of the project we want to create.
+    pub description: String,
+    /// The default branch name for the project.
+    pub default_branch: OneLevel,
+    /// What kind of working copy we're working with, i.e. new or existing.
+    pub repo: Repo,
+}
+
+impl Create {
+    /// Validate `Create` into a [`validation::Repository`]. This ensures that
+    /// we have valid paths when we attempt to create the working copy.
+    ///
+    /// # Errors
+    ///
+    /// See [`validation::Repository::validate`]
+    pub fn validate(
+        self,
+        url: LocalUrl,
+        signature: Signature,
+    ) -> Result<validation::Repository, validation::Error> {
+        validation::Repository::validate(self.repo, url, self.default_branch, signature)
+    }
+}
+
+// Clippy is stupid and doesn't realise the `Create`s here are different types
+// than `Self`.
+#[allow(clippy::use_self)]
+impl Create {
+    /// Transforms into an existing project.
+    #[must_use]
+    pub fn into_existing(self) -> Self {
+        let path = self.repo.full_path();
+        Self {
+            repo: Repo::Existing { path },
+            description: self.description,
+            default_branch: self.default_branch,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom as _;
+
+    use assert_matches::assert_matches;
+
+    use librad::{git_ext::OneLevel, identities::Urn, reflike};
+    use radicle_git_ext::Oid;
+
+    use super::*;
+
+    #[test]
+    fn validation_fails_on_non_empty_existing_directory() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let url = LocalUrl::from(Urn::new(Oid::try_from(
+            "7ab8629dd6da14dcacde7f65b3d58cd291d7e235",
+        )?));
+        let tmpdir = tempfile::tempdir().expect("failed to create tmp dir");
+        let exists = tmpdir.path().join("exists");
+        std::fs::create_dir(exists.clone())?;
+        std::fs::File::create(exists.join("nonempty.rs"))?;
+
+        let create = Create {
+            description: "Radicle".to_string(),
+            default_branch: OneLevel::from(reflike!("radicle")),
+            repo: Repo::New {
+                name: "exists".to_string(),
+                path: tmpdir.path().to_path_buf(),
+            },
+        };
+        assert_matches!(
+            create
+                .validate(
+                    url,
+                    Signature {
+                        name: "functor".to_string(),
+                        email: "map@functor.ct".to_string(),
+                    }
+                )
+                .err(),
+            Some(validation::Error::AlreadExists(_))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn validation_succeeds_on_empty_existing_directory() -> Result<(), Box<dyn std::error::Error>> {
+        let url = LocalUrl::from(Urn::new(Oid::try_from(
+            "7ab8629dd6da14dcacde7f65b3d58cd291d7e235",
+        )?));
+        let tmpdir = tempfile::tempdir().expect("failed to create tmp dir");
+        let exists = tmpdir.path().join("exists");
+        std::fs::create_dir(exists)?;
+
+        let create = Create {
+            description: "Radicle".to_string(),
+            default_branch: OneLevel::from(reflike!("radicle")),
+            repo: Repo::New {
+                name: "exists".to_string(),
+                path: tmpdir.path().to_path_buf(),
+            },
+        };
+        assert!(create
+            .validate(
+                url,
+                Signature {
+                    name: "cocone".to_string(),
+                    email: "cocone@pushout.ct".to_string(),
+                }
+            )
+            .is_ok());
+
+        Ok(())
+    }
+}

--- a/upstream-proxy/src/daemon/create/validation.rs
+++ b/upstream-proxy/src/daemon/create/validation.rs
@@ -1,0 +1,395 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Validation logic for safely checking that a [`super::Repo`] is valid before
+//! setting up the working copy.
+
+use std::{convert::TryFrom, io, path::PathBuf};
+
+use librad::{
+    git::{
+        local::{transport::CanOpenStorage, url::LocalUrl},
+        types::{
+            remote::{self, LocalPushspec, Remote},
+            Fetchspec,
+            Force,
+            Refspec,
+        },
+    },
+    git_ext::{self, OneLevel},
+    reflike,
+    refspec_pattern,
+    std_ext::result::ResultExt as _,
+};
+use nonempty::NonEmpty;
+
+use super::Signature;
+
+/// Errors that occur when validating a [`super::Repo`]'s path.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The path already existed when trying to create a new project.
+    #[error("the path provided '{0}' already exists")]
+    AlreadExists(PathBuf),
+
+    /// An existing project is being created, but we couldn't get the `name` of
+    /// the project, i.e. the final suffix of the file path.
+    #[error(
+        "the existing path provided '{0}' was empty, and we could not get the project name from it"
+    )]
+    EmptyExistingPath(PathBuf),
+
+    /// An error occurred in `git2` that we could not handle.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// When trying to inspect a path, an I/O error occurred.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// When checking the default git config for `user.email` we could not find
+    /// it.
+    #[error("the author email for creating the project could not be found - have you configured your git config?")]
+    MissingAuthorEmail,
+
+    /// When checking the default git config for `user.name` we could not find
+    /// it.
+    #[error("the author name for creating the project could not be found - have you configured your git config?")]
+    MissingAuthorName,
+
+    /// Configured default branch for the project is missing.
+    #[error(
+        "the default branch '{branch}' supplied was not found for the repository at '{repo_path}'"
+    )]
+    MissingDefaultBranch {
+        /// The repository path we're setting up.
+        repo_path: PathBuf,
+        /// The default branch that was expected to be found.
+        branch: String,
+    },
+
+    /// When checking for default git config we could not find it.
+    #[error(
+        "the git config for creating the project could not be found - have you configured it?"
+    )]
+    MissingGitConfig,
+
+    /// The `rad` remote was found but it did not have a URL.
+    #[error("the `rad` remote exists but is missing its url field")]
+    MissingUrl,
+
+    /// The path was expected to point to a git repository but it did not.
+    #[error("the path '{0}' does not point to an existing repository")]
+    NotARepo(PathBuf),
+
+    /// The path was expected to exist already but does not.
+    #[error("the path provided '{0}' does not exist when it was expected to")]
+    PathDoesNotExist(PathBuf),
+
+    /// When attempting to find a particular remote that _should_ exist, it did
+    /// not.
+    #[error(transparent)]
+    Remote(#[from] remote::FindError),
+
+    /// An internal error occurred when talking to the local transport for git
+    /// related I/O.
+    #[error(transparent)]
+    Transport(#[from] librad::git::local::transport::Error),
+
+    /// The `rad` remote was found, but the URL did not match the URL we were
+    /// expecting.
+    #[error("the `rad` remote was found but the url field does not match the provided url, found: '{found}' expected: '{expected}'")]
+    UrlMismatch {
+        /// The expected URL of the `rad` remote.
+        expected: String,
+        /// The URL that was found for the `rad` remote.
+        found: String,
+    },
+}
+
+/// A `Repository` represents the validated information for setting up a working
+/// copy.
+///
+/// We can get a `Repository` by calling [`Repository::validate`].
+pub enum Repository {
+    /// The existing repository.
+    Existing {
+        /// Le [`git2::Repository`] that exists.
+        repo: git2::Repository,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+    },
+    /// A new repository will be created using these fields.
+    New {
+        /// The path to the working copy.
+        path: PathBuf,
+        /// The name of the project.
+        name: String,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+        /// The signature to use for the initial commit.
+        signature: Signature,
+    },
+}
+
+impl Repository {
+    /// Validate a [`super::Repo`] to construct a `Repository`.
+    ///
+    /// This ensures that when setting up a working copy, that there should be
+    /// no errors. The following are validated for each case:
+    ///
+    /// **Existing**:
+    ///   * The path provided should exist
+    ///   * The path provided should have at least one component, which forms
+    ///     the name of the
+    ///   project. E.g. `Developer/radicle-upstream` is the directory and
+    /// `radicle-upstream` is the   project name.
+    ///   * The path leads to a git repository
+    ///   * The default branch passed exists in the repository
+    ///   * If a `rad` remote exists, that it:
+    ///         * Has a url field
+    ///         * If it does have a url field, that it matches the one provided
+    ///           here
+    ///
+    /// **New**:
+    ///   * The path provided does not exist:
+    ///         * If it does exist, it should be a directory and it should be
+    ///           empty
+    ///
+    /// # Errors
+    ///
+    /// If any of the criteria outlined above are violated, this will result in
+    /// an [`Error`].
+    pub fn validate(
+        repo: super::Repo,
+        url: LocalUrl,
+        default_branch: OneLevel,
+        signature: Signature,
+    ) -> Result<Self, Error> {
+        match repo {
+            super::Repo::Existing { path } => {
+                if !path.exists() {
+                    return Err(Error::PathDoesNotExist(path));
+                }
+
+                let _components = path
+                    .components()
+                    .next_back()
+                    .and_then(|component| component.as_os_str().to_str())
+                    .map(ToString::to_string)
+                    .ok_or_else(|| Error::EmptyExistingPath(path.clone()))?;
+
+                let repo = git2::Repository::open(path.clone())
+                    .or_matches(git_ext::is_not_found_err, || Err(Error::NotARepo(path)))?;
+
+                {
+                    let _default_branch_ref = Self::existing_branch(&repo, &default_branch)?;
+                    let _remote = Self::existing_remote(&repo, &url)?;
+                }
+                Ok(Self::Existing {
+                    repo,
+                    url,
+                    default_branch,
+                })
+            },
+            super::Repo::New { name, path } => {
+                let repo_path = path.join(name.clone());
+                let _repo_path = crate::project::ensure_directory(&repo_path)?
+                    .ok_or_else(|| Error::AlreadExists(repo_path.clone()))?;
+
+                Ok(Self::New {
+                    name,
+                    path,
+                    url,
+                    default_branch,
+                    signature,
+                })
+            },
+        }
+    }
+
+    /// Initialise the [`git2::Repository`].
+    ///
+    /// # Errors
+    ///
+    ///   * Failed to setup the repository
+    pub fn setup_repo<F>(
+        self,
+        open_storage: F,
+        description: &str,
+    ) -> Result<git2::Repository, super::Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        match self {
+            Self::Existing {
+                repo,
+                url,
+                default_branch,
+            } => {
+                tracing::debug!(path = ?repo.path(), "Setting up existing repository");
+                Self::setup_remote(&repo, open_storage, url, &default_branch)?;
+                Ok(repo)
+            },
+            Self::New {
+                path,
+                name,
+                url,
+                default_branch,
+                signature,
+            } => {
+                let path = path.join(name);
+                tracing::debug!(?path, "Setting up new repository",);
+                let repo = Self::initialise(path, description, &default_branch)?;
+                Self::initial_commit(
+                    &repo,
+                    &default_branch,
+                    &git2::Signature::try_from(signature)?,
+                )?;
+                let mut remote =
+                    Self::setup_remote(&repo, open_storage.clone(), url, &default_branch)?;
+                // Set up the default branch under the remote to allow setting the upstream
+                let _fetched = remote
+                    .fetch(
+                        open_storage,
+                        &repo,
+                        remote::LocalFetchspec::Specs(NonEmpty::new(Fetchspec::from(Refspec {
+                            src: reflike!("refs/heads").join(default_branch.clone()),
+                            dst: reflike!("refs/remotes")
+                                .join(remote.name.clone())
+                                .join(default_branch.clone()),
+                            force: Force::False,
+                        }))),
+                    )
+                    .map_err(Error::from)?;
+
+                crate::project::set_upstream(&repo, &remote, default_branch)?;
+
+                Ok(repo)
+            },
+        }
+    }
+
+    fn initialise(
+        path: PathBuf,
+        description: &str,
+        default_branch: &OneLevel,
+    ) -> Result<git2::Repository, git2::Error> {
+        tracing::debug!(?path, "Setting up new repository");
+        let mut options = git2::RepositoryInitOptions::new();
+        options.no_reinit(true);
+        options.mkpath(true);
+        options.description(description);
+        options.initial_head(default_branch.as_str());
+
+        git2::Repository::init_opts(path, &options)
+    }
+
+    fn initial_commit(
+        repo: &git2::Repository,
+        default_branch: &OneLevel,
+        signature: &git2::Signature<'static>,
+    ) -> Result<(), git2::Error> {
+        // Now let's create an empty tree for this commit
+        let tree_id = {
+            let mut index = repo.index()?;
+
+            // For our purposes, we'll leave the index empty for now.
+            index.write_tree()?
+        };
+        {
+            let tree = repo.find_tree(tree_id)?;
+            // Normally creating a commit would involve looking up the current HEAD
+            // commit and making that be the parent of the initial commit, but here this
+            // is the first commit so there will be no parent.
+            repo.commit(
+                Some(&format!("refs/heads/{}", default_branch.as_str())),
+                signature,
+                signature,
+                "Initial commit",
+                &tree,
+                &[],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Equips a repository with a rad remote for the given id. If the directory
+    /// at the given path is not managed by git yet we initialise it first.
+    fn setup_remote<F>(
+        repo: &git2::Repository,
+        open_storage: F,
+        url: LocalUrl,
+        default_branch: &OneLevel,
+    ) -> Result<Remote<LocalUrl>, Error>
+    where
+        F: CanOpenStorage + 'static,
+    {
+        let _default_branch_ref = Self::existing_branch(repo, default_branch)?;
+
+        tracing::debug!("Creating rad remote");
+
+        let fetchspec = Refspec {
+            src: refspec_pattern!("refs/heads/*"),
+            dst: refspec_pattern!("refs/remotes/rad/*"),
+            force: Force::True,
+        };
+        let mut git_remote = Self::existing_remote(repo, &url)?.map_or_else(
+            || {
+                let mut rad = Remote::rad_remote(url, fetchspec);
+                rad.save(repo)?;
+                Ok::<_, Error>(rad)
+            },
+            Ok,
+        )?;
+        for pushed in git_remote.push(
+            open_storage,
+            repo,
+            LocalPushspec::Matching {
+                pattern: refspec_pattern!("refs/heads/*"),
+                force: Force::True,
+            },
+        )? {
+            tracing::debug!(branch = ?pushed, "Pushed local branch");
+        }
+        Ok(git_remote)
+    }
+
+    fn existing_branch<'a>(
+        repo: &'a git2::Repository,
+        default_branch: &OneLevel,
+    ) -> Result<git2::Reference<'a>, Error> {
+        repo.resolve_reference_from_short_name(default_branch.as_str())
+            .or_matches(git_ext::is_not_found_err, || {
+                Err(Error::MissingDefaultBranch {
+                    repo_path: repo.path().to_path_buf(),
+                    branch: default_branch.as_str().to_string(),
+                })
+            })
+    }
+
+    fn existing_remote(
+        repo: &git2::Repository,
+        url: &LocalUrl,
+    ) -> Result<Option<Remote<LocalUrl>>, Error> {
+        match Remote::<LocalUrl>::find(repo, reflike!("rad")) {
+            Err(remote::FindError::ParseUrl(_)) => {
+                tracing::warn!("renaming invalid rad URL");
+                repo.remote_rename("rad", "rad_old")?;
+                Ok(None)
+            },
+            Err(err) => Err(err.into()),
+            Ok(Some(remote)) if remote.url != *url => Err(Error::UrlMismatch {
+                expected: url.to_string(),
+                found: remote.url.to_string(),
+            }),
+            Ok(remote) => Ok(remote),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/error.rs
+++ b/upstream-proxy/src/daemon/error.rs
@@ -1,0 +1,205 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Capture `State` related error variants.
+
+use librad::{
+    git::{
+        tracking,
+        types::{One, Reference},
+        Urn,
+    },
+    net,
+    PeerId,
+};
+use std::{convert::Infallible, panic};
+
+/// Errors that may occur when interacting with [`librad::net::peer::Peer`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An error occurred while trying to create a working copy of a project.
+    #[error(transparent)]
+    Create(#[from] crate::project::create::Error),
+
+    /// An error occurred while performing the checkout of a project.
+    #[error(transparent)]
+    Checkout(#[from] crate::project::checkout::Error),
+
+    /// Could not acquire the lock to replicate the identity.
+    #[error("a fetch is in progress for urn={urn}, remote={remote_peer}")]
+    FetchLocked {
+        /// The Urn we are fetching
+        urn: Urn,
+        /// The remote peer we are fetching from
+        remote_peer: PeerId,
+    },
+
+    /// An error occurred when performing git operations.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// An attempt to create an identity failed.
+    #[error("failed to create identity")]
+    IdentityCreationFailed,
+
+    /// An interaction involving an identity failed.
+    #[error(transparent)]
+    Identities(#[from] Box<librad::git::identities::Error>),
+
+    /// An interaction involving
+    /// [`librad::git::identities::local::LocalIdentity`] failed.
+    #[error(transparent)]
+    IdentitiesLocal(#[from] librad::git::identities::local::Error),
+
+    /// An error occurred building include files.
+    #[error(transparent)]
+    Include(#[from] librad::git::include::Error),
+
+    /// The namespace was expected in a reference but was not found.
+    #[error("missing namespace in reference")]
+    MissingNamespace,
+
+    /// An operation relied on a default owner being set, but it was not.
+    #[error("this operation depends on the present of a default owner")]
+    MissingOwner,
+
+    /// The [`librad::git::identities::Person`] was not found for the provided
+    /// [`Urn`].
+    #[error("person not found for '{0}'")]
+    PersonNotFound(Urn),
+
+    /// The [`librad::git::identities::Project`] was not found for the provided
+    /// [`Urn`].
+    #[error("project not found for '{0}'")]
+    ProjectNotFound(Urn),
+
+    /// Failed to parse a reference.
+    #[error(transparent)]
+    ReferenceName(#[from] librad::git_ext::reference::name::Error),
+
+    /// An action involving `rad/signed_refs` resulted in an error.
+    #[error(transparent)]
+    Refs(#[from] librad::git::refs::stored::Error),
+
+    /// An error occurred when attempting to replicate data from another peer.
+    #[error(transparent)]
+    Replication(#[from] librad::net::peer::error::Replicate),
+
+    /// Peer storage error.
+    #[error(transparent)]
+    PeerStorage(#[from] net::peer::error::Storage),
+
+    /// Peer storage error.
+    #[error(transparent)]
+    Storage(#[from] storage::Error),
+
+    /// An interaction with the config file for the storage failed.
+    #[error(transparent)]
+    StorageConfig(#[from] librad::git::storage::config::Error),
+
+    /// Error while performing tracking operation
+    #[error(transparent)]
+    Tracking(#[from] Tracking),
+
+    /// Attempted to create an identity that already exists.
+    #[error("the URN `{0}` already exists")]
+    IdentityExists(Urn),
+
+    /// There were no references for a Browser to be initialised.
+    #[error("we could not find a default branch for '{name}@{urn}'")]
+    NoDefaultBranch {
+        /// Name of the project.
+        name: String,
+        /// RadUrn of the project.
+        urn: Urn,
+    },
+
+    /// Could not find a `NamespacedRef` when searching for it in the `Storage`.
+    #[error("we could not find the '{reference}'")]
+    MissingRef {
+        /// The reference that we looked for in the `Storage`.
+        reference: Reference<One>,
+    },
+
+    /// A document payload extension was malformed
+    #[error(transparent)]
+    MalformedPayloadExt(#[from] librad::identities::payload::ExtError),
+
+    /// A spawned task was cancelled
+    #[error("spawned task cancelled")]
+    TaskCancelled,
+}
+
+/// Error while performing tracking operation
+#[derive(Debug, thiserror::Error)]
+pub enum Tracking {
+    /// An error occurred when attempting to track a peer.
+    #[error(transparent)]
+    Track(#[from] tracking::error::Track),
+
+    /// An error occurred when attempting to get tracked peers.
+    #[error(transparent)]
+    Tracked(#[from] tracking::error::TrackedPeers),
+
+    /// An error occurred when attempting to untrack a peer.
+    #[error(transparent)]
+    Untrack(#[from] tracking::error::Untrack),
+}
+
+impl From<tracking::error::Track> for Error {
+    fn from(err: tracking::error::Track) -> Self {
+        Self::Tracking(err.into())
+    }
+}
+
+impl From<tracking::error::Untrack> for Error {
+    fn from(err: tracking::error::Untrack) -> Self {
+        Self::Tracking(err.into())
+    }
+}
+
+impl From<tracking::error::TrackedPeers> for Error {
+    fn from(err: tracking::error::TrackedPeers) -> Self {
+        Self::Tracking(err.into())
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(infallible: Infallible) -> Self {
+        match infallible {}
+    }
+}
+
+impl From<librad::git::identities::Error> for Error {
+    fn from(err: librad::git::identities::Error) -> Self {
+        Self::Identities(Box::new(err))
+    }
+}
+
+impl From<tokio::task::JoinError> for Error {
+    fn from(err: tokio::task::JoinError) -> Self {
+        if err.is_cancelled() {
+            Self::TaskCancelled
+        } else if err.is_panic() {
+            panic::resume_unwind(err.into_panic())
+        } else {
+            unreachable!("unexpected join error: {:?}", err)
+        }
+    }
+}
+
+/// Re-export the underlying [`storage::Error`] so that consumers don't need to
+/// add `librad` as a dependency to match on the variant. Instead, they can
+/// import `coco::state::error::storage`.
+pub mod storage {
+    pub use librad::git::storage::Error;
+}
+
+/// Re-export the underlying [`blob::Error`] so that consumers don't need to add
+/// `librad` as a dependency to match on the variant. Instead, they can import
+/// `coco::state::error::blob`.
+pub mod blob {
+    pub use librad::git_ext::blob::Error;
+}

--- a/upstream-proxy/src/daemon/existential.rs
+++ b/upstream-proxy/src/daemon/existential.rs
@@ -1,0 +1,247 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The enumeration of different [`super::Request`] states unified under a
+//! single enum called [`SomeRequest`].
+
+// I reserve the right to not match all the arms when picking out particular cases, thank you very
+// much.
+#![allow(clippy::wildcard_enum_match_arm)]
+
+use librad::PeerId;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    Attempts,
+    Cancelled,
+    Cloned,
+    Clones,
+    Cloning,
+    Created,
+    Either,
+    Found,
+    Queries,
+    Request,
+    RequestState,
+    Requested,
+    TimedOut,
+    Urn,
+};
+
+use super::Status;
+
+/// Since a `Request` is parameterised over its state, it makes it difficult to
+/// talk about a `Request` in general without the compiler complaining at us.
+/// For example, we cannot have something like `vec![created, requested,
+/// cloning, timedout]` since they all have distinct types where they differ in
+/// states.
+///
+/// To allow us to do this we unify all the states into `SomeRequest` where each
+/// state is a variant in the enumeration.
+///
+/// When we pattern match we get back the request parameterised over the
+/// specific state and can work in a type safe manner with this request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    bound = "T: serde_millis::Milliseconds",
+    rename_all = "camelCase",
+    tag = "type"
+)]
+pub enum SomeRequest<T> {
+    /// The `Request` has been created.
+    Created(Request<Created, T>),
+
+    /// The `Request` has been requested.
+    Requested(Request<Requested, T>),
+
+    /// The `Request` has found a peer and is possibly searching for more.
+    Found(Request<Found, T>),
+
+    /// The `Request` is attempting to clone from a peer.
+    Cloning(Request<Cloning, T>),
+
+    /// The `Request` has successfully cloned from a peer.
+    Cloned(Request<Cloned, T>),
+
+    /// The `Request` has been cancelled.
+    Cancelled(Request<Cancelled, T>),
+
+    /// The `Request` has timed out on querying or cloning.
+    TimedOut(Request<TimedOut, T>),
+}
+
+impl<T> From<&SomeRequest<T>> for RequestState {
+    fn from(other: &SomeRequest<T>) -> RequestState {
+        match other {
+            SomeRequest::Created(_) => Self::Created,
+            SomeRequest::Requested(_) => Self::Requested,
+            SomeRequest::Found(_) => Self::Found,
+            SomeRequest::Cloning(_) => Self::Cloning,
+            SomeRequest::Cloned(_) => Self::Cloned,
+            SomeRequest::Cancelled(_) => Self::Cancelled,
+            SomeRequest::TimedOut(_) => Self::TimedOut,
+        }
+    }
+}
+
+impl<T> From<Request<Created, T>> for SomeRequest<T> {
+    fn from(request: Request<Created, T>) -> Self {
+        Self::Created(request)
+    }
+}
+
+impl<T> From<Request<Requested, T>> for SomeRequest<T> {
+    fn from(request: Request<Requested, T>) -> Self {
+        Self::Requested(request)
+    }
+}
+
+impl<T> From<Request<Found, T>> for SomeRequest<T> {
+    fn from(request: Request<Found, T>) -> Self {
+        Self::Found(request)
+    }
+}
+
+impl<T> From<Request<Cloning, T>> for SomeRequest<T> {
+    fn from(request: Request<Cloning, T>) -> Self {
+        Self::Cloning(request)
+    }
+}
+
+impl<T> From<Request<Cloned, T>> for SomeRequest<T> {
+    fn from(request: Request<Cloned, T>) -> Self {
+        Self::Cloned(request)
+    }
+}
+
+impl<T> From<Request<Cancelled, T>> for SomeRequest<T> {
+    fn from(request: Request<Cancelled, T>) -> Self {
+        Self::Cancelled(request)
+    }
+}
+
+impl<T> From<Request<TimedOut, T>> for SomeRequest<T> {
+    fn from(request: Request<TimedOut, T>) -> Self {
+        Self::TimedOut(request)
+    }
+}
+
+impl<T, L: Into<SomeRequest<T>>, R: Into<SomeRequest<T>>> From<Either<L, R>> for SomeRequest<T> {
+    fn from(other: Either<L, R>) -> Self {
+        other.either(L::into, R::into)
+    }
+}
+
+impl<T> SomeRequest<T> {
+    /// Get the `Urn` of whatever kind of [`Request`] is below.
+    pub const fn urn(&self) -> &Urn {
+        match self {
+            SomeRequest::Created(request) => request.urn(),
+            SomeRequest::Requested(request) => request.urn(),
+            SomeRequest::Found(request) => request.urn(),
+            SomeRequest::Cloning(request) => request.urn(),
+            SomeRequest::Cloned(request) => request.urn(),
+            SomeRequest::Cancelled(request) => request.urn(),
+            SomeRequest::TimedOut(request) => request.urn(),
+        }
+    }
+
+    /// Get the [`Attempts`] of whatever kind of [`Request`] is below.
+    pub const fn attempts(&self) -> &Attempts {
+        match self {
+            SomeRequest::Created(request) => &request.attempts,
+            SomeRequest::Requested(request) => &request.attempts,
+            SomeRequest::Found(request) => &request.attempts,
+            SomeRequest::Cloning(request) => &request.attempts,
+            SomeRequest::Cloned(request) => &request.attempts,
+            SomeRequest::Cancelled(request) => &request.attempts,
+            SomeRequest::TimedOut(request) => &request.attempts,
+        }
+    }
+
+    /// Get the current timestamp of the underlying `Request`.
+    pub const fn timestamp(&self) -> &T {
+        match self {
+            SomeRequest::Created(request) => request.timestamp(),
+            SomeRequest::Requested(request) => request.timestamp(),
+            SomeRequest::Found(request) => request.timestamp(),
+            SomeRequest::Cloning(request) => request.timestamp(),
+            SomeRequest::Cloned(request) => request.timestamp(),
+            SomeRequest::Cancelled(request) => request.timestamp(),
+            SomeRequest::TimedOut(request) => request.timestamp(),
+        }
+    }
+
+    /// We can cancel an underlying `Request` if it is allowed to be cancelled.
+    /// In the case that it is allowed, then we get back the cancelled
+    /// request in the `Right` variant. Otherwise we get back our original
+    /// `SomeRequest` in the `Left` variant.
+    pub fn cancel(self, timestamp: T) -> Either<SomeRequest<T>, Request<Cancelled, T>> {
+        match self {
+            SomeRequest::Created(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Requested(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Found(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Cloning(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Cancelled(request) => Either::Right(request.cancel(timestamp)),
+            request => Either::Left(request),
+        }
+    }
+
+    /// We can see if our underlying `Request` timed out if it is in a state
+    /// where a time out can occur. In the case that it can time out, then
+    /// we get back the timed out request in the `Right` variant. Otherwise
+    /// we get back our original `SomeRequest` in the `Left` variant.
+    pub fn timed_out(
+        self,
+        max_queries: Queries,
+        max_clones: Clones,
+        timestamp: T,
+    ) -> Either<SomeRequest<T>, Request<TimedOut, T>> {
+        match self {
+            SomeRequest::Requested(request) => request
+                .timed_out(max_queries, max_clones, timestamp)
+                .map_left(SomeRequest::Requested),
+            SomeRequest::Found(request) => request
+                .timed_out(max_queries, max_clones, timestamp)
+                .map_left(SomeRequest::Found),
+            SomeRequest::Cloning(request) => request
+                .timed_out(max_queries, max_clones, timestamp)
+                .map_left(SomeRequest::Cloning),
+            request => Either::Left(request),
+        }
+    }
+
+    /// If we have some way of picking a specific `Request` from `SomeRequest`
+    /// and a function that transitions that `Request` into a next state
+    /// then we follow that transition.
+    ///
+    /// If not we leave the `SomeRequest` as is.
+    pub fn transition<Prev, Next>(
+        self,
+        matcher: impl FnOnce(SomeRequest<T>) -> Option<Prev>,
+        transition: impl FnOnce(Prev) -> Next,
+    ) -> Either<SomeRequest<T>, Next>
+    where
+        T: Clone,
+    {
+        match matcher(self.clone()) {
+            Some(previous) => Either::Right(transition(previous)),
+            None => Either::Left(self),
+        }
+    }
+
+    /// Get any peers associated with this request
+    pub fn peers(&self) -> Option<&std::collections::HashMap<PeerId, Status>> {
+        match self {
+            SomeRequest::Created(_)
+            | SomeRequest::Requested(_)
+            | SomeRequest::Cloned(_)
+            | SomeRequest::Cancelled(_)
+            | SomeRequest::TimedOut(..) => None,
+            SomeRequest::Found(f) => Some(&f.peers),
+            SomeRequest::Cloning(c) => Some(&c.peers),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/gossip.rs
+++ b/upstream-proxy/src/daemon/gossip.rs
@@ -1,0 +1,47 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Emit `Have`s and `Want`s on the network.
+
+use librad::{
+    git::Urn,
+    git_ext::Oid,
+    net::{
+        peer::Peer,
+        protocol::gossip::{Payload, Rev},
+    },
+    PeerId,
+    Signer,
+};
+
+/// Announce a new rev for the `urn`.
+pub fn announce<S>(peer: &Peer<S>, urn: &Urn, rev: Option<Oid>)
+where
+    S: Clone + Signer,
+{
+    match peer.announce(Payload {
+        urn: urn.clone(),
+        rev: rev.map(|rev| Rev::Git(rev.into())),
+        origin: None,
+    }) {
+        Ok(()) => tracing::trace!(%urn, ?rev, "successfully announced URN"),
+        Err(_payload) => tracing::warn!(%urn, ?rev, "failed to announce URN"),
+    }
+}
+
+/// Emit a [`Payload`] request for the given `urn`.
+pub fn query<S>(peer: &Peer<S>, urn: &Urn, origin: Option<PeerId>)
+where
+    S: Clone + Signer,
+{
+    match peer.query(Payload {
+        urn: urn.clone(),
+        rev: None,
+        origin,
+    }) {
+        Ok(()) => tracing::trace!(%urn, ?origin, "successfully queried URN"),
+        Err(_payload) => tracing::warn!(%urn, "failed to query URN"),
+    };
+}

--- a/upstream-proxy/src/daemon/include.rs
+++ b/upstream-proxy/src/daemon/include.rs
@@ -1,0 +1,20 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Handling of include files
+
+use librad::{git::Urn, net::peer::Peer, Signer};
+
+use crate::state;
+
+/// Update the include file for the given `RadUrn` and log the result.
+pub async fn update<S>(peer: Peer<S>, urn: Urn)
+where
+    S: Clone + Signer,
+{
+    if let Err(err) = state::update_include(&peer, urn.clone()).await {
+        tracing::error!(%urn, error = ?err, "Failed to update include file");
+    }
+}

--- a/upstream-proxy/src/daemon/input.rs
+++ b/upstream-proxy/src/daemon/input.rs
@@ -1,0 +1,97 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{net::SocketAddr, time::SystemTime};
+
+use librad::{git::Urn, net, net::peer::ProtocolEvent, PeerId};
+use tokio::sync::oneshot;
+
+use crate::{
+    peer::announcement,
+    request::{waiting_room, SomeRequest},
+};
+
+/// Significant events that occur during peer’s lifetime.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum Input {
+    /// Announcement subroutine lifecycle events.
+    Announce(Announce),
+    /// Peer state change events.
+    Control(Control),
+    ListenAddrs(Vec<SocketAddr>),
+    /// Inputs from the underlying coco protocol.
+    Protocol(ProtocolEvent),
+    /// Request subroutine events that wish to attempt to fetch an identity from
+    /// the network.
+    Request(Request),
+    Stats(Stats),
+}
+
+/// Announcement subroutine lifecycle events.
+#[derive(Clone, Debug)]
+pub enum Announce {
+    /// Operation failed.
+    Failed,
+    /// Operation succeeded and emitted the enclosed list of updates.
+    Succeeded(announcement::Updates),
+    /// The ticker duration has elapsed.
+    Tick,
+}
+
+/// Requests from the peer control.
+#[derive(Debug)]
+pub enum Control {
+    ListenAddrs(oneshot::Sender<Vec<SocketAddr>>),
+    /// New status.
+    Status(oneshot::Sender<super::Status>),
+
+    /// Cancel an ongoing project search.
+    CancelRequest(
+        Urn,
+        SystemTime,
+        oneshot::Sender<Result<Option<SomeRequest<SystemTime>>, waiting_room::Error>>,
+    ),
+    /// Initiate a new project search on the network.
+    CreateRequest(
+        Urn,
+        SystemTime,
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
+    ),
+    /// Request a project search.
+    GetRequest(Urn, oneshot::Sender<Option<SomeRequest<SystemTime>>>),
+    /// Request the list of project searches.
+    ListRequests(oneshot::Sender<Vec<SomeRequest<SystemTime>>>),
+}
+
+/// Request event for projects requested from the network.
+#[derive(Debug)]
+pub enum Request {
+    /// Started cloning the requested urn from a peer.
+    Cloning(Urn, PeerId),
+    /// Succeeded cloning from the `RadUrl`.
+    Cloned(Urn, PeerId),
+    /// Failed to clone from the `RadUrl`.
+    Failed {
+        /// The URN we attempted to clone.
+        urn: Urn,
+        // The id of the remote peer we attempted to clone from.
+        remote_peer: PeerId,
+        /// The reason the clone failed.
+        reason: Box<dyn std::error::Error + Send>,
+    },
+    /// Query the network for the `Urn`.
+    Queried(Urn),
+    /// [`crate::request::waiting_room::WaitingRoom`] query interval.
+    Tick,
+    /// The request for [`Urn`] timed out.
+    TimedOut(Urn),
+}
+
+#[derive(Debug)]
+pub enum Stats {
+    Tick,
+    Values(net::protocol::event::downstream::Stats),
+}

--- a/upstream-proxy/src/daemon/peer.rs
+++ b/upstream-proxy/src/daemon/peer.rs
@@ -1,0 +1,276 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Machinery to advance the underlying network protocol and manage auxiliary
+//! tasks ensuring prorper state updates.
+
+use std::{io, net::SocketAddr, vec};
+
+use futures::{
+    future::{Either, FutureExt as _, TryFutureExt as _},
+    stream::StreamExt as _,
+    Future,
+};
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    task::JoinError,
+};
+
+use crate::daemon::state;
+use librad::{net, Signer};
+
+pub mod announcement;
+pub use announcement::Announcement;
+
+mod control;
+pub use control::Control;
+
+pub mod gossip;
+
+pub mod include;
+
+mod run_state;
+pub use run_state::{config as run_config, Config as RunConfig, Event, Status, WaitingRoomEvent};
+
+mod subroutines;
+use subroutines::Subroutines;
+
+mod waiting_room;
+
+/// Upper bound of messages stored in receiver channels.
+pub const RECEIVER_CAPACITY: usize = 128;
+
+/// Peer operation errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failed to build and announce state updates.
+    #[error(transparent)]
+    Announcement(#[from] announcement::Error),
+
+    /// Peer bootstrap error.
+    #[error(transparent)]
+    Bootstrap(#[from] net::protocol::error::Bootstrap),
+
+    /// Encountered an I/O error, for example fetching the peer's listen
+    /// addresses.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// The joining of a thread failed.
+    #[error("the running peer was either cancelled, or one of its tasks panicked")]
+    Join(#[source] JoinError),
+
+    /// The protocol encountered an error.
+    #[error(transparent)]
+    Protocol(#[from] net::quic::Error),
+
+    /// An interaction with the underlying storage failed.
+    #[error(transparent)]
+    State(#[from] state::error::Error),
+
+    /// Peer initialisation error.
+    #[error(transparent)]
+    Init(#[from] net::peer::error::Init),
+}
+
+/// Local peer to participate in the radicle code-collaboration network.
+pub struct Peer<S, D> {
+    /// The API for interacting with the protocol and storage.
+    pub peer: net::peer::Peer<S>,
+
+    disco: D,
+    /// On-disk storage for caching.
+    store: kv::Store,
+    /// Handle used to broadcast [`Event`]s.
+    subscriber: broadcast::Sender<Event>,
+    /// Subroutine config.
+    run_config: RunConfig,
+    /// Receiving end of requests fired from control handles.
+    control_receiver: mpsc::Receiver<control::Request>,
+    /// Sending end for control handles to send requests to the running peer.
+    control_sender: mpsc::Sender<control::Request>,
+}
+
+impl<S, D> Peer<S, D>
+where
+    S: Clone + Signer,
+    D: net::discovery::Discovery<Addr = SocketAddr> + Clone + Send + Sync + 'static,
+{
+    /// Constructs a new [`Peer`].
+    ///
+    /// To kick-off the peer's subroutines be sure to use
+    /// [`start`][`Self::start`].
+    ///
+    /// # Errors
+    ///
+    /// If the underlying [`librad::net::peer::Peer`] fails to initialise.
+    #[must_use = "give a peer some love"]
+    pub fn new(
+        config: net::peer::Config<S>,
+        disco: D,
+        store: kv::Store,
+        run_config: RunConfig,
+    ) -> Result<Self, Error>
+    where
+        S: Clone + Signer,
+    {
+        let peer = librad::net::peer::Peer::new(config)?;
+        Ok(Self::with_peer(peer, disco, store, run_config))
+    }
+
+    /// Construct a new [`Peer`] using an existing [`net::peer::Peer`].
+    ///
+    /// To kick-off the peer's subroutines be sure to use
+    /// [`start`][`Self::start`].
+    #[must_use = "give a peer some love"]
+    pub fn with_peer(
+        peer: net::peer::Peer<S>,
+        disco: D,
+        store: kv::Store,
+        run_config: RunConfig,
+    ) -> Self {
+        let (subscriber, _receiver) = broadcast::channel(RECEIVER_CAPACITY);
+        let (control_sender, control_receiver) = mpsc::channel(RECEIVER_CAPACITY);
+        Self {
+            peer,
+            disco,
+            store,
+            subscriber,
+            run_config,
+            control_receiver,
+            control_sender,
+        }
+    }
+
+    /// Acquire a handle to inspect state and perform actions on a running peer.
+    #[must_use = "take control"]
+    pub fn control(&self) -> Control {
+        Control::new(self.control_sender.clone())
+    }
+
+    /// Subscribe to peer events.
+    ///
+    /// NB(xla): A caller must call this before the run loop is started, as that
+    /// consumes the peer. There is also a configured [`RECEIVER_CAPACITY`],
+    /// which prevents unbounded queues fron filling up.
+    #[must_use = "eat your events"]
+    pub fn subscribe(&self) -> broadcast::Receiver<Event> {
+        self.subscriber.subscribe()
+    }
+
+    /// Returns a future that runs the peer and a handle that shuts the peer
+    /// down when it is dropped.
+    ///
+    /// The function only returns when an error occurs or the [`Shutdown`] value
+    /// is dropped. becomes ready.
+    ///
+    /// The future returned by this function must be run to completion for the
+    /// daemon to shut down properly.
+    ///
+    /// # Errors
+    /// * Failed to accept peer connections
+    /// * A subroutine panicked or was cancelled
+    ///
+    /// # Panics
+    /// * If the subroutine is gone when the protocol network is still setting up shop.
+    pub fn start(self) -> (Shutdown, impl Future<Output = Result<(), Error>>) {
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel(1);
+        let shutdown = Shutdown(shutdown_tx.clone());
+
+        // We move all code inside the future so that this function can be called
+        // without a runtime being present yet.
+        let run = async move {
+            let Self {
+                peer,
+                disco,
+                store,
+                subscriber,
+                run_config,
+                control_receiver,
+                ..
+            } = self;
+            let (addrs_tx, addrs_rx) = watch::channel(vec![]);
+
+            let protocol_events = peer.subscribe().boxed();
+            let subroutines = Subroutines::new(
+                peer.clone(),
+                addrs_rx,
+                store,
+                &run_config,
+                protocol_events,
+                subscriber,
+                control_receiver,
+            )
+            .run()
+            .fuse()
+            .map_err(Error::Join);
+
+            let protocol = async move {
+                loop {
+                    match peer.bind().await {
+                        Ok(bound) => {
+                            addrs_tx
+                                .send(bound.listen_addrs())
+                                .expect("subroutines is gone");
+                            let (stop_accepting, run) = bound.accept(disco.clone().discover());
+                            let shutdown_recv = shutdown_rx.recv();
+                            futures::pin_mut!(shutdown_recv);
+                            futures::pin_mut!(run);
+                            let result = match futures::future::select(shutdown_recv, run).await {
+                                Either::Left((_, run)) => {
+                                    stop_accepting();
+                                    run.await
+                                },
+                                Either::Right((run_result, _)) => run_result,
+                            };
+                            match result {
+                                Err(net::protocol::io::error::Accept::Done) => {
+                                    tracing::info!("network endpoint shut down");
+                                    return Ok(());
+                                },
+                                Err(error) => {
+                                    tracing::error!(?error, "accept error");
+                                },
+                                Ok(never) => unreachable!("absurd: {}", never),
+                            };
+                        },
+                        Err(e) => {
+                            tracing::error!(error = ?e, "bound error");
+                            return Err(Error::Bootstrap(e));
+                        },
+                    }
+                }
+            }
+            .fuse();
+
+            futures::pin_mut!(subroutines);
+            futures::pin_mut!(protocol);
+            match futures::future::select(subroutines, protocol).await {
+                Either::Left((result, protocol)) => {
+                    let _result = shutdown_tx.send(());
+
+                    protocol.await?;
+                    result
+                },
+                Either::Right((result, _subroutines)) => result,
+            }
+        };
+
+        (shutdown, run)
+    }
+}
+
+/// Shutdown handle returned by [`Peer::start`].
+///
+/// If this value is dropped, the peer will shutdown.
+#[derive(Debug)]
+pub struct Shutdown(mpsc::Sender<()>);
+
+impl Drop for Shutdown {
+    fn drop(&mut self) {
+        // If this errors, the peer has already shut down.
+        let _ = self.0.try_send(());
+    }
+}

--- a/upstream-proxy/src/daemon/peer/announcement.rs
+++ b/upstream-proxy/src/daemon/peer/announcement.rs
@@ -1,0 +1,301 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Compute, track and announce noteworthy changes to the network.
+
+use std::collections::HashSet;
+
+use librad::{
+    git::Urn,
+    git_ext::{Oid, RefLike},
+    identities::{urn, SomeIdentity},
+    net::peer::Peer,
+    Signer,
+};
+use tokio::task::spawn_blocking;
+
+use crate::daemon::{peer::gossip, state};
+
+/// Name for the bucket used in [`kv::Store`].
+const BUCKET_NAME: &str = "announcements";
+/// Key for the single value used as cache.
+const KEY_NAME: &str = "latest";
+
+/// Announcement errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failures from [`kv`].
+    #[error(transparent)]
+    Kv(#[from] kv::Error),
+
+    /// Failures parsing.
+    #[error(transparent)]
+    Parse(#[from] urn::error::FromStr<git2::Error>),
+
+    /// Error occurred when interacting with [`Peer`].
+    #[error(transparent)]
+    State(#[from] Box<state::Error>),
+
+    /// Error in spawned task.
+    #[error(transparent)]
+    Task(#[from] tokio::task::JoinError),
+}
+
+impl From<state::Error> for Error {
+    fn from(e: state::Error) -> Self {
+        Self::from(Box::new(e))
+    }
+}
+
+/// An update and all the required information that can be announced on the
+/// network.
+pub type Announcement = (Urn, Oid);
+
+/// Unique list of [`Announcement`]s.
+pub type Updates = HashSet<Announcement>;
+
+/// Announces the list of given `updates` with the [`librad::net::protocol`].
+///
+/// # Errors
+///
+/// * if the announcemnet of one of the project heads failed
+fn announce<'a, S>(peer: &Peer<S>, updates: impl Iterator<Item = &'a Announcement> + Send)
+where
+    S: Clone + Signer,
+{
+    for (urn, hash) in updates {
+        gossip::announce(peer, urn, Some(*hash));
+    }
+}
+
+/// Builds the latest list of [`Announcement`]s for the current state of the
+/// peer.
+///
+/// # Errors
+///
+/// * if listing of the projects fails
+/// * if listing of the Refs for a project fails
+async fn build<S>(peer: &Peer<S>) -> Result<Updates, Error>
+where
+    S: Clone + Signer,
+{
+    let identities = state::list_identities(peer).await?;
+    let mut updates: Updates = HashSet::new();
+    for identity in identities {
+        let urn = match identity {
+            SomeIdentity::Person(person) => person.urn(),
+            SomeIdentity::Project(project) => project.urn(),
+            _ => continue,
+        };
+        let refs = match state::load_refs(peer, urn.clone()).await? {
+            Some(refs) => refs,
+            None => continue,
+        };
+        for ((one_level, oid), category) in refs.iter_categorised() {
+            let path = RefLike::from(one_level.clone().into_qualified(category.into()));
+            let urn = urn.clone().with_path(path);
+            updates.insert((urn, *oid));
+        }
+    }
+    Ok(updates)
+}
+
+/// Computes the list of announcements based on the difference of the `new` and
+/// `old` state. An [`Announcement`] will be included if an entry in `new` can't
+/// be found in `old`.
+#[allow(clippy::implicit_hasher)]
+#[must_use]
+fn diff<'a>(old_state: &'a Updates, new_state: &'a Updates) -> Updates {
+    new_state.difference(old_state).cloned().collect()
+}
+
+/// Load the cached announcements from the [`kv::Store`].
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the access of the key in the [`kv::Bucket`] fails
+fn load(store: &kv::Store) -> Result<Updates, Error> {
+    let bucket = store.bucket::<&'static str, kv::Json<Updates>>(Some(BUCKET_NAME))?;
+    let value = bucket.get(KEY_NAME)?.map_or(HashSet::new(), |json| json.0);
+
+    Ok(value)
+}
+
+/// Runs the entire announcement procedure.
+///
+/// # Errors
+///
+/// * if it can't build the new list of updates
+/// * access to the storage fails
+pub async fn run<S>(peer: &Peer<S>, store: kv::Store) -> Result<Updates, Error>
+where
+    S: Clone + Signer,
+{
+    let old = spawn_blocking({
+        let store = store.clone();
+        move || load(&store)
+    })
+    .await??;
+    let new = build(peer).await?;
+    let updates = diff(&old, &new);
+
+    announce(peer, updates.iter());
+
+    if !updates.is_empty() {
+        spawn_blocking(move || save(&store, new.clone())).await??;
+    }
+
+    Ok(updates)
+}
+
+/// Update the cache with the latest announcements.
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the storage of the new updates fails
+#[allow(clippy::implicit_hasher)]
+fn save(store: &kv::Store, updates: Updates) -> Result<(), Error> {
+    let bucket = store.bucket::<&'static str, kv::Json<Updates>>(Some(BUCKET_NAME))?;
+    bucket.set(KEY_NAME, kv::Json(updates)).map_err(Error::from)
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashSet, convert::TryFrom as _};
+
+    use pretty_assertions::assert_eq;
+
+    use librad::{
+        crypto::{BoxedSigner, SomeSigner},
+        git::Urn,
+        net, SecretKey,
+    };
+    use radicle_git_ext::{oid, RefLike};
+
+    use crate::daemon::{config, identities::payload::Person};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::unwrap_used)] // XXX: clippy sees an unwrap where there is none
+    async fn announce() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = BoxedSigner::new(SomeSigner {
+            signer: key.clone(),
+        });
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+
+        let _owner = crate::daemon::state::init_owner(
+            &peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
+
+        // TODO(xla): Build up proper testnet to assert that haves are announced.
+        let updates = super::build(&peer).await?;
+        super::announce(&peer, updates.iter());
+
+        Ok(())
+    }
+
+    #[test]
+    fn diff() -> Result<(), Box<dyn std::error::Error>> {
+        let both = vec![
+            (project0("dev"), "68986574".parse::<oid::Oid>()?),
+            (project0("master"), "c8d2ad44".parse::<oid::Oid>()?),
+            (project0("stable"), "2d2e1408".parse::<oid::Oid>()?),
+            (
+                project0("cloudhead/cool-feature"),
+                "68986574".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("fintohaps/doc-tests"),
+                "f90353ba".parse::<oid::Oid>()?,
+            ),
+            (project1("dev"), "c8d2ad44".parse::<oid::Oid>()?),
+            (project0("master"), "2d2e1408".parse::<oid::Oid>()?),
+            (project1("stable"), "a3403e2d".parse::<oid::Oid>()?),
+        ];
+        let old = vec![
+            (
+                project0("igor/zero-assertions"),
+                "72a78226".parse::<oid::Oid>()?,
+            ),
+            (project0("thoshol/remove"), "7c69d71a".parse::<oid::Oid>()?),
+            (project1("rudolfs/release"), "8c085d58".parse::<oid::Oid>()?),
+        ];
+        let new = vec![
+            (
+                project0("cloudhead/new-language"),
+                "7dec3269".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("fintohaps/notations"),
+                "b4d3276d".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("kalt/eat-my-impls"),
+                "2206e5dc".parse::<oid::Oid>()?,
+            ),
+            (project1("backport"), "869e5740".parse::<oid::Oid>()?),
+        ];
+
+        let left: HashSet<_> = [&both[..], &old[..]].concat().iter().cloned().collect();
+        let right: HashSet<_> = [&both[..], &new[..]].concat().iter().cloned().collect();
+        let announcements = super::diff(&left, &right);
+
+        assert_eq!(announcements, new.iter().cloned().collect::<HashSet<_>>());
+
+        Ok(())
+    }
+
+    #[test]
+    fn save_and_load() -> Result<(), Box<dyn std::error::Error>> {
+        let updates: HashSet<_> = vec![
+            (
+                project0("cloudead/new-language"),
+                "7dec3269".parse::<oid::Oid>()?,
+            ),
+            (
+                project0("fintohaps/notations"),
+                "b4d3276d".parse::<oid::Oid>()?,
+            ),
+            (project0("kalt/loops"), "2206e5dc".parse::<oid::Oid>()?),
+            (project1("backport"), "869e5740".parse::<oid::Oid>()?),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        let dir = tempfile::tempdir()?;
+        let store = kv::Store::new(kv::Config::new(dir.path().join("store")))?;
+
+        super::save(&store, updates.clone())?;
+
+        assert_eq!(super::load(&store)?, updates);
+
+        Ok(())
+    }
+
+    fn project0(head: &str) -> Urn {
+        Urn {
+            id: "7ab8629dd6da14dcacde7f65b3d58cd291d7e235"
+                .parse::<radicle_git_ext::Oid>()
+                .expect("oid parse failed"),
+            path: Some(RefLike::try_from(head).expect("head was not reflike")),
+        }
+    }
+    fn project1(head: &str) -> Urn {
+        Urn {
+            id: "7ab8629dd6da14dcacde7f65b3d58cd291d7e234"
+                .parse::<radicle_git_ext::Oid>()
+                .expect("oid parse failed"),
+            path: Some(RefLike::try_from(head).expect("head was not reflike")),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/peer/control.rs
+++ b/upstream-proxy/src/daemon/peer/control.rs
@@ -1,0 +1,181 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Inspect state and perform actions on a running peer.
+
+use std::{net::SocketAddr, time::SystemTime};
+
+use either::Either;
+use tokio::sync::{mpsc, oneshot};
+
+use librad::git::Urn;
+
+use crate::daemon::{request, request::waiting_room};
+
+use super::run_state::Status;
+
+/// Requests sent to the peer.
+#[derive(Debug)]
+pub enum Request {
+    ListenAddrs(oneshot::Sender<Vec<SocketAddr>>),
+    /// Request the current peer status.
+    CurrentStatus(oneshot::Sender<Status>),
+
+    /// Cancel an ongoing project search.
+    CancelSearch(
+        Urn,
+        SystemTime,
+        oneshot::Sender<Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>>,
+    ),
+    #[cfg(test)]
+    /// Get a project search.
+    GetSearch(
+        Urn,
+        oneshot::Sender<Option<request::SomeRequest<SystemTime>>>,
+    ),
+    /// List all project searches.
+    ListSearches(oneshot::Sender<Vec<request::SomeRequest<SystemTime>>>),
+    /// Initiate a search for a project on the network.
+    StartSearch(
+        Urn,
+        SystemTime,
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
+    ),
+}
+
+/// Returned responses from the peer.
+#[derive(Debug)]
+pub enum Response {
+    ListenAddrs(oneshot::Sender<Vec<SocketAddr>>, Vec<SocketAddr>),
+    /// Response to a status request.
+    CurrentStatus(oneshot::Sender<Status>, Status),
+    /// Response to a cancel project search request.
+    CancelSearch(
+        oneshot::Sender<Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>>,
+        Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error>,
+    ),
+    /// Response to list project searches request.
+    ListSearches(
+        oneshot::Sender<Vec<request::SomeRequest<SystemTime>>>,
+        Vec<request::SomeRequest<SystemTime>>,
+    ),
+    /// Response to a start project search request.
+    StartSearch(
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
+        waiting_room::Created<SystemTime>,
+    ),
+
+    #[cfg(test)]
+    /// Response to get project search request.
+    GetSearch(
+        oneshot::Sender<Option<request::SomeRequest<SystemTime>>>,
+        Option<request::SomeRequest<SystemTime>>,
+    ),
+}
+
+/// A handle to inspect state and perform actions on a running peer.
+#[derive(Clone)]
+pub struct Control {
+    /// Channel to send requests to the peer.
+    sender: mpsc::Sender<Request>,
+}
+
+impl Control {
+    /// Construct a new [`Control`] handle.
+    #[must_use = "take control"]
+    pub const fn new(sender: mpsc::Sender<Request>) -> Self {
+        Self { sender }
+    }
+
+    /// Initiate a new request for the status.
+    pub async fn current_status(&mut self) -> Status {
+        let (sender, receiver) = oneshot::channel::<Status>();
+
+        self.sender
+            .send(Request::CurrentStatus(sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// List listen addrs of the running peer.
+    pub async fn listen_addrs(&mut self) -> Vec<SocketAddr> {
+        let (sender, receiver) = oneshot::channel::<Vec<SocketAddr>>();
+
+        self.sender
+            .send(Request::ListenAddrs(sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// Cancel an ongoing search for a project.
+    ///
+    /// # Errors
+    ///
+    /// * if the waiting room returns an error
+    pub async fn cancel_project_request(
+        &mut self,
+        urn: &Urn,
+        timestamp: SystemTime,
+    ) -> Result<Option<request::SomeRequest<SystemTime>>, waiting_room::Error> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .send(Request::CancelSearch(urn.clone(), timestamp, sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    #[cfg(test)]
+    /// Initiate a new request to fetch a project from the network.
+    pub async fn get_project_request(
+        &mut self,
+        urn: &Urn,
+    ) -> Option<request::SomeRequest<SystemTime>> {
+        let (sender, receiver) = oneshot::channel::<Option<request::SomeRequest<SystemTime>>>();
+
+        self.sender
+            .send(Request::GetSearch(urn.clone(), sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// Initiate a new reuest for the list of existing project requests.
+    pub async fn get_project_requests(&mut self) -> Vec<request::SomeRequest<SystemTime>> {
+        let (sender, receiver) = oneshot::channel::<Vec<request::SomeRequest<SystemTime>>>();
+
+        self.sender
+            .send(Request::ListSearches(sender))
+            .await
+            .expect("peer is gone");
+
+        receiver.await.expect("receiver is gone")
+    }
+
+    /// Initiate a new request for the `urn`.
+    pub async fn request_project(
+        &mut self,
+        urn: &Urn,
+        timestamp: SystemTime,
+    ) -> request::SomeRequest<SystemTime> {
+        let (sender, receiver) = oneshot::channel::<waiting_room::Created<SystemTime>>();
+
+        self.sender
+            .send(Request::StartSearch(urn.clone(), timestamp, sender))
+            .await
+            .expect("peer is gone");
+
+        match receiver.await.expect("receiver is gone") {
+            Either::Left(req) | Either::Right(req) => req,
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/peer/gossip.rs
+++ b/upstream-proxy/src/daemon/peer/gossip.rs
@@ -1,0 +1,46 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Emit `Have`s and `Want`s on the network.
+
+use librad::{
+    git::Urn,
+    git_ext::Oid,
+    net::{
+        peer::Peer,
+        protocol::gossip::{Payload, Rev},
+    },
+    PeerId, Signer,
+};
+
+/// Announce a new rev for the `urn`.
+pub fn announce<S>(peer: &Peer<S>, urn: &Urn, rev: Option<Oid>)
+where
+    S: Clone + Signer,
+{
+    match peer.announce(Payload {
+        urn: urn.clone(),
+        rev: rev.map(|rev| Rev::Git(rev.into())),
+        origin: None,
+    }) {
+        Ok(()) => tracing::trace!(%urn, ?rev, "successfully announced URN"),
+        Err(_payload) => tracing::warn!(%urn, ?rev, "failed to announce URN"),
+    }
+}
+
+/// Emit a [`Payload`] request for the given `urn`.
+pub fn query<S>(peer: &Peer<S>, urn: &Urn, origin: Option<PeerId>)
+where
+    S: Clone + Signer,
+{
+    match peer.query(Payload {
+        urn: urn.clone(),
+        rev: None,
+        origin,
+    }) {
+        Ok(()) => tracing::trace!(%urn, ?origin, "successfully queried URN"),
+        Err(_payload) => tracing::warn!(%urn, "failed to query URN"),
+    };
+}

--- a/upstream-proxy/src/daemon/peer/include.rs
+++ b/upstream-proxy/src/daemon/peer/include.rs
@@ -1,0 +1,20 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Handling of include files
+
+use librad::{git::Urn, net::peer::Peer, Signer};
+
+use crate::daemon::state;
+
+/// Update the include file for the given `RadUrn` and log the result.
+pub async fn update<S>(peer: Peer<S>, urn: Urn)
+where
+    S: Clone + Signer,
+{
+    if let Err(err) = state::update_include(&peer, urn.clone()).await {
+        tracing::error!(%urn, error = ?err, "Failed to update include file");
+    }
+}

--- a/upstream-proxy/src/daemon/peer/run_state.rs
+++ b/upstream-proxy/src/daemon/peer/run_state.rs
@@ -1,0 +1,581 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! State machine to manage the current mode of operation during peer lifecycle.
+
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    time::{Duration, SystemTime},
+};
+
+use serde::Serialize;
+
+use librad::{
+    git::Urn,
+    net::{
+        self,
+        peer::{PeerInfo, ProtocolEvent},
+        protocol::{
+            broadcast::PutResult,
+            event::{downstream, upstream},
+            gossip::Payload,
+        },
+    },
+    PeerId,
+};
+
+use crate::daemon::{
+    convert::MaybeFrom,
+    peer::{announcement, control},
+    request::waiting_room::{self, WaitingRoom},
+};
+
+pub mod command;
+pub use command::Command;
+
+pub mod config;
+pub use config::Config;
+
+pub mod input;
+pub use input::Input;
+
+mod running_waiting_room;
+pub use running_waiting_room::Event as WaitingRoomEvent;
+use running_waiting_room::{RunningWaitingRoom, WaitingRoomTransition};
+
+/// Events external subscribers can observe for internal peer operations.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+pub enum Event {
+    /// Announcement subroutine completed and emitted the enclosed updates.
+    Announced(announcement::Updates),
+    /// A fetch originated by a gossip message succeeded
+    GossipFetched {
+        /// Provider of the fetched update.
+        provider: PeerInfo<SocketAddr>,
+        /// Cooresponding gossip message.
+        gossip: Payload,
+        /// Result of the storage fetch.
+        result: PutResult<Payload>,
+    },
+    /// An event from the underlying coco network stack.
+    /// FIXME(xla): Align variant naming to indicate observed occurrences.
+    Protocol(ProtocolEvent),
+    /// Request fullfilled with a successful clone.
+    RequestCloned(Urn, PeerId),
+    /// Request is being cloned from a peer.
+    RequestCloning(Urn, PeerId),
+    /// Request for the URN was created and is pending submission to the
+    /// network.
+    RequestCreated(Urn),
+    /// Request for the URN was submitted to the network.
+    RequestQueried(Urn),
+    /// Waiting room interval ticked.
+    RequestTick,
+    /// The request for [`Urn`] timed out.
+    RequestTimedOut(Urn),
+    /// The [`Status`] of the peer changed.
+    StatusChanged {
+        /// The old status
+        old: Status,
+        /// The net status
+        new: Status,
+    },
+    /// A state change occurred in the waiting room
+    WaitingRoomTransition(WaitingRoomTransition<SystemTime>),
+}
+
+impl From<WaitingRoomTransition<SystemTime>> for Event {
+    fn from(transition: WaitingRoomTransition<SystemTime>) -> Self {
+        Self::WaitingRoomTransition(transition)
+    }
+}
+
+impl MaybeFrom<&Input> for Event {
+    fn maybe_from(input: &Input) -> Option<Self> {
+        match input {
+            Input::Announce(input::Announce::Succeeded(updates)) => {
+                Some(Self::Announced(updates.clone()))
+            },
+            Input::Protocol(protocol_event) => match protocol_event {
+                ProtocolEvent::Gossip(gossip) => match &**gossip {
+                    upstream::Gossip::Put {
+                        provider,
+                        payload,
+                        result,
+                    } => Some(Self::GossipFetched {
+                        provider: provider.clone(),
+                        gossip: payload.clone(),
+                        result: result.clone(),
+                    }),
+                },
+                event => Some(Self::Protocol(event.clone())),
+            },
+            Input::Request(input::Request::Cloned(urn, remote_peer)) => {
+                Some(Self::RequestCloned(urn.clone(), *remote_peer))
+            },
+            Input::Request(input::Request::Cloning(urn, remote_peer)) => {
+                Some(Self::RequestCloning(urn.clone(), *remote_peer))
+            },
+            Input::Request(input::Request::Queried(urn)) => Some(Self::RequestQueried(urn.clone())),
+            Input::Request(input::Request::Tick) => Some(Self::RequestTick),
+            Input::Request(input::Request::TimedOut(urn)) => {
+                Some(Self::RequestTimedOut(urn.clone()))
+            },
+            _ => None,
+        }
+    }
+}
+
+/// The current status of the local peer and its relation to the network.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Status {
+    /// Nothing is setup, not even a socket to listen on.
+    Stopped,
+    /// Local peer is listening on a socket but has not connected to any peers
+    /// yet.
+    Started,
+    /// The local peer lost its connections to all its peers.
+    Offline,
+    /// The local peer is operational and is able to interact with the peers it
+    /// has connected to.
+    #[serde(rename_all = "camelCase")]
+    Online {
+        /// Connected peers
+        connected_peers: HashMap<PeerId, Vec<SocketAddr>>,
+    },
+}
+
+/// State kept for a running local peer.
+pub struct RunState {
+    listen_addrs: Vec<SocketAddr>,
+    /// Current internal status.
+    pub status: Status,
+    stats: net::protocol::event::downstream::Stats,
+    /// Current set of requests.
+    waiting_room: RunningWaitingRoom,
+}
+
+impl RunState {
+    /// Constructs a new state.
+    #[cfg(test)]
+    fn construct(status: Status) -> Self {
+        Self {
+            listen_addrs: vec![],
+            stats: downstream::Stats::default(),
+            status,
+            waiting_room: RunningWaitingRoom::new(
+                WaitingRoom::new(waiting_room::Config::default()),
+            ),
+        }
+    }
+
+    /// Creates a new `RunState` initialising it with the provided `config` and
+    /// `waiting_room`.
+    pub fn new(waiting_room: WaitingRoom<SystemTime, Duration>) -> Self {
+        Self {
+            listen_addrs: vec![],
+            stats: downstream::Stats::default(),
+            status: Status::Stopped,
+            waiting_room: RunningWaitingRoom::new(waiting_room),
+        }
+    }
+
+    /// Applies the `input` and based on the current state, transforms to the
+    /// new state and in some cases produes commands which should be
+    /// executed in the appropriate subroutines.
+    pub fn transition(&mut self, input: Input) -> Vec<Command> {
+        tracing::trace!(?input, status = ?self.status, "transition start");
+
+        let cmds = match input {
+            Input::Announce(announce_input) => self.handle_announce(announce_input),
+            Input::Control(control_input) => self.handle_control(control_input),
+            Input::ListenAddrs(addrs) => self.handle_listen_addrs(addrs),
+            Input::Protocol(protocol_event) => self.handle_protocol(protocol_event),
+            Input::Request(request_input) => self.handle_request(request_input),
+            Input::Stats(stats_input) => self.handle_stats(stats_input),
+        };
+
+        tracing::trace!(?cmds, status = ?self.status, "transition end");
+
+        cmds
+    }
+
+    /// Handle [`input::Announce`]s.
+    fn handle_announce(&mut self, input: input::Announce) -> Vec<Command> {
+        match (&self.status, input) {
+            // Announce new updates while the peer is online.
+            (Status::Online { .. } | Status::Started { .. }, input::Announce::Tick)
+                if !self.stats.connected_peers.is_empty() && self.stats.membership_active > 0 =>
+            {
+                vec![Command::Announce]
+            },
+            _ => vec![],
+        }
+    }
+
+    /// Handle [`input::Control`]s.
+    fn handle_control(&mut self, input: input::Control) -> Vec<Command> {
+        match input {
+            input::Control::CancelRequest(urn, timestamp, sender) => {
+                self.waiting_room.cancel(urn, timestamp, sender)
+            },
+            input::Control::CreateRequest(urn, time, sender) => {
+                self.waiting_room.request(urn, time, sender)
+            },
+            input::Control::ListRequests(sender) => vec![Command::Control(
+                command::Control::Respond(control::Response::ListSearches(
+                    sender,
+                    self.waiting_room
+                        .iter()
+                        .map(|pair| pair.1.clone())
+                        .collect::<Vec<_>>(),
+                )),
+            )],
+            input::Control::ListenAddrs(sender) => {
+                vec![Command::Control(command::Control::Respond(
+                    control::Response::ListenAddrs(sender, self.listen_addrs.clone()),
+                ))]
+            },
+            input::Control::Status(sender) => vec![Command::Control(command::Control::Respond(
+                control::Response::CurrentStatus(sender, self.status.clone()),
+            ))],
+
+            #[cfg(test)]
+            input::Control::GetRequest(urn, sender) => {
+                vec![Command::Control(command::Control::Respond(
+                    control::Response::GetSearch(sender, self.waiting_room.get(&urn).cloned()),
+                ))]
+            },
+        }
+    }
+
+    fn handle_listen_addrs(&mut self, addrs: Vec<SocketAddr>) -> Vec<Command> {
+        self.listen_addrs = addrs;
+        vec![]
+    }
+
+    /// Handle [`ProtocolEvent`]s.
+    #[allow(clippy::wildcard_enum_match_arm)]
+    fn handle_protocol(&mut self, event: ProtocolEvent) -> Vec<Command> {
+        match (&self.status, event) {
+            (Status::Stopped, ProtocolEvent::Endpoint(upstream::Endpoint::Up { .. })) => {
+                self.status = Status::Started;
+
+                vec![]
+            },
+            (_, ProtocolEvent::Endpoint(upstream::Endpoint::Down)) => {
+                self.status = Status::Stopped;
+
+                vec![]
+            },
+            (_, ProtocolEvent::Gossip(gossip)) => {
+                let mut cmds = vec![];
+
+                match *gossip {
+                    // FIXME(xla): Find out if we care about the result variance.
+                    upstream::Gossip::Put {
+                        payload: Payload { urn, .. },
+                        provider: PeerInfo { peer_id, .. },
+                        result,
+                    } => {
+                        if self.waiting_room.get(&urn).is_some() {
+                            cmds.extend(self.waiting_room.found(&urn, peer_id, SystemTime::now()));
+                        }
+
+                        if let PutResult::Applied(_) = result {
+                            cmds.push(Command::Include(urn));
+                        }
+                    },
+                }
+
+                cmds
+            },
+            _ => vec![],
+        }
+    }
+
+    /// Handle [`input::Request`]s.
+    #[allow(clippy::wildcard_enum_match_arm)]
+    fn handle_request(&mut self, input: input::Request) -> Vec<Command> {
+        match (&self.status, input) {
+            // Check for new query and clone requests.
+            (Status::Online { .. }, input::Request::Tick) => {
+                self.waiting_room.tick(SystemTime::now())
+            },
+            (_, input::Request::Cloning(urn, remote_peer)) => {
+                self.waiting_room
+                    .cloning(&urn, remote_peer, SystemTime::now())
+            },
+            (_, input::Request::Cloned(urn, remote_peer)) => {
+                self.waiting_room
+                    .cloned(&urn, remote_peer, SystemTime::now())
+            },
+            (_, input::Request::Queried(urn)) => self.waiting_room.queried(&urn, SystemTime::now()),
+            (
+                _,
+                input::Request::Failed {
+                    remote_peer,
+                    reason,
+                    urn,
+                },
+            ) => {
+                tracing::warn!(?reason, "cloning failed");
+                self.waiting_room
+                    .cloning_failed(&urn, remote_peer, SystemTime::now(), reason)
+            },
+            _ => vec![],
+        }
+    }
+
+    fn handle_stats(&mut self, input: input::Stats) -> Vec<Command> {
+        match (&self.status, input) {
+            (_, input::Stats::Tick) => vec![Command::Stats],
+            (status, input::Stats::Values(stats)) => {
+                match status {
+                    Status::Online { .. } if stats.connected_peers.is_empty() => {
+                        self.status = Status::Offline;
+                    },
+                    Status::Offline if !stats.connected_peers.is_empty() => {
+                        self.status = Status::Online {
+                            connected_peers: stats.connected_peers.clone(),
+                        };
+                    },
+                    Status::Started if !stats.connected_peers.is_empty() => {
+                        self.status = Status::Online {
+                            connected_peers: stats.connected_peers.clone(),
+                        };
+                    },
+                    _ => {},
+                };
+
+                self.stats = stats;
+
+                vec![]
+            },
+        }
+    }
+}
+
+#[allow(clippy::needless_update, clippy::panic, clippy::unwrap_used)]
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, iter, net::SocketAddr, str::FromStr, time::SystemTime};
+
+    use assert_matches::assert_matches;
+    use pretty_assertions::assert_eq;
+    use tokio::sync::oneshot;
+
+    use librad::{
+        data::BoundedVec,
+        git::Urn,
+        git_ext::Oid,
+        net::{
+            self,
+            peer::ProtocolEvent,
+            protocol::{
+                broadcast,
+                event::{
+                    downstream,
+                    upstream::{Endpoint, Gossip},
+                },
+                gossip::Payload,
+            },
+        },
+        PeerId, SecretKey,
+    };
+
+    use super::{command, input, Command, Input, RunState, Status};
+
+    #[test]
+    fn transition_to_started_on_listen() -> Result<(), Box<dyn std::error::Error>> {
+        let addr = "127.0.0.1:12345".parse::<SocketAddr>()?;
+
+        let status = Status::Stopped;
+        let mut state = RunState::construct(status);
+
+        let cmds = state.transition(Input::Protocol(ProtocolEvent::Endpoint(Endpoint::Up {
+            listen_addrs: vec![addr],
+        })));
+        assert!(cmds.is_empty());
+        assert_matches!(state.status, Status::Started { .. });
+
+        Ok(())
+    }
+
+    #[test]
+    fn transition_to_online() {
+        let status = Status::Started;
+        let mut state = RunState::construct(status);
+
+        let cmds = {
+            let key = SecretKey::new();
+            let peer_id = PeerId::from(key);
+            state.transition(Input::Stats(input::Stats::Values(downstream::Stats {
+                connections_total: 1,
+                connected_peers: one_connected_peer(peer_id),
+                membership_active: 1,
+                membership_passive: 1,
+                caches: downstream::CacheStats::default(),
+            })))
+        };
+        assert!(cmds.is_empty());
+        assert_matches!(state.status, Status::Online { .. });
+    }
+
+    #[test]
+    fn transition_to_offline_when_last_peer_disconnects() {
+        let status = Status::Online {
+            connected_peers: HashMap::new(),
+        };
+        let mut state = RunState::construct(status);
+
+        let _cmds = state.transition(Input::Stats(input::Stats::Values(
+            downstream::Stats::default(),
+        )));
+        assert_matches!(state.status, Status::Offline);
+    }
+
+    #[test]
+    fn issue_announce_while_online_and_active_membering() {
+        let peer_id = PeerId::from(SecretKey::new());
+        let status = Status::Online {
+            connected_peers: one_connected_peer(peer_id),
+        };
+        let mut state = RunState::construct(status);
+
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+        assert!(cmds.is_empty(), "expected no command");
+
+        state.stats = librad::net::protocol::event::downstream::Stats {
+            connected_peers: one_connected_peer(peer_id),
+            membership_active: 1,
+            ..librad::net::protocol::event::downstream::Stats::default()
+        };
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+
+        assert!(!cmds.is_empty(), "expected command");
+        assert_matches!(cmds.first().unwrap(), Command::Announce);
+    }
+
+    #[test]
+    fn dont_announce_with_inactive_member() {
+        let peer_id = PeerId::from(SecretKey::new());
+        let status = Status::Online {
+            connected_peers: one_connected_peer(peer_id),
+        };
+        let mut state = RunState::construct(status);
+
+        state.stats = librad::net::protocol::event::downstream::Stats {
+            connected_peers: HashMap::new(),
+            membership_active: 0,
+            membership_passive: 1,
+            ..librad::net::protocol::event::downstream::Stats::default()
+        };
+
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+        assert!(cmds.is_empty(), "expected no command");
+    }
+
+    #[test]
+    fn dont_announce_when_offline() {
+        let status = Status::Offline;
+        let mut state = RunState::construct(status);
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+
+        assert!(cmds.is_empty(), "expected no command");
+    }
+
+    #[test]
+    fn issue_query_when_requested_and_online() -> Result<(), Box<dyn std::error::Error + 'static>> {
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let connected_peers = one_connected_peer(PeerId::from(SecretKey::new()));
+        let status = Status::Online { connected_peers };
+        let (response_sender, _) = oneshot::channel();
+        let mut state = RunState::construct(status);
+        state.transition(Input::Control(input::Control::CreateRequest(
+            urn.clone(),
+            SystemTime::now(),
+            response_sender,
+        )));
+
+        let cmds = state.transition(Input::Request(input::Request::Tick));
+        assert_matches!(
+            cmds.first().unwrap(),
+            Command::Request(command::Request::Query(have)) => {
+                assert_eq!(*have, urn);
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn issue_clone_when_found() -> Result<(), Box<dyn std::error::Error + 'static>> {
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let peer_id = PeerId::from(SecretKey::new());
+        let addr = "127.0.0.0:80".parse()?;
+
+        let connected_peers = one_connected_peer(PeerId::from(SecretKey::new()));
+        let status = Status::Online { connected_peers };
+        let (response_sender, _) = oneshot::channel();
+        let mut state = RunState::construct(status);
+
+        state.transition(Input::Control(input::Control::CreateRequest(
+            urn.clone(),
+            SystemTime::now(),
+            response_sender,
+        )));
+        assert_matches!(
+            state
+                .transition(Input::Request(input::Request::Queried(urn.clone())))
+                .first(),
+            Some(Command::PersistWaitingRoom(_))
+        );
+        // Gossip(Box<upstream::Gossip<SocketAddr, gossip::Payload>>),
+        assert_matches!(
+            state
+                .transition(Input::Protocol(ProtocolEvent::Gossip(Box::new(
+                    Gossip::Put {
+                        provider: librad::net::protocol::PeerInfo {
+                            advertised_info: net::protocol::PeerAdvertisement::new(addr),
+                            peer_id,
+                            seen_addrs: BoundedVec::from(iter::empty()),
+                        },
+                        payload: Payload {
+                            urn: urn.clone(),
+                            origin: None,
+                            rev: None
+                        },
+                        result: broadcast::PutResult::Applied(Payload {
+                            urn: urn.clone(),
+                            origin: None,
+                            rev: None,
+                        }),
+                    }
+                ))))
+                .last(),
+            Some(Command::Include(_))
+        );
+
+        let cmds = state.transition(Input::Request(input::Request::Tick));
+        assert_matches!(
+            cmds.first().unwrap(),
+            Command::Request(command::Request::Clone(remote_urn, remote_peer)) => {
+                assert_eq!(remote_urn.clone(), urn);
+                assert_eq!(*remote_peer, peer_id);
+            }
+        );
+
+        Ok(())
+    }
+
+    fn one_connected_peer(peer_id: PeerId) -> HashMap<PeerId, Vec<SocketAddr>> {
+        std::iter::once((peer_id, vec!["127.0.0.1:1234".parse().unwrap()])).collect()
+    }
+}

--- a/upstream-proxy/src/daemon/peer/run_state/command.rs
+++ b/upstream-proxy/src/daemon/peer/run_state/command.rs
@@ -1,0 +1,56 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::time::{Duration, SystemTime};
+
+use librad::{git::Urn, PeerId};
+
+use crate::daemon::{peer::control, request::waiting_room::WaitingRoom};
+
+/// Instructions to issue side-effectful operations which are the results from
+/// state transitions.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum Command {
+    /// Start the announcement subroutine.
+    Announce,
+    /// Answer control requests.
+    Control(Control),
+    /// Update the include file for the provided [`Urn`].
+    Include(Urn),
+    /// Tell the subroutine to persist the [`WaitingRoom`].
+    PersistWaitingRoom(WaitingRoom<SystemTime, Duration>),
+    /// Fulfill request commands.
+    Request(Request),
+    Stats,
+    /// Emit an external event to all subscribers
+    EmitEvent(super::Event),
+}
+
+/// Reactions for incoming control requests.
+#[derive(Debug)]
+pub enum Control {
+    /// Send a response corresponding to a control request.
+    Respond(control::Response),
+}
+
+/// Commands issued when requesting an identity from the network.
+#[derive(Debug, PartialEq)]
+pub enum Request {
+    /// Tell the subroutine to attempt a clone from the given [`Urn`] and
+    /// [`PeerId`].
+    Clone(Urn, PeerId),
+    /// Tell the subroutine that we should query for the given [`Urn`] on the
+    /// network.
+    Query(Urn),
+    /// The request for [`Urn`] timed out.
+    TimedOut(Urn),
+}
+
+impl From<Request> for Command {
+    fn from(other: Request) -> Self {
+        Self::Request(other)
+    }
+}

--- a/upstream-proxy/src/daemon/peer/run_state/config.rs
+++ b/upstream-proxy/src/daemon/peer/run_state/config.rs
@@ -1,0 +1,77 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Configuration types for configuring the `RunState`.
+
+use std::time::Duration;
+
+/// Default time to wait between announcement subroutine runs.
+const DEFAULT_ANNOUNCE_INTERVAL: Duration = std::time::Duration::from_secs(1);
+
+const DEFAULT_STATS_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// Default period at which we query the waiting room.
+const DEFAULT_WAITING_ROOM_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Default period to consider until a query has timed out.
+pub const DEFAULT_WAITING_ROOM_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Set of knobs to change the behaviour of the `RunState`.
+#[derive(Clone, Default)]
+pub struct Config {
+    /// Set of knobs to alter announce behaviour.
+    pub announce: Announce,
+    /// Set of knobs to alter stats polling.
+    pub stats: Stats,
+    /// Set of knobs to alter [`WaitingRoom`] behaviour.
+    pub waiting_room: WaitingRoom,
+}
+
+/// Set of knobs to alter announce behaviour.
+#[derive(Clone, Debug)]
+pub struct Announce {
+    /// Determines how often the announcement subroutine should be run.
+    pub interval: Duration,
+}
+
+impl Default for Announce {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_ANNOUNCE_INTERVAL,
+        }
+    }
+}
+
+/// Set of knobs to alter stats polling.
+#[derive(Clone, Debug)]
+pub struct Stats {
+    /// Determines how often the stats subroutine should be run.
+    pub interval: Duration,
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_STATS_INTERVAL,
+        }
+    }
+}
+
+/// Set of knobs to alter the [`crate::daemon::request::waiting_room::WaitingRoom`]
+/// behvaviour.
+#[derive(Clone, Debug)]
+pub struct WaitingRoom {
+    /// Interval at which to query the
+    /// [`crate::daemon::request::waiting_room::WaitingRoom`] for ready requests.
+    pub interval: Duration,
+}
+
+impl Default for WaitingRoom {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_WAITING_ROOM_INTERVAL,
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/peer/run_state/input.rs
+++ b/upstream-proxy/src/daemon/peer/run_state/input.rs
@@ -1,0 +1,99 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{net::SocketAddr, time::SystemTime};
+
+use librad::{git::Urn, net, net::peer::ProtocolEvent, PeerId};
+use tokio::sync::oneshot;
+
+use crate::daemon::{
+    peer::announcement,
+    request::{waiting_room, SomeRequest},
+};
+
+/// Significant events that occur during peer’s lifetime.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum Input {
+    /// Announcement subroutine lifecycle events.
+    Announce(Announce),
+    /// Peer state change events.
+    Control(Control),
+    ListenAddrs(Vec<SocketAddr>),
+    /// Inputs from the underlying coco protocol.
+    Protocol(ProtocolEvent),
+    /// Request subroutine events that wish to attempt to fetch an identity from
+    /// the network.
+    Request(Request),
+    Stats(Stats),
+}
+
+/// Announcement subroutine lifecycle events.
+#[derive(Clone, Debug)]
+pub enum Announce {
+    /// Operation failed.
+    Failed,
+    /// Operation succeeded and emitted the enclosed list of updates.
+    Succeeded(announcement::Updates),
+    /// The ticker duration has elapsed.
+    Tick,
+}
+
+/// Requests from the peer control.
+#[derive(Debug)]
+pub enum Control {
+    ListenAddrs(oneshot::Sender<Vec<SocketAddr>>),
+    /// New status.
+    Status(oneshot::Sender<super::Status>),
+
+    /// Cancel an ongoing project search.
+    CancelRequest(
+        Urn,
+        SystemTime,
+        oneshot::Sender<Result<Option<SomeRequest<SystemTime>>, waiting_room::Error>>,
+    ),
+    /// Initiate a new project search on the network.
+    CreateRequest(
+        Urn,
+        SystemTime,
+        oneshot::Sender<waiting_room::Created<SystemTime>>,
+    ),
+    /// Request the list of project searches.
+    ListRequests(oneshot::Sender<Vec<SomeRequest<SystemTime>>>),
+
+    #[cfg(test)]
+    /// Request a project search.
+    GetRequest(Urn, oneshot::Sender<Option<SomeRequest<SystemTime>>>),
+}
+
+/// Request event for projects requested from the network.
+#[derive(Debug)]
+pub enum Request {
+    /// Started cloning the requested urn from a peer.
+    Cloning(Urn, PeerId),
+    /// Succeeded cloning from the `RadUrl`.
+    Cloned(Urn, PeerId),
+    /// Failed to clone from the `RadUrl`.
+    Failed {
+        /// The URN we attempted to clone.
+        urn: Urn,
+        // The id of the remote peer we attempted to clone from.
+        remote_peer: PeerId,
+        /// The reason the clone failed.
+        reason: Box<dyn std::error::Error + Send>,
+    },
+    /// Query the network for the `Urn`.
+    Queried(Urn),
+    /// [`crate::daemon::request::waiting_room::WaitingRoom`] query interval.
+    Tick,
+    /// The request for [`Urn`] timed out.
+    TimedOut(Urn),
+}
+
+#[derive(Debug)]
+pub enum Stats {
+    Tick,
+    Values(net::protocol::event::downstream::Stats),
+}

--- a/upstream-proxy/src/daemon/peer/run_state/running_waiting_room.rs
+++ b/upstream-proxy/src/daemon/peer/run_state/running_waiting_room.rs
@@ -1,0 +1,329 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use either::Either;
+use librad::{git::Urn, identities::Revision, PeerId};
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
+
+use crate::daemon::request::SomeRequest;
+
+use super::{
+    command, control, waiting_room::Error as WaitingRoomError, Command, Event as RunStateEvent,
+    WaitingRoom,
+};
+use tokio::sync::oneshot::Sender;
+
+use serde::Serialize;
+
+/// Events that can affect the state of the waiting room
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Event {
+    /// A request was created for a urn
+    Created {
+        /// The urn bein requested
+        urn: Urn,
+    },
+    /// A query was initiated for a urn
+    Queried {
+        /// The urn bein queried
+        urn: Urn,
+    },
+    /// A peer was found who claims to have a urn
+    Found {
+        /// The urn that was found
+        urn: Urn,
+        /// The peer who claims to have it
+        peer: PeerId,
+    },
+    /// Cloning was initiated for a urn and peer
+    Cloning {
+        /// The urn we are cloning
+        urn: Urn,
+        /// The peer we are cloning from
+        peer: PeerId,
+    },
+    /// Cloning failed for a urn and peer
+    CloningFailed {
+        /// The urn that failed
+        urn: Urn,
+        /// The peer we failed to clone from
+        peer: PeerId,
+        /// A description of why the cloning failed
+        reason: String,
+    },
+    /// Cloning succeeded for a urn and peer
+    Cloned {
+        /// The urn we cloned
+        urn: Urn,
+        /// The peer we cloned from
+        peer: PeerId,
+    },
+    /// A request for a urn was canceled
+    Canceled {
+        /// The urn that was canceled
+        urn: Urn,
+    },
+    /// A request was timed out
+    TimedOut {
+        /// The urn that timed out
+        urn: Urn,
+        /// The attempts that were made before the timeout
+        attempts: Option<usize>,
+    },
+}
+
+/// `RunningWaitingRoom` is an adapter from the interface of `WaitingRoom` to
+/// the language of commands which is spoken by `RunState`. Whenever `RunState`
+/// needs to talk to `WaitingRoom` it does so via a wrapper method on
+/// `RunningWaitingRoom`. These wrapper methods contain the logic to convert
+/// the values  returned by `WaitingRoom` methods into `Vec<Command>`.
+pub(super) struct RunningWaitingRoom {
+    waiting_room: WaitingRoom<SystemTime, Duration>,
+}
+
+impl RunningWaitingRoom {
+    pub const fn new(waiting_room: WaitingRoom<SystemTime, Duration>) -> Self {
+        Self { waiting_room }
+    }
+
+    pub fn cancel(
+        &mut self,
+        urn: Urn,
+        timestamp: SystemTime,
+        sender: Sender<Result<Option<SomeRequest<SystemTime>>, WaitingRoomError>>,
+    ) -> Vec<Command> {
+        let state_before = self.waiting_room.requests();
+        match self.waiting_room.canceled(&urn, timestamp) {
+            Ok(()) => {
+                let request = self.waiting_room.remove(&urn);
+                let state_after = self.waiting_room.requests();
+                let transition = WaitingRoomTransition {
+                    timestamp,
+                    state_before,
+                    state_after,
+                    event: Event::Canceled { urn },
+                };
+                vec![
+                    Command::Control(command::Control::Respond(control::Response::CancelSearch(
+                        sender,
+                        Ok(request),
+                    ))),
+                    Command::PersistWaitingRoom(self.waiting_room.clone()),
+                    Command::EmitEvent(transition.into()),
+                ]
+            },
+            Err(e) => vec![
+                Command::Control(command::Control::Respond(control::Response::CancelSearch(
+                    sender,
+                    Err(e),
+                ))),
+                Command::PersistWaitingRoom(self.waiting_room.clone()),
+            ],
+        }
+    }
+
+    pub fn request(
+        &mut self,
+        urn: Urn,
+        timestamp: SystemTime,
+        sender: Sender<Either<SomeRequest<SystemTime>, SomeRequest<SystemTime>>>,
+    ) -> Vec<Command> {
+        let state_before = self.waiting_room.requests();
+        let request = self.waiting_room.request(&urn, timestamp);
+        let state_after = self.waiting_room.requests();
+        match request {
+            Either::Left(request) => {
+                let transition = WaitingRoomTransition {
+                    timestamp,
+                    state_before,
+                    state_after,
+                    event: Event::Created { urn: urn.clone() },
+                };
+                vec![
+                    Command::Control(command::Control::Respond(control::Response::StartSearch(
+                        sender,
+                        Either::Left(request),
+                    ))),
+                    Command::EmitEvent(RunStateEvent::RequestCreated(urn)),
+                    Command::EmitEvent(transition.into()),
+                ]
+            },
+            Either::Right(request) => vec![
+                Command::Control(command::Control::Respond(control::Response::StartSearch(
+                    sender,
+                    Either::Right(request),
+                ))),
+                Command::EmitEvent(RunStateEvent::RequestCreated(urn)),
+            ],
+        }
+    }
+
+    pub fn get(&self, urn: &Urn) -> Option<&SomeRequest<SystemTime>> {
+        self.waiting_room.get(urn)
+    }
+
+    /// Return the list of all `Urn`/`SomeRequest` pairs in the `WaitingRoom`.
+    pub fn iter(&self) -> impl Iterator<Item = (Urn, &SomeRequest<SystemTime>)> {
+        self.waiting_room.iter()
+    }
+
+    pub fn found(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: SystemTime) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Found {
+                urn: urn.clone(),
+                peer: remote_peer,
+            },
+            timestamp,
+            |w| w.found(urn, remote_peer, timestamp),
+        )
+    }
+
+    /// Issue "query" and "clone" requests for requests that are next in the
+    /// queue.
+    pub fn tick(&mut self, timestamp: SystemTime) -> Vec<Command> {
+        let mut cmds = Vec::with_capacity(2);
+
+        if let Some(urn) = self.waiting_room.next_query(timestamp) {
+            cmds.push(Command::Request(command::Request::Query(urn)));
+        }
+        if let Some((urn, remote_peer)) = self.waiting_room.next_clone() {
+            cmds.push(Command::Request(command::Request::Clone(urn, remote_peer)));
+        }
+
+        cmds
+    }
+
+    pub fn cloning(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: SystemTime,
+    ) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Cloning {
+                urn: urn.clone(),
+                peer: remote_peer,
+            },
+            timestamp,
+            |w| w.cloning(urn, remote_peer, timestamp),
+        )
+    }
+
+    pub fn cloned(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: SystemTime,
+    ) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Cloned {
+                urn: urn.clone(),
+                peer: remote_peer,
+            },
+            timestamp,
+            |w| w.cloned(urn, remote_peer, timestamp),
+        )
+    }
+
+    pub fn queried(&mut self, urn: &Urn, timestamp: SystemTime) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Queried { urn: urn.clone() },
+            timestamp,
+            |w| w.queried(urn, timestamp),
+        )
+    }
+
+    pub fn cloning_failed(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: SystemTime,
+        reason: Box<dyn std::error::Error>,
+    ) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::CloningFailed {
+                urn: urn.clone(),
+                peer: remote_peer,
+                reason: reason.to_string(),
+            },
+            timestamp,
+            |w| w.cloning_failed(urn, remote_peer, timestamp, reason),
+        )
+    }
+
+    fn simple_command_helper<F>(
+        waiting_room: &mut WaitingRoom<SystemTime, Duration>,
+        urn: &Urn,
+        event: Event,
+        timestamp: SystemTime,
+        f: F,
+    ) -> Vec<Command>
+    where
+        F: FnOnce(&mut WaitingRoom<SystemTime, Duration>) -> Result<(), WaitingRoomError>,
+    {
+        let state_before = waiting_room.requests();
+        let result = f(waiting_room);
+        let state_after = waiting_room.requests();
+        let mut commands = Vec::with_capacity(4);
+        commands.push(Command::PersistWaitingRoom(waiting_room.clone()));
+        match result {
+            Ok(()) => {
+                commands.push(Command::EmitEvent(
+                    WaitingRoomTransition {
+                        timestamp,
+                        state_before,
+                        state_after,
+                        event,
+                    }
+                    .into(),
+                ));
+                commands
+            },
+            Err(WaitingRoomError::TimeOut { attempts, .. }) => {
+                commands.push(Command::EmitEvent(
+                    WaitingRoomTransition {
+                        timestamp,
+                        state_before,
+                        state_after,
+                        event: Event::TimedOut {
+                            urn: urn.clone(),
+                            attempts,
+                        },
+                    }
+                    .into(),
+                ));
+                commands.push(Command::Request(command::Request::TimedOut(urn.clone())));
+                commands
+            },
+            // FIXME(alexjg): Figure out how to report this error to the client
+            Err(error) => {
+                tracing::warn!(?error, "waiting room error");
+                Vec::new()
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WaitingRoomTransition<T> {
+    pub timestamp: T,
+    pub state_before: HashMap<Revision, SomeRequest<T>>,
+    pub state_after: HashMap<Revision, SomeRequest<T>>,
+    pub event: Event,
+}

--- a/upstream-proxy/src/daemon/peer/subroutines.rs
+++ b/upstream-proxy/src/daemon/peer/subroutines.rs
@@ -1,0 +1,426 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Management of peer subroutine tasks driven by advancing the core state
+//! machine with a stream of inputs, producing commands.
+
+use std::{
+    net::SocketAddr,
+    time::{Duration, SystemTime},
+};
+
+use async_stream::stream;
+use futures::stream::{BoxStream, FuturesUnordered, SelectAll, StreamExt as _};
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    task::{JoinError, JoinHandle},
+    time::interval,
+};
+
+use librad::{
+    git::Urn,
+    net::{self, peer::ProtocolEvent},
+    PeerId, Signer,
+};
+
+use crate::daemon::{
+    convert::MaybeFrom as _,
+    request::{self, waiting_room::WaitingRoom},
+    state,
+};
+
+use super::{
+    announcement, control, gossip, include,
+    run_state::{command, config, input, Command, Config as RunConfig, Event, Input, RunState},
+    waiting_room, RECEIVER_CAPACITY,
+};
+
+/// Management of "subroutine" tasks.
+pub struct Subroutines<S> {
+    /// Set of handles of spawned subroutine tasks. Draining them will ensure
+    /// resources are release.
+    pending_tasks: FuturesUnordered<JoinHandle<()>>,
+    /// Stream of inputs to [`RunState`] state machine.
+    inputs: SelectAll<BoxStream<'static, Input>>,
+
+    /// [`net::peer::Peer`] for suborutine task fulfillment.
+    peer: net::peer::Peer<S>,
+    /// [`kv::Store`] for suborutine task fulfillment.
+    store: kv::Store,
+
+    /// Main peer state machine.
+    run_state: RunState,
+
+    /// Feedback channel for subroutine tasks send new inputs to the state
+    /// machine.
+    input_sender: mpsc::Sender<Input>,
+    /// Channel for public subscribers to get to know of significant events of
+    /// the peer machinery.
+    subscriber: broadcast::Sender<Event>,
+}
+
+impl<S> Subroutines<S>
+where
+    S: Clone + Signer,
+{
+    /// Constructs a new subroutines manager.
+    pub fn new(
+        peer: net::peer::Peer<S>,
+        mut listen_addrs: watch::Receiver<Vec<SocketAddr>>,
+        store: kv::Store,
+        run_config: &RunConfig,
+        protocol_events: BoxStream<'static, Result<ProtocolEvent, net::protocol::RecvError>>,
+        subscriber: broadcast::Sender<Event>,
+        mut control_receiver: mpsc::Receiver<control::Request>,
+    ) -> Self {
+        let announce_timer = if run_config.announce.interval.is_zero() {
+            None
+        } else {
+            Some(interval(run_config.announce.interval))
+        };
+        let waiting_room = match waiting_room::load(&store) {
+            Err(err) => {
+                tracing::warn!(?err, "Failed to load waiting room");
+                WaitingRoom::new(request::waiting_room::Config {
+                    delta: config::DEFAULT_WAITING_ROOM_TIMEOUT,
+                    ..request::waiting_room::Config::default()
+                })
+            },
+            Ok(None) => WaitingRoom::new(request::waiting_room::Config {
+                delta: config::DEFAULT_WAITING_ROOM_TIMEOUT,
+                ..request::waiting_room::Config::default()
+            }),
+            Ok(Some(room)) => room,
+        };
+        let mut waiting_room_timer = interval(run_config.waiting_room.interval);
+        let (input_sender, mut external_inputs) = mpsc::channel::<Input>(RECEIVER_CAPACITY);
+        let mut stats_timer = interval(run_config.stats.interval);
+
+        let run_state = RunState::new(waiting_room);
+
+        let inputs = {
+            let mut coalesced = SelectAll::new();
+            coalesced.push(
+                // TODO(xla): Ensure stream of Results has significance, or should just signal
+                // stream close.
+                protocol_events
+                    .filter_map(|res| async move {
+                        match res {
+                            Ok(ev) => Some(Input::Protocol(ev)),
+                            Err(err) => {
+                                tracing::warn!(?err, "receive error");
+                                None
+                            },
+                        }
+                    })
+                    .boxed(),
+            );
+
+            coalesced.push(
+                stream! {
+                    while listen_addrs.changed().await.is_ok() {
+                        let addrs = listen_addrs.borrow().clone();
+                        yield Input::ListenAddrs(addrs);
+                    }
+                }
+                .boxed(),
+            );
+
+            if let Some(mut timer) = announce_timer {
+                coalesced.push(
+                    stream! {
+                        loop {
+                            timer.tick().await;
+                            yield Input::Announce(input::Announce::Tick);
+                        }
+                    }
+                    .boxed(),
+                );
+            }
+            coalesced.push(
+                stream! {
+                    loop {
+                        waiting_room_timer.tick().await;
+                        yield Input::Request(input::Request::Tick);
+                    }
+                }
+                .boxed(),
+            );
+            coalesced.push(
+                stream! {
+                    loop {
+                        stats_timer.tick().await;
+                        yield Input::Stats(input::Stats::Tick);
+                    }
+                }
+                .boxed(),
+            );
+            coalesced.push(
+                stream! {
+                while let Some(request) = control_receiver.recv().await { yield request } }
+                .map(|request| match request {
+                    control::Request::CurrentStatus(sender) => {
+                        Input::Control(input::Control::Status(sender))
+                    },
+                    control::Request::ListenAddrs(sender) => {
+                        Input::Control(input::Control::ListenAddrs(sender))
+                    },
+                    control::Request::CancelSearch(urn, time, sender) => {
+                        Input::Control(input::Control::CancelRequest(urn, time, sender))
+                    },
+                    control::Request::ListSearches(sender) => {
+                        Input::Control(input::Control::ListRequests(sender))
+                    },
+                    control::Request::StartSearch(urn, time, sender) => {
+                        Input::Control(input::Control::CreateRequest(urn, time, sender))
+                    },
+
+                    #[cfg(test)]
+                    control::Request::GetSearch(urn, sender) => {
+                        Input::Control(input::Control::GetRequest(urn, sender))
+                    },
+                })
+                .boxed(),
+            );
+            coalesced.push(
+                stream! {
+                    while let Some(input) = external_inputs.recv().await {
+                        yield input;
+                    }
+                }
+                .boxed(),
+            );
+
+            coalesced
+        };
+
+        Self {
+            pending_tasks: FuturesUnordered::new(),
+            inputs,
+
+            peer,
+            store,
+            run_state,
+
+            subscriber,
+            input_sender,
+        }
+    }
+
+    /// Map commands produced by the state machine to spawned subroutine tasks.
+    fn spawn_command(&self, cmd: Command) -> JoinHandle<()> {
+        match cmd {
+            Command::Announce => tokio::spawn(announce(
+                self.peer.clone(),
+                self.store.clone(),
+                self.input_sender.clone(),
+            )),
+            Command::Control(control_command) => match control_command {
+                command::Control::Respond(respond_command) => {
+                    tokio::spawn(control_respond(respond_command))
+                },
+            },
+            Command::Include(urn) => tokio::spawn(include::update(self.peer.clone(), urn)),
+            Command::PersistWaitingRoom(waiting_room) => {
+                tokio::spawn(persist_waiting_room(waiting_room, self.store.clone()))
+            },
+            Command::Request(command::Request::Query(urn)) => {
+                tokio::spawn(query(urn, self.peer.clone(), self.input_sender.clone()))
+            },
+            Command::Request(command::Request::Clone(urn, remote_peer)) => tokio::spawn(clone(
+                urn,
+                remote_peer,
+                self.peer.clone(),
+                self.input_sender.clone(),
+            )),
+            Command::Request(command::Request::TimedOut(urn)) => {
+                let sender = self.input_sender.clone();
+                tokio::spawn(async move {
+                    sender
+                        .send(Input::Request(input::Request::TimedOut(urn)))
+                        .await
+                        .ok();
+                })
+            },
+            Command::Stats => tokio::spawn(get_stats(self.peer.clone(), self.input_sender.clone())),
+            Command::EmitEvent(event) => {
+                self.subscriber.send(event).ok();
+                tokio::spawn(async move {})
+            },
+        }
+    }
+
+    fn handle_input(&mut self, input: Input) {
+        tracing::trace!(?input, "handling subroutine input");
+
+        let old_status = self.run_state.status.clone();
+
+        if let Some(event) = Event::maybe_from(&input) {
+            // Ignore if there are no subscribers.
+            self.subscriber.send(event).ok();
+        }
+
+        for cmd in self.run_state.transition(input) {
+            let task = self.spawn_command(cmd);
+
+            self.pending_tasks.push(task);
+        }
+
+        if old_status != self.run_state.status {
+            self.subscriber
+                .send(Event::StatusChanged {
+                    old: old_status,
+                    new: self.run_state.status.clone(),
+                })
+                .ok();
+        }
+    }
+
+    pub async fn run(mut self) -> Result<(), JoinError> {
+        #![allow(clippy::mut_mut)]
+        loop {
+            futures::select! {
+                maybe_result = self.pending_tasks.next() => {
+                    if let Some(Err(err)) = maybe_result {
+                        return Err(err)
+                    }
+                }
+                maybe_input = self.inputs.next() => {
+                    if let Some(input) = maybe_input {
+                        self.handle_input(input);
+                    } else {
+                        return Ok(())
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<S> Drop for Subroutines<S> {
+    fn drop(&mut self) {
+        for task in self.pending_tasks.iter_mut() {
+            task.abort();
+        }
+    }
+}
+
+/// Run the announcement of updated refs for local projects. On completion
+/// report back with the success or failure.
+async fn announce<S>(peer: net::peer::Peer<S>, store: kv::Store, sender: mpsc::Sender<Input>)
+where
+    S: Clone + Signer,
+{
+    match announcement::run(&peer, store).await {
+        Ok(updates) => {
+            sender
+                .send(Input::Announce(input::Announce::Succeeded(updates)))
+                .await
+                .ok();
+        },
+        Err(err) => {
+            tracing::error!(?err, "announce error");
+            sender
+                .send(Input::Announce(input::Announce::Failed))
+                .await
+                .ok();
+        },
+    }
+}
+
+/// Fulfill control requests by sending the scheduled responses.
+#[allow(clippy::unused_async)]
+async fn control_respond(cmd: control::Response) {
+    match cmd {
+        control::Response::CurrentStatus(sender, status) => sender.send(status).ok(),
+        control::Response::CancelSearch(sender, request) => sender.send(request).ok(),
+        control::Response::ListenAddrs(sender, addrs) => sender.send(addrs).ok(),
+        control::Response::ListSearches(sender, requests) => sender.send(requests).ok(),
+        control::Response::StartSearch(sender, request) => sender.send(request).ok(),
+
+        #[cfg(test)]
+        control::Response::GetSearch(sender, request) => sender.send(request).ok(),
+    };
+}
+
+async fn get_stats<S>(peer: net::peer::Peer<S>, sender: mpsc::Sender<Input>)
+where
+    S: Clone + Signer,
+{
+    let stats = peer.stats().await;
+
+    sender
+        .send(Input::Stats(input::Stats::Values(stats)))
+        .await
+        .ok();
+}
+
+#[allow(clippy::unused_async)]
+async fn persist_waiting_room(waiting_room: WaitingRoom<SystemTime, Duration>, store: kv::Store) {
+    match waiting_room::save(&store, waiting_room) {
+        Ok(()) => tracing::debug!("Successfully persisted the waiting room"),
+        Err(err) => tracing::debug!(?err, "Error while persisting the waiting room"),
+    }
+}
+
+/// Send a query on the network for the given urn.
+async fn query<S>(urn: Urn, peer: net::peer::Peer<S>, sender: mpsc::Sender<Input>)
+where
+    S: Clone + Signer,
+{
+    gossip::query(&peer, &urn, None);
+    sender
+        .send(Input::Request(input::Request::Queried(urn)))
+        .await
+        .ok();
+}
+
+/// Run a clone for the given `url`. On completion report back with the success
+/// or failure.
+async fn clone<S>(
+    urn: Urn,
+    remote_peer: PeerId,
+    peer: net::peer::Peer<S>,
+    sender: mpsc::Sender<Input>,
+) where
+    S: Clone + Signer,
+{
+    sender
+        .send(Input::Request(input::Request::Cloning(
+            urn.clone(),
+            remote_peer,
+        )))
+        .await
+        .ok();
+
+    match state::clone_project(&peer, urn.clone(), remote_peer, None).await {
+        Ok(_urn) => {
+            sender
+                .send(Input::Request(input::Request::Cloned(
+                    urn.clone(),
+                    remote_peer,
+                )))
+                .await
+                .ok();
+            gossip::announce(&peer, &urn, None);
+        },
+        Err(err) => {
+            tracing::warn!(
+                %urn,
+                %remote_peer,
+                ?err,
+                "an error occurred for the command 'Clone'",
+            );
+            sender
+                .send(Input::Request(input::Request::Failed {
+                    urn,
+                    remote_peer,
+                    reason: Box::new(err),
+                }))
+                .await
+                .ok();
+        },
+    }
+}

--- a/upstream-proxy/src/daemon/peer/waiting_room.rs
+++ b/upstream-proxy/src/daemon/peer/waiting_room.rs
@@ -1,0 +1,54 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Persist the `WaitingRoom` to a k/v store.
+
+use std::time::{Duration, SystemTime};
+
+use crate::daemon::request::waiting_room::WaitingRoom;
+
+/// Name for the bucket used in [`kv::Store`].
+const BUCKET_NAME: &str = "waiting_room";
+
+/// Key for the single value used as cache.
+const KEY_NAME: &str = "latest";
+
+/// Announcement errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failures from [`kv`].
+    #[error(transparent)]
+    Kv(#[from] kv::Error),
+}
+
+/// Load the cached [`WaitingRoom`] from the [`kv::Store`].
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the access of the key in the [`kv::Bucket`] fails
+pub fn load(store: &kv::Store) -> Result<Option<WaitingRoom<SystemTime, Duration>>, Error> {
+    let bucket = store
+        .bucket::<&'static str, kv::Json<WaitingRoom<SystemTime, Duration>>>(Some(BUCKET_NAME))?;
+    Ok(bucket.get(KEY_NAME)?.map(|json| json.0))
+}
+
+/// Update the cache with the latest [`WaitingRoom`].
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the storage of the new updates fails
+#[allow(clippy::implicit_hasher)]
+pub fn save(
+    store: &kv::Store,
+    waiting_room: WaitingRoom<SystemTime, Duration>,
+) -> Result<(), Error> {
+    let bucket = store
+        .bucket::<&'static str, kv::Json<WaitingRoom<SystemTime, Duration>>>(Some(BUCKET_NAME))?;
+    bucket
+        .set(KEY_NAME, kv::Json(waiting_room))
+        .map_err(Error::from)
+}

--- a/upstream-proxy/src/daemon/project.rs
+++ b/upstream-proxy/src/daemon/project.rs
@@ -1,0 +1,77 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Project creation data and functions.
+
+use std::{io, path::Path};
+
+use librad::{
+    git::types::remote::Remote,
+    git_ext::{is_not_found_err, OneLevel, Qualified},
+    std_ext::result::ResultExt,
+};
+
+/// Module concerned with creating new projects and repositories.
+pub mod create;
+pub use create::{Create, Repo};
+
+/// Module concerned with checkout out working copies of projects, as git
+/// repositories.
+pub mod checkout;
+pub use checkout::Checkout;
+
+pub mod peer;
+pub use peer::Peer;
+
+/// Set the upstream of the given branch to the given remote.
+///
+/// This writes to the `config` directly. The entry will look like the
+/// following:
+///
+/// ```text
+/// [branch "main"]
+///     remote = rad
+///     merge = refs/heads/main
+/// ```
+fn set_upstream<Url>(
+    repo: &git2::Repository,
+    remote: &Remote<Url>,
+    branch: OneLevel,
+) -> Result<(), git2::Error> {
+    let mut config = repo.config()?;
+    let branch_remote = format!("branch.{}.remote", branch);
+    let branch_merge = format!("branch.{}.merge", branch);
+    config
+        .remove_multivar(&branch_remote, ".*")
+        .or_matches::<git2::Error, _, _>(is_not_found_err, || Ok(()))?;
+    config
+        .remove_multivar(&branch_merge, ".*")
+        .or_matches::<git2::Error, _, _>(is_not_found_err, || Ok(()))?;
+    config.set_multivar(&branch_remote, ".*", remote.name.as_str())?;
+    config.set_multivar(&branch_merge, ".*", Qualified::from(branch).as_str())?;
+    Ok(())
+}
+
+/// Check that the `path` provided is either:
+///  * an empty directory
+///  * a non-existent directory
+/// If these checks pass then the path is returned as `Ok(Some(path))`.
+///
+/// If the `path` is a file or is a directory with contents, then it will return
+/// `Ok(None)`.
+///
+/// # Errors
+///   * I/O error in reading the directory contents
+pub fn ensure_directory(path: &Path) -> Result<Option<&Path>, io::Error> {
+    if path.is_file() {
+        return Ok(None);
+    }
+
+    if path.exists() && path.is_dir() && path.read_dir()?.next().is_some() {
+        return Ok(None);
+    }
+
+    Ok(Some(path))
+}

--- a/upstream-proxy/src/daemon/project/checkout.rs
+++ b/upstream-proxy/src/daemon/project/checkout.rs
@@ -1,0 +1,316 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{
+    convert::TryFrom,
+    ffi, io,
+    path::{self, PathBuf},
+};
+
+use librad::{
+    git::{
+        include,
+        local::{transport::CanOpenStorage, url::LocalUrl},
+        types::{
+            remote::{LocalFetchspec, LocalPushspec, Remote},
+            Flat, Force, GenericRef, Reference, Refspec,
+        },
+        Urn,
+    },
+    git_ext::{self, OneLevel, Qualified, RefLike},
+    reflike, refspec_pattern, PeerId,
+};
+
+/// When checking out a working copy, we can run into several I/O failures.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The path already existed when trying to checkout the project.
+    #[error("the path provided '{0}' already exists")]
+    AlreadExists(PathBuf),
+
+    /// Git error when checking out the project.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// An error occurred building include files.
+    #[error(transparent)]
+    Include(#[from] include::Error),
+
+    /// An error occurred validating the project path
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// An error occurred when attempting to strip a prefix from a reference.
+    #[error(transparent)]
+    Prefix(#[from] git_ext::name::StripPrefixError),
+
+    /// An error occurred in the local transport.
+    #[error(transparent)]
+    Transport(#[from] librad::git::local::transport::Error),
+}
+
+/// The data necessary for checking out a project.
+pub struct Checkout<P>
+where
+    P: AsRef<path::Path>,
+{
+    /// The URN identifier for the project we are checking out.
+    pub urn: Urn,
+    /// The name of the project.
+    pub name: String,
+    /// The default branch of the project.
+    pub default_branch: OneLevel,
+    /// The path on the filesystem where we're going to checkout to.
+    pub path: P,
+    /// Absolute path of the include file that will be set in the working copy
+    /// config.
+    pub include_path: PathBuf,
+}
+
+/// We want to know whether we're checking out from one of our own copies, or if
+/// we're checking out based off of a remote's branch.
+pub enum Ownership {
+    /// We're checking out our own copy of the project.
+    Local(PeerId),
+    /// We're checking out a remote's version of the project.
+    Remote {
+        /// The handle of the remote peer gives themselves via their user
+        /// profile. For example, `90s-kid` -- the name of the remote
+        /// will then be `90s-kid@<urn.id>`.
+        handle: String,
+        /// The `PeerId` of the remote.
+        remote: PeerId,
+        /// Our own `PeerId`.
+        local: PeerId,
+    },
+}
+
+/// Clone a git repository to the `path` location, based off of the `remote`
+/// provided.
+///
+/// # Errors
+///   * if initialisation of the repository fails
+///   * if branch or remote manipulation fails
+pub fn clone<F>(
+    path: &path::Path,
+    storage: F,
+    mut remote: Remote<LocalUrl>,
+) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+where
+    F: CanOpenStorage + 'static,
+{
+    let repo = git2::Repository::init(path)?;
+    remote.save(&repo)?;
+    for (reference, oid) in remote.fetch(storage, &repo, LocalFetchspec::Configured)? {
+        let msg = format!("Fetched `{}->{}`", reference, oid);
+        tracing::debug!("{}", msg);
+
+        // FIXME(finto): we should ignore refs that don't start with heads to avoid
+        // unintended side-effects.
+        let branch: RefLike = OneLevel::from(reference).into();
+        let branch = branch.strip_prefix(remote.name.clone())?;
+        let branch = branch.strip_prefix(reflike!("heads")).unwrap_or(branch);
+        let _remote_branch = repo.reference(
+            reflike!("refs/remotes")
+                .join(remote.name.clone())
+                .join(branch.clone())
+                .as_str(),
+            oid,
+            true,
+            &msg,
+        )?;
+        let _local_branch = repo.reference(Qualified::from(branch).as_str(), oid, true, &msg);
+    }
+
+    Ok((repo, remote))
+}
+
+impl Ownership {
+    /// Clone a project based off of the `Ownership` value. See
+    /// [`Checkout::run`] for more details.
+    ///
+    /// # Errors
+    ///   * If the cloning of the working copy fails.
+    ///   * In the case of a remote clone, if the pushing of the default branch fails.
+    pub fn clone<F>(
+        self,
+        open_storage: F,
+        urn: Urn,
+        default_branch: &OneLevel,
+        path: &path::Path,
+    ) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        match self {
+            Self::Local(_peer_id) => {
+                let url = LocalUrl::from(urn);
+                Self::local(open_storage, url, path).map_err(Error::from)
+            },
+            Self::Remote { handle, remote, .. } => {
+                let url = LocalUrl::from(urn);
+                Self::remote(open_storage, &handle, remote, url, default_branch, path)
+            },
+        }
+    }
+
+    /// See [`Checkout::run`].
+    fn local<F>(
+        open_storage: F,
+        url: LocalUrl,
+        path: &path::Path,
+    ) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+    where
+        F: CanOpenStorage + 'static,
+    {
+        let rad = Remote::rad_remote(
+            url,
+            Refspec {
+                src: refspec_pattern!("refs/heads/*"),
+                dst: refspec_pattern!("refs/remotes/rad/*"),
+                force: Force::True,
+            },
+        );
+        clone(path, open_storage, rad)
+    }
+
+    /// See [`Checkout::run`].
+    fn remote<F>(
+        open_storage: F,
+        handle: &str,
+        peer: PeerId,
+        url: LocalUrl,
+        default_branch: &OneLevel,
+        path: &path::Path,
+    ) -> Result<(git2::Repository, Remote<LocalUrl>), Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        let name =
+            RefLike::try_from(format!("{}@{}", handle, peer)).expect("failed to parse remote name");
+
+        let remote = Remote::new(url.clone(), name.clone()).with_fetchspecs(vec![Refspec {
+            src: Reference::heads(Flat, peer),
+            dst: GenericRef::heads(Flat, name),
+            force: Force::True,
+        }]);
+
+        let (repo, _) = clone(path, open_storage.clone(), remote)?;
+
+        // Create a rad remote and push the default branch so we can set it as the
+        // upstream.
+        let rad = {
+            // Create a fetchspec `refs/heads/*:refs/remotes/rad/*`
+            let fetchspec = Refspec {
+                src: GenericRef::<_, RefLike, _>::heads(Flat, None),
+                dst: refspec_pattern!("refs/remotes/rad/*"),
+                force: Force::True,
+            };
+            let mut rad = Remote::rad_remote(url, fetchspec);
+            rad.save(&repo)?;
+            let _refs = rad.push(
+                open_storage,
+                &repo,
+                LocalPushspec::Matching {
+                    pattern: Qualified::from(default_branch.clone()).into(),
+                    force: Force::False,
+                },
+            )?;
+            rad
+        };
+
+        Ok((repo, rad))
+    }
+}
+
+impl<P> Checkout<P>
+where
+    P: AsRef<path::Path>,
+{
+    /// Based off of the `Ownership`, clone the project using the provided
+    /// inputs.
+    ///
+    /// ## Local Clone
+    ///
+    /// If the `Ownership` is `Local` this means that we are cloning based off
+    /// the user's own project and so the `url` used to clone will be built
+    /// from the user's `PeerId`. The only remote that will be created is
+    /// `rad` remote, pointing to the `url` built from the provided `urn`
+    /// and the user's `PeerId`.
+    ///
+    /// ## Remote Clone
+    ///
+    /// If the `Ownership` is `Remote` this means that we are cloning based off
+    /// of a peer's project.
+    /// Due to this we need to point the remote to the specific remote in our
+    /// project's hierarchy. What this means is that we need to set up a
+    /// fetch refspec in the form of `refs/remotes/<peer_id>/heads/*` where
+    /// the name of the remote is given by `<user_handle>@<peer_id>` -- this
+    /// keeps in line with `librad::git::include`. To finalise the setup of
+    /// the clone, we also want to add the `rad` remote, which is the designated
+    /// remote the user pushes their own work to update their monorepo for this
+    /// project. To do this, we create a `url` that is built using the
+    /// provided `urn` and the user's `PeerId` and create the `rad` remote.
+    /// Finally, we initialise the `default_branch` of the proejct --
+    /// think upstream branch in git. We do this by pushing to the `rad` remote.
+    /// This means that the working copy will be now setup where when we
+    /// open it up we see the initial branch as being `default_branch`.
+    ///
+    /// To illustrate further, the `config` of the final repository will look
+    /// similar to:
+    ///
+    /// ```text
+    /// [remote "rad"]
+    ///     url = rad://hyymr17h1fg5zk7duikgc7xoqonqorhwnxxs98kdb63f9etnsjxxmo@hwd1yrerzpjbmtshsqw6ajokqtqrwaswty6p7kfeer3yt1n76t46iqggzcr.git
+    ///     fetch = +refs/heads/*:refs/remotes/rad/*
+    /// [remote "banana@hyy36ey56mfayah398n7w4i8hy5ywci43hbyhwf1krfwonc1ur87ch"]
+    ///     url = rad://hyymr17h1fg5zk7duikgc7xoqonqorhwnxxs98kdb63f9etnsjxxmo@hwd1yrerzpjbmtshsqw6ajokqtqrwaswty6p7kfeer3yt1n76t46iqggzcr.git
+    ///     fetch = +refs/remotes/hyy36ey56mfayah398n7w4i8hy5ywci43hbyhwf1krfwonc1ur87ch/heads/*:refs/remotes/banana@hyy36ey56mfayah398n7w4i8hy5ywci43hbyhwf1krfwonc1ur87ch/*
+    /// [branch "master"]
+    ///     remote = rad
+    ///     merge = refs/heads/master
+    /// [include]
+    ///     path = /home/user/.config/radicle/git-includes/hwd1yrerzpjbmtshsqw6ajokqtqrwaswty6p7kfeer3yt1n76t46iqggzcr.inc
+    /// ```
+    ///
+    /// # Errors
+    ///  * If the project cloning fails.
+    ///  * If we cannot set the upstream branch for the `rad` remote.
+    ///  * If we cannot set the include path for the working copy.
+    pub fn run<F>(self, open_storage: F, ownership: Ownership) -> Result<PathBuf, Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        // Check if the path provided ends in the 'directory_name' provided. If not we
+        // create the full path to that name.
+        let path = &self.path.as_ref();
+        let project_path: PathBuf =
+            path.components()
+                .next_back()
+                .map_or(path.join(&self.name), |destination| {
+                    let destination: &ffi::OsStr = destination.as_ref();
+                    let name: &ffi::OsStr = self.name.as_ref();
+                    if destination == name {
+                        path.to_path_buf()
+                    } else {
+                        path.join(name)
+                    }
+                });
+        crate::daemon::project::ensure_directory(&project_path)?
+            .ok_or_else(|| Error::AlreadExists(project_path.clone()))?;
+
+        // Clone the repository
+        let (repo, rad) =
+            ownership.clone(open_storage, self.urn, &self.default_branch, &project_path)?;
+
+        // Set configurations
+        super::set_upstream(&repo, &rad, self.default_branch.clone())?;
+        include::set_include_path(&repo, self.include_path)?;
+        repo.set_head(Qualified::from(self.default_branch).as_str())?;
+        repo.checkout_head(None)?;
+
+        Ok(project_path)
+    }
+}

--- a/upstream-proxy/src/daemon/project/create.rs
+++ b/upstream-proxy/src/daemon/project/create.rs
@@ -1,0 +1,184 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use std::{convert::TryFrom, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use librad::{git::local::url::LocalUrl, git_ext::OneLevel};
+
+pub mod validation;
+
+/// Errors that occur when attempting to create a working copy of a project.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Internal git error while trying to create the project.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// An error occurred while validating input.
+    #[error(transparent)]
+    Validation(#[from] validation::Error),
+}
+
+/// The signature of a git author. Used internally to convert into a
+/// `git2::Signature`, which _cannot_ be shared between threads.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct Signature {
+    /// The name of the author
+    pub name: String,
+    /// The email of the author
+    pub email: String,
+}
+
+impl TryFrom<Signature> for git2::Signature<'static> {
+    type Error = git2::Error;
+
+    fn try_from(signature: Signature) -> Result<Self, Self::Error> {
+        Self::now(&signature.name, &signature.email)
+    }
+}
+
+/// The data required to either open an existing repository or create a new one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Repo {
+    /// Open an existing repository.
+    Existing {
+        /// The path to the existing project.
+        path: PathBuf,
+    },
+    /// Create a new project where the final directory path is `<path>/<name>`.
+    New {
+        /// The name of the project.
+        name: String,
+        /// The directory where we create the project.
+        path: PathBuf,
+    },
+}
+
+impl Repo {
+    /// Get the project name based off of `path` or `path` + `name`.
+    ///
+    /// # Errors
+    ///
+    ///   * The existing path provided was empty, so we could not get the project's name.
+    pub fn project_name(&self) -> Result<String, validation::Error> {
+        match self {
+            Self::Existing { path } => path
+                .components()
+                .next_back()
+                .and_then(|component| component.as_os_str().to_str())
+                .map(ToString::to_string)
+                .ok_or_else(|| validation::Error::EmptyExistingPath(path.clone())),
+            Self::New { name, .. } => Ok(name.to_string()),
+        }
+    }
+}
+
+/// The data required for creating a new project.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Create {
+    /// Description of the project we want to create.
+    pub description: String,
+    /// The default branch name for the project.
+    pub default_branch: OneLevel,
+    /// What kind of working copy we're working with, i.e. new or existing.
+    pub repo: Repo,
+}
+
+impl Create {
+    /// Validate `Create` into a [`validation::Repository`]. This ensures that
+    /// we have valid paths when we attempt to create the working copy.
+    ///
+    /// # Errors
+    ///
+    /// See [`validation::Repository::validate`]
+    pub fn validate(
+        self,
+        url: LocalUrl,
+        signature: Signature,
+    ) -> Result<validation::Repository, validation::Error> {
+        validation::Repository::validate(self.repo, url, self.default_branch, signature)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom as _;
+
+    use assert_matches::assert_matches;
+
+    use librad::{git_ext::OneLevel, identities::Urn, reflike};
+    use radicle_git_ext::Oid;
+
+    use super::*;
+
+    #[test]
+    fn validation_fails_on_non_empty_existing_directory() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let url = LocalUrl::from(Urn::new(Oid::try_from(
+            "7ab8629dd6da14dcacde7f65b3d58cd291d7e235",
+        )?));
+        let tmpdir = tempfile::tempdir().expect("failed to create tmp dir");
+        let exists = tmpdir.path().join("exists");
+        std::fs::create_dir(exists.clone())?;
+        std::fs::File::create(exists.join("nonempty.rs"))?;
+
+        let create = Create {
+            description: "Radicle".to_string(),
+            default_branch: OneLevel::from(reflike!("radicle")),
+            repo: Repo::New {
+                name: "exists".to_string(),
+                path: tmpdir.path().to_path_buf(),
+            },
+        };
+        assert_matches!(
+            create
+                .validate(
+                    url,
+                    Signature {
+                        name: "functor".to_string(),
+                        email: "map@functor.ct".to_string(),
+                    }
+                )
+                .err(),
+            Some(validation::Error::AlreadExists(_))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn validation_succeeds_on_empty_existing_directory() -> Result<(), Box<dyn std::error::Error>> {
+        let url = LocalUrl::from(Urn::new(Oid::try_from(
+            "7ab8629dd6da14dcacde7f65b3d58cd291d7e235",
+        )?));
+        let tmpdir = tempfile::tempdir().expect("failed to create tmp dir");
+        let exists = tmpdir.path().join("exists");
+        std::fs::create_dir(exists)?;
+
+        let create = Create {
+            description: "Radicle".to_string(),
+            default_branch: OneLevel::from(reflike!("radicle")),
+            repo: Repo::New {
+                name: "exists".to_string(),
+                path: tmpdir.path().to_path_buf(),
+            },
+        };
+        assert!(create
+            .validate(
+                url,
+                Signature {
+                    name: "cocone".to_string(),
+                    email: "cocone@pushout.ct".to_string(),
+                }
+            )
+            .is_ok());
+
+        Ok(())
+    }
+}

--- a/upstream-proxy/src/daemon/project/create/validation.rs
+++ b/upstream-proxy/src/daemon/project/create/validation.rs
@@ -1,0 +1,369 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Validation logic for safely checking that a [`super::Repo`] is valid before
+//! setting up the working copy.
+
+use std::{convert::TryFrom, io, path::PathBuf};
+
+use librad::{
+    git::{
+        local::{transport::CanOpenStorage, url::LocalUrl},
+        types::{
+            remote::{self, LocalPushspec, Remote},
+            Fetchspec, Force, Refspec,
+        },
+    },
+    git_ext::{self, OneLevel},
+    reflike, refspec_pattern,
+    std_ext::result::ResultExt as _,
+};
+use nonempty::NonEmpty;
+
+use super::Signature;
+
+/// Errors that occur when validating a [`super::Repo`]'s path.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The path already existed when trying to create a new project.
+    #[error("the path provided '{0}' already exists")]
+    AlreadExists(PathBuf),
+
+    /// An existing project is being created, but we couldn't get the `name` of
+    /// the project, i.e. the final suffix of the file path.
+    #[error(
+        "the existing path provided '{0}' was empty, and we could not get the project name from it"
+    )]
+    EmptyExistingPath(PathBuf),
+
+    /// An error occurred in `git2` that we could not handle.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// When trying to inspect a path, an I/O error occurred.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// Configured default branch for the project is missing.
+    #[error(
+        "the default branch '{branch}' supplied was not found for the repository at '{repo_path}'"
+    )]
+    MissingDefaultBranch {
+        /// The repository path we're setting up.
+        repo_path: PathBuf,
+        /// The default branch that was expected to be found.
+        branch: String,
+    },
+
+    /// The path was expected to point to a git repository but it did not.
+    #[error("the path '{0}' does not point to an existing repository")]
+    NotARepo(PathBuf),
+
+    /// The path was expected to exist already but does not.
+    #[error("the path provided '{0}' does not exist when it was expected to")]
+    PathDoesNotExist(PathBuf),
+
+    /// When attempting to find a particular remote that _should_ exist, it did
+    /// not.
+    #[error(transparent)]
+    Remote(#[from] remote::FindError),
+
+    /// An internal error occurred when talking to the local transport for git
+    /// related I/O.
+    #[error(transparent)]
+    Transport(#[from] librad::git::local::transport::Error),
+
+    /// The `rad` remote was found, but the URL did not match the URL we were
+    /// expecting.
+    #[error("the `rad` remote was found but the url field does not match the provided url, found: '{found}' expected: '{expected}'")]
+    UrlMismatch {
+        /// The expected URL of the `rad` remote.
+        expected: String,
+        /// The URL that was found for the `rad` remote.
+        found: String,
+    },
+}
+
+/// A `Repository` represents the validated information for setting up a working
+/// copy.
+///
+/// We can get a `Repository` by calling [`Repository::validate`].
+pub enum Repository {
+    /// The existing repository.
+    Existing {
+        /// Le [`git2::Repository`] that exists.
+        repo: git2::Repository,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+    },
+    /// A new repository will be created using these fields.
+    New {
+        /// The path to the working copy.
+        path: PathBuf,
+        /// The name of the project.
+        name: String,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+        /// The signature to use for the initial commit.
+        signature: Signature,
+    },
+}
+
+impl Repository {
+    /// Validate a [`super::Repo`] to construct a `Repository`.
+    ///
+    /// This ensures that when setting up a working copy, that there should be
+    /// no errors. The following are validated for each case:
+    ///
+    /// **Existing**:
+    ///   * The path provided should exist
+    ///   * The path provided should have at least one component, which forms the name of the
+    ///   project. E.g. `Developer/radicle-upstream` is the directory and
+    /// `radicle-upstream` is the   project name.
+    ///   * The path leads to a git repository
+    ///   * The default branch passed exists in the repository
+    ///   * If a `rad` remote exists, that it:
+    ///         * Has a url field
+    ///         * If it does have a url field, that it matches the one provided here
+    ///
+    /// **New**:
+    ///   * The path provided does not exist:
+    ///         * If it does exist, it should be a directory and it should be empty
+    ///
+    /// # Errors
+    ///
+    /// If any of the criteria outlined above are violated, this will result in
+    /// an [`Error`].
+    pub fn validate(
+        repo: super::Repo,
+        url: LocalUrl,
+        default_branch: OneLevel,
+        signature: Signature,
+    ) -> Result<Self, Error> {
+        match repo {
+            super::Repo::Existing { path } => {
+                if !path.exists() {
+                    return Err(Error::PathDoesNotExist(path));
+                }
+
+                let _components = path
+                    .components()
+                    .next_back()
+                    .and_then(|component| component.as_os_str().to_str())
+                    .map(ToString::to_string)
+                    .ok_or_else(|| Error::EmptyExistingPath(path.clone()))?;
+
+                let repo = git2::Repository::open(path.clone())
+                    .or_matches(git_ext::is_not_found_err, || Err(Error::NotARepo(path)))?;
+
+                {
+                    let _default_branch_ref = Self::existing_branch(&repo, &default_branch)?;
+                    let _remote = Self::existing_remote(&repo, &url)?;
+                }
+                Ok(Self::Existing {
+                    repo,
+                    url,
+                    default_branch,
+                })
+            },
+            super::Repo::New { name, path } => {
+                let repo_path = path.join(name.clone());
+                let _repo_path = crate::daemon::project::ensure_directory(&repo_path)?
+                    .ok_or_else(|| Error::AlreadExists(repo_path.clone()))?;
+
+                Ok(Self::New {
+                    name,
+                    path,
+                    url,
+                    default_branch,
+                    signature,
+                })
+            },
+        }
+    }
+
+    /// Initialise the [`git2::Repository`].
+    ///
+    /// # Errors
+    ///
+    ///   * Failed to setup the repository
+    pub fn setup_repo<F>(
+        self,
+        open_storage: F,
+        description: &str,
+    ) -> Result<git2::Repository, super::Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        match self {
+            Self::Existing {
+                repo,
+                url,
+                default_branch,
+            } => {
+                tracing::debug!(path = ?repo.path(), "Setting up existing repository");
+                Self::setup_remote(&repo, open_storage, url, &default_branch)?;
+                Ok(repo)
+            },
+            Self::New {
+                path,
+                name,
+                url,
+                default_branch,
+                signature,
+            } => {
+                let path = path.join(name);
+                tracing::debug!(?path, "Setting up new repository",);
+                let repo = Self::initialise(path, description, &default_branch)?;
+                Self::initial_commit(
+                    &repo,
+                    &default_branch,
+                    &git2::Signature::try_from(signature)?,
+                )?;
+                let mut remote =
+                    Self::setup_remote(&repo, open_storage.clone(), url, &default_branch)?;
+                // Set up the default branch under the remote to allow setting the upstream
+                let _fetched = remote
+                    .fetch(
+                        open_storage,
+                        &repo,
+                        remote::LocalFetchspec::Specs(NonEmpty::new(Fetchspec::from(Refspec {
+                            src: reflike!("refs/heads").join(default_branch.clone()),
+                            dst: reflike!("refs/remotes")
+                                .join(remote.name.clone())
+                                .join(default_branch.clone()),
+                            force: Force::False,
+                        }))),
+                    )
+                    .map_err(Error::from)?;
+
+                crate::daemon::project::set_upstream(&repo, &remote, default_branch)?;
+
+                Ok(repo)
+            },
+        }
+    }
+
+    fn initialise(
+        path: PathBuf,
+        description: &str,
+        default_branch: &OneLevel,
+    ) -> Result<git2::Repository, git2::Error> {
+        tracing::debug!(?path, "Setting up new repository");
+        let mut options = git2::RepositoryInitOptions::new();
+        options.no_reinit(true);
+        options.mkpath(true);
+        options.description(description);
+        options.initial_head(default_branch.as_str());
+
+        git2::Repository::init_opts(path, &options)
+    }
+
+    fn initial_commit(
+        repo: &git2::Repository,
+        default_branch: &OneLevel,
+        signature: &git2::Signature<'static>,
+    ) -> Result<(), git2::Error> {
+        // Now let's create an empty tree for this commit
+        let tree_id = {
+            let mut index = repo.index()?;
+
+            // For our purposes, we'll leave the index empty for now.
+            index.write_tree()?
+        };
+        {
+            let tree = repo.find_tree(tree_id)?;
+            // Normally creating a commit would involve looking up the current HEAD
+            // commit and making that be the parent of the initial commit, but here this
+            // is the first commit so there will be no parent.
+            repo.commit(
+                Some(&format!("refs/heads/{}", default_branch.as_str())),
+                signature,
+                signature,
+                "Initial commit",
+                &tree,
+                &[],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Equips a repository with a rad remote for the given id. If the directory
+    /// at the given path is not managed by git yet we initialise it first.
+    fn setup_remote<F>(
+        repo: &git2::Repository,
+        open_storage: F,
+        url: LocalUrl,
+        default_branch: &OneLevel,
+    ) -> Result<Remote<LocalUrl>, Error>
+    where
+        F: CanOpenStorage + 'static,
+    {
+        let _default_branch_ref = Self::existing_branch(repo, default_branch)?;
+
+        tracing::debug!("Creating rad remote");
+
+        let fetchspec = Refspec {
+            src: refspec_pattern!("refs/heads/*"),
+            dst: refspec_pattern!("refs/remotes/rad/*"),
+            force: Force::True,
+        };
+        let mut git_remote = Self::existing_remote(repo, &url)?.map_or_else(
+            || {
+                let mut rad = Remote::rad_remote(url, fetchspec);
+                rad.save(repo)?;
+                Ok::<_, Error>(rad)
+            },
+            Ok,
+        )?;
+        for pushed in git_remote.push(
+            open_storage,
+            repo,
+            LocalPushspec::Matching {
+                pattern: refspec_pattern!("refs/heads/*"),
+                force: Force::True,
+            },
+        )? {
+            tracing::debug!(branch = ?pushed, "Pushed local branch");
+        }
+        Ok(git_remote)
+    }
+
+    fn existing_branch<'a>(
+        repo: &'a git2::Repository,
+        default_branch: &OneLevel,
+    ) -> Result<git2::Reference<'a>, Error> {
+        repo.resolve_reference_from_short_name(default_branch.as_str())
+            .or_matches(git_ext::is_not_found_err, || {
+                Err(Error::MissingDefaultBranch {
+                    repo_path: repo.path().to_path_buf(),
+                    branch: default_branch.as_str().to_string(),
+                })
+            })
+    }
+
+    fn existing_remote(
+        repo: &git2::Repository,
+        url: &LocalUrl,
+    ) -> Result<Option<Remote<LocalUrl>>, Error> {
+        match Remote::<LocalUrl>::find(repo, reflike!("rad")) {
+            Err(remote::FindError::ParseUrl(_)) => {
+                tracing::warn!("renaming invalid rad URL");
+                repo.remote_rename("rad", "rad_old")?;
+                Ok(None)
+            },
+            Err(err) => Err(err.into()),
+            Ok(Some(remote)) if remote.url != *url => Err(Error::UrlMismatch {
+                expected: url.to_string(),
+                found: remote.url.to_string(),
+            }),
+            Ok(remote) => Ok(remote),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/project/peer.rs
+++ b/upstream-proxy/src/daemon/project/peer.rs
@@ -1,0 +1,177 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The `peer` module models the data representing a peer's relation to a
+//! project.
+//!
+//! A [`Peer`] can be `Local` or `Remote`, it can be `NotReplicated` or
+//! `Replicated`, and it can be a `Tracker`, `Contributor`, or `Maintainer` of
+//! the project.
+use serde::Serialize;
+
+use librad::PeerId;
+
+/// Relation of the peer to the project.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Role {
+    /// Replicating, but not participating.
+    Tracker,
+    /// Participated with unique changes.
+    Contributor,
+    /// Part of the set of maintainers.
+    Maintainer,
+}
+
+/// A peer is split between a `Local` peer and a `Remote` peer. The `Local`
+/// variant corresponds to the user browsing from their own machine. The
+/// `Remote` variant corresponds to a peer that they have connected with by
+/// exchanging data over the newtork.
+///
+/// Both variants are keyed by their `PeerId` which identifies them in the
+/// network.
+///
+/// The `status` field is left generic so that we can use a combination of
+/// [`Status`] and [`Replicated`]. When `S` is `Status` it means that the `Peer`
+/// could be in one of two states: `NotReplicated` or `Replicated`. When `S` is
+/// `Replicated` it means the peer is definitely `Replicated` on the local
+/// peer's machine.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Peer<S> {
+    /// Represents the local peer.
+    #[serde(rename_all = "camelCase")]
+    Local {
+        /// [`PeerId`] of the peer.
+        peer_id: PeerId,
+        /// State of replication.
+        status: S,
+    },
+    /// Represents a remote peer.
+    #[serde(rename_all = "camelCase")]
+    Remote {
+        /// [`PeerId`] of the peer.
+        peer_id: PeerId,
+        /// State of replication.
+        status: S,
+    },
+}
+
+impl<U> Peer<Status<U>> {
+    /// Get the user details for a `Remote` peer.
+    ///
+    /// This will return `Some` if the `Peer` is `Replicated`, and `None`
+    /// otherwise.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn replicated_remote(self) -> Option<(PeerId, U)> {
+        match self {
+            Self::Remote {
+                peer_id,
+                status: Status::Replicated(Replicated { user, .. }),
+            } => Some((peer_id, user)),
+            Self::Local { .. } | Self::Remote { .. } => None,
+        }
+    }
+}
+
+impl<S> Peer<S> {
+    /// Get the [`PeerId`] of the `Peer`, regardless whether they are `Local` or
+    /// `Remote`.
+    pub const fn peer_id(&self) -> PeerId {
+        match self {
+            Self::Local { peer_id, .. } | Self::Remote { peer_id, .. } => *peer_id,
+        }
+    }
+}
+
+#[allow(clippy::use_self)]
+impl<S> Peer<S> {
+    /// Apply the function `f` to the `status` of the `Peer`. This allows us to
+    /// easily change the underlying type of the `Peer` without changing the
+    /// `peer_id` field.
+    pub fn map<T, F>(self, f: F) -> Peer<T>
+    where
+        F: FnOnce(S) -> T,
+    {
+        match self {
+            Self::Local { peer_id, status } => Peer::Local {
+                peer_id,
+                status: f(status),
+            },
+            Self::Remote { peer_id, status } => Peer::Remote {
+                peer_id,
+                status: f(status),
+            },
+        }
+    }
+}
+
+/// If data has been replicated locally we should be able to determine the
+/// [`Role`] the peer had with this project as well as their user metadata.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Replicated<U> {
+    /// The role this peer has with the project.
+    pub role: Role,
+    /// The user metadata the peer used with the project.
+    pub user: U,
+}
+
+#[allow(clippy::use_self)]
+impl<U> Replicated<U> {
+    /// Apply the supplied function `f` to the `user` field of `Replicated`.
+    /// This leaves the `role` field untouched.
+    ///
+    /// This is useful for changing the `user` type by augmenting the data
+    /// inside with the supplied function.
+    pub fn map<V, F>(self, f: F) -> Replicated<V>
+    where
+        F: FnOnce(U) -> V,
+    {
+        Replicated {
+            role: self.role,
+            user: f(self.user),
+        }
+    }
+}
+
+/// `Status` represents the state of data that relates a peer and some project.
+///
+/// If it is `NotReplicated`, it means the peer is being tracked but we have not
+/// received any data relating to them yet.
+///
+/// If it is `Replicated`, it means the data has been replicated and we have the
+/// associated role and user metadata for this peer.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Status<U> {
+    /// No data has been replicated locally (yet).
+    NotReplicated,
+    /// The data has been replicated locally, and so we can determine the `Role`
+    /// and `User`.
+    Replicated(Replicated<U>),
+}
+
+impl<U> Status<U> {
+    /// Helper for constructing the `Status::Replicated` variant.
+    pub const fn replicated(role: Role, user: U) -> Self {
+        Self::Replicated(Replicated { role, user })
+    }
+}
+
+#[allow(clippy::use_self)]
+impl<U> Status<U> {
+    /// Apply the supplied function `f` to [`Replicated`], otherwise it leaves
+    /// the `NotReplicated` variant untouched.
+    pub fn map<V, F>(self, f: F) -> Status<V>
+    where
+        F: FnOnce(U) -> V,
+    {
+        match self {
+            Self::NotReplicated => Status::NotReplicated,
+            Self::Replicated(replicated) => Status::Replicated(replicated.map(f)),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/request.rs
+++ b/upstream-proxy/src/daemon/request.rs
@@ -1,0 +1,344 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! An API for keeping track of requests and their state transitions.
+//!
+//! See [`Request`] and [`waiting_room::WaitingRoom`] for a high-level view of
+//! the API.
+
+// We need to allow this because there's a bug and clippy doesn't realise that the type parameter
+// is changing during state transitions.
+// See https://github.com/rust-lang/rust-clippy/issues/4859 for more information.
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::use_self)]
+
+use std::{collections::HashMap, ops::Deref};
+
+use either::Either;
+use serde::{Deserialize, Serialize};
+
+use librad::{git::Urn, net::protocol::gossip::Payload, PeerId};
+
+pub mod existential;
+pub use existential::SomeRequest;
+pub mod states;
+pub use states::*;
+pub mod waiting_room;
+
+/// Private trait for sealing the traits we use here.
+mod sealed;
+
+/// A `Request` represents the lifetime of requesting an identity in the network
+/// via its [`Urn`].
+///
+/// The `Request`'s state is represented by the `S` type parameter. This
+/// parameter makes sure that a `Request` transitions through specific states in
+/// a type safe manner.
+///
+/// These transitions are pictured below:
+///
+/// ```text
+///      +----------------------------------v
+///      |                             +---------+
+///      |                   +-------->+cancelled+<------+
+///      |                   |         +----+----+       |
+///      |                   |              ^            |
+///      |                   |              |            |
+/// +----+----+       +------+--+       +---+-+      +---+---+       +------+
+/// | created +------>+requested+------>+found+----->+cloning+------>+cloned|
+/// +---------+       +------+--+       +--+--+      +---+---+       +------+
+///                          |  ^-------+  |  ^------+   |
+///                          |    failed   |   failed    |
+///                          |             v             |
+///                          |          +--+------+      |
+///                          +--------->+timed out+------+
+///                                     +---------+
+/// ```
+///
+/// The `T` type parameter represents some timestamp that is chosen by the user
+/// of the `Request` API. Note that it makes it easy to test by just choosing
+/// `()` for the timestamp.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Request<S, T> {
+    /// The identifier of the identity on the network.
+    urn: Urn,
+    /// The number of attempts this request has made to complete its job.
+    attempts: Attempts,
+    /// The timestamp of the latest action to be taken on this request.
+    #[serde(with = "serde_millis", bound = "T: serde_millis::Milliseconds")]
+    timestamp: T,
+    /// The state of the request, as mentioned above.
+    state: S,
+}
+
+impl<S, T> Deref for Request<S, T> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl<S, T> From<Request<S, T>> for Payload {
+    fn from(request: Request<S, T>) -> Self {
+        Self {
+            urn: request.urn,
+            rev: None,
+            origin: None,
+        }
+    }
+}
+
+impl<S, T> Request<S, T> {
+    /// Get the [`Urn`] that this `Request` is searching for.
+    pub const fn urn(&self) -> &Urn {
+        &self.urn
+    }
+
+    /// Get the the current timestamp of the `Request`.
+    pub const fn timestamp(&self) -> &T {
+        &self.timestamp
+    }
+
+    /// Transition this `Request` into an `Cancelled` state. We can only
+    /// transition a particular subset of the states which are: `{Created,
+    /// Requested, Found, Cloning, Cancelled}`.
+    ///
+    /// That is, attempting to cancel a `Cloned` `Request` is not permitted and
+    /// will complain at compile time.
+    pub fn cancel(self, timestamp: T) -> Request<Cancelled, T>
+    where
+        S: Cancel,
+    {
+        Request {
+            urn: self.urn,
+            attempts: self.attempts,
+            timestamp,
+            state: self.state.cancel(),
+        }
+    }
+
+    /// If a state keeps track of found peers then it can transition back to
+    /// itself by adding a `PeerId` to the existing set of peers.
+    #[must_use]
+    pub fn found(mut self, peer: PeerId, timestamp: T) -> Request<S, T>
+    where
+        S: HasPeers,
+    {
+        self.state.peers().entry(peer).or_insert(Status::Available);
+        self.timestamp = timestamp;
+        self
+    }
+
+    /// A `Request` transitions into a timed out state if it exceeds the maximum
+    /// number of queries or maximum number of clones. Otherwise, the
+    /// `Request` proceeds as normal.
+    ///
+    /// The subset of states that can transition to the `TimedOut` state consist
+    /// of `{Requested, Found, Cloning}`.
+    pub fn timed_out(
+        mut self,
+        max_queries: Queries,
+        max_clones: Clones,
+        timestamp: T,
+    ) -> Either<Self, Request<TimedOut, T>>
+    where
+        S: TimeOut,
+    {
+        if self.attempts.queries > max_queries {
+            Either::Right(Request {
+                urn: self.urn,
+                attempts: self.attempts,
+                timestamp,
+                state: self.state.time_out(TimedOut::Query),
+            })
+        } else if self.attempts.clones > max_clones {
+            Either::Right(Request {
+                urn: self.urn,
+                attempts: self.attempts,
+                timestamp,
+                state: self.state.time_out(TimedOut::Clone),
+            })
+        } else {
+            self.timestamp = timestamp;
+            Either::Left(self)
+        }
+    }
+
+    /// When a `Request` is queried, we increment the `queries` count -- tracked
+    /// via the `attempts` of the `Request`. If incrementing this count
+    /// makes it exceed the maximum then the `Request` transitions into the
+    /// `TimedOut` state.
+    pub fn queried(
+        mut self,
+        max_queries: Queries,
+        max_clones: Clones,
+        timestamp: T,
+    ) -> Either<Request<TimedOut, T>, Self>
+    where
+        S: TimeOut + QueryAttempt,
+    {
+        self.attempts.queries += 1;
+        self.timed_out(max_queries, max_clones, timestamp).flip()
+    }
+}
+
+impl<T> Request<Created, T> {
+    /// Create a fresh `Request` for the given `urn`.
+    ///
+    /// Once this request has been made, we can transition this `Request` to the
+    /// `Requested` state by calling [`Request::request`].
+    #[allow(clippy::missing_const_for_fn, clippy::needless_pass_by_value)]
+    pub fn new(urn: Urn, timestamp: T) -> Self {
+        let urn = Urn { path: None, ..urn };
+        Self {
+            urn,
+            attempts: Attempts::new(),
+            timestamp,
+            state: Created {},
+        }
+    }
+
+    /// Transition the `Request` from the `Created` state to the `Requested`
+    /// state.
+    ///
+    /// This signifies that the `Request` has been queried and will be looking
+    /// for peers to fulfill the request.
+    ///
+    /// The number of queries is incremented by 1.
+    pub fn request(self, timestamp: T) -> Request<Requested, T> {
+        Request {
+            urn: self.urn,
+            attempts: Attempts {
+                queries: self.attempts.queries + 1,
+                ..self.attempts
+            },
+            timestamp,
+            state: Requested {
+                peers: HashMap::new(),
+            },
+        }
+    }
+}
+
+impl<T> Request<Requested, T> {
+    /// Transition the `Request` from the `Requested` state to the `Found`
+    /// state.
+    ///
+    /// This signifies that the `Request` found its first peer and will be ready
+    /// to attempt to clone from the peer.
+    pub fn into_found(self, peer: PeerId, timestamp: T) -> Request<Found, T> {
+        let mut peers = self.state.peers;
+        peers.entry(peer).or_insert(Status::Available);
+        Request {
+            urn: self.urn,
+            attempts: self.attempts,
+            timestamp,
+            state: Found { peers },
+        }
+    }
+}
+
+impl<T> Request<Found, T> {
+    /// Transition the `Request` from the `Found` state to the `Cloning` state.
+    ///
+    /// This signifies that the `Request` is attempting to clone from the
+    /// provided `peer`.
+    pub fn cloning(
+        self,
+        max_queries: Queries,
+        max_clones: Clones,
+        peer: PeerId,
+        timestamp: T,
+    ) -> Either<Request<TimedOut, T>, Request<Cloning, T>>
+    where
+        T: Clone,
+    {
+        let mut peers = self.state.peers;
+        peers
+            .entry(peer)
+            .and_modify(|status| *status = status.join(&Status::InProgress))
+            .or_insert(Status::InProgress);
+        let this = Request {
+            urn: self.urn,
+            attempts: Attempts {
+                queries: self.attempts.queries,
+                clones: self.attempts.clones + 1,
+            },
+            timestamp: timestamp.clone(),
+            state: Cloning { peers },
+        };
+        this.timed_out(max_queries, max_clones, timestamp).flip()
+    }
+
+    /// Transition the `Request` from the `Found` back to the `Requested` state.
+    ///
+    /// This signifies that the `Request` has exhausted its list of peers to
+    /// attempt cloning from and needs to re-attempt the request for the
+    /// search.
+    ///
+    /// Should be used in tandem with [`HasPeers::all_failed`] to ensure that we
+    /// transition back when all peers have failed to clone.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn failed(self) -> Either<Request<Requested, T>, Request<Found, T>> {
+        if self.state.all_failed() {
+            Either::Left(Request {
+                urn: self.urn,
+                attempts: self.attempts,
+                timestamp: self.timestamp,
+                state: Requested {
+                    peers: self.state.peers,
+                },
+            })
+        } else {
+            Either::Right(self)
+        }
+    }
+}
+
+impl<T> Request<Cloning, T> {
+    /// Transition from the `Cloning` state back to the `Found` state.
+    ///
+    /// This signifies that the `peer` failed to clone the identity and we mark
+    /// it as failed.
+    pub fn failed(
+        self,
+        peer: PeerId,
+        reason: String,
+        timestamp: T,
+    ) -> Either<Request<Requested, T>, Request<Found, T>> {
+        let mut peers = self.state.peers;
+        peers
+            .entry(peer)
+            .and_modify(|status| {
+                *status = status.join(&Status::Failed {
+                    reason: reason.clone(),
+                });
+            })
+            .or_insert(Status::Failed { reason });
+        Request {
+            urn: self.urn,
+            attempts: self.attempts,
+            timestamp,
+            state: Found { peers },
+        }
+        .failed()
+    }
+
+    /// Transition from the `Cloning` to the `Cloned` state.
+    ///
+    /// This signifies that the clone was successful and that the whole request
+    /// was successful, congratulations.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn cloned(self, remote_peer: PeerId, timestamp: T) -> Request<Cloned, T> {
+        Request {
+            urn: self.urn.clone(),
+            attempts: self.attempts,
+            timestamp,
+            state: Cloned { remote_peer },
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/request/existential.rs
+++ b/upstream-proxy/src/daemon/request/existential.rs
@@ -1,0 +1,198 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The enumeration of different [`super::Request`] states unified under a
+//! single enum called [`SomeRequest`].
+
+// I reserve the right to not match all the arms when picking out particular cases, thank you very
+// much.
+#![allow(clippy::wildcard_enum_match_arm)]
+
+use librad::PeerId;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    Attempts, Cancelled, Cloned, Cloning, Created, Either, Found, Request, RequestState, Requested,
+    TimedOut,
+};
+
+use super::Status;
+
+/// Since a `Request` is parameterised over its state, it makes it difficult to
+/// talk about a `Request` in general without the compiler complaining at us.
+/// For example, we cannot have something like `vec![created, requested,
+/// cloning, timedout]` since they all have distinct types where they differ in
+/// states.
+///
+/// To allow us to do this we unify all the states into `SomeRequest` where each
+/// state is a variant in the enumeration.
+///
+/// When we pattern match we get back the request parameterised over the
+/// specific state and can work in a type safe manner with this request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    bound = "T: serde_millis::Milliseconds",
+    rename_all = "camelCase",
+    tag = "type"
+)]
+pub enum SomeRequest<T> {
+    /// The `Request` has been created.
+    Created(Request<Created, T>),
+
+    /// The `Request` has been requested.
+    Requested(Request<Requested, T>),
+
+    /// The `Request` has found a peer and is possibly searching for more.
+    Found(Request<Found, T>),
+
+    /// The `Request` is attempting to clone from a peer.
+    Cloning(Request<Cloning, T>),
+
+    /// The `Request` has successfully cloned from a peer.
+    Cloned(Request<Cloned, T>),
+
+    /// The `Request` has been cancelled.
+    Cancelled(Request<Cancelled, T>),
+
+    /// The `Request` has timed out on querying or cloning.
+    TimedOut(Request<TimedOut, T>),
+}
+
+impl<T> From<&SomeRequest<T>> for RequestState {
+    fn from(other: &SomeRequest<T>) -> RequestState {
+        match other {
+            SomeRequest::Created(_) => Self::Created,
+            SomeRequest::Requested(_) => Self::Requested,
+            SomeRequest::Found(_) => Self::Found,
+            SomeRequest::Cloning(_) => Self::Cloning,
+            SomeRequest::Cloned(_) => Self::Cloned,
+            SomeRequest::Cancelled(_) => Self::Cancelled,
+            SomeRequest::TimedOut(_) => Self::TimedOut,
+        }
+    }
+}
+
+impl<T> From<Request<Created, T>> for SomeRequest<T> {
+    fn from(request: Request<Created, T>) -> Self {
+        Self::Created(request)
+    }
+}
+
+impl<T> From<Request<Requested, T>> for SomeRequest<T> {
+    fn from(request: Request<Requested, T>) -> Self {
+        Self::Requested(request)
+    }
+}
+
+impl<T> From<Request<Found, T>> for SomeRequest<T> {
+    fn from(request: Request<Found, T>) -> Self {
+        Self::Found(request)
+    }
+}
+
+impl<T> From<Request<Cloning, T>> for SomeRequest<T> {
+    fn from(request: Request<Cloning, T>) -> Self {
+        Self::Cloning(request)
+    }
+}
+
+impl<T> From<Request<Cloned, T>> for SomeRequest<T> {
+    fn from(request: Request<Cloned, T>) -> Self {
+        Self::Cloned(request)
+    }
+}
+
+impl<T> From<Request<Cancelled, T>> for SomeRequest<T> {
+    fn from(request: Request<Cancelled, T>) -> Self {
+        Self::Cancelled(request)
+    }
+}
+
+impl<T> From<Request<TimedOut, T>> for SomeRequest<T> {
+    fn from(request: Request<TimedOut, T>) -> Self {
+        Self::TimedOut(request)
+    }
+}
+
+impl<T, L: Into<SomeRequest<T>>, R: Into<SomeRequest<T>>> From<Either<L, R>> for SomeRequest<T> {
+    fn from(other: Either<L, R>) -> Self {
+        other.either(L::into, R::into)
+    }
+}
+
+impl<T> SomeRequest<T> {
+    /// Get the [`Attempts`] of whatever kind of [`Request`] is below.
+    pub const fn attempts(&self) -> &Attempts {
+        match self {
+            SomeRequest::Created(request) => &request.attempts,
+            SomeRequest::Requested(request) => &request.attempts,
+            SomeRequest::Found(request) => &request.attempts,
+            SomeRequest::Cloning(request) => &request.attempts,
+            SomeRequest::Cloned(request) => &request.attempts,
+            SomeRequest::Cancelled(request) => &request.attempts,
+            SomeRequest::TimedOut(request) => &request.attempts,
+        }
+    }
+
+    /// Get the current timestamp of the underlying `Request`.
+    pub const fn timestamp(&self) -> &T {
+        match self {
+            SomeRequest::Created(request) => request.timestamp(),
+            SomeRequest::Requested(request) => request.timestamp(),
+            SomeRequest::Found(request) => request.timestamp(),
+            SomeRequest::Cloning(request) => request.timestamp(),
+            SomeRequest::Cloned(request) => request.timestamp(),
+            SomeRequest::Cancelled(request) => request.timestamp(),
+            SomeRequest::TimedOut(request) => request.timestamp(),
+        }
+    }
+
+    /// We can cancel an underlying `Request` if it is allowed to be cancelled.
+    /// In the case that it is allowed, then we get back the cancelled
+    /// request in the `Right` variant. Otherwise we get back our original
+    /// `SomeRequest` in the `Left` variant.
+    pub fn cancel(self, timestamp: T) -> Either<SomeRequest<T>, Request<Cancelled, T>> {
+        match self {
+            SomeRequest::Created(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Requested(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Found(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Cloning(request) => Either::Right(request.cancel(timestamp)),
+            SomeRequest::Cancelled(request) => Either::Right(request.cancel(timestamp)),
+            request => Either::Left(request),
+        }
+    }
+
+    /// If we have some way of picking a specific `Request` from `SomeRequest`
+    /// and a function that transitions that `Request` into a next state
+    /// then we follow that transition.
+    ///
+    /// If not we leave the `SomeRequest` as is.
+    pub fn transition<Prev, Next>(
+        self,
+        matcher: impl FnOnce(SomeRequest<T>) -> Option<Prev>,
+        transition: impl FnOnce(Prev) -> Next,
+    ) -> Either<SomeRequest<T>, Next>
+    where
+        T: Clone,
+    {
+        match matcher(self.clone()) {
+            Some(previous) => Either::Right(transition(previous)),
+            None => Either::Left(self),
+        }
+    }
+
+    /// Get any peers associated with this request
+    pub fn peers(&self) -> Option<&std::collections::HashMap<PeerId, Status>> {
+        match self {
+            SomeRequest::Created(_)
+            | SomeRequest::Requested(_)
+            | SomeRequest::Cloned(_)
+            | SomeRequest::Cancelled(_)
+            | SomeRequest::TimedOut(..) => None,
+            SomeRequest::Found(f) => Some(&f.peers),
+            SomeRequest::Cloning(c) => Some(&c.peers),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/request/sealed.rs
+++ b/upstream-proxy/src/daemon/request/sealed.rs
@@ -1,0 +1,7 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+/// A private trait to seal away traits that we use in `states`.
+pub trait Sealed {}

--- a/upstream-proxy/src/daemon/request/states.rs
+++ b/upstream-proxy/src/daemon/request/states.rs
@@ -1,0 +1,414 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The state types and traits that we can use for [`super::Request`]'s `S`
+//! parameter.
+
+use std::{
+    collections::HashMap,
+    fmt,
+    ops::{Add, AddAssign, Deref},
+};
+
+use serde::{Deserialize, Serialize};
+
+use librad::PeerId;
+
+use super::sealed;
+
+impl sealed::Sealed for Created {}
+impl sealed::Sealed for Requested {}
+impl sealed::Sealed for Found {}
+impl sealed::Sealed for Cloning {}
+impl sealed::Sealed for Cancelled {}
+
+// State Types
+
+/// An enumeration of the different states a `Request` can be in. This is useful
+/// if we want to convey the state information without any of the other state
+/// data.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum RequestState {
+    /// The initial state where the `Request` has been created.
+    Created,
+
+    /// The state where the `Request` has been requested.
+    Requested,
+
+    /// The state where the `Request` has found at least one peer.
+    Found,
+
+    /// The state where the `Request` has is cloning from a peer.
+    Cloning,
+
+    /// The state where the `Request` has successfully cloned from a peer.
+    Cloned,
+
+    /// The state where the `Request` has been cancelled.
+    Cancelled,
+
+    /// The state where the `Request` has timed out.
+    TimedOut,
+}
+
+impl fmt::Display for RequestState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// The initial state for a `Request`. It has simply been created.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Created {}
+
+/// The state signifying that the `Request` has been kicked-off.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Requested {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(super) peers: HashMap<PeerId, Status>,
+}
+
+/// `Status` represents the lifecycle of some action on data. The data could be
+/// available to take the action on, the action could be in progress, or it
+/// could have failed.
+///
+/// Note that the related data isn't in the `Status` variants. The status is
+/// free to be associated with any external data, e.g. using it as a value in a
+/// `HashMap`.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Status {
+    /// The status of the related data is: ready to go!
+    Available,
+    /// The status of the related data is: in progress!
+    InProgress,
+    /// The status of the related data is: failed :(
+    Failed {
+        #[allow(missing_docs)]
+        reason: String,
+    },
+}
+
+impl Status {
+    /// Joining two `Status` favours `Failed` over any other `Status`, then
+    /// `InProgress`, and finally `Available`.
+    ///
+    /// This translates to the fact that if something has `Failed` then that's
+    /// it, there's no going back.
+    /// If it's `InProgress`, it doesn't matter that the other `Status` is
+    /// saying its `Available`, because you know what? It's actually in
+    /// progress. And finally, the last case is that both `Status`es agree
+    /// the `Status` is `Available`.
+    #[must_use]
+    pub fn join(&self, other: &Self) -> Self {
+        match (self, &other) {
+            (Self::Failed { reason: reason1 }, Self::Failed { reason: reason2 }) => Self::Failed {
+                reason: format!("{} and {}", reason1, reason2),
+            },
+            (Self::Failed { reason }, _) | (_, Self::Failed { reason }) => Self::Failed {
+                reason: reason.clone(),
+            },
+            (Self::InProgress, _) | (_, Self::InProgress) => Self::InProgress,
+            (Self::Available, Self::Available) => Self::Available,
+        }
+    }
+
+    #[allow(missing_docs)]
+    #[must_use]
+    pub const fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+}
+
+/// The `Found` state means that we have found at least one peer and can
+/// possibly find more.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Found {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(crate) peers: HashMap<PeerId, Status>,
+}
+
+impl Deref for Found {
+    type Target = HashMap<PeerId, Status>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.peers
+    }
+}
+
+/// The `Cloning` state means that we have found at least one peer and we are
+/// attempting a clone on one of them.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cloning {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(crate) peers: HashMap<PeerId, Status>,
+}
+
+impl Deref for Cloning {
+    type Target = HashMap<PeerId, Status>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.peers
+    }
+}
+
+/// The `Cloned` state means that we have successfully cloned the desired
+/// identity.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cloned {
+    /// The identity that we were attempting to find and the peer that we found
+    /// it from.
+    pub(crate) remote_peer: PeerId,
+}
+/// One of the terminal states for a `Request` where the task has been
+/// cancelled.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cancelled {}
+
+/// One of the terminal states for a `Request` where the task made too many
+/// attempts.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TimedOut {
+    /// The `Request` made too many query attempts.
+    Query,
+    /// The `Request` made too many clone attempts.
+    Clone,
+}
+
+impl fmt::Display for TimedOut {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Query => write!(f, "query"),
+            Self::Clone => write!(f, "clone"),
+        }
+    }
+}
+
+/// `Queries` is a wrapper around `usize` so that we can differentiate it from
+/// [`Clones`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Queries {
+    /// The max number of queries allowed per request.
+    Max(usize),
+    /// The max number is infinite, and so we allow the request to never time
+    /// out.
+    Infinite,
+}
+
+impl Queries {
+    /// Create a new `Queries` wrapping around `n`.
+    #[must_use]
+    pub const fn new(n: usize) -> Self {
+        Self::Max(n)
+    }
+}
+
+impl From<Queries> for Option<usize> {
+    fn from(other: Queries) -> Self {
+        match other {
+            Queries::Max(i) => Some(i),
+            Queries::Infinite => None,
+        }
+    }
+}
+
+impl Add<usize> for Queries {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self::Output {
+        match self {
+            Self::Max(i) => Self::Max(i + other),
+            Self::Infinite => Self::Infinite,
+        }
+    }
+}
+
+impl AddAssign<usize> for Queries {
+    fn add_assign(&mut self, other: usize) {
+        match self {
+            Self::Max(i) => *i += other,
+            Self::Infinite => {},
+        }
+    }
+}
+
+/// `Clones` is a wrapper around `usize` so that we can differentiate it from
+/// [`Queries`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Clones {
+    /// The max number of clones allowed per request.
+    Max(usize),
+    /// The max number is infinite, and so we allow the request to never time
+    /// out.
+    Infinite,
+}
+
+impl Clones {
+    /// Create a new `Clones` wrapping around `n`.
+    #[must_use]
+    pub const fn new(n: usize) -> Self {
+        Self::Max(n)
+    }
+}
+
+impl From<Clones> for Option<usize> {
+    fn from(other: Clones) -> Self {
+        match other {
+            Clones::Max(i) => Some(i),
+            Clones::Infinite => None,
+        }
+    }
+}
+
+impl Add<usize> for Clones {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self::Output {
+        match self {
+            Self::Max(i) => Self::Max(i + other),
+            Self::Infinite => Self::Infinite,
+        }
+    }
+}
+
+impl AddAssign<usize> for Clones {
+    fn add_assign(&mut self, other: usize) {
+        match self {
+            Self::Max(i) => *i += other,
+            Self::Infinite => {},
+        }
+    }
+}
+
+/// The number of different attempts a `Request` has made during its lifetime.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attempts {
+    /// The number of query attempts we have made.
+    pub(super) queries: Queries,
+    /// The number of clone attempts we have made.
+    pub(super) clones: Clones,
+}
+
+impl Attempts {
+    /// Get a new `Attempts` where the number of queires and clones is initially
+    /// `0`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Attempts {
+            queries: Queries::Max(0),
+            clones: Clones::Max(0),
+        }
+    }
+}
+
+impl Default for Attempts {
+    fn default() -> Self {
+        Attempts::new()
+    }
+}
+
+impl sealed::Sealed for Attempts {}
+
+// State Traits
+
+/// If a state type implements this trait then it means that the type is allowed
+/// to increment the query attempts in a `Request`.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait QueryAttempt: sealed::Sealed {}
+impl QueryAttempt for Requested {}
+
+/// If a state type implements this trait then it means that the type holds a
+/// `HashMap` of peers and their status of cloning.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait HasPeers: sealed::Sealed
+where
+    Self: Sized + Deref<Target = HashMap<PeerId, Status>>,
+{
+    /// Give back the underlying `HashMap` of peers that is contained in `Self`.
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status>;
+
+    /// Returns `false` if the `peers` are empty or if any of them are
+    /// `Status::Available` or `Status::InProgress`.
+    ///
+    /// Otherwise, if all are in the `Status::Failed` state, then we return
+    /// `true`.
+    fn all_failed(&self) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+
+        self.iter().all(|(_, status)| status.is_failed())
+    }
+}
+
+impl HasPeers for Found {
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status> {
+        &mut self.peers
+    }
+}
+
+impl HasPeers for Cloning {
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status> {
+        &mut self.peers
+    }
+}
+
+/// If a state type implements this trait it means that there is a valid
+/// transition from that state to the `Cancelled` state.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait Cancel: sealed::Sealed
+where
+    Self: Sized,
+{
+    /// Transition the state into `Cancelled`. This ignores whatever state we
+    /// were in and defaults by returning the `Cancelled` state.
+    fn cancel(self) -> Cancelled {
+        Cancelled {}
+    }
+}
+
+impl Cancel for Created {}
+impl Cancel for Requested {}
+impl Cancel for Found {}
+impl Cancel for Cloning {}
+impl Cancel for Cancelled {}
+
+/// If a state type implements this trait it means that there is a valid
+/// transition from that state to the `TimedOut` state.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait TimeOut: sealed::Sealed
+where
+    Self: Sized,
+{
+    /// Transition the state into `TimedOut`. This ignores whatever state we
+    /// were in and defaults by returning the `TimedOut` state by returning
+    /// the `kind` of timeout.
+    fn time_out(self, kind: TimedOut) -> TimedOut {
+        kind
+    }
+}
+
+impl TimeOut for Requested {}
+impl TimeOut for Found {}
+impl TimeOut for Cloning {}

--- a/upstream-proxy/src/daemon/request/waiting_room.rs
+++ b/upstream-proxy/src/daemon/request/waiting_room.rs
@@ -1,0 +1,832 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The black box tracker of [`Request`]s and their lifecycles.
+
+// I reserve the right to not match all the arms when picking out a single case, thank you very
+// much.
+#![allow(clippy::wildcard_enum_match_arm)]
+
+use std::{
+    cmp::PartialOrd,
+    collections::HashMap,
+    convert::TryFrom,
+    ops::{Add, Mul},
+};
+
+use either::Either;
+use serde::{Deserialize, Serialize};
+
+use librad::{
+    git::{identities::Revision, Urn},
+    PeerId,
+};
+
+use crate::daemon::request::{
+    Clones, Queries, Request, RequestState, SomeRequest, Status, TimedOut,
+};
+
+/// The maximum number of query attempts that can be made for a single request.
+const MAX_QUERIES: Queries = Queries::Infinite;
+
+/// The maximum number of clone attempts that can be made for a single request.
+const MAX_CLONES: Clones = Clones::Infinite;
+
+/// An error that can occur when interacting with the [`WaitingRoom`] API.
+#[derive(Clone, Debug, thiserror::Error, PartialEq)]
+pub enum Error {
+    /// When looking up a `Urn` in the [`WaitingRoom`] it was missing.
+    #[error("the URN '{0}' was not found in the waiting room")]
+    MissingUrn(Urn),
+
+    /// When performing an operation on the a [`Request`] in the [`WaitingRoom`]
+    /// it was found to be in the wrong state for the desired operation.
+    ///
+    /// For example, if we tried to call `cloning` on a request that has only
+    /// been created then this would be an invalid transition.
+    #[error("the state fetched '{0}' from the waiting room was not one of the expected states")]
+    StateMismatch(RequestState),
+
+    /// The [`Request`] timed out when performing an operation on it by
+    /// exceeding the number of attempts it was allowed to make.
+    #[error("encountered {timeout} time out after {attempts:?} attempts")]
+    TimeOut {
+        /// What kind of the time out that occurred.
+        timeout: TimedOut,
+        /// The number of attempts that were made when we timed out.
+        attempts: Option<usize>,
+    },
+}
+
+impl<T> From<Request<TimedOut, T>> for Error {
+    fn from(other: Request<TimedOut, T>) -> Self {
+        match &other.state {
+            TimedOut::Query => Error::TimeOut {
+                timeout: other.state,
+                attempts: other.attempts.queries.into(),
+            },
+            TimedOut::Clone => Error::TimeOut {
+                timeout: other.state,
+                attempts: other.attempts.clones.into(),
+            },
+        }
+    }
+}
+
+/// Holds either the newly created request or the request already present for
+/// the requested urn.
+pub type Created<T> = Either<SomeRequest<T>, SomeRequest<T>>;
+
+/// A `WaitingRoom` knows about a set of `Request`s that have been made, and can
+/// look them up via their `Urn`.
+///
+/// It keeps track of these states as the user tells the waiting room what is
+/// happening to the request on the outside.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WaitingRoom<T, D> {
+    /// The set of requests keyed by their `Urn`. This helps us keep only unique
+    /// requests in the waiting room.
+    #[serde(bound = "T: serde_millis::Milliseconds")]
+    requests: HashMap<Revision, SomeRequest<T>>,
+
+    /// The configuration of the waiting room.
+    config: Config<D>,
+}
+
+/// The `Config` for the waiting room tells it what are the maximum number of
+/// query and clone attempts that can be made for a single request.
+///
+/// The recommended approach to initialising the `Config` is to use its
+/// `Default` implementation, i.e. `Config::default()`, followed by setting the
+/// `delta`, since the usual default values for number values are `0`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Config<D> {
+    /// The maximum number of query attempts that can be made.
+    pub max_queries: Queries,
+    /// The maximum number of clone attempts that can be made.
+    pub max_clones: Clones,
+    /// The minimum elapsed time between some provided time and a request's
+    /// timestamp. For example, if we had the following setup:
+    ///   * `delta = 1`
+    ///   * `now = 3`
+    ///   * `request.timestamp = 2`
+    /// then the `delta` would be compared against `now - request.timestamp`.
+    pub delta: D,
+}
+
+impl<D> Default for Config<D>
+where
+    D: Default,
+{
+    fn default() -> Self {
+        Self {
+            max_queries: MAX_QUERIES,
+            max_clones: MAX_CLONES,
+            delta: D::default(),
+        }
+    }
+}
+
+impl<T, D> WaitingRoom<T, D> {
+    /// Initialise a new `WaitingRoom` with the supplied `config`.
+    #[must_use]
+    pub fn new(config: Config<D>) -> Self {
+        Self {
+            requests: HashMap::new(),
+            config,
+        }
+    }
+
+    /// Get the underlying [`SomeRequest`] for the given `urn`.
+    ///
+    /// Returns `None` if there is no such request.
+    #[must_use]
+    pub fn get(&self, urn: &Urn) -> Option<&SomeRequest<T>> {
+        self.requests.get(&urn.id)
+    }
+
+    /// Permanently remove a request from the `WaitingRoom`. If the `urn` did
+    /// exist in the `WaitingRoom` then the request will be returned.
+    ///
+    /// Otherwise, it will return `None` if no such request existed.
+    pub fn remove(&mut self, urn: &Urn) -> Option<SomeRequest<T>> {
+        self.requests.remove(&urn.id)
+    }
+
+    /// This will return the request for the given `urn` if one exists in the
+    /// `WaitingRoom`.
+    ///
+    /// If there is no such `urn` then it create a fresh `Request` using the
+    /// `urn` and `timestamp` and it will return `None`.
+    pub fn request(&mut self, urn: &Urn, timestamp: T) -> Either<SomeRequest<T>, SomeRequest<T>>
+    where
+        T: Clone,
+    {
+        match self.get(urn) {
+            None => {
+                let request = SomeRequest::Created(Request::new(urn.clone(), timestamp));
+                self.requests.insert(urn.id, request.clone());
+                Either::Left(request)
+            },
+            Some(request) => Either::Right(request.clone()),
+        }
+    }
+
+    /// Transition the `Request` found at the provided `urn` and call the
+    /// transition function to move it into its `Next` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    ///   * If the transition function supplied returns an error.
+    fn transition<Prev, Next>(
+        &mut self,
+        matcher: impl FnOnce(SomeRequest<T>) -> Option<Prev>,
+        transition: impl FnOnce(Prev) -> Either<Request<TimedOut, T>, Next>,
+        urn: &Urn,
+    ) -> Result<(), Error>
+    where
+        T: Clone,
+        Prev: Clone,
+        Next: Into<SomeRequest<T>> + Clone,
+    {
+        match self.get(urn) {
+            None => Err(Error::MissingUrn(urn.clone())),
+            Some(request) => match request.clone().transition(matcher, transition) {
+                Either::Right(Either::Right(next)) => {
+                    self.requests.insert(urn.id, next.into());
+                    Ok(())
+                },
+                Either::Right(Either::Left(timeout)) => {
+                    self.requests.insert(urn.id, timeout.clone().into());
+                    Err(timeout.into())
+                },
+                Either::Left(mismatch) => Err(Error::StateMismatch((&mismatch).into())),
+            },
+        }
+    }
+
+    /// Tell the `WaitingRoom` that a query was made for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Created` state then it will
+    /// transition to the `IsRequested` state.
+    ///
+    /// If the underlying `Request` was in the `IsRequested` state then it
+    /// increments the query attempt.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    ///   * If the underlying `Request` timed out.
+    pub fn queried(&mut self, urn: &Urn, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        let max_queries = self.config.max_queries;
+        let max_clones = self.config.max_clones;
+        self.transition(
+            |request| match request {
+                SomeRequest::Created(request) => Some(Either::Right(request.request(timestamp))),
+                SomeRequest::Requested(request) => {
+                    Some(request.queried(max_queries, max_clones, timestamp))
+                },
+                _ => None,
+            },
+            |previous| previous,
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that a `peer` was found for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `IsRequested` state then it will
+    /// transition to the `Found` state.
+    ///
+    /// If the underlying `Request` was in the `Found` or `Cloning` state then
+    /// it add this `peer` to the set of found peers.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    pub fn found(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        self.transition(
+            |request| match request {
+                SomeRequest::Requested(request) => {
+                    Some(request.into_found(remote_peer, timestamp).into())
+                },
+                SomeRequest::Found(request) => {
+                    let some_request: SomeRequest<T> = request.found(remote_peer, timestamp).into();
+                    Some(some_request)
+                },
+                SomeRequest::Cloning(request) => {
+                    let some_request: SomeRequest<T> = request.found(remote_peer, timestamp).into();
+                    Some(some_request)
+                },
+                _ => None,
+            },
+            Either::Right,
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we are attempting a clone from the `peer`
+    /// for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Found` state then it will
+    /// transition to the `Cloning` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    ///   * If the underlying `Request` timed out.
+    pub fn cloning(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        let max_queries = self.config.max_queries;
+        let max_clones = self.config.max_clones;
+        self.transition(
+            |request| match request {
+                SomeRequest::Found(request) => Some(request),
+                _ => None,
+            },
+            |previous| previous.cloning(max_queries, max_clones, remote_peer, timestamp),
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we failed the attempt to clone from the
+    /// `peer` for the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Cloning` state then it will
+    /// transition to the `Found` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn cloning_failed(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: T,
+        reason: Box<dyn std::error::Error>,
+    ) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        #[allow(clippy::non_ascii_literal)]
+        let reason_str = anyhow::Chain::new(reason.as_ref())
+            .fold("".to_string(), |acc, e| format!("{} ⮩ {}", acc, e));
+        self.transition(
+            |request| match request {
+                SomeRequest::Cloning(request) => Some(request),
+                _ => None,
+            },
+            |previous| Either::Right(previous.failed(remote_peer, reason_str.clone(), timestamp)),
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we successfully cloned the given `urn`.
+    ///
+    /// If the underlying `Request` was in the `Cloning` state then it will
+    /// transition to the `Cloned` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    pub fn cloned(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        self.transition(
+            |request| match request {
+                SomeRequest::Cloning(request) => Some(request),
+                _ => None,
+            },
+            |previous| Either::Right(previous.cloned(remote_peer, timestamp)),
+            urn,
+        )
+    }
+
+    /// Tell the `WaitingRoom` that we are cancelling the request for the given
+    /// `urn`.
+    ///
+    /// If the underlying `Request` was in the `{Created, IsRequested, Found,
+    /// Cloning, Cancelled}` state then it will transition to the
+    /// `Cancelled` state.
+    ///
+    /// # Errors
+    ///
+    ///   * If the `urn` was not in the `WaitingRoom`.
+    ///   * If the underlying `Request` was not in the expected state.
+    pub fn canceled(&mut self, urn: &Urn, timestamp: T) -> Result<(), Error>
+    where
+        T: Clone,
+    {
+        self.transition(
+            |request| request.cancel(timestamp).right(),
+            Either::Right,
+            urn,
+        )
+    }
+
+    /// Return the list of all `Urn`/`SomeRequest` pairs in the `WaitingRoom`.
+    pub fn iter(&self) -> impl Iterator<Item = (Urn, &SomeRequest<T>)> {
+        self.requests
+            .iter()
+            .map(|(id, request)| (Urn::new(*id), request))
+    }
+
+    /// Filter the `WaitingRoom` by:
+    ///   * Choosing which [`RequestState`] you are looking for
+    pub fn filter_by_state(
+        &self,
+        request_state: RequestState,
+    ) -> impl Iterator<Item = (Urn, &SomeRequest<T>)> {
+        self.iter()
+            .filter(move |(_, request)| RequestState::from(*request) == request_state.clone())
+    }
+
+    /// Find the first occurring request based on the call to
+    /// [`WaitingRoom::filter_by_state`].
+    pub fn find_by_state(&self, request_state: RequestState) -> Option<(Urn, &SomeRequest<T>)> {
+        self.filter_by_state(request_state).next()
+    }
+
+    /// Get the next `Request` that is in a query state, i.e. `Created` or
+    /// `Requested`.
+    ///
+    /// In the case of the `Requested` state we check if:
+    ///   * The request is a fresh request that hasn't had an attempt to clone yet
+    ///   * Or the elapsed time between the `timestamp` and the `Request`'s timestamp is greater
+    ///     than the `delta` provided in the [`Config`].
+    pub fn next_query(&self, timestamp: T) -> Option<Urn>
+    where
+        T: Add<D, Output = T> + PartialOrd + Clone,
+        D: Mul<u32, Output = D> + Ord + Clone,
+    {
+        let backoff = |tries: Queries| match tries {
+            Queries::Max(i) => self.config.delta.clone() * u32::try_from(i).unwrap_or(u32::MAX),
+            Queries::Infinite => self.config.delta.clone(),
+        };
+        let created = self.find_by_state(RequestState::Created);
+        let requested = self
+            .filter_by_state(RequestState::Requested)
+            .find(move |(_, request)| {
+                request.timestamp().clone() + backoff(request.attempts().queries) <= timestamp
+            });
+
+        created.or(requested).map(|(urn, _request)| urn)
+    }
+
+    /// Get the next `Request` that is in the the `Found` state and the status
+    /// of the peer is `Available`.
+    pub fn next_clone(&self) -> Option<(Urn, PeerId)> {
+        self.find_by_state(RequestState::Found)
+            .and_then(|(urn, request)| match request {
+                SomeRequest::Found(request) => {
+                    request.iter().find_map(|(peer_id, status)| match status {
+                        Status::Available => Some((urn.clone(), *peer_id)),
+                        _ => None,
+                    })
+                },
+                _ => None,
+            })
+    }
+
+    #[cfg(test)]
+    pub fn insert<R>(&mut self, urn: &Urn, request: R)
+    where
+        R: Into<SomeRequest<T>>,
+    {
+        self.requests.insert(urn.id, request.into());
+    }
+}
+
+impl<T, D> WaitingRoom<T, D>
+where
+    T: Clone,
+{
+    /// The state of requests currently in the waiting room
+    pub fn requests(&self) -> HashMap<Revision, SomeRequest<T>> {
+        self.requests.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{error, str::FromStr};
+
+    use assert_matches::assert_matches;
+    use librad::{git::Urn, git_ext::Oid, PeerId, SecretKey};
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn happy_path_of_full_request() -> Result<(), Box<dyn error::Error + 'static>> {
+        let mut waiting_room: WaitingRoom<usize, usize> = WaitingRoom::new(Config::default());
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let remote_peer = PeerId::from(SecretKey::new());
+        let have = waiting_room.request(&urn, 0);
+        let want = waiting_room.get(&urn).expect("urn was missing");
+
+        assert_eq!(have, Either::Left(want.clone()));
+
+        let created = waiting_room.find_by_state(RequestState::Created);
+        assert_eq!(
+            created,
+            Some((
+                urn.clone(),
+                &SomeRequest::Created(Request::new(urn.clone(), 0))
+            )),
+        );
+
+        waiting_room.queried(&urn, 0)?;
+        let expected = SomeRequest::Requested(Request::new(urn.clone(), 0).request(0));
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        waiting_room.found(&urn, remote_peer, 0)?;
+        let expected = SomeRequest::Found(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0),
+        );
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        waiting_room.cloning(&urn, remote_peer, 0)?;
+        let expected = SomeRequest::Cloning(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0)
+                .cloning(MAX_QUERIES, MAX_CLONES, remote_peer, 0)
+                .unwrap_right(),
+        );
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        waiting_room.cloned(&urn, remote_peer, 0)?;
+        let expected = SomeRequest::Cloned(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0)
+                .cloning(MAX_QUERIES, MAX_CLONES, remote_peer, 0)
+                .unwrap_right()
+                .cloned(remote_peer, 0),
+        );
+        assert_eq!(waiting_room.get(&urn), Some(&expected));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cannot_create_twice() -> Result<(), Box<dyn error::Error>> {
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(Config::default());
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        waiting_room.request(&urn, ());
+        let request = waiting_room.request(&urn, ());
+
+        assert_eq!(
+            request,
+            Either::Right(SomeRequest::Created(Request::new(urn.clone(), ())))
+        );
+
+        waiting_room.queried(&urn, ())?;
+        let request = waiting_room.request(&urn, ());
+
+        assert_eq!(
+            request,
+            Either::Right(SomeRequest::Requested(Request::new(urn, ()).request(())))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn timeout_on_delta() -> Result<(), Box<dyn std::error::Error>> {
+        let mut waiting_room: WaitingRoom<u32, u32> = WaitingRoom::new(Config {
+            delta: 5,
+            ..Config::default()
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let _req = waiting_room.request(&urn, 0);
+
+        // Initial schedule to be querying after it has been requested.
+        let request = waiting_room.next_query(1);
+        assert_eq!(request, Some(urn.clone()));
+
+        waiting_room.queried(&urn, 2)?;
+
+        // Should not return the urn again before delta has elapsed.
+        let request = waiting_room.next_query(3);
+        assert_eq!(request, None);
+
+        // Should return the urn again after delta has elapsed.
+        let request = waiting_room.next_query(7);
+        assert_eq!(request, Some(urn));
+
+        Ok(())
+    }
+
+    #[test]
+    fn timeout_on_requests() -> Result<(), Box<dyn error::Error + 'static>> {
+        const NUM_QUERIES: usize = 16;
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(Config {
+            max_queries: Queries::new(NUM_QUERIES),
+            max_clones: Clones::new(0),
+            delta: (),
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let _req = waiting_room.request(&urn, ());
+        for _ in 0..NUM_QUERIES {
+            waiting_room.queried(&urn, ())?;
+        }
+
+        assert_eq!(
+            waiting_room.queried(&urn, ()),
+            Err(Error::TimeOut {
+                timeout: TimedOut::Query,
+                attempts: Some(17),
+            })
+        );
+
+        assert_matches!(waiting_room.get(&urn), Some(SomeRequest::TimedOut(_)));
+
+        Ok(())
+    }
+
+    #[allow(clippy::indexing_slicing)]
+    #[test]
+    fn timeout_on_clones() -> Result<(), Box<dyn error::Error + 'static>> {
+        const NUM_CLONES: usize = 16;
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(Config {
+            max_queries: Queries::new(1),
+            max_clones: Clones::new(NUM_CLONES),
+            delta: (),
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let mut peers = vec![];
+        for _ in 0..=NUM_CLONES {
+            peers.push(PeerId::from(SecretKey::new()));
+        }
+
+        let _req = waiting_room.request(&urn, ());
+        waiting_room.queried(&urn, ())?;
+
+        for remote_peer in &peers {
+            waiting_room.found(&urn, *remote_peer, ())?;
+        }
+
+        for remote_peer in &peers[0..NUM_CLONES] {
+            waiting_room.cloning(&urn, *remote_peer, ())?;
+            waiting_room.cloning_failed(&urn, *remote_peer, (), "no reason".into())?;
+        }
+
+        assert_eq!(
+            waiting_room.cloning(
+                &urn,
+                *peers
+                    .last()
+                    .expect("unless you changed NUM_CLONES to < -1 we should be fine here. qed."),
+                ()
+            ),
+            Err(Error::TimeOut {
+                timeout: TimedOut::Clone,
+                attempts: Some(17),
+            })
+        );
+
+        assert_matches!(waiting_room.get(&urn), Some(SomeRequest::TimedOut(_)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cloning_fails_back_to_requested() -> Result<(), Box<dyn error::Error + 'static>> {
+        const NUM_CLONES: usize = 5;
+        let mut waiting_room: WaitingRoom<u32, u32> = WaitingRoom::new(Config {
+            max_queries: Queries::new(1),
+            max_clones: Clones::new(NUM_CLONES),
+            delta: 5,
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let mut peers = vec![];
+        for _ in 0..NUM_CLONES {
+            peers.push(PeerId::from(SecretKey::new()));
+        }
+
+        let _req = waiting_room.request(&urn, 0);
+        waiting_room.queried(&urn, 1)?;
+
+        for remote_peer in peers {
+            waiting_room.found(&urn, remote_peer, 2)?;
+            waiting_room.cloning(&urn, remote_peer, 2)?;
+            waiting_room.cloning_failed(&urn, remote_peer, 2, "no reason".into())?;
+        }
+
+        assert_matches!(waiting_room.get(&urn), Some(SomeRequest::Requested(_)));
+
+        let request = waiting_room.next_query(3);
+        assert_eq!(request, None);
+
+        let request = waiting_room.next_query(7);
+        assert_eq!(request, Some(urn));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cancel_transitions() -> Result<(), Box<dyn error::Error + 'static>> {
+        let config = Config::default();
+        let mut waiting_room: WaitingRoom<(), ()> = WaitingRoom::new(config);
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let peer = PeerId::from(SecretKey::new());
+
+        // created
+        let _req = waiting_room.request(&urn, ());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(
+                Request::new(urn.clone(), ()).cancel(())
+            ))
+        );
+
+        // requested
+        let is_requested = Request::new(urn.clone(), ()).request(());
+        waiting_room.insert(&urn, is_requested.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(is_requested.clone().cancel(())))
+        );
+
+        // found
+        let found = is_requested.into_found(peer, ());
+        waiting_room.insert(&urn, found.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(found.clone().cancel(())))
+        );
+
+        // cloning
+        let cloning = found
+            .cloning(config.max_queries, config.max_clones, peer, ())
+            .unwrap_right();
+        waiting_room.insert(&urn, cloning.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(cloning.clone().cancel(())))
+        );
+
+        // cloned
+        let cloned = cloning.cloned(peer, ());
+        waiting_room.insert(&urn, cloned);
+        assert_eq!(
+            waiting_room.canceled(&urn, ()),
+            Err(Error::StateMismatch(RequestState::Cloned))
+        );
+
+        // cancel
+        let cancelled = Request::new(urn.clone(), ()).cancel(());
+        waiting_room.insert(&urn, cancelled.clone());
+        waiting_room.canceled(&urn, ())?;
+        assert_eq!(
+            waiting_room.get(&urn),
+            Some(&SomeRequest::Cancelled(cancelled))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_get_request_that_is_ready() -> Result<(), Box<dyn error::Error + 'static>> {
+        let config = Config::default();
+        let mut waiting_room: WaitingRoom<usize, usize> = WaitingRoom::new(config);
+
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let remote_peer = PeerId::from(SecretKey::new());
+
+        let ready = waiting_room.find_by_state(RequestState::Cloned);
+        assert_eq!(ready, None);
+
+        let _req = waiting_room.request(&urn, 0);
+        waiting_room.queried(&urn, 0)?;
+        waiting_room.found(&urn, remote_peer, 0)?;
+        waiting_room.cloning(&urn, remote_peer, 0)?;
+        waiting_room.cloned(&urn, remote_peer, 0)?;
+
+        let ready = waiting_room.find_by_state(RequestState::Cloned);
+        let expected = SomeRequest::Cloned(
+            Request::new(urn.clone(), 0)
+                .request(0)
+                .into_found(remote_peer, 0)
+                .cloning(config.max_queries, config.max_clones, remote_peer, 0)
+                .unwrap_right()
+                .cloned(remote_peer, 0),
+        );
+        assert_eq!(ready, Some((urn, &expected)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_remove_requests() -> Result<(), Box<dyn error::Error + 'static>> {
+        let mut waiting_room: WaitingRoom<usize, usize> = WaitingRoom::new(Config::default());
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        assert_eq!(waiting_room.remove(&urn), None);
+
+        let expected = {
+            waiting_room.request(&urn, 0);
+            waiting_room.get(&urn).cloned()
+        };
+        let removed = waiting_room.remove(&urn);
+        assert_eq!(removed, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn can_backoff_requests() -> Result<(), Box<dyn std::error::Error>> {
+        let mut waiting_room: WaitingRoom<u32, u32> = WaitingRoom::new(Config {
+            delta: 5,
+            ..Config::default()
+        });
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let _req = waiting_room.request(&urn, 0);
+
+        // Initial schedule to be querying after it has been requested.
+        let request = waiting_room.next_query(1);
+        assert_eq!(request, Some(urn.clone()));
+
+        waiting_room.queried(&urn, 5)?;
+
+        // Should not return the urn again before delta + backoff has elapsed, i.e. 5 +
+        // (5 * 1) = 10.
+        let request = waiting_room.next_query(8);
+        assert_eq!(request, None);
+
+        // The delta + backoff has elapsed.
+        let request = waiting_room.next_query(10);
+        assert_eq!(request, Some(urn));
+
+        Ok(())
+    }
+}

--- a/upstream-proxy/src/daemon/run_state.rs
+++ b/upstream-proxy/src/daemon/run_state.rs
@@ -1,0 +1,579 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! State machine to manage the current mode of operation during peer lifecycle.
+
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    time::{Duration, SystemTime},
+};
+
+use serde::Serialize;
+
+use librad::{
+    git::Urn,
+    net::{
+        self,
+        peer::{PeerInfo, ProtocolEvent},
+        protocol::{
+            broadcast::PutResult,
+            event::{downstream, upstream},
+            gossip::Payload,
+        },
+    },
+    PeerId,
+};
+
+use crate::daemon::{
+    convert::MaybeFrom,
+    peer::{announcement, control},
+    request::waiting_room::{self, WaitingRoom},
+};
+
+pub mod command;
+pub use command::Command;
+
+pub mod config;
+pub use config::Config;
+
+pub mod input;
+pub use input::Input;
+
+mod running_waiting_room;
+pub use running_waiting_room::Event as WaitingRoomEvent;
+use running_waiting_room::{RunningWaitingRoom, WaitingRoomTransition};
+
+/// Events external subscribers can observe for internal peer operations.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+pub enum Event {
+    /// Announcement subroutine completed and emitted the enclosed updates.
+    Announced(announcement::Updates),
+    /// A fetch originated by a gossip message succeeded
+    GossipFetched {
+        /// Provider of the fetched update.
+        provider: PeerInfo<SocketAddr>,
+        /// Cooresponding gossip message.
+        gossip: Payload,
+        /// Result of the storage fetch.
+        result: PutResult<Payload>,
+    },
+    /// An event from the underlying coco network stack.
+    /// FIXME(xla): Align variant naming to indicate observed occurrences.
+    Protocol(ProtocolEvent),
+    /// Request fullfilled with a successful clone.
+    RequestCloned(Urn, PeerId),
+    /// Request is being cloned from a peer.
+    RequestCloning(Urn, PeerId),
+    /// Request for the URN was created and is pending submission to the
+    /// network.
+    RequestCreated(Urn),
+    /// Request for the URN was submitted to the network.
+    RequestQueried(Urn),
+    /// Waiting room interval ticked.
+    RequestTick,
+    /// The request for [`Urn`] timed out.
+    RequestTimedOut(Urn),
+    /// The [`Status`] of the peer changed.
+    StatusChanged {
+        /// The old status
+        old: Status,
+        /// The net status
+        new: Status,
+    },
+    /// A state change occurred in the waiting room
+    WaitingRoomTransition(WaitingRoomTransition<SystemTime>),
+}
+
+impl From<WaitingRoomTransition<SystemTime>> for Event {
+    fn from(transition: WaitingRoomTransition<SystemTime>) -> Self {
+        Self::WaitingRoomTransition(transition)
+    }
+}
+
+impl MaybeFrom<&Input> for Event {
+    fn maybe_from(input: &Input) -> Option<Self> {
+        match input {
+            Input::Announce(input::Announce::Succeeded(updates)) => {
+                Some(Self::Announced(updates.clone()))
+            },
+            Input::Protocol(protocol_event) => match protocol_event {
+                ProtocolEvent::Gossip(gossip) => match &**gossip {
+                    upstream::Gossip::Put {
+                        provider,
+                        payload,
+                        result,
+                    } => Some(Self::GossipFetched {
+                        provider: provider.clone(),
+                        gossip: payload.clone(),
+                        result: result.clone(),
+                    }),
+                },
+                event => Some(Self::Protocol(event.clone())),
+            },
+            Input::Request(input::Request::Cloned(urn, remote_peer)) => {
+                Some(Self::RequestCloned(urn.clone(), *remote_peer))
+            },
+            Input::Request(input::Request::Cloning(urn, remote_peer)) => {
+                Some(Self::RequestCloning(urn.clone(), *remote_peer))
+            },
+            Input::Request(input::Request::Queried(urn)) => Some(Self::RequestQueried(urn.clone())),
+            Input::Request(input::Request::Tick) => Some(Self::RequestTick),
+            Input::Request(input::Request::TimedOut(urn)) => {
+                Some(Self::RequestTimedOut(urn.clone()))
+            },
+            _ => None,
+        }
+    }
+}
+
+/// The current status of the local peer and its relation to the network.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Status {
+    /// Nothing is setup, not even a socket to listen on.
+    Stopped,
+    /// Local peer is listening on a socket but has not connected to any peers
+    /// yet.
+    Started,
+    /// The local peer lost its connections to all its peers.
+    Offline,
+    /// The local peer is operational and is able to interact with the peers it
+    /// has connected to.
+    #[serde(rename_all = "camelCase")]
+    Online {
+        /// Connected peers
+        connected_peers: HashMap<PeerId, Vec<SocketAddr>>,
+    },
+}
+
+/// State kept for a running local peer.
+pub struct RunState {
+    listen_addrs: Vec<SocketAddr>,
+    /// Current internal status.
+    pub status: Status,
+    stats: net::protocol::event::downstream::Stats,
+    /// Current set of requests.
+    waiting_room: RunningWaitingRoom,
+}
+
+impl RunState {
+    /// Constructs a new state.
+    #[cfg(test)]
+    fn construct(status: Status) -> Self {
+        Self {
+            listen_addrs: vec![],
+            stats: downstream::Stats::default(),
+            status,
+            waiting_room: RunningWaitingRoom::new(
+                WaitingRoom::new(waiting_room::Config::default()),
+            ),
+        }
+    }
+
+    /// Creates a new `RunState` initialising it with the provided `config` and
+    /// `waiting_room`.
+    pub fn new(waiting_room: WaitingRoom<SystemTime, Duration>) -> Self {
+        Self {
+            listen_addrs: vec![],
+            stats: downstream::Stats::default(),
+            status: Status::Stopped,
+            waiting_room: RunningWaitingRoom::new(waiting_room),
+        }
+    }
+
+    /// Applies the `input` and based on the current state, transforms to the
+    /// new state and in some cases produes commands which should be
+    /// executed in the appropriate subroutines.
+    pub fn transition(&mut self, input: Input) -> Vec<Command> {
+        tracing::trace!(?input, status = ?self.status, "transition start");
+
+        let cmds = match input {
+            Input::Announce(announce_input) => self.handle_announce(announce_input),
+            Input::Control(control_input) => self.handle_control(control_input),
+            Input::ListenAddrs(addrs) => self.handle_listen_addrs(addrs),
+            Input::Protocol(protocol_event) => self.handle_protocol(protocol_event),
+            Input::Request(request_input) => self.handle_request(request_input),
+            Input::Stats(stats_input) => self.handle_stats(stats_input),
+        };
+
+        tracing::trace!(?cmds, status = ?self.status, "transition end");
+
+        cmds
+    }
+
+    /// Handle [`input::Announce`]s.
+    fn handle_announce(&mut self, input: input::Announce) -> Vec<Command> {
+        match (&self.status, input) {
+            // Announce new updates while the peer is online.
+            (Status::Online { .. } | Status::Started { .. }, input::Announce::Tick)
+                if !self.stats.connected_peers.is_empty() && self.stats.membership_active > 0 =>
+            {
+                vec![Command::Announce]
+            },
+            _ => vec![],
+        }
+    }
+
+    /// Handle [`input::Control`]s.
+    fn handle_control(&mut self, input: input::Control) -> Vec<Command> {
+        match input {
+            input::Control::CancelRequest(urn, timestamp, sender) => {
+                self.waiting_room.cancel(urn, timestamp, sender)
+            },
+            input::Control::CreateRequest(urn, time, sender) => {
+                self.waiting_room.request(urn, time, sender)
+            },
+            input::Control::GetRequest(urn, sender) => {
+                vec![Command::Control(command::Control::Respond(
+                    control::Response::GetSearch(sender, self.waiting_room.get(&urn).cloned()),
+                ))]
+            },
+            input::Control::ListRequests(sender) => vec![Command::Control(
+                command::Control::Respond(control::Response::ListSearches(
+                    sender,
+                    self.waiting_room
+                        .iter()
+                        .map(|pair| pair.1.clone())
+                        .collect::<Vec<_>>(),
+                )),
+            )],
+            input::Control::ListenAddrs(sender) => {
+                vec![Command::Control(command::Control::Respond(
+                    control::Response::ListenAddrs(sender, self.listen_addrs.clone()),
+                ))]
+            },
+            input::Control::Status(sender) => vec![Command::Control(command::Control::Respond(
+                control::Response::CurrentStatus(sender, self.status.clone()),
+            ))],
+        }
+    }
+
+    fn handle_listen_addrs(&mut self, addrs: Vec<SocketAddr>) -> Vec<Command> {
+        self.listen_addrs = addrs;
+        vec![]
+    }
+
+    /// Handle [`ProtocolEvent`]s.
+    #[allow(clippy::wildcard_enum_match_arm)]
+    fn handle_protocol(&mut self, event: ProtocolEvent) -> Vec<Command> {
+        match (&self.status, event) {
+            (Status::Stopped, ProtocolEvent::Endpoint(upstream::Endpoint::Up { .. })) => {
+                self.status = Status::Started;
+
+                vec![]
+            },
+            (_, ProtocolEvent::Endpoint(upstream::Endpoint::Down)) => {
+                self.status = Status::Stopped;
+
+                vec![]
+            },
+            (_, ProtocolEvent::Gossip(gossip)) => {
+                let mut cmds = vec![];
+
+                match *gossip {
+                    // FIXME(xla): Find out if we care about the result variance.
+                    upstream::Gossip::Put {
+                        payload: Payload { urn, .. },
+                        provider: PeerInfo { peer_id, .. },
+                        result,
+                    } => {
+                        if self.waiting_room.get(&urn).is_some() {
+                            cmds.extend(self.waiting_room.found(&urn, peer_id, SystemTime::now()));
+                        }
+
+                        if let PutResult::Applied(_) = result {
+                            cmds.push(Command::Include(urn));
+                        }
+                    },
+                }
+
+                cmds
+            },
+            _ => vec![],
+        }
+    }
+
+    /// Handle [`input::Request`]s.
+    #[allow(clippy::wildcard_enum_match_arm)]
+    fn handle_request(&mut self, input: input::Request) -> Vec<Command> {
+        match (&self.status, input) {
+            // Check for new query and clone requests.
+            (Status::Online { .. }, input::Request::Tick) => {
+                self.waiting_room.tick(SystemTime::now())
+            },
+            (_, input::Request::Cloning(urn, remote_peer)) => {
+                self.waiting_room
+                    .cloning(&urn, remote_peer, SystemTime::now())
+            },
+            (_, input::Request::Cloned(urn, remote_peer)) => {
+                self.waiting_room
+                    .cloned(&urn, remote_peer, SystemTime::now())
+            },
+            (_, input::Request::Queried(urn)) => self.waiting_room.queried(&urn, SystemTime::now()),
+            (
+                _,
+                input::Request::Failed {
+                    remote_peer,
+                    reason,
+                    urn,
+                },
+            ) => {
+                tracing::warn!(?reason, "cloning failed");
+                self.waiting_room
+                    .cloning_failed(&urn, remote_peer, SystemTime::now(), reason)
+            },
+            _ => vec![],
+        }
+    }
+
+    fn handle_stats(&mut self, input: input::Stats) -> Vec<Command> {
+        match (&self.status, input) {
+            (_, input::Stats::Tick) => vec![Command::Stats],
+            (status, input::Stats::Values(stats)) => {
+                match status {
+                    Status::Online { .. } if stats.connected_peers.is_empty() => {
+                        self.status = Status::Offline;
+                    },
+                    Status::Offline if !stats.connected_peers.is_empty() => {
+                        self.status = Status::Online {
+                            connected_peers: stats.connected_peers.clone(),
+                        };
+                    },
+                    Status::Started if !stats.connected_peers.is_empty() => {
+                        self.status = Status::Online {
+                            connected_peers: stats.connected_peers.clone(),
+                        };
+                    },
+                    _ => {},
+                };
+
+                self.stats = stats;
+
+                vec![]
+            },
+        }
+    }
+}
+
+#[allow(clippy::needless_update, clippy::panic, clippy::unwrap_used)]
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, iter, net::SocketAddr, str::FromStr, time::SystemTime};
+
+    use assert_matches::assert_matches;
+    use pretty_assertions::assert_eq;
+    use tokio::sync::oneshot;
+
+    use librad::{
+        data::BoundedVec,
+        git::Urn,
+        git_ext::Oid,
+        net::{
+            self,
+            peer::ProtocolEvent,
+            protocol::{
+                broadcast,
+                event::{
+                    downstream,
+                    upstream::{Endpoint, Gossip},
+                },
+                gossip::Payload,
+            },
+        },
+        PeerId, SecretKey,
+    };
+
+    use super::{command, input, Command, Input, RunState, Status};
+
+    #[test]
+    fn transition_to_started_on_listen() -> Result<(), Box<dyn std::error::Error>> {
+        let addr = "127.0.0.1:12345".parse::<SocketAddr>()?;
+
+        let status = Status::Stopped;
+        let mut state = RunState::construct(status);
+
+        let cmds = state.transition(Input::Protocol(ProtocolEvent::Endpoint(Endpoint::Up {
+            listen_addrs: vec![addr],
+        })));
+        assert!(cmds.is_empty());
+        assert_matches!(state.status, Status::Started { .. });
+
+        Ok(())
+    }
+
+    #[test]
+    fn transition_to_online() {
+        let status = Status::Started;
+        let mut state = RunState::construct(status);
+
+        let cmds = {
+            let key = SecretKey::new();
+            let peer_id = PeerId::from(key);
+            state.transition(Input::Stats(input::Stats::Values(downstream::Stats {
+                connections_total: 1,
+                connected_peers: one_connected_peer(peer_id),
+                membership_active: 1,
+                membership_passive: 1,
+                caches: downstream::CacheStats::default(),
+            })))
+        };
+        assert!(cmds.is_empty());
+        assert_matches!(state.status, Status::Online { .. });
+    }
+
+    #[test]
+    fn transition_to_offline_when_last_peer_disconnects() {
+        let status = Status::Online {
+            connected_peers: HashMap::new(),
+        };
+        let mut state = RunState::construct(status);
+
+        let _cmds = state.transition(Input::Stats(input::Stats::Values(
+            downstream::Stats::default(),
+        )));
+        assert_matches!(state.status, Status::Offline);
+    }
+
+    #[test]
+    fn issue_announce_while_online_and_active_membering() {
+        let peer_id = PeerId::from(SecretKey::new());
+        let status = Status::Online {
+            connected_peers: one_connected_peer(peer_id),
+        };
+        let mut state = RunState::construct(status);
+
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+        assert!(cmds.is_empty(), "expected no command");
+
+        state.stats = librad::net::protocol::event::downstream::Stats {
+            connected_peers: one_connected_peer(peer_id),
+            membership_active: 1,
+            ..librad::net::protocol::event::downstream::Stats::default()
+        };
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+
+        assert!(!cmds.is_empty(), "expected command");
+        assert_matches!(cmds.first().unwrap(), Command::Announce);
+    }
+
+    #[test]
+    fn dont_announce_with_inactive_member() {
+        let peer_id = PeerId::from(SecretKey::new());
+        let status = Status::Online {
+            connected_peers: one_connected_peer(peer_id),
+        };
+        let mut state = RunState::construct(status);
+
+        state.stats = librad::net::protocol::event::downstream::Stats {
+            connected_peers: HashMap::new(),
+            membership_active: 0,
+            membership_passive: 1,
+            ..librad::net::protocol::event::downstream::Stats::default()
+        };
+
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+        assert!(cmds.is_empty(), "expected no command");
+    }
+
+    #[test]
+    fn dont_announce_when_offline() {
+        let status = Status::Offline;
+        let mut state = RunState::construct(status);
+        let cmds = state.transition(Input::Announce(input::Announce::Tick));
+
+        assert!(cmds.is_empty(), "expected no command");
+    }
+
+    #[test]
+    fn issue_query_when_requested_and_online() -> Result<(), Box<dyn std::error::Error + 'static>> {
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+
+        let connected_peers = one_connected_peer(PeerId::from(SecretKey::new()));
+        let status = Status::Online { connected_peers };
+        let (response_sender, _) = oneshot::channel();
+        let mut state = RunState::construct(status);
+        state.transition(Input::Control(input::Control::CreateRequest(
+            urn.clone(),
+            SystemTime::now(),
+            response_sender,
+        )));
+
+        let cmds = state.transition(Input::Request(input::Request::Tick));
+        assert_matches!(
+            cmds.first().unwrap(),
+            Command::Request(command::Request::Query(have)) => {
+                assert_eq!(*have, urn);
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn issue_clone_when_found() -> Result<(), Box<dyn std::error::Error + 'static>> {
+        let urn: Urn = Urn::new(Oid::from_str("7ab8629dd6da14dcacde7f65b3d58cd291d7e235")?);
+        let peer_id = PeerId::from(SecretKey::new());
+        let addr = "127.0.0.0:80".parse()?;
+
+        let connected_peers = one_connected_peer(PeerId::from(SecretKey::new()));
+        let status = Status::Online { connected_peers };
+        let (response_sender, _) = oneshot::channel();
+        let mut state = RunState::construct(status);
+
+        state.transition(Input::Control(input::Control::CreateRequest(
+            urn.clone(),
+            SystemTime::now(),
+            response_sender,
+        )));
+        assert_matches!(
+            state
+                .transition(Input::Request(input::Request::Queried(urn.clone())))
+                .first(),
+            Some(Command::PersistWaitingRoom(_))
+        );
+        // Gossip(Box<upstream::Gossip<SocketAddr, gossip::Payload>>),
+        assert_matches!(
+            state
+                .transition(Input::Protocol(ProtocolEvent::Gossip(Box::new(
+                    Gossip::Put {
+                        provider: librad::net::protocol::PeerInfo {
+                            advertised_info: net::protocol::PeerAdvertisement::new(addr),
+                            peer_id,
+                            seen_addrs: BoundedVec::from(iter::empty()),
+                        },
+                        payload: Payload {
+                            urn: urn.clone(),
+                            origin: None,
+                            rev: None
+                        },
+                        result: broadcast::PutResult::Applied(Payload {
+                            urn: urn.clone(),
+                            origin: None,
+                            rev: None,
+                        }),
+                    }
+                ))))
+                .last(),
+            Some(Command::Include(_))
+        );
+
+        let cmds = state.transition(Input::Request(input::Request::Tick));
+        assert_matches!(
+            cmds.first().unwrap(),
+            Command::Request(command::Request::Clone(remote_urn, remote_peer)) => {
+                assert_eq!(remote_urn.clone(), urn);
+                assert_eq!(*remote_peer, peer_id);
+            }
+        );
+
+        Ok(())
+    }
+
+    fn one_connected_peer(peer_id: PeerId) -> HashMap<PeerId, Vec<SocketAddr>> {
+        std::iter::once((peer_id, vec!["127.0.0.1:1234".parse().unwrap()])).collect()
+    }
+}

--- a/upstream-proxy/src/daemon/running_waiting_room.rs
+++ b/upstream-proxy/src/daemon/running_waiting_room.rs
@@ -1,0 +1,333 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use either::Either;
+use librad::{git::Urn, identities::Revision, PeerId};
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
+
+use crate::request::SomeRequest;
+
+use super::{
+    command,
+    control,
+    waiting_room::Error as WaitingRoomError,
+    Command,
+    Event as RunStateEvent,
+    WaitingRoom,
+};
+use tokio::sync::oneshot::Sender;
+
+use serde::Serialize;
+
+/// Events that can affect the state of the waiting room
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Event {
+    /// A request was created for a urn
+    Created {
+        /// The urn bein requested
+        urn: Urn,
+    },
+    /// A query was initiated for a urn
+    Queried {
+        /// The urn bein queried
+        urn: Urn,
+    },
+    /// A peer was found who claims to have a urn
+    Found {
+        /// The urn that was found
+        urn: Urn,
+        /// The peer who claims to have it
+        peer: PeerId,
+    },
+    /// Cloning was initiated for a urn and peer
+    Cloning {
+        /// The urn we are cloning
+        urn: Urn,
+        /// The peer we are cloning from
+        peer: PeerId,
+    },
+    /// Cloning failed for a urn and peer
+    CloningFailed {
+        /// The urn that failed
+        urn: Urn,
+        /// The peer we failed to clone from
+        peer: PeerId,
+        /// A description of why the cloning failed
+        reason: String,
+    },
+    /// Cloning succeeded for a urn and peer
+    Cloned {
+        /// The urn we cloned
+        urn: Urn,
+        /// The peer we cloned from
+        peer: PeerId,
+    },
+    /// A request for a urn was canceled
+    Canceled {
+        /// The urn that was canceled
+        urn: Urn,
+    },
+    /// A request was timed out
+    TimedOut {
+        /// The urn that timed out
+        urn: Urn,
+        /// The attempts that were made before the timeout
+        attempts: Option<usize>,
+    },
+}
+
+/// `RunningWaitingRoom` is an adapter from the interface of `WaitingRoom` to
+/// the language of commands which is spoken by `RunState`. Whenever `RunState`
+/// needs to talk to `WaitingRoom` it does so via a wrapper method on
+/// `RunningWaitingRoom`. These wrapper methods contain the logic to convert
+/// the values  returned by `WaitingRoom` methods into `Vec<Command>`.
+pub(super) struct RunningWaitingRoom {
+    waiting_room: WaitingRoom<SystemTime, Duration>,
+}
+
+impl RunningWaitingRoom {
+    pub const fn new(waiting_room: WaitingRoom<SystemTime, Duration>) -> Self {
+        Self { waiting_room }
+    }
+
+    pub fn cancel(
+        &mut self,
+        urn: Urn,
+        timestamp: SystemTime,
+        sender: Sender<Result<Option<SomeRequest<SystemTime>>, WaitingRoomError>>,
+    ) -> Vec<Command> {
+        let state_before = self.waiting_room.requests();
+        match self.waiting_room.canceled(&urn, timestamp) {
+            Ok(()) => {
+                let request = self.waiting_room.remove(&urn);
+                let state_after = self.waiting_room.requests();
+                let transition = WaitingRoomTransition {
+                    timestamp,
+                    state_before,
+                    state_after,
+                    event: Event::Canceled { urn },
+                };
+                vec![
+                    Command::Control(command::Control::Respond(control::Response::CancelSearch(
+                        sender,
+                        Ok(request),
+                    ))),
+                    Command::PersistWaitingRoom(self.waiting_room.clone()),
+                    Command::EmitEvent(transition.into()),
+                ]
+            },
+            Err(e) => vec![
+                Command::Control(command::Control::Respond(control::Response::CancelSearch(
+                    sender,
+                    Err(e),
+                ))),
+                Command::PersistWaitingRoom(self.waiting_room.clone()),
+            ],
+        }
+    }
+
+    pub fn request(
+        &mut self,
+        urn: Urn,
+        timestamp: SystemTime,
+        sender: Sender<Either<SomeRequest<SystemTime>, SomeRequest<SystemTime>>>,
+    ) -> Vec<Command> {
+        let state_before = self.waiting_room.requests();
+        let request = self.waiting_room.request(&urn, timestamp);
+        let state_after = self.waiting_room.requests();
+        match request {
+            Either::Left(request) => {
+                let transition = WaitingRoomTransition {
+                    timestamp,
+                    state_before,
+                    state_after,
+                    event: Event::Created { urn: urn.clone() },
+                };
+                vec![
+                    Command::Control(command::Control::Respond(control::Response::StartSearch(
+                        sender,
+                        Either::Left(request),
+                    ))),
+                    Command::EmitEvent(RunStateEvent::RequestCreated(urn)),
+                    Command::EmitEvent(transition.into()),
+                ]
+            },
+            Either::Right(request) => vec![
+                Command::Control(command::Control::Respond(control::Response::StartSearch(
+                    sender,
+                    Either::Right(request),
+                ))),
+                Command::EmitEvent(RunStateEvent::RequestCreated(urn)),
+            ],
+        }
+    }
+
+    pub fn get(&self, urn: &Urn) -> Option<&SomeRequest<SystemTime>> {
+        self.waiting_room.get(urn)
+    }
+
+    /// Return the list of all `Urn`/`SomeRequest` pairs in the `WaitingRoom`.
+    pub fn iter(&self) -> impl Iterator<Item = (Urn, &SomeRequest<SystemTime>)> {
+        self.waiting_room.iter()
+    }
+
+    pub fn found(&mut self, urn: &Urn, remote_peer: PeerId, timestamp: SystemTime) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Found {
+                urn: urn.clone(),
+                peer: remote_peer,
+            },
+            timestamp,
+            |w| w.found(urn, remote_peer, timestamp),
+        )
+    }
+
+    /// Issue "query" and "clone" requests for requests that are next in the
+    /// queue.
+    pub fn tick(&mut self, timestamp: SystemTime) -> Vec<Command> {
+        let mut cmds = Vec::with_capacity(2);
+
+        if let Some(urn) = self.waiting_room.next_query(timestamp) {
+            cmds.push(Command::Request(command::Request::Query(urn)));
+        }
+        if let Some((urn, remote_peer)) = self.waiting_room.next_clone() {
+            cmds.push(Command::Request(command::Request::Clone(urn, remote_peer)));
+        }
+
+        cmds
+    }
+
+    pub fn cloning(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: SystemTime,
+    ) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Cloning {
+                urn: urn.clone(),
+                peer: remote_peer,
+            },
+            timestamp,
+            |w| w.cloning(urn, remote_peer, timestamp),
+        )
+    }
+
+    pub fn cloned(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: SystemTime,
+    ) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Cloned {
+                urn: urn.clone(),
+                peer: remote_peer,
+            },
+            timestamp,
+            |w| w.cloned(urn, remote_peer, timestamp),
+        )
+    }
+
+    pub fn queried(&mut self, urn: &Urn, timestamp: SystemTime) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::Queried { urn: urn.clone() },
+            timestamp,
+            |w| w.queried(urn, timestamp),
+        )
+    }
+
+    pub fn cloning_failed(
+        &mut self,
+        urn: &Urn,
+        remote_peer: PeerId,
+        timestamp: SystemTime,
+        reason: Box<dyn std::error::Error>,
+    ) -> Vec<Command> {
+        Self::simple_command_helper(
+            &mut self.waiting_room,
+            urn,
+            Event::CloningFailed {
+                urn: urn.clone(),
+                peer: remote_peer,
+                reason: reason.to_string(),
+            },
+            timestamp,
+            |w| w.cloning_failed(urn, remote_peer, timestamp, reason),
+        )
+    }
+
+    fn simple_command_helper<F>(
+        waiting_room: &mut WaitingRoom<SystemTime, Duration>,
+        urn: &Urn,
+        event: Event,
+        timestamp: SystemTime,
+        f: F,
+    ) -> Vec<Command>
+    where
+        F: FnOnce(&mut WaitingRoom<SystemTime, Duration>) -> Result<(), WaitingRoomError>,
+    {
+        let state_before = waiting_room.requests();
+        let result = f(waiting_room);
+        let state_after = waiting_room.requests();
+        let mut commands = Vec::with_capacity(4);
+        commands.push(Command::PersistWaitingRoom(waiting_room.clone()));
+        match result {
+            Ok(()) => {
+                commands.push(Command::EmitEvent(
+                    WaitingRoomTransition {
+                        timestamp,
+                        state_before,
+                        state_after,
+                        event,
+                    }
+                    .into(),
+                ));
+                commands
+            },
+            Err(WaitingRoomError::TimeOut { attempts, .. }) => {
+                commands.push(Command::EmitEvent(
+                    WaitingRoomTransition {
+                        timestamp,
+                        state_before,
+                        state_after,
+                        event: Event::TimedOut {
+                            urn: urn.clone(),
+                            attempts,
+                        },
+                    }
+                    .into(),
+                ));
+                commands.push(Command::Request(command::Request::TimedOut(urn.clone())));
+                commands
+            },
+            // FIXME(alexjg): Figure out how to report this error to the client
+            Err(error) => {
+                tracing::warn!(?error, "waiting room error");
+                Vec::new()
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WaitingRoomTransition<T> {
+    pub timestamp: T,
+    pub state_before: HashMap<Revision, SomeRequest<T>>,
+    pub state_after: HashMap<Revision, SomeRequest<T>>,
+    pub event: Event,
+}

--- a/upstream-proxy/src/daemon/sealed.rs
+++ b/upstream-proxy/src/daemon/sealed.rs
@@ -1,0 +1,7 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+/// A private trait to seal away traits that we use in `states`.
+pub trait Sealed {}

--- a/upstream-proxy/src/daemon/seed.rs
+++ b/upstream-proxy/src/daemon/seed.rs
@@ -1,0 +1,131 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Seed nodes.
+use std::{io, net::SocketAddr};
+
+use librad::{crypto, PeerId};
+
+/// Errors that occur when resolving seed addresses.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Seed DNS failed to resolve to an address.
+    #[error("the seed '{0}' failed to resolve to an address")]
+    DnsLookupFailed(String),
+
+    /// Seed input is invalid.
+    #[error("the seed '{0}' is invalid: {:1}")]
+    InvalidSeed(String, Option<crypto::peer::conversion::Error>),
+
+    /// I/O error.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// A peer used to seed our client.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Seed {
+    /// The seed peer id.
+    pub peer_id: PeerId,
+    /// The seed address.
+    pub addrs: Vec<SocketAddr>,
+}
+
+impl From<Seed> for (PeerId, Vec<SocketAddr>) {
+    fn from(seed: Seed) -> Self {
+        (seed.peer_id, seed.addrs)
+    }
+}
+
+impl Seed {
+    /// Create a seed from a string.
+    ///
+    /// # Errors
+    ///
+    /// If the supplied seed cannot be parsed or resolved, an error is returned.
+    #[allow(clippy::indexing_slicing)]
+    pub async fn from_str(seed: &str) -> Result<Self, Error> {
+        if let Some(ix) = seed.chars().position(|c| c == '@') {
+            let (peer_id, rest) = seed.split_at(ix);
+            let host = &rest[1..]; // Skip '@'
+
+            if let Some(addr) = tokio::net::lookup_host(host).await?.next() {
+                let peer_id = PeerId::from_default_encoding(peer_id)
+                    .map_err(|err| Error::InvalidSeed(seed.to_string(), Some(err)))?;
+
+                Ok(Self {
+                    peer_id,
+                    addrs: vec![addr],
+                })
+            } else {
+                Err(Error::DnsLookupFailed(seed.to_string()))
+            }
+        } else {
+            Err(Error::InvalidSeed(seed.to_string(), None))
+        }
+    }
+}
+
+/// Resolve seed identifiers into `(PeerId, SocketAddr)` pairs.
+///
+/// The expected format is `<peer-id>@<host>:<port>`
+///
+/// # Errors
+///
+/// If any of the supplied seeds cannot be parsed or resolved, an error is
+/// returned.
+pub async fn resolve<T: AsRef<str> + Send + Sync>(seeds: &[T]) -> Result<Vec<Seed>, Error> {
+    let mut resolved = Vec::with_capacity(seeds.len());
+
+    for seed in seeds.iter() {
+        let seed = seed.as_ref();
+        resolved.push(Seed::from_str(seed).await?);
+    }
+
+    Ok(resolved)
+}
+
+#[allow(clippy::panic, clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use std::net;
+
+    use pretty_assertions::assert_eq;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_resolve_seeds() -> Result<(), super::Error> {
+        let seeds = super::resolve(&[
+            "hydsst3z3d5bc6pxq4gz1g4cu6sgbx38czwf3bmmk3ouz4ibjbbtds@localhost:9999",
+        ])
+        .await?;
+
+        assert!(!seeds.is_empty(), "seeds should not be empty");
+
+        if let Some(super::Seed { addrs, .. }) = seeds.first() {
+            let addr = addrs.first().unwrap();
+            let expected: net::SocketAddr = match *addr {
+                net::SocketAddr::V4(_addr) => ([127, 0, 0, 1], 9999).into(),
+                net::SocketAddr::V6(_addr) => "[::1]:9999".parse().expect("valid ivp6 address"),
+            };
+
+            assert_eq!(expected, *addr);
+        }
+
+        super::resolve(&[String::from("hydsst3obtds@localhost:9999")])
+            .await
+            .expect_err("an invalid seed returns an error");
+        super::resolve(&[String::from("localhost:9999")])
+            .await
+            .expect_err("an invalid seed returns an error");
+        super::resolve(&[String::from("hydsst3obtds@localhost")])
+            .await
+            .expect_err("an invalid seed returns an error");
+        super::resolve(&[String::from("hydsst3obtds")])
+            .await
+            .expect_err("an invalid seed returns an error");
+
+        Ok(())
+    }
+}

--- a/upstream-proxy/src/daemon/state.rs
+++ b/upstream-proxy/src/daemon/state.rs
@@ -1,0 +1,1115 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Utility to work with the peer api of librad.
+
+use std::{
+    convert::{TryFrom as _, TryInto},
+    net::SocketAddr,
+    path::PathBuf,
+};
+
+use either::Either;
+use tokio::task::spawn_blocking;
+
+use librad::{
+    canonical::Cstring,
+    crypto::{BoxedSigner, SomeSigner},
+    git::{
+        identities::{
+            self,
+            local::{self, LocalIdentity},
+            person, project,
+        },
+        include::{self, Include},
+        local::{transport, url::LocalUrl},
+        refs::Refs,
+        storage::ReadOnlyStorage as _,
+        tracking,
+        types::{Namespace, Reference, Single},
+        Urn,
+    },
+    git_ext::{OneLevel, RefLike},
+    identities::{
+        delegation::{Direct, Indirect},
+        payload::{self, PersonPayload},
+        Person, Project, SomeIdentity,
+    },
+    net::{peer::Peer, replication},
+    paths, PeerId, PublicKey, Signer,
+};
+
+use crate::daemon::{
+    peer::gossip,
+    project::{create::Signature, peer},
+};
+
+pub mod error;
+pub use error::Error;
+
+/// Get the default owner for this `PeerApi`.
+///
+/// # Errors
+///   * Opening the storage config failed
+///   * Fetching the `Urn` from the config failed
+///   * Loading the `LocalIdentity` failed
+pub async fn default_owner<S>(peer: &Peer<S>) -> Result<Option<LocalIdentity>, Error>
+where
+    S: Clone + Signer,
+{
+    Ok(peer.using_storage(local::default).await??)
+}
+
+/// Set the default owner for this `PeerApi`.
+///
+/// # Errors
+///
+///   * Fails to set the default `rad/self` for this `PeerApi`.
+pub async fn set_default_owner<S, U>(peer: &Peer<S>, user: U) -> Result<(), Error>
+where
+    S: Clone + Signer,
+    U: Into<Option<LocalIdentity>> + Send + Sync + 'static,
+{
+    peer.using_storage(move |storage| storage.config()?.set_user(user).map_err(Error::from))
+        .await?
+}
+
+/// Initialise a [`LocalIdentity`] and make them the default owner of this
+/// [`Peer`].
+///
+/// # Errors
+///
+///   * Fails to initialise `User`.
+///   * Fails to verify `User`.
+///   * Fails to set the default `rad/self` for this `PeerApi`.
+#[allow(clippy::single_match_else)]
+pub async fn init_owner<S, P>(peer: &Peer<S>, payload: P) -> Result<LocalIdentity, Error>
+where
+    S: Clone + Signer,
+    P: TryInto<PersonPayload> + Send,
+    Error: From<P::Error>,
+{
+    if let Some(owner) = default_owner(peer).await? {
+        return Ok(owner);
+    }
+
+    let payload = payload.try_into()?;
+    let pk = PublicKey::from(peer.signer().public_key());
+    let delegations = Direct::new(pk);
+    let person = peer
+        .using_storage(move |store| person::create(store, payload, delegations))
+        .await??;
+
+    let urn = person.urn();
+    let owner = peer
+        .using_storage(move |store| local::load(store, urn))
+        .await??
+        .ok_or_else(|| Error::PersonNotFound(person.urn()))?;
+
+    set_default_owner(peer, owner.clone()).await?;
+
+    Ok(owner)
+}
+
+/// Sets a new person payload for the default owner of this [`Peer`].
+///
+/// # Errors
+///
+///   * Fails to load the default owner
+///   * Fails to verify `User`.
+///   * Fails to set the default `rad/self` for this `PeerApi`.
+#[allow(clippy::single_match_else)]
+pub async fn update_owner_payload<S, P>(peer: &Peer<S>, payload: P) -> Result<(), Error>
+where
+    S: Clone + Signer,
+    P: TryInto<PersonPayload> + Send,
+    Error: From<P::Error>,
+{
+    let urn = default_owner(peer).await?.ok_or(Error::MissingOwner)?.urn();
+    let payload = payload.try_into()?;
+    peer.using_storage(move |store| person::update(store, &urn, None, payload, None))
+        .await??;
+    Ok(())
+}
+
+/// Given some hints as to where you might find it, get the urn of the project
+/// found at `url`.
+///
+/// # Errors
+///   * Could not successfully acquire a lock to the API.
+///   * Could not open librad storage.
+///   * Failed to clone the project.
+///   * Failed to set the rad/self of this project.
+pub async fn clone_project<S, Addrs>(
+    peer: &Peer<S>,
+    urn: Urn,
+    remote_peer: PeerId,
+    addr_hints: Addrs,
+) -> Result<replication::Success, Error>
+where
+    S: Clone + Signer,
+    Addrs: IntoIterator<Item = SocketAddr> + Send + 'static,
+{
+    let owner = default_owner(peer).await?.ok_or(Error::MissingOwner)?;
+    let addr_hints = addr_hints.into_iter().collect::<Vec<_>>();
+    Ok(peer
+        .replicate((remote_peer, addr_hints), urn, Some(owner))
+        .await?)
+}
+
+/// Get the project found at `urn`.
+///
+/// # Errors
+///
+///   * Resolving the project fails.
+pub async fn get_project<S>(peer: &Peer<S>, urn: Urn) -> Result<Option<Project>, Error>
+where
+    S: Clone + Signer,
+{
+    peer.using_storage(move |store| identities::project::get(store, &urn))
+        .await?
+        .map_err(Error::from)
+}
+
+/// Returns the list of [`Project`]s for the local peer.
+///
+/// # Errors
+///
+///   * Retrieving the project entities from the store fails.
+pub async fn list_projects<S>(peer: &Peer<S>) -> Result<Vec<Project>, Error>
+where
+    S: Clone + Signer,
+{
+    // FIXME(xla): Instead of implicitely expecting a presence of a default owner,
+    // there either should be an explicit argument, or it's made impossible to
+    // call this function without an owner associated with the state.
+    let owner = match default_owner(peer).await? {
+        None => return Err(Error::MissingOwner),
+        Some(owner) => owner.into_inner().into_inner(),
+    };
+
+    peer.using_storage(move |store| {
+        let projects = identities::any::list(store)?
+            .filter_map(Result::ok)
+            .filter_map(|id| match id {
+                SomeIdentity::Project(project) => {
+                    let rad_self = Reference::rad_self(Namespace::from(project.urn()), None);
+                    let urn = Urn::try_from(rad_self).ok()?;
+                    let project_self = person::get(store, &urn).ok()??;
+                    // Filter projects that have a rad/self pointing to current default
+                    // owner
+                    if project_self == owner {
+                        Some(project)
+                    } else {
+                        None
+                    }
+                },
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        Ok::<_, Error>(projects)
+    })
+    .await?
+}
+
+/// Retrieves the [`librad::git::refs::Refs`] for the state owner.
+///
+/// # Errors
+///
+/// * if opening the storage fails
+pub async fn load_refs<S>(peer: &Peer<S>, urn: Urn) -> Result<Option<Refs>, Error>
+where
+    S: Clone + Signer,
+{
+    peer.using_storage(move |store| Refs::load(store, &urn, None))
+        .await?
+        .map_err(Error::from)
+}
+
+/// Initialize a [`Project`] that is owned by the `owner`.
+/// This kicks off the history of the project, tracked by `librad`'s mono-repo.
+///
+/// # Errors
+///
+/// Will error if:
+///     * The signing of the project metadata fails.
+///     * The interaction with `librad` [`librad::git::storage::Storage`] fails.
+pub async fn init_project<S>(
+    peer: &Peer<S>,
+    owner: &LocalIdentity,
+    create: crate::daemon::project::Create,
+) -> Result<Project, Error>
+where
+    S: Clone + Signer,
+{
+    let default_branch = create.default_branch.to_string();
+    let description = create.description.to_string();
+    let name = create
+        .repo
+        .project_name()
+        .map_err(crate::daemon::project::create::Error::from)?;
+    let owner = owner.clone();
+    let payload = payload::Project {
+        default_branch: Some(Cstring::from(default_branch)),
+        description: Some(Cstring::from(description)),
+        name: Cstring::from(name),
+    };
+    let delegations = Indirect::from(owner.clone().into_inner().into_inner());
+    let (repository, project) = peer
+        .using_storage(move |store| {
+            let urn = project::urn(store, payload.clone(), delegations.clone())?;
+            let url = LocalUrl::from(urn.clone());
+            let config = store.config()?;
+            let signature = Signature {
+                name: config.user_name()?,
+                email: config.user_email()?,
+            };
+            let repository = create
+                .validate(url, signature)
+                .map_err(crate::daemon::project::create::Error::from)?;
+
+            if store.has_urn(&urn)? {
+                Err(Error::IdentityExists(urn))
+            } else {
+                Ok((
+                    repository,
+                    project::create(store, owner.clone(), payload, delegations)?,
+                ))
+            }
+        })
+        .await??;
+
+    tracing::debug!(
+        urn = ?project.urn(),
+        name = ?project.subject().name,
+        "created project",
+    );
+
+    let repo = spawn_blocking({
+        let peer = peer.clone();
+        let desc = project
+            .subject()
+            .description
+            .as_deref()
+            .cloned()
+            .unwrap_or_default();
+        move || {
+            repository
+                .setup_repo(settings(&peer), &desc)
+                .map_err(crate::daemon::project::create::Error::from)
+        }
+    })
+    .await??;
+    let include_path = update_include(peer, project.urn()).await?;
+    spawn_blocking(move || include::set_include_path(&repo, include_path)).await??;
+    gossip::announce(peer, &project.urn(), None);
+
+    Ok(project)
+}
+
+#[cfg(test)]
+/// Create a [`LocalIdentity`] with the provided `handle`. This assumes that you
+/// are creating a user that uses the secret key the `PeerApi` was configured
+/// with.
+///
+/// # Errors
+///
+/// Will error if:
+///     * The signing of the user metadata fails.
+///     * The interaction with `librad` [`librad::git::storage::Storage`] fails.
+pub async fn init_user<S>(peer: &Peer<S>, name: String) -> Result<LocalIdentity, Error>
+where
+    S: Clone + Signer,
+{
+    let pk = PublicKey::from(peer.signer().public_key());
+    peer.using_storage(move |store| {
+        let malkovich = person::create(
+            store,
+            payload::Person {
+                name: Cstring::from(name),
+            },
+            Direct::new(pk),
+        )?;
+
+        Ok::<_, Error>(local::load(store, malkovich.urn())?)
+    })
+    .await??
+    .ok_or(Error::IdentityCreationFailed)
+}
+
+#[cfg(test)]
+/// Returns the list of [`Person`]s known for your peer.
+///
+/// # Errors
+///
+///   * Retrieval of the user entities from the store fails.
+pub async fn list_users<S>(peer: &Peer<S>) -> Result<Vec<Person>, Error>
+where
+    S: Clone + Signer,
+{
+    peer.using_storage(move |store| {
+        let projects = identities::any::list(store)?
+            .filter_map(Result::ok)
+            .filter_map(|id| match id {
+                SomeIdentity::Person(person) => Some(person),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        Ok::<_, Error>(projects)
+    })
+    .await?
+}
+
+/// Wrapper around the storage track.
+///
+/// # Errors
+///
+/// * When the storage operation fails.
+pub async fn track<S>(peer: &Peer<S>, urn: Urn, remote_peer: PeerId) -> Result<(), Error>
+where
+    S: Clone + Signer,
+{
+    {
+        match peer
+            .using_storage({
+                let urn = urn.clone();
+                move |store| {
+                    tracking::track(
+                        store,
+                        &urn,
+                        Some(remote_peer),
+                        tracking::Config::default(),
+                        tracking::policy::Track::MustNotExist,
+                    )
+                }
+            })
+            .await??
+        {
+            Ok(r) => {
+                tracing::trace!(reference = %r.name, peer = %remote_peer, "successfully tracked peer");
+            },
+            Err(err) => tracing::trace!(err = %err, "tracking policy violated"),
+        }
+    }
+
+    gossip::query(peer, &urn, Some(remote_peer));
+    update_include(peer, urn).await?;
+    Ok(())
+}
+
+/// Wrapper around the storage untrack.
+///
+/// # Errors
+///
+/// * When the storage operation fails.
+pub async fn untrack<S>(peer: &Peer<S>, urn: Urn, remote_peer: PeerId) -> Result<bool, Error>
+where
+    S: Clone + Signer,
+{
+    let res = {
+        let urn = urn.clone();
+        peer.using_storage(move |store| {
+            tracking::untrack(
+                store,
+                &urn,
+                remote_peer,
+                tracking::UntrackArgs::prune(tracking::policy::Untrack::Any),
+            )
+        })
+        .await??
+        .is_ok()
+    };
+
+    // Only need to update if we did untrack an existing peer
+    if res {
+        update_include(peer, urn).await?;
+    }
+    Ok(res)
+}
+
+/// Get the [`crate::daemon::project::Peer`]s that are tracking this project, including
+/// their [`PeerId`].
+///
+/// # Errors
+///
+/// * If we could not acquire the lock
+/// * If we could not open the storage
+/// * If did not have the `urn` in storage
+/// * If we could not fetch the tracked peers
+/// * If we could not get the `rad/self` of the peer
+pub async fn tracked<S>(
+    peer: &Peer<S>,
+    urn: Urn,
+) -> Result<Vec<crate::daemon::project::Peer<peer::Status<Person>>>, Error>
+where
+    S: Clone + Signer,
+{
+    let project = get_project(peer, urn.clone())
+        .await?
+        .ok_or_else(|| Error::ProjectNotFound(urn.clone()))?;
+
+    peer.using_storage(move |store| {
+        let mut peers = vec![];
+
+        for peer_id in tracking::tracked_peers(store, Some(&urn))? {
+            let peer_id = peer_id?;
+            let rad_self =
+                Urn::try_from(Reference::rad_self(Namespace::from(urn.clone()), peer_id))
+                    .expect("namespace is set");
+            let status = if store.has_urn(&rad_self)? {
+                let malkovich =
+                    person::get(store, &rad_self)?.ok_or(Error::PersonNotFound(rad_self))?;
+
+                let role = role(store, &project, Either::Right(peer_id))?;
+                peer::Status::replicated(role, malkovich)
+            } else {
+                peer::Status::NotReplicated
+            };
+
+            peers.push(crate::daemon::project::Peer::Remote { peer_id, status });
+        }
+
+        Ok::<_, Error>(peers)
+    })
+    .await?
+}
+
+// TODO(xla): Account for projects not replicated but wanted.
+/// Constructs the list of [`crate::daemon::project::Peer`] for the given `urn`. The
+/// basis is the list of tracking peers of the project combined with the local
+/// view.
+///
+/// # Errors
+///
+/// * if the project is not present in the monorepo
+/// * if the retrieval of tracking peers fails
+///
+/// # Panics
+///
+/// * if the default owner can't be fetched
+#[allow(clippy::blocks_in_if_conditions)]
+pub async fn list_project_peers<S>(
+    peer: &Peer<S>,
+    urn: Urn,
+) -> Result<Vec<crate::daemon::project::Peer<peer::Status<Person>>>, Error>
+where
+    S: Clone + Signer,
+{
+    let project = get_project(peer, urn.clone())
+        .await?
+        .ok_or_else(|| Error::ProjectNotFound(urn.clone()))?;
+
+    let mut peers = vec![];
+
+    let owner = default_owner(peer)
+        .await?
+        .ok_or(Error::MissingOwner)?
+        .into_inner()
+        .into_inner();
+
+    let local = peer.peer_id();
+    let role = peer
+        .using_storage(move |store| role(store, &project, Either::Left(local)))
+        .await??;
+    let status = peer::Status::replicated(role, owner);
+    peers.push(crate::daemon::project::Peer::Local {
+        peer_id: peer.peer_id(),
+        status,
+    });
+
+    let mut remotes = tracked(peer, urn).await?;
+
+    peers.append(&mut remotes);
+
+    Ok(peers)
+}
+
+/// Creates a working copy for the project of the given `urn`.
+///
+/// The `destination` is the directory where the caller wishes to place the
+/// working copy.
+///
+/// The `peer_id` is from which peer we wish to base our checkout from.
+///
+/// # Errors
+///
+/// * if the project can't be found
+/// * if the include file creation fails
+/// * if the clone of the working copy fails
+pub async fn checkout<S, P>(
+    peer: &Peer<S>,
+    urn: Urn,
+    peer_id: P,
+    destination: PathBuf,
+) -> Result<PathBuf, Error>
+where
+    S: Clone + Signer,
+    P: Into<Option<PeerId>> + Send + 'static,
+{
+    let peer_id = peer_id.into();
+    let proj = get_project(peer, urn.clone())
+        .await?
+        .ok_or_else(|| Error::ProjectNotFound(urn.clone()))?;
+    let include_path = update_include(peer, urn.clone()).await?;
+    let name = proj.subject().name.to_string();
+    let default_branch: OneLevel = OneLevel::from(
+        proj.subject()
+            .default_branch
+            .clone()
+            .ok_or(Error::NoDefaultBranch {
+                name: name.clone(),
+                urn: urn.clone(),
+            })?
+            .parse::<RefLike>()?,
+    );
+    let checkout = crate::daemon::project::Checkout {
+        urn: proj.urn(),
+        name,
+        default_branch,
+        path: destination,
+        include_path,
+    };
+
+    let ownership = match peer_id {
+        None => crate::daemon::project::checkout::Ownership::Local(peer.peer_id()),
+        Some(remote) => {
+            let handle = {
+                let rad_self =
+                    Urn::try_from(Reference::rad_self(Namespace::from(urn.clone()), peer_id))
+                        .expect("namespace is set");
+                let person = peer
+                    .using_storage(move |store| {
+                        tracing::debug!(?rad_self, "cloning from peer");
+                        person::get(store, &rad_self)?.ok_or(Error::PersonNotFound(rad_self))
+                    })
+                    .await??;
+
+                person.subject().name.to_string()
+            };
+
+            crate::daemon::project::checkout::Ownership::Remote {
+                handle,
+                remote,
+                local: peer.peer_id(),
+            }
+        },
+    };
+
+    let settings = settings(peer);
+    let path = spawn_blocking(move || checkout.run(settings, ownership)).await??;
+
+    Ok(path)
+}
+
+/// Prepare the include file for the given `project` with the latest tracked
+/// peers.
+///
+/// # Errors
+///
+/// * if getting the list of tracked peers fails
+pub async fn update_include<S>(peer: &Peer<S>, urn: Urn) -> Result<PathBuf, Error>
+where
+    S: Clone + Signer,
+{
+    let local_url = LocalUrl::from(urn.clone());
+    let tracked = tracked(peer, urn).await?;
+    let include = spawn_blocking({
+        let path = paths(peer).git_includes_dir().to_path_buf();
+        move || {
+            let inc = Include::from_tracked_persons(
+                path,
+                local_url,
+                tracked
+                    .into_iter()
+                    .filter_map(|peer| {
+                        crate::daemon::project::Peer::replicated_remote(peer).map(|(p, u)| {
+                            RefLike::try_from(u.subject().name.to_string()).map(|r| (r, p))
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+            Ok::<_, Error>(inc)
+        }
+    })
+    .await??;
+    let include_path = include.file_path();
+    tracing::debug!(path = ?include_path, "updaing include");
+    include.save()?;
+
+    Ok(include_path)
+}
+
+/// This method helps us get a branch for a given [`Urn`] and optional
+/// [`PeerId`].
+///
+/// If the `branch_name` is `None` then we get the project for the given [`Urn`]
+/// and use its `default_branch`.
+///
+/// # Errors
+///   * If the storage operations fail.
+///   * If the requested reference was not found.
+pub async fn get_branch<S, P, B>(
+    peer: &Peer<S>,
+    urn: Urn,
+    remote: P,
+    branch_name: B,
+) -> Result<Reference<Single>, Error>
+where
+    S: Clone + Signer,
+    P: Into<Option<PeerId>> + Clone + Send,
+    B: Into<Option<Cstring>> + Clone + Send,
+{
+    let name = match branch_name.into() {
+        None => {
+            let project = get_project(peer, urn.clone())
+                .await?
+                .ok_or_else(|| Error::ProjectNotFound(urn.clone()))?;
+            project
+                .subject()
+                .default_branch
+                .clone()
+                .ok_or(Error::NoDefaultBranch {
+                    name: project.subject().name.to_string(),
+                    urn: urn.clone(),
+                })?
+        },
+        Some(name) => name,
+    }
+    .parse()?;
+
+    let remote = match remote.into() {
+        Some(peer_id) if peer_id == peer.peer_id() => None,
+        Some(peer_id) => Some(peer_id),
+        None => None,
+    };
+    let reference = Reference::head(Namespace::from(urn), remote, name);
+    let exists = {
+        let reference = reference.clone();
+        peer.using_storage(move |storage| storage.has_ref(&reference))
+            .await??
+    };
+
+    if exists {
+        Ok(reference)
+    } else {
+        Err(Error::MissingRef { reference })
+    }
+}
+
+/// This method helps us get the default branch for a given [`Urn`].
+///
+/// It does this by:
+///     * First checking if the owner of this storage has a reference to the default
+/// branch.
+///     * If the owner does not have this reference then it falls back to the first maintainer.
+///
+/// # Errors
+///   * If the storage operations fail.
+///   * If no default branch was found for the provided [`Urn`].
+pub async fn find_default_branch<S>(peer: &Peer<S>, urn: Urn) -> Result<Reference<Single>, Error>
+where
+    S: Clone + Signer,
+{
+    let project = get_project(peer, urn.clone())
+        .await?
+        .ok_or_else(|| Error::ProjectNotFound(urn.clone()))?;
+
+    let default_branch =
+        project
+            .subject()
+            .default_branch
+            .clone()
+            .ok_or(Error::NoDefaultBranch {
+                name: project.subject().name.to_string(),
+                urn: urn.clone(),
+            })?;
+
+    // TODO(xla): Check for all delegations if there is default branch.
+    let remote = project
+        .delegations()
+        .iter()
+        .flat_map(|either| match either {
+            Either::Left(pk) => Either::Left(std::iter::once(PeerId::from(*pk))),
+            Either::Right(indirect) => {
+                Either::Right(indirect.delegations().iter().map(|pk| PeerId::from(*pk)))
+            },
+        })
+        .next()
+        .expect("missing delegation");
+
+    let (owner, remote) = tokio::join!(
+        get_branch(peer, urn.clone(), None, default_branch.clone()),
+        get_branch(peer, urn.clone(), remote, default_branch.clone())
+    );
+    match owner.or(remote) {
+        Ok(reference) => Ok(reference),
+        Err(Error::MissingRef { .. }) => Err(Error::NoDefaultBranch {
+            name: project.subject().name.to_string(),
+            urn,
+        }),
+        Err(err) => Err(err),
+    }
+}
+
+/// Returns the [`PathBuf`] to the underlying monorepo.
+#[must_use]
+pub fn monorepo<S>(peer: &Peer<S>) -> PathBuf
+where
+    S: Clone + Signer,
+{
+    peer.protocol_config().paths.git_dir().to_owned()
+}
+
+/// Returns the underlying [`paths::Paths`].
+#[must_use]
+pub fn paths<S>(peer: &Peer<S>) -> paths::Paths
+where
+    S: Clone + Signer,
+{
+    peer.protocol_config().paths.clone()
+}
+
+/// Construct the local [`transport::Settings`] for interacting with git related
+/// I/O.
+#[must_use]
+pub fn settings<S>(peer: &Peer<S>) -> transport::Settings
+where
+    S: Clone + Signer,
+{
+    transport::Settings {
+        paths: peer.protocol_config().paths.clone(),
+        signer: BoxedSigner::from(SomeSigner {
+            signer: peer.signer().clone(),
+        }),
+    }
+}
+
+/// Returns the list of [`SomeIdentity`]s for the local peer.
+///
+/// # Errors
+///
+///   * Retrieving the project entities from the store fails.
+pub async fn list_identities<S>(peer: &Peer<S>) -> Result<Vec<SomeIdentity>, Error>
+where
+    S: Clone + Signer,
+{
+    peer.using_storage(move |store| {
+        let identities = identities::any::list(store)?
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>();
+        Ok(identities)
+    })
+    .await?
+}
+
+/// Determine the [`peer::Role`] for a given [`Project`] and [`PeerId`].
+///
+/// If `peer` is `Either::Left` then we have the local `PeerId` and we can
+/// ignore it for looking at `rad/signed_refs`.
+///
+/// If `peer` is `Either::Right` then it is a remote peer and we use it for
+/// looking at `rad/signed_refs`.
+fn role(
+    store: &librad::git::storage::Storage,
+    project: &Project,
+    peer: Either<PeerId, PeerId>,
+) -> Result<peer::Role, Error> {
+    let role = if project
+        .delegations()
+        .owner(peer.into_inner().as_public_key())
+        .is_some()
+    {
+        peer::Role::Maintainer
+    } else if Refs::load(store, &project.urn(), peer.right())?
+        .map_or(false, |refs| refs.heads().next().is_some())
+    {
+        peer::Role::Contributor
+    } else {
+        peer::Role::Tracker
+    };
+
+    Ok(role)
+}
+
+#[allow(clippy::panic, clippy::unwrap_used)]
+#[cfg(test)]
+pub mod test {
+    use crate::daemon::{config, identities::payload::HasNamespace, project};
+    use lazy_static::lazy_static;
+    use librad::{
+        crypto::BoxedSigner, git_ext::OneLevel, identities::payload::Person, net, reflike,
+        SecretKey,
+    };
+    use serde::{Deserialize, Serialize};
+    use std::{env, path::PathBuf};
+    use url::Url;
+
+    #[derive(Deserialize, Serialize)]
+    struct TestExt(String);
+
+    lazy_static! {
+        static ref NAMESPACE: Url = "https://radicle.xyz/test"
+            .parse()
+            .expect("Static URL malformed");
+    }
+
+    impl HasNamespace for TestExt {
+        fn namespace() -> &'static Url {
+            &NAMESPACE
+        }
+    }
+
+    fn fakie_project(path: PathBuf) -> project::Create {
+        project::Create {
+            repo: project::Repo::New {
+                path,
+                name: "fakie-nose-kickflip-backside-180-to-handplant".to_string(),
+            },
+            description: "rad git tricks".to_string(),
+            default_branch: OneLevel::from(reflike!("dope")),
+        }
+    }
+
+    fn radicle_project(path: PathBuf) -> project::Create {
+        project::Create {
+            repo: project::Repo::New {
+                path,
+                name: "radicalise".to_string(),
+            },
+            description: "the people".to_string(),
+            default_branch: OneLevel::from(reflike!("power")),
+        }
+    }
+
+    fn fixtures(path: PathBuf) -> Vec<project::Create> {
+        vec![
+            project::Create {
+                repo: project::Repo::New {
+                    path: path.clone(),
+                    name: "monokel".to_string(),
+                },
+                description: "A looking glass into the future".to_string(),
+                default_branch: OneLevel::from(reflike!("mastor")),
+            },
+            project::Create {
+                repo: project::Repo::New {
+                    path: path.clone(),
+                    name: "Monadic".to_string(),
+                },
+                description: "Open source organization of amazing things.".to_string(),
+                default_branch: OneLevel::from(reflike!("mastor")),
+            },
+            project::Create {
+                repo: project::Repo::New {
+                    path: path.clone(),
+                    name: "open source coin".to_string(),
+                },
+                description: "Research for the sustainability of the open source community."
+                    .to_string(),
+                default_branch: OneLevel::from(reflike!("mastor")),
+            },
+            project::Create {
+                repo: project::Repo::New {
+                    path,
+                    name: "radicle".to_string(),
+                },
+                description: "Decentralized open source collaboration".to_string(),
+                default_branch: OneLevel::from(reflike!("mastor")),
+            },
+        ]
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn can_create_user() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+
+        let annie = super::init_user(&peer, "annie_are_you_ok?".to_string()).await;
+        assert!(annie.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn can_init_owner() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+        let payload = super::PersonPayload::new(Person {
+            name: "cloudhead".into(),
+        })
+        .with_ext(TestExt("test".to_string()))?;
+
+        super::init_owner(&peer, payload).await?;
+
+        peer.using_storage(|storage| {
+            assert_eq!(
+                storage.config()?.user_name()?,
+                "cloudhead",
+                "Invalid config user name"
+            );
+            Ok::<_, super::Error>(())
+        })
+        .await??;
+        let owner = super::default_owner(&peer).await?.expect("No owner set");
+        assert_eq!(*owner.subject().name, "cloudhead", "Invalid owner name");
+        let ext: TestExt = owner.payload().get_ext()?.expect("No owner extension");
+        assert_eq!(ext.0, "test", "Invalid owner extension");
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn can_update_owner_payload() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+        let payload = super::PersonPayload::new(Person {
+            name: "cloudhead".into(),
+        })
+        .with_ext(TestExt("test".to_string()))?;
+        super::init_owner(&peer, payload).await?;
+        let new_payload = super::PersonPayload::new(Person {
+            name: "cloudhead_next".into(),
+        })
+        .with_ext(TestExt("test_next".to_string()))?;
+
+        super::update_owner_payload(&peer, new_payload).await?;
+
+        let owner = super::default_owner(&peer).await?.expect("No owner set");
+        assert_eq!(
+            *owner.subject().name,
+            "cloudhead_next",
+            "Invalid owner name"
+        );
+        let ext: TestExt = owner.payload().get_ext()?.expect("No owner extension");
+        assert_eq!(ext.0, "test_next", "Invalid owner extension");
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn can_create_project() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        env::set_var("RAD_HOME", tmp_dir.path());
+        let key = SecretKey::new();
+        let signer = BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+
+        let user = super::init_owner(
+            &peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
+        let project =
+            super::init_project(&peer, &user, radicle_project(tmp_dir.path().to_path_buf())).await;
+
+        assert!(project.is_ok());
+        assert!(tmp_dir.path().join("radicalise").exists());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn can_create_project_for_existing_repo() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let repo_path = tmp_dir.path().join("radicle");
+        let repo_path = repo_path.join("radicalise");
+        std::fs::create_dir_all(repo_path.clone()).expect("failed to create directory path");
+        let key = SecretKey::new();
+        let signer = BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+
+        let user = super::init_owner(
+            &peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
+        let project = super::init_project(&peer, &user, radicle_project(repo_path.clone())).await;
+
+        assert!(project.is_ok());
+        assert!(repo_path.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_projects() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+
+        let key = SecretKey::new();
+        let signer = BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+
+        let user = super::init_owner(
+            &peer,
+            Person {
+                name: "cloudhead".into(),
+            },
+        )
+        .await?;
+
+        for fixture in fixtures(tmp_dir.path().to_path_buf()) {
+            super::init_project(&peer, &user, fixture).await?;
+        }
+
+        let kalt = super::init_user(&peer, "kalt".to_string()).await?;
+        let fakie =
+            super::init_project(&peer, &kalt, fakie_project(tmp_dir.path().to_path_buf())).await?;
+
+        let projects = super::list_projects(&peer).await?;
+        let mut project_names = projects
+            .into_iter()
+            .map(|project| project.subject().name.to_string())
+            .collect::<Vec<_>>();
+        project_names.sort();
+
+        assert_eq!(
+            project_names,
+            vec!["Monadic", "monokel", "open source coin", "radicle"]
+        );
+
+        assert!(!project_names.contains(&fakie.subject().name.to_string()));
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_users() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir().expect("failed to create temdir");
+        let key = SecretKey::new();
+        let signer = BoxedSigner::from(key.clone());
+        let config = config::default(signer.clone(), tmp_dir.path())?;
+        let peer = net::peer::Peer::new(config)?;
+
+        let _cloudhead = super::init_user(&peer, "cloudhead".to_string()).await?;
+        let _kalt = super::init_user(&peer, "kalt".to_string()).await?;
+
+        let users = super::list_users(&peer).await?;
+        let mut user_handles = users
+            .into_iter()
+            .map(|user| user.subject().name.to_string())
+            .collect::<Vec<_>>();
+        user_handles.sort();
+
+        assert_eq!(user_handles, vec!["cloudhead", "kalt"],);
+
+        Ok(())
+    }
+}

--- a/upstream-proxy/src/daemon/state/error.rs
+++ b/upstream-proxy/src/daemon/state/error.rs
@@ -1,0 +1,196 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Capture `State` related error variants.
+
+use librad::{
+    git::{
+        tracking,
+        types::{One, Reference},
+        Urn,
+    },
+    net,
+};
+use std::{convert::Infallible, panic};
+
+/// Errors that may occur when interacting with [`librad::net::peer::Peer`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An error occurred while trying to create a working copy of a project.
+    #[error(transparent)]
+    Create(#[from] crate::daemon::project::create::Error),
+
+    /// An error occurred while performing the checkout of a project.
+    #[error(transparent)]
+    Checkout(#[from] crate::daemon::project::checkout::Error),
+
+    /// An error occurred when performing git operations.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    #[cfg(test)]
+    /// An attempt to create an identity failed.
+    #[error("failed to create identity")]
+    IdentityCreationFailed,
+
+    /// An interaction involving an identity failed.
+    #[error(transparent)]
+    Identities(#[from] Box<librad::git::identities::Error>),
+
+    /// An interaction involving
+    /// [`librad::git::identities::local::LocalIdentity`] failed.
+    #[error(transparent)]
+    IdentitiesLocal(#[from] librad::git::identities::local::Error),
+
+    /// An error occurred building include files.
+    #[error(transparent)]
+    Include(#[from] librad::git::include::Error),
+
+    /// The namespace was expected in a reference but was not found.
+    #[error("missing namespace in reference")]
+    MissingNamespace,
+
+    /// An operation relied on a default owner being set, but it was not.
+    #[error("this operation depends on the present of a default owner")]
+    MissingOwner,
+
+    /// The [`librad::git::identities::Person`] was not found for the provided
+    /// [`Urn`].
+    #[error("person not found for '{0}'")]
+    PersonNotFound(Urn),
+
+    /// The [`librad::git::identities::Project`] was not found for the provided
+    /// [`Urn`].
+    #[error("project not found for '{0}'")]
+    ProjectNotFound(Urn),
+
+    /// Failed to parse a reference.
+    #[error(transparent)]
+    ReferenceName(#[from] librad::git_ext::reference::name::Error),
+
+    /// An action involving `rad/signed_refs` resulted in an error.
+    #[error(transparent)]
+    Refs(#[from] librad::git::refs::stored::Error),
+
+    /// An error occurred when attempting to replicate data from another peer.
+    #[error(transparent)]
+    Replication(#[from] librad::net::peer::error::Replicate),
+
+    /// Peer storage error.
+    #[error(transparent)]
+    PeerStorage(#[from] net::peer::error::Storage),
+
+    /// Peer storage error.
+    #[error(transparent)]
+    Storage(#[from] storage::Error),
+
+    /// An interaction with the config file for the storage failed.
+    #[error(transparent)]
+    StorageConfig(#[from] librad::git::storage::config::Error),
+
+    /// Error while performing tracking operation
+    #[error(transparent)]
+    Tracking(#[from] Tracking),
+
+    /// Attempted to create an identity that already exists.
+    #[error("the URN `{0}` already exists")]
+    IdentityExists(Urn),
+
+    /// There were no references for a Browser to be initialised.
+    #[error("we could not find a default branch for '{name}@{urn}'")]
+    NoDefaultBranch {
+        /// Name of the project.
+        name: String,
+        /// RadUrn of the project.
+        urn: Urn,
+    },
+
+    /// Could not find a `NamespacedRef` when searching for it in the `Storage`.
+    #[error("we could not find the '{reference}'")]
+    MissingRef {
+        /// The reference that we looked for in the `Storage`.
+        reference: Reference<One>,
+    },
+
+    /// A document payload extension was malformed
+    #[error(transparent)]
+    MalformedPayloadExt(#[from] librad::identities::payload::ExtError),
+
+    /// A spawned task was cancelled
+    #[error("spawned task cancelled")]
+    TaskCancelled,
+}
+
+/// Error while performing tracking operation
+#[derive(Debug, thiserror::Error)]
+pub enum Tracking {
+    /// An error occurred when attempting to track a peer.
+    #[error(transparent)]
+    Track(#[from] tracking::error::Track),
+
+    /// An error occurred when attempting to get tracked peers.
+    #[error(transparent)]
+    Tracked(#[from] tracking::error::TrackedPeers),
+
+    /// An error occurred when attempting to untrack a peer.
+    #[error(transparent)]
+    Untrack(#[from] tracking::error::Untrack),
+}
+
+impl From<tracking::error::Track> for Error {
+    fn from(err: tracking::error::Track) -> Self {
+        Self::Tracking(err.into())
+    }
+}
+
+impl From<tracking::error::Untrack> for Error {
+    fn from(err: tracking::error::Untrack) -> Self {
+        Self::Tracking(err.into())
+    }
+}
+
+impl From<tracking::error::TrackedPeers> for Error {
+    fn from(err: tracking::error::TrackedPeers) -> Self {
+        Self::Tracking(err.into())
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(infallible: Infallible) -> Self {
+        match infallible {}
+    }
+}
+
+impl From<librad::git::identities::Error> for Error {
+    fn from(err: librad::git::identities::Error) -> Self {
+        Self::Identities(Box::new(err))
+    }
+}
+
+impl From<tokio::task::JoinError> for Error {
+    fn from(err: tokio::task::JoinError) -> Self {
+        if err.is_cancelled() {
+            Self::TaskCancelled
+        } else if err.is_panic() {
+            panic::resume_unwind(err.into_panic())
+        } else {
+            unreachable!("unexpected join error: {:?}", err)
+        }
+    }
+}
+
+/// Re-export the underlying [`storage::Error`] so that consumers don't need to
+/// add `librad` as a dependency to match on the variant. Instead, they can
+/// import `coco::state::error::storage`.
+pub mod storage {
+    pub use librad::git::storage::Error;
+}
+
+/// Re-export the underlying [`blob::Error`] so that consumers don't need to add
+/// `librad` as a dependency to match on the variant. Instead, they can import
+/// `coco::state::error::blob`.
+pub mod blob {
+    pub use librad::git_ext::blob::Error;
+}

--- a/upstream-proxy/src/daemon/states.rs
+++ b/upstream-proxy/src/daemon/states.rs
@@ -1,0 +1,424 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! The state types and traits that we can use for [`super::Request`]'s `S`
+//! parameter.
+
+use std::{
+    collections::HashMap,
+    fmt,
+    ops::{Add, AddAssign, Deref},
+};
+
+use serde::{Deserialize, Serialize};
+
+use librad::PeerId;
+
+use super::sealed;
+
+impl sealed::Sealed for Created {}
+impl sealed::Sealed for Requested {}
+impl sealed::Sealed for Found {}
+impl sealed::Sealed for Cloning {}
+impl sealed::Sealed for Cancelled {}
+
+// State Types
+
+/// An enumeration of the different states a `Request` can be in. This is useful
+/// if we want to convey the state information without any of the other state
+/// data.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum RequestState {
+    /// The initial state where the `Request` has been created.
+    Created,
+
+    /// The state where the `Request` has been requested.
+    Requested,
+
+    /// The state where the `Request` has found at least one peer.
+    Found,
+
+    /// The state where the `Request` has is cloning from a peer.
+    Cloning,
+
+    /// The state where the `Request` has successfully cloned from a peer.
+    Cloned,
+
+    /// The state where the `Request` has been cancelled.
+    Cancelled,
+
+    /// The state where the `Request` has timed out.
+    TimedOut,
+}
+
+impl fmt::Display for RequestState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// The initial state for a `Request`. It has simply been created.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Created {}
+
+/// The state signifying that the `Request` has been kicked-off.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Requested {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(super) peers: HashMap<PeerId, Status>,
+}
+
+/// `Status` represents the lifecycle of some action on data. The data could be
+/// available to take the action on, the action could be in progress, or it
+/// could have failed.
+///
+/// Note that the related data isn't in the `Status` variants. The status is
+/// free to be associated with any external data, e.g. using it as a value in a
+/// `HashMap`.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Status {
+    /// The status of the related data is: ready to go!
+    Available,
+    /// The status of the related data is: in progress!
+    InProgress,
+    /// The status of the related data is: failed :(
+    Failed {
+        #[allow(missing_docs)]
+        reason: String,
+    },
+}
+
+impl Status {
+    /// Joining two `Status` favours `Failed` over any other `Status`, then
+    /// `InProgress`, and finally `Available`.
+    ///
+    /// This translates to the fact that if something has `Failed` then that's
+    /// it, there's no going back.
+    /// If it's `InProgress`, it doesn't matter that the other `Status` is
+    /// saying its `Available`, because you know what? It's actually in
+    /// progress. And finally, the last case is that both `Status`es agree
+    /// the `Status` is `Available`.
+    #[must_use]
+    pub fn join(&self, other: &Self) -> Self {
+        match (self, &other) {
+            (Self::Failed { reason: reason1 }, Self::Failed { reason: reason2 }) => Self::Failed {
+                reason: format!("{} and {}", reason1, reason2),
+            },
+            (Self::Failed { reason }, _) | (_, Self::Failed { reason }) => Self::Failed {
+                reason: reason.clone(),
+            },
+            (Self::InProgress, _) | (_, Self::InProgress) => Self::InProgress,
+            (Self::Available, Self::Available) => Self::Available,
+        }
+    }
+
+    #[allow(missing_docs)]
+    #[must_use]
+    pub const fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+}
+
+/// The `Found` state means that we have found at least one peer and can
+/// possibly find more.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Found {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(crate) peers: HashMap<PeerId, Status>,
+}
+
+impl Deref for Found {
+    type Target = HashMap<PeerId, Status>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.peers
+    }
+}
+
+/// The `Cloning` state means that we have found at least one peer and we are
+/// attempting a clone on one of them.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cloning {
+    /// A set of found peers and the lifecycle of clone attempts made on those
+    /// peers.
+    pub(crate) peers: HashMap<PeerId, Status>,
+}
+
+impl Deref for Cloning {
+    type Target = HashMap<PeerId, Status>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.peers
+    }
+}
+
+/// The `Cloned` state means that we have successfully cloned the desired
+/// identity.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cloned {
+    /// The identity that we were attempting to find and the peer that we found
+    /// it from.
+    pub(crate) remote_peer: PeerId,
+}
+/// One of the terminal states for a `Request` where the task has been
+/// cancelled.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cancelled {}
+
+/// One of the terminal states for a `Request` where the task made too many
+/// attempts.
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TimedOut {
+    /// The `Request` made too many query attempts.
+    Query,
+    /// The `Request` made too many clone attempts.
+    Clone,
+}
+
+impl fmt::Display for TimedOut {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Query => write!(f, "query"),
+            Self::Clone => write!(f, "clone"),
+        }
+    }
+}
+
+/// `Queries` is a wrapper around `usize` so that we can differentiate it from
+/// [`Clones`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Queries {
+    /// The max number of queries allowed per request.
+    Max(usize),
+    /// The max number is infinite, and so we allow the request to never time
+    /// out.
+    Infinite,
+}
+
+impl Queries {
+    /// Create a new `Queries` wrapping around `n`.
+    #[must_use]
+    pub const fn new(n: usize) -> Self {
+        Self::Max(n)
+    }
+}
+
+impl From<Queries> for Option<usize> {
+    fn from(other: Queries) -> Self {
+        match other {
+            Queries::Max(i) => Some(i),
+            Queries::Infinite => None,
+        }
+    }
+}
+
+impl Add<usize> for Queries {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self::Output {
+        match self {
+            Self::Max(i) => Self::Max(i + other),
+            Self::Infinite => Self::Infinite,
+        }
+    }
+}
+
+impl AddAssign<usize> for Queries {
+    fn add_assign(&mut self, other: usize) {
+        match self {
+            Self::Max(i) => *i += other,
+            Self::Infinite => {},
+        }
+    }
+}
+
+/// `Clones` is a wrapper around `usize` so that we can differentiate it from
+/// [`Queries`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Clones {
+    /// The max number of clones allowed per request.
+    Max(usize),
+    /// The max number is infinite, and so we allow the request to never time
+    /// out.
+    Infinite,
+}
+
+impl Clones {
+    /// Create a new `Clones` wrapping around `n`.
+    #[must_use]
+    pub const fn new(n: usize) -> Self {
+        Self::Max(n)
+    }
+}
+
+impl From<Clones> for Option<usize> {
+    fn from(other: Clones) -> Self {
+        match other {
+            Clones::Max(i) => Some(i),
+            Clones::Infinite => None,
+        }
+    }
+}
+
+impl Add<usize> for Clones {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self::Output {
+        match self {
+            Self::Max(i) => Self::Max(i + other),
+            Self::Infinite => Self::Infinite,
+        }
+    }
+}
+
+impl AddAssign<usize> for Clones {
+    fn add_assign(&mut self, other: usize) {
+        match self {
+            Self::Max(i) => *i += other,
+            Self::Infinite => {},
+        }
+    }
+}
+
+/// The number of different attempts a `Request` has made during its lifetime.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attempts {
+    /// The number of query attempts we have made.
+    pub(super) queries: Queries,
+    /// The number of clone attempts we have made.
+    pub(super) clones: Clones,
+}
+
+impl Attempts {
+    /// Get a new `Attempts` where the number of queires and clones is initially
+    /// `0`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Attempts {
+            queries: Queries::Max(0),
+            clones: Clones::Max(0),
+        }
+    }
+
+    /// Construct an `Attempts` where the number of queries and clones is
+    /// `Infinite`.
+    #[must_use]
+    pub const fn infinite() -> Self {
+        Attempts {
+            queries: Queries::Infinite,
+            clones: Clones::Infinite,
+        }
+    }
+}
+
+impl Default for Attempts {
+    fn default() -> Self {
+        Attempts::new()
+    }
+}
+
+impl sealed::Sealed for Attempts {}
+
+// State Traits
+
+/// If a state type implements this trait then it means that the type is allowed
+/// to increment the query attempts in a `Request`.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait QueryAttempt: sealed::Sealed {}
+impl QueryAttempt for Requested {}
+
+/// If a state type implements this trait then it means that the type holds a
+/// `HashMap` of peers and their status of cloning.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait HasPeers: sealed::Sealed
+where
+    Self: Sized + Deref<Target = HashMap<PeerId, Status>>,
+{
+    /// Give back the underlying `HashMap` of peers that is contained in `Self`.
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status>;
+
+    /// Returns `false` if the `peers` are empty or if any of them are
+    /// `Status::Available` or `Status::InProgress`.
+    ///
+    /// Otherwise, if all are in the `Status::Failed` state, then we return
+    /// `true`.
+    fn all_failed(&self) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+
+        self.iter().all(|(_, status)| status.is_failed())
+    }
+}
+
+impl HasPeers for Found {
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status> {
+        &mut self.peers
+    }
+}
+
+impl HasPeers for Cloning {
+    fn peers(&mut self) -> &mut HashMap<PeerId, Status> {
+        &mut self.peers
+    }
+}
+
+/// If a state type implements this trait it means that there is a valid
+/// transition from that state to the `Cancelled` state.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait Cancel: sealed::Sealed
+where
+    Self: Sized,
+{
+    /// Transition the state into `Cancelled`. This ignores whatever state we
+    /// were in and defaults by returning the `Cancelled` state.
+    fn cancel(self) -> Cancelled {
+        Cancelled {}
+    }
+}
+
+impl Cancel for Created {}
+impl Cancel for Requested {}
+impl Cancel for Found {}
+impl Cancel for Cloning {}
+impl Cancel for Cancelled {}
+
+/// If a state type implements this trait it means that there is a valid
+/// transition from that state to the `TimedOut` state.
+///
+/// The trait is sealed internally, so we do not expect end-users to implement
+/// it.
+pub trait TimeOut: sealed::Sealed
+where
+    Self: Sized,
+{
+    /// Transition the state into `TimedOut`. This ignores whatever state we
+    /// were in and defaults by returning the `TimedOut` state by returning
+    /// the `kind` of timeout.
+    fn time_out(self, kind: TimedOut) -> TimedOut {
+        kind
+    }
+}
+
+impl TimeOut for Requested {}
+impl TimeOut for Found {}
+impl TimeOut for Cloning {}

--- a/upstream-proxy/src/daemon/subroutines.rs
+++ b/upstream-proxy/src/daemon/subroutines.rs
@@ -1,0 +1,427 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Management of peer subroutine tasks driven by advancing the core state
+//! machine with a stream of inputs, producing commands.
+
+use std::{
+    net::SocketAddr,
+    time::{Duration, SystemTime},
+};
+
+use async_stream::stream;
+use futures::stream::{BoxStream, FuturesUnordered, SelectAll, StreamExt as _};
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    task::{JoinError, JoinHandle},
+    time::interval,
+};
+
+use librad::{
+    git::Urn,
+    net::{self, peer::ProtocolEvent},
+    PeerId,
+    Signer,
+};
+
+use crate::{
+    convert::MaybeFrom as _,
+    request::{self, waiting_room::WaitingRoom},
+    state,
+};
+
+use super::{
+    announcement,
+    control,
+    gossip,
+    include,
+    run_state::{command, config, input, Command, Config as RunConfig, Event, Input, RunState},
+    waiting_room,
+    RECEIVER_CAPACITY,
+};
+
+/// Management of "subroutine" tasks.
+pub struct Subroutines<S> {
+    /// Set of handles of spawned subroutine tasks. Draining them will ensure
+    /// resources are release.
+    pending_tasks: FuturesUnordered<JoinHandle<()>>,
+    /// Stream of inputs to [`RunState`] state machine.
+    inputs: SelectAll<BoxStream<'static, Input>>,
+
+    /// [`net::peer::Peer`] for suborutine task fulfillment.
+    peer: net::peer::Peer<S>,
+    /// [`kv::Store`] for suborutine task fulfillment.
+    store: kv::Store,
+
+    /// Main peer state machine.
+    run_state: RunState,
+
+    /// Feedback channel for subroutine tasks send new inputs to the state
+    /// machine.
+    input_sender: mpsc::Sender<Input>,
+    /// Channel for public subscribers to get to know of significant events of
+    /// the peer machinery.
+    subscriber: broadcast::Sender<Event>,
+}
+
+impl<S> Subroutines<S>
+where
+    S: Clone + Signer,
+{
+    /// Constructs a new subroutines manager.
+    pub fn new(
+        peer: net::peer::Peer<S>,
+        mut listen_addrs: watch::Receiver<Vec<SocketAddr>>,
+        store: kv::Store,
+        run_config: &RunConfig,
+        protocol_events: BoxStream<'static, Result<ProtocolEvent, net::protocol::RecvError>>,
+        subscriber: broadcast::Sender<Event>,
+        mut control_receiver: mpsc::Receiver<control::Request>,
+    ) -> Self {
+        let announce_timer = if run_config.announce.interval.is_zero() {
+            None
+        } else {
+            Some(interval(run_config.announce.interval))
+        };
+        let waiting_room = match waiting_room::load(&store) {
+            Err(err) => {
+                tracing::warn!(?err, "Failed to load waiting room");
+                WaitingRoom::new(request::waiting_room::Config {
+                    delta: config::DEFAULT_WAITING_ROOM_TIMEOUT,
+                    ..request::waiting_room::Config::default()
+                })
+            },
+            Ok(None) => WaitingRoom::new(request::waiting_room::Config {
+                delta: config::DEFAULT_WAITING_ROOM_TIMEOUT,
+                ..request::waiting_room::Config::default()
+            }),
+            Ok(Some(room)) => room,
+        };
+        let mut waiting_room_timer = interval(run_config.waiting_room.interval);
+        let (input_sender, mut external_inputs) = mpsc::channel::<Input>(RECEIVER_CAPACITY);
+        let mut stats_timer = interval(run_config.stats.interval);
+
+        let run_state = RunState::new(waiting_room);
+
+        let inputs = {
+            let mut coalesced = SelectAll::new();
+            coalesced.push(
+                // TODO(xla): Ensure stream of Results has significance, or should just signal
+                // stream close.
+                protocol_events
+                    .filter_map(|res| async move {
+                        match res {
+                            Ok(ev) => Some(Input::Protocol(ev)),
+                            Err(err) => {
+                                tracing::warn!(?err, "receive error");
+                                None
+                            },
+                        }
+                    })
+                    .boxed(),
+            );
+
+            coalesced.push(
+                stream! {
+                    while listen_addrs.changed().await.is_ok() {
+                        let addrs = listen_addrs.borrow().clone();
+                        yield Input::ListenAddrs(addrs);
+                    }
+                }
+                .boxed(),
+            );
+
+            if let Some(mut timer) = announce_timer {
+                coalesced.push(
+                    stream! {
+                        loop {
+                            timer.tick().await;
+                            yield Input::Announce(input::Announce::Tick);
+                        }
+                    }
+                    .boxed(),
+                );
+            }
+            coalesced.push(
+                stream! {
+                    loop {
+                        waiting_room_timer.tick().await;
+                        yield Input::Request(input::Request::Tick);
+                    }
+                }
+                .boxed(),
+            );
+            coalesced.push(
+                stream! {
+                    loop {
+                        stats_timer.tick().await;
+                        yield Input::Stats(input::Stats::Tick);
+                    }
+                }
+                .boxed(),
+            );
+            coalesced.push(
+                stream! {
+                while let Some(request) = control_receiver.recv().await { yield request } }
+                .map(|request| match request {
+                    control::Request::CurrentStatus(sender) => {
+                        Input::Control(input::Control::Status(sender))
+                    },
+                    control::Request::ListenAddrs(sender) => {
+                        Input::Control(input::Control::ListenAddrs(sender))
+                    },
+                    control::Request::CancelSearch(urn, time, sender) => {
+                        Input::Control(input::Control::CancelRequest(urn, time, sender))
+                    },
+                    control::Request::GetSearch(urn, sender) => {
+                        Input::Control(input::Control::GetRequest(urn, sender))
+                    },
+                    control::Request::ListSearches(sender) => {
+                        Input::Control(input::Control::ListRequests(sender))
+                    },
+                    control::Request::StartSearch(urn, time, sender) => {
+                        Input::Control(input::Control::CreateRequest(urn, time, sender))
+                    },
+                })
+                .boxed(),
+            );
+            coalesced.push(
+                stream! {
+                    while let Some(input) = external_inputs.recv().await {
+                        yield input;
+                    }
+                }
+                .boxed(),
+            );
+
+            coalesced
+        };
+
+        Self {
+            pending_tasks: FuturesUnordered::new(),
+            inputs,
+
+            peer,
+            store,
+            run_state,
+
+            subscriber,
+            input_sender,
+        }
+    }
+
+    /// Map commands produced by the state machine to spawned subroutine tasks.
+    fn spawn_command(&self, cmd: Command) -> JoinHandle<()> {
+        match cmd {
+            Command::Announce => tokio::spawn(announce(
+                self.peer.clone(),
+                self.store.clone(),
+                self.input_sender.clone(),
+            )),
+            Command::Control(control_command) => match control_command {
+                command::Control::Respond(respond_command) => {
+                    tokio::spawn(control_respond(respond_command))
+                },
+            },
+            Command::Include(urn) => tokio::spawn(include::update(self.peer.clone(), urn)),
+            Command::PersistWaitingRoom(waiting_room) => {
+                tokio::spawn(persist_waiting_room(waiting_room, self.store.clone()))
+            },
+            Command::Request(command::Request::Query(urn)) => {
+                tokio::spawn(query(urn, self.peer.clone(), self.input_sender.clone()))
+            },
+            Command::Request(command::Request::Clone(urn, remote_peer)) => tokio::spawn(clone(
+                urn,
+                remote_peer,
+                self.peer.clone(),
+                self.input_sender.clone(),
+            )),
+            Command::Request(command::Request::TimedOut(urn)) => {
+                let sender = self.input_sender.clone();
+                tokio::spawn(async move {
+                    sender
+                        .send(Input::Request(input::Request::TimedOut(urn)))
+                        .await
+                        .ok();
+                })
+            },
+            Command::Stats => tokio::spawn(get_stats(self.peer.clone(), self.input_sender.clone())),
+            Command::EmitEvent(event) => {
+                self.subscriber.send(event).ok();
+                tokio::spawn(async move {})
+            },
+        }
+    }
+
+    fn handle_input(&mut self, input: Input) {
+        tracing::trace!(?input, "handling subroutine input");
+
+        let old_status = self.run_state.status.clone();
+
+        if let Some(event) = Event::maybe_from(&input) {
+            // Ignore if there are no subscribers.
+            self.subscriber.send(event).ok();
+        }
+
+        for cmd in self.run_state.transition(input) {
+            let task = self.spawn_command(cmd);
+
+            self.pending_tasks.push(task);
+        }
+
+        if old_status != self.run_state.status {
+            self.subscriber
+                .send(Event::StatusChanged {
+                    old: old_status,
+                    new: self.run_state.status.clone(),
+                })
+                .ok();
+        }
+    }
+
+    pub async fn run(mut self) -> Result<(), JoinError> {
+        #![allow(clippy::mut_mut)]
+        loop {
+            futures::select! {
+                maybe_result = self.pending_tasks.next() => {
+                    if let Some(Err(err)) = maybe_result {
+                        return Err(err)
+                    }
+                }
+                maybe_input = self.inputs.next() => {
+                    if let Some(input) = maybe_input {
+                        self.handle_input(input);
+                    } else {
+                        return Ok(())
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<S> Drop for Subroutines<S> {
+    fn drop(&mut self) {
+        for task in self.pending_tasks.iter_mut() {
+            task.abort();
+        }
+    }
+}
+
+/// Run the announcement of updated refs for local projects. On completion
+/// report back with the success or failure.
+async fn announce<S>(peer: net::peer::Peer<S>, store: kv::Store, sender: mpsc::Sender<Input>)
+where
+    S: Clone + Signer,
+{
+    match announcement::run(&peer, store).await {
+        Ok(updates) => {
+            sender
+                .send(Input::Announce(input::Announce::Succeeded(updates)))
+                .await
+                .ok();
+        },
+        Err(err) => {
+            tracing::error!(?err, "announce error");
+            sender
+                .send(Input::Announce(input::Announce::Failed))
+                .await
+                .ok();
+        },
+    }
+}
+
+/// Fulfill control requests by sending the scheduled responses.
+#[allow(clippy::unused_async)]
+async fn control_respond(cmd: control::Response) {
+    match cmd {
+        control::Response::CurrentStatus(sender, status) => sender.send(status).ok(),
+        control::Response::CancelSearch(sender, request) => sender.send(request).ok(),
+        control::Response::ListenAddrs(sender, addrs) => sender.send(addrs).ok(),
+        control::Response::GetSearch(sender, request) => sender.send(request).ok(),
+        control::Response::ListSearches(sender, requests) => sender.send(requests).ok(),
+        control::Response::StartSearch(sender, request) => sender.send(request).ok(),
+    };
+}
+
+async fn get_stats<S>(peer: net::peer::Peer<S>, sender: mpsc::Sender<Input>)
+where
+    S: Clone + Signer,
+{
+    let stats = peer.stats().await;
+
+    sender
+        .send(Input::Stats(input::Stats::Values(stats)))
+        .await
+        .ok();
+}
+
+#[allow(clippy::unused_async)]
+async fn persist_waiting_room(waiting_room: WaitingRoom<SystemTime, Duration>, store: kv::Store) {
+    match waiting_room::save(&store, waiting_room) {
+        Ok(()) => tracing::debug!("Successfully persisted the waiting room"),
+        Err(err) => tracing::debug!(?err, "Error while persisting the waiting room"),
+    }
+}
+
+/// Send a query on the network for the given urn.
+async fn query<S>(urn: Urn, peer: net::peer::Peer<S>, sender: mpsc::Sender<Input>)
+where
+    S: Clone + Signer,
+{
+    gossip::query(&peer, &urn, None);
+    sender
+        .send(Input::Request(input::Request::Queried(urn)))
+        .await
+        .ok();
+}
+
+/// Run a clone for the given `url`. On completion report back with the success
+/// or failure.
+async fn clone<S>(
+    urn: Urn,
+    remote_peer: PeerId,
+    peer: net::peer::Peer<S>,
+    sender: mpsc::Sender<Input>,
+) where
+    S: Clone + Signer,
+{
+    sender
+        .send(Input::Request(input::Request::Cloning(
+            urn.clone(),
+            remote_peer,
+        )))
+        .await
+        .ok();
+
+    match state::clone_project(&peer, urn.clone(), remote_peer, None).await {
+        Ok(_urn) => {
+            sender
+                .send(Input::Request(input::Request::Cloned(
+                    urn.clone(),
+                    remote_peer,
+                )))
+                .await
+                .ok();
+            gossip::announce(&peer, &urn, None);
+        },
+        Err(err) => {
+            tracing::warn!(
+                %urn,
+                %remote_peer,
+                ?err,
+                "an error occurred for the command 'Clone'",
+            );
+            sender
+                .send(Input::Request(input::Request::Failed {
+                    urn,
+                    remote_peer,
+                    reason: Box::new(err),
+                }))
+                .await
+                .ok();
+        },
+    }
+}

--- a/upstream-proxy/src/daemon/validation.rs
+++ b/upstream-proxy/src/daemon/validation.rs
@@ -1,0 +1,395 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Validation logic for safely checking that a [`super::Repo`] is valid before
+//! setting up the working copy.
+
+use std::{convert::TryFrom, io, path::PathBuf};
+
+use librad::{
+    git::{
+        local::{transport::CanOpenStorage, url::LocalUrl},
+        types::{
+            remote::{self, LocalPushspec, Remote},
+            Fetchspec,
+            Force,
+            Refspec,
+        },
+    },
+    git_ext::{self, OneLevel},
+    reflike,
+    refspec_pattern,
+    std_ext::result::ResultExt as _,
+};
+use nonempty::NonEmpty;
+
+use super::Signature;
+
+/// Errors that occur when validating a [`super::Repo`]'s path.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The path already existed when trying to create a new project.
+    #[error("the path provided '{0}' already exists")]
+    AlreadExists(PathBuf),
+
+    /// An existing project is being created, but we couldn't get the `name` of
+    /// the project, i.e. the final suffix of the file path.
+    #[error(
+        "the existing path provided '{0}' was empty, and we could not get the project name from it"
+    )]
+    EmptyExistingPath(PathBuf),
+
+    /// An error occurred in `git2` that we could not handle.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+
+    /// When trying to inspect a path, an I/O error occurred.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// When checking the default git config for `user.email` we could not find
+    /// it.
+    #[error("the author email for creating the project could not be found - have you configured your git config?")]
+    MissingAuthorEmail,
+
+    /// When checking the default git config for `user.name` we could not find
+    /// it.
+    #[error("the author name for creating the project could not be found - have you configured your git config?")]
+    MissingAuthorName,
+
+    /// Configured default branch for the project is missing.
+    #[error(
+        "the default branch '{branch}' supplied was not found for the repository at '{repo_path}'"
+    )]
+    MissingDefaultBranch {
+        /// The repository path we're setting up.
+        repo_path: PathBuf,
+        /// The default branch that was expected to be found.
+        branch: String,
+    },
+
+    /// When checking for default git config we could not find it.
+    #[error(
+        "the git config for creating the project could not be found - have you configured it?"
+    )]
+    MissingGitConfig,
+
+    /// The `rad` remote was found but it did not have a URL.
+    #[error("the `rad` remote exists but is missing its url field")]
+    MissingUrl,
+
+    /// The path was expected to point to a git repository but it did not.
+    #[error("the path '{0}' does not point to an existing repository")]
+    NotARepo(PathBuf),
+
+    /// The path was expected to exist already but does not.
+    #[error("the path provided '{0}' does not exist when it was expected to")]
+    PathDoesNotExist(PathBuf),
+
+    /// When attempting to find a particular remote that _should_ exist, it did
+    /// not.
+    #[error(transparent)]
+    Remote(#[from] remote::FindError),
+
+    /// An internal error occurred when talking to the local transport for git
+    /// related I/O.
+    #[error(transparent)]
+    Transport(#[from] librad::git::local::transport::Error),
+
+    /// The `rad` remote was found, but the URL did not match the URL we were
+    /// expecting.
+    #[error("the `rad` remote was found but the url field does not match the provided url, found: '{found}' expected: '{expected}'")]
+    UrlMismatch {
+        /// The expected URL of the `rad` remote.
+        expected: String,
+        /// The URL that was found for the `rad` remote.
+        found: String,
+    },
+}
+
+/// A `Repository` represents the validated information for setting up a working
+/// copy.
+///
+/// We can get a `Repository` by calling [`Repository::validate`].
+pub enum Repository {
+    /// The existing repository.
+    Existing {
+        /// Le [`git2::Repository`] that exists.
+        repo: git2::Repository,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+    },
+    /// A new repository will be created using these fields.
+    New {
+        /// The path to the working copy.
+        path: PathBuf,
+        /// The name of the project.
+        name: String,
+        /// The URL that will be used for the remote.
+        url: LocalUrl,
+        /// The default branch the repository should be set up with.
+        default_branch: OneLevel,
+        /// The signature to use for the initial commit.
+        signature: Signature,
+    },
+}
+
+impl Repository {
+    /// Validate a [`super::Repo`] to construct a `Repository`.
+    ///
+    /// This ensures that when setting up a working copy, that there should be
+    /// no errors. The following are validated for each case:
+    ///
+    /// **Existing**:
+    ///   * The path provided should exist
+    ///   * The path provided should have at least one component, which forms
+    ///     the name of the
+    ///   project. E.g. `Developer/radicle-upstream` is the directory and
+    /// `radicle-upstream` is the   project name.
+    ///   * The path leads to a git repository
+    ///   * The default branch passed exists in the repository
+    ///   * If a `rad` remote exists, that it:
+    ///         * Has a url field
+    ///         * If it does have a url field, that it matches the one provided
+    ///           here
+    ///
+    /// **New**:
+    ///   * The path provided does not exist:
+    ///         * If it does exist, it should be a directory and it should be
+    ///           empty
+    ///
+    /// # Errors
+    ///
+    /// If any of the criteria outlined above are violated, this will result in
+    /// an [`Error`].
+    pub fn validate(
+        repo: super::Repo,
+        url: LocalUrl,
+        default_branch: OneLevel,
+        signature: Signature,
+    ) -> Result<Self, Error> {
+        match repo {
+            super::Repo::Existing { path } => {
+                if !path.exists() {
+                    return Err(Error::PathDoesNotExist(path));
+                }
+
+                let _components = path
+                    .components()
+                    .next_back()
+                    .and_then(|component| component.as_os_str().to_str())
+                    .map(ToString::to_string)
+                    .ok_or_else(|| Error::EmptyExistingPath(path.clone()))?;
+
+                let repo = git2::Repository::open(path.clone())
+                    .or_matches(git_ext::is_not_found_err, || Err(Error::NotARepo(path)))?;
+
+                {
+                    let _default_branch_ref = Self::existing_branch(&repo, &default_branch)?;
+                    let _remote = Self::existing_remote(&repo, &url)?;
+                }
+                Ok(Self::Existing {
+                    repo,
+                    url,
+                    default_branch,
+                })
+            },
+            super::Repo::New { name, path } => {
+                let repo_path = path.join(name.clone());
+                let _repo_path = crate::project::ensure_directory(&repo_path)?
+                    .ok_or_else(|| Error::AlreadExists(repo_path.clone()))?;
+
+                Ok(Self::New {
+                    name,
+                    path,
+                    url,
+                    default_branch,
+                    signature,
+                })
+            },
+        }
+    }
+
+    /// Initialise the [`git2::Repository`].
+    ///
+    /// # Errors
+    ///
+    ///   * Failed to setup the repository
+    pub fn setup_repo<F>(
+        self,
+        open_storage: F,
+        description: &str,
+    ) -> Result<git2::Repository, super::Error>
+    where
+        F: CanOpenStorage + Clone + 'static,
+    {
+        match self {
+            Self::Existing {
+                repo,
+                url,
+                default_branch,
+            } => {
+                tracing::debug!(path = ?repo.path(), "Setting up existing repository");
+                Self::setup_remote(&repo, open_storage, url, &default_branch)?;
+                Ok(repo)
+            },
+            Self::New {
+                path,
+                name,
+                url,
+                default_branch,
+                signature,
+            } => {
+                let path = path.join(name);
+                tracing::debug!(?path, "Setting up new repository",);
+                let repo = Self::initialise(path, description, &default_branch)?;
+                Self::initial_commit(
+                    &repo,
+                    &default_branch,
+                    &git2::Signature::try_from(signature)?,
+                )?;
+                let mut remote =
+                    Self::setup_remote(&repo, open_storage.clone(), url, &default_branch)?;
+                // Set up the default branch under the remote to allow setting the upstream
+                let _fetched = remote
+                    .fetch(
+                        open_storage,
+                        &repo,
+                        remote::LocalFetchspec::Specs(NonEmpty::new(Fetchspec::from(Refspec {
+                            src: reflike!("refs/heads").join(default_branch.clone()),
+                            dst: reflike!("refs/remotes")
+                                .join(remote.name.clone())
+                                .join(default_branch.clone()),
+                            force: Force::False,
+                        }))),
+                    )
+                    .map_err(Error::from)?;
+
+                crate::project::set_upstream(&repo, &remote, default_branch)?;
+
+                Ok(repo)
+            },
+        }
+    }
+
+    fn initialise(
+        path: PathBuf,
+        description: &str,
+        default_branch: &OneLevel,
+    ) -> Result<git2::Repository, git2::Error> {
+        tracing::debug!(?path, "Setting up new repository");
+        let mut options = git2::RepositoryInitOptions::new();
+        options.no_reinit(true);
+        options.mkpath(true);
+        options.description(description);
+        options.initial_head(default_branch.as_str());
+
+        git2::Repository::init_opts(path, &options)
+    }
+
+    fn initial_commit(
+        repo: &git2::Repository,
+        default_branch: &OneLevel,
+        signature: &git2::Signature<'static>,
+    ) -> Result<(), git2::Error> {
+        // Now let's create an empty tree for this commit
+        let tree_id = {
+            let mut index = repo.index()?;
+
+            // For our purposes, we'll leave the index empty for now.
+            index.write_tree()?
+        };
+        {
+            let tree = repo.find_tree(tree_id)?;
+            // Normally creating a commit would involve looking up the current HEAD
+            // commit and making that be the parent of the initial commit, but here this
+            // is the first commit so there will be no parent.
+            repo.commit(
+                Some(&format!("refs/heads/{}", default_branch.as_str())),
+                signature,
+                signature,
+                "Initial commit",
+                &tree,
+                &[],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Equips a repository with a rad remote for the given id. If the directory
+    /// at the given path is not managed by git yet we initialise it first.
+    fn setup_remote<F>(
+        repo: &git2::Repository,
+        open_storage: F,
+        url: LocalUrl,
+        default_branch: &OneLevel,
+    ) -> Result<Remote<LocalUrl>, Error>
+    where
+        F: CanOpenStorage + 'static,
+    {
+        let _default_branch_ref = Self::existing_branch(repo, default_branch)?;
+
+        tracing::debug!("Creating rad remote");
+
+        let fetchspec = Refspec {
+            src: refspec_pattern!("refs/heads/*"),
+            dst: refspec_pattern!("refs/remotes/rad/*"),
+            force: Force::True,
+        };
+        let mut git_remote = Self::existing_remote(repo, &url)?.map_or_else(
+            || {
+                let mut rad = Remote::rad_remote(url, fetchspec);
+                rad.save(repo)?;
+                Ok::<_, Error>(rad)
+            },
+            Ok,
+        )?;
+        for pushed in git_remote.push(
+            open_storage,
+            repo,
+            LocalPushspec::Matching {
+                pattern: refspec_pattern!("refs/heads/*"),
+                force: Force::True,
+            },
+        )? {
+            tracing::debug!(branch = ?pushed, "Pushed local branch");
+        }
+        Ok(git_remote)
+    }
+
+    fn existing_branch<'a>(
+        repo: &'a git2::Repository,
+        default_branch: &OneLevel,
+    ) -> Result<git2::Reference<'a>, Error> {
+        repo.resolve_reference_from_short_name(default_branch.as_str())
+            .or_matches(git_ext::is_not_found_err, || {
+                Err(Error::MissingDefaultBranch {
+                    repo_path: repo.path().to_path_buf(),
+                    branch: default_branch.as_str().to_string(),
+                })
+            })
+    }
+
+    fn existing_remote(
+        repo: &git2::Repository,
+        url: &LocalUrl,
+    ) -> Result<Option<Remote<LocalUrl>>, Error> {
+        match Remote::<LocalUrl>::find(repo, reflike!("rad")) {
+            Err(remote::FindError::ParseUrl(_)) => {
+                tracing::warn!("renaming invalid rad URL");
+                repo.remote_rename("rad", "rad_old")?;
+                Ok(None)
+            },
+            Err(err) => Err(err.into()),
+            Ok(Some(remote)) if remote.url != *url => Err(Error::UrlMismatch {
+                expected: url.to_string(),
+                found: remote.url.to_string(),
+            }),
+            Ok(remote) => Ok(remote),
+        }
+    }
+}

--- a/upstream-proxy/src/daemon/waiting_room.rs
+++ b/upstream-proxy/src/daemon/waiting_room.rs
@@ -1,0 +1,54 @@
+// Copyright © 2022 The Radicle Upstream Contributors
+//
+// This file is part of radicle-upstream, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Persist the `WaitingRoom` to a k/v store.
+
+use std::time::{Duration, SystemTime};
+
+use crate::request::waiting_room::WaitingRoom;
+
+/// Name for the bucket used in [`kv::Store`].
+const BUCKET_NAME: &str = "waiting_room";
+
+/// Key for the single value used as cache.
+const KEY_NAME: &str = "latest";
+
+/// Announcement errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failures from [`kv`].
+    #[error(transparent)]
+    Kv(#[from] kv::Error),
+}
+
+/// Load the cached [`WaitingRoom`] from the [`kv::Store`].
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the access of the key in the [`kv::Bucket`] fails
+pub fn load(store: &kv::Store) -> Result<Option<WaitingRoom<SystemTime, Duration>>, Error> {
+    let bucket = store
+        .bucket::<&'static str, kv::Json<WaitingRoom<SystemTime, Duration>>>(Some(BUCKET_NAME))?;
+    Ok(bucket.get(KEY_NAME)?.map(|json| json.0))
+}
+
+/// Update the cache with the latest [`WaitingRoom`].
+///
+/// # Errors
+///
+/// * if the [`kv::Bucket`] can't be accessed
+/// * if the storage of the new updates fails
+#[allow(clippy::implicit_hasher)]
+pub fn save(
+    store: &kv::Store,
+    waiting_room: WaitingRoom<SystemTime, Duration>,
+) -> Result<(), Error> {
+    let bucket = store
+        .bucket::<&'static str, kv::Json<WaitingRoom<SystemTime, Duration>>>(Some(BUCKET_NAME))?;
+    bucket
+        .set(KEY_NAME, kv::Json(waiting_room))
+        .map_err(Error::from)
+}

--- a/upstream-proxy/src/error.rs
+++ b/upstream-proxy/src/error.rs
@@ -17,15 +17,15 @@ pub enum Error {
     #[error(transparent)]
     Keystore(#[from] keystore::Error),
 
-    /// Error interacting with [`radicle_daemon::net::peer::Peer`].
+    /// Error interacting with [`crate::daemon::net::peer::Peer`].
     #[error(transparent)]
-    State(#[from] radicle_daemon::state::Error),
+    State(#[from] crate::daemon::state::Error),
 
     #[error(transparent)]
     Source(#[from] radicle_source::error::Error),
 
     #[error(transparent)]
-    Peer(#[from] radicle_daemon::peer::Error),
+    Peer(#[from] crate::daemon::peer::Error),
 
     /// An I/O error occurred.
     #[error(transparent)]
@@ -43,9 +43,9 @@ pub enum Error {
     #[error("invalid authentication token")]
     InvalidAuthCookie,
 
-    /// Errors stemming from [`radicle_daemon::request::waiting_room::WaitingRoom`] interactions.
+    /// Errors stemming from [`crate::daemon::request::waiting_room::WaitingRoom`] interactions.
     #[error(transparent)]
-    WaitingRoom(#[from] radicle_daemon::request::waiting_room::Error),
+    WaitingRoom(#[from] crate::daemon::request::waiting_room::Error),
 
     #[error("project not found")]
     ProjectNotFound,

--- a/upstream-proxy/src/http.rs
+++ b/upstream-proxy/src/http.rs
@@ -104,7 +104,7 @@ pub fn api(ctx: context::Context) -> impl Filter<Extract = impl Reply, Error = R
 /// Asserts presence of the owner and rejects the request early if missing. Otherwise unpacks and
 /// passes down.
 #[must_use]
-fn with_owner_guard(ctx: context::Context) -> BoxedFilter<(radicle_daemon::LocalIdentity,)> {
+fn with_owner_guard(ctx: context::Context) -> BoxedFilter<(crate::daemon::LocalIdentity,)> {
     warp::any()
         .and(with_context_unsealed(ctx))
         .and_then(|ctx: context::Unsealed| async move {

--- a/upstream-proxy/src/http/control.rs
+++ b/upstream-proxy/src/http/control.rs
@@ -61,7 +61,7 @@ mod handler {
     #[allow(clippy::let_underscore_must_use)]
     pub async fn create_project(
         ctx: context::Unsealed,
-        owner: radicle_daemon::LocalIdentity,
+        owner: crate::daemon::LocalIdentity,
         input: super::CreateInput,
     ) -> Result<impl Reply, Rejection> {
         let meta = crate::control::replicate_platinum(

--- a/upstream-proxy/src/http/error.rs
+++ b/upstream-proxy/src/http/error.rs
@@ -123,125 +123,107 @@ impl From<&radicle_source::error::Error> for Response {
     }
 }
 
-impl From<&radicle_daemon::state::Error> for Response {
+impl From<&crate::daemon::state::Error> for Response {
     #[allow(clippy::too_many_lines)]
-    fn from(err: &radicle_daemon::state::Error) -> Self {
+    fn from(err: &crate::daemon::state::Error) -> Self {
         let (status_code, variant, message) = match err {
-            radicle_daemon::state::Error::Checkout(checkout_error) => match checkout_error {
-                radicle_daemon::project::checkout::Error::AlreadExists(_) => (
+            crate::daemon::state::Error::Checkout(checkout_error) => match checkout_error {
+                crate::daemon::project::checkout::Error::AlreadExists(_) => (
                     StatusCode::CONFLICT,
                     "PATH_EXISTS",
                     checkout_error.to_string(),
                 ),
-                radicle_daemon::project::checkout::Error::Git(git_error) => (
+                crate::daemon::project::checkout::Error::Git(git_error) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "GIT_ERROR",
                     git_error.message().to_string(),
                 ),
-                radicle_daemon::project::checkout::Error::Include(include_error) => (
+                crate::daemon::project::checkout::Error::Include(include_error) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "INTERNAL_ERROR",
                     include_error.to_string(),
                 ),
-                radicle_daemon::project::checkout::Error::Io(io) => (
+                crate::daemon::project::checkout::Error::Io(io) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "INTERNAL_ERROR",
                     io.to_string(),
                 ),
-                radicle_daemon::project::checkout::Error::Transport(err) => (
+                crate::daemon::project::checkout::Error::Transport(err) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "TRANSPORT_ERROR",
                     err.to_string(),
                 ),
-                radicle_daemon::project::checkout::Error::Prefix(err) => (
+                crate::daemon::project::checkout::Error::Prefix(err) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "PREFIX_ERROR",
                     err.to_string(),
                 ),
             },
-            radicle_daemon::state::Error::Create(
-                radicle_daemon::project::create::Error::Validation(err),
+            crate::daemon::state::Error::Create(
+                crate::daemon::project::create::Error::Validation(err),
             ) => match err {
-                radicle_daemon::project::create::validation::Error::AlreadExists(_) => {
+                crate::daemon::project::create::validation::Error::AlreadExists(_) => {
                     (StatusCode::CONFLICT, "PATH_EXISTS", err.to_string())
                 },
-                radicle_daemon::project::create::validation::Error::EmptyExistingPath(_) => {
+                crate::daemon::project::create::validation::Error::EmptyExistingPath(_) => {
                     (StatusCode::BAD_REQUEST, "EMPTY_PATH", err.to_string())
                 },
-                radicle_daemon::project::create::validation::Error::Git(_) => (
+                crate::daemon::project::create::validation::Error::Git(_) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "GIT_ERROR",
                     err.to_string(),
                 ),
-                radicle_daemon::project::create::validation::Error::MissingAuthorEmail => (
-                    StatusCode::BAD_REQUEST,
-                    "MISSING_AUTHOR_EMAIL",
-                    err.to_string(),
-                ),
-                radicle_daemon::project::create::validation::Error::MissingGitConfig => (
-                    StatusCode::BAD_REQUEST,
-                    "MISSING_GIT_CONFIG",
-                    err.to_string(),
-                ),
-                radicle_daemon::project::create::validation::Error::MissingAuthorName => (
-                    StatusCode::BAD_REQUEST,
-                    "MISSING_AUTHOR_NAME",
-                    err.to_string(),
-                ),
-                radicle_daemon::project::create::validation::Error::MissingDefaultBranch {
+                crate::daemon::project::create::validation::Error::MissingDefaultBranch {
                     ..
                 } => (
                     StatusCode::BAD_REQUEST,
                     "MISSING_DEFAULT_BRANCH",
                     err.to_string(),
                 ),
-                radicle_daemon::project::create::validation::Error::MissingUrl => {
-                    (StatusCode::BAD_REQUEST, "MISSING_URL", err.to_string())
-                },
-                radicle_daemon::project::create::validation::Error::PathDoesNotExist(_) => (
+                crate::daemon::project::create::validation::Error::PathDoesNotExist(_) => (
                     StatusCode::NOT_FOUND,
                     "PATH_DOES_NOT_EXIST",
                     err.to_string(),
                 ),
-                radicle_daemon::project::create::validation::Error::NotARepo(_) => {
+                crate::daemon::project::create::validation::Error::NotARepo(_) => {
                     (StatusCode::BAD_REQUEST, "NOT_A_REPO", err.to_string())
                 },
-                radicle_daemon::project::create::validation::Error::Io(err) => {
+                crate::daemon::project::create::validation::Error::Io(err) => {
                     (StatusCode::BAD_REQUEST, "IO_ERROR", err.to_string())
                 },
-                radicle_daemon::project::create::validation::Error::UrlMismatch { .. } => {
+                crate::daemon::project::create::validation::Error::UrlMismatch { .. } => {
                     (StatusCode::BAD_REQUEST, "URL_MISMATCH", err.to_string())
                 },
 
-                radicle_daemon::project::create::validation::Error::Transport(_) => (
+                crate::daemon::project::create::validation::Error::Transport(_) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "TRANSPORT_ERROR",
                     err.to_string(),
                 ),
-                radicle_daemon::project::create::validation::Error::Remote(_) => (
+                crate::daemon::project::create::validation::Error::Remote(_) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "MISSING_REMOTE",
                     err.to_string(),
                 ),
             },
-            radicle_daemon::state::Error::Git(git_error) => (
+            crate::daemon::state::Error::Git(git_error) => (
                 StatusCode::BAD_REQUEST,
                 "GIT_ERROR",
                 format!("Internal Git error: {:?}", git_error),
             ),
-            radicle_daemon::state::Error::MissingOwner => {
+            crate::daemon::state::Error::MissingOwner => {
                 (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", err.to_string())
             },
-            radicle_daemon::state::Error::Storage(
-                radicle_daemon::state::error::storage::Error::Blob(
-                    radicle_daemon::state::error::blob::Error::NotFound(_),
+            crate::daemon::state::Error::Storage(
+                crate::daemon::state::error::storage::Error::Blob(
+                    crate::daemon::state::error::blob::Error::NotFound(_),
                 ),
             ) => (
                 StatusCode::NOT_FOUND,
                 "NOT_FOUND",
                 "entity not found".to_string(),
             ),
-            radicle_daemon::state::Error::IdentityExists(_) => {
+            crate::daemon::state::Error::IdentityExists(_) => {
                 (StatusCode::CONFLICT, "IDENTITY_EXISTS", err.to_string())
             },
             _ => (

--- a/upstream-proxy/src/http/identity.rs
+++ b/upstream-proxy/src/http/identity.rs
@@ -144,7 +144,7 @@ mod test {
             .await;
 
         let peer_id = ctx.peer.librad_peer().peer_id();
-        let default_owner = radicle_daemon::state::default_owner(ctx.peer.librad_peer())
+        let default_owner = crate::daemon::state::default_owner(ctx.peer.librad_peer())
             .await
             .unwrap()
             .unwrap();
@@ -202,7 +202,7 @@ mod test {
             .reply(&api)
             .await;
 
-        let default_owner = radicle_daemon::state::default_owner(ctx.peer.librad_peer())
+        let default_owner = crate::daemon::state::default_owner(ctx.peer.librad_peer())
             .await
             .unwrap()
             .unwrap();
@@ -263,7 +263,7 @@ mod test {
             .await;
 
         let peer_id = ctx.peer.librad_peer().peer_id();
-        let default_owner = radicle_daemon::state::default_owner(ctx.peer.librad_peer())
+        let default_owner = crate::daemon::state::default_owner(ctx.peer.librad_peer())
             .await
             .unwrap()
             .unwrap();

--- a/upstream-proxy/src/http/project.rs
+++ b/upstream-proxy/src/http/project.rs
@@ -187,7 +187,7 @@ mod handler {
         super::CheckoutInput { path, peer_id }: super::CheckoutInput,
     ) -> Result<impl Reply, Rejection> {
         let peer_id = http::guard_self_peer_id(&ctx.peer, peer_id);
-        let path = radicle_daemon::state::checkout(ctx.peer.librad_peer(), urn, peer_id, path)
+        let path = crate::daemon::state::checkout(ctx.peer.librad_peer(), urn, peer_id, path)
             .await
             .map_err(Error::from)?;
         Ok(reply::with_status(reply::json(&path), StatusCode::CREATED))
@@ -196,15 +196,15 @@ mod handler {
     /// Create a new [`project::Project`].
     pub async fn create(
         ctx: context::Unsealed,
-        owner: radicle_daemon::LocalIdentity,
-        input: radicle_daemon::project::Create,
+        owner: crate::daemon::LocalIdentity,
+        input: crate::daemon::project::Create,
     ) -> Result<impl Reply, Rejection> {
-        let project = radicle_daemon::state::init_project(ctx.peer.librad_peer(), &owner, input)
+        let project = crate::daemon::state::init_project(ctx.peer.librad_peer(), &owner, input)
             .await
             .map_err(Error::from)?;
         let urn = project.urn();
 
-        let branch = radicle_daemon::state::get_branch(
+        let branch = crate::daemon::state::get_branch(
             ctx.peer.librad_peer(),
             urn,
             None,
@@ -263,7 +263,7 @@ mod handler {
     /// List the remote peers for a project.
     pub async fn peers(ctx: context::Unsealed, urn: Urn) -> Result<impl Reply, Rejection> {
         let peers: Vec<project::Peer> =
-            radicle_daemon::state::list_project_peers(ctx.peer.librad_peer(), urn)
+            crate::daemon::state::list_project_peers(ctx.peer.librad_peer(), urn)
                 .await
                 .map_err(Error::from)?
                 .into_iter()
@@ -279,7 +279,7 @@ mod handler {
         peer_id: PeerId,
         ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
-        radicle_daemon::state::track(ctx.peer.librad_peer(), urn, peer_id)
+        crate::daemon::state::track(ctx.peer.librad_peer(), urn, peer_id)
             .await
             .map_err(Error::from)?;
         Ok(reply::json(&true))
@@ -291,7 +291,7 @@ mod handler {
         peer_id: PeerId,
         ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
-        radicle_daemon::state::untrack(ctx.peer.librad_peer(), urn, peer_id)
+        crate::daemon::state::untrack(ctx.peer.librad_peer(), urn, peer_id)
             .await
             .map_err(Error::from)?;
         Ok(reply::json(&true))
@@ -365,7 +365,7 @@ mod test {
 
         let urn = {
             let handle = "cloudhead";
-            let owner = radicle_daemon::state::init_owner(
+            let owner = crate::daemon::state::init_owner(
                 ctx.peer.librad_peer(),
                 Person {
                     name: handle.into(),
@@ -416,7 +416,7 @@ mod test {
         assert_eq!(
             remote.url(),
             Some(
-                radicle_daemon::LocalUrl::from(urn.clone())
+                crate::daemon::LocalUrl::from(urn.clone())
                     .to_string()
                     .as_str()
             )
@@ -426,7 +426,7 @@ mod test {
         // Verify presence of include file.
         let config = repo.config()?;
         let include_path = config
-            .get_entry(radicle_daemon::include::GIT_CONFIG_PATH_KEY)?
+            .get_entry(crate::daemon::include::GIT_CONFIG_PATH_KEY)?
             .value()
             .unwrap()
             .to_string();
@@ -457,8 +457,8 @@ mod test {
         };
         identity::create(ctx.peer.librad_peer(), metadata).await?;
 
-        let project = radicle_daemon::project::Create {
-            repo: radicle_daemon::project::Repo::New {
+        let project = crate::daemon::project::Create {
+            repo: crate::daemon::project::Repo::New {
                 path: dir.path().to_path_buf(),
                 name: "Upstream".to_string(),
             },
@@ -521,8 +521,8 @@ mod test {
         };
         identity::create(ctx.peer.librad_peer(), metadata).await?;
 
-        let project = radicle_daemon::project::Create {
-            repo: radicle_daemon::project::Repo::Existing {
+        let project = crate::daemon::project::Create {
+            repo: crate::daemon::project::Repo::Existing {
                 path: repo_path.clone(),
             },
             description: "Desktop client for radicle.".into(),
@@ -603,7 +603,7 @@ mod test {
         let api = super::filters(ctx.clone().into());
 
         let urn = {
-            let owner = radicle_daemon::state::init_owner(
+            let owner = crate::daemon::state::init_owner(
                 ctx.peer.librad_peer(),
                 Person {
                     name: "cloudhead".into(),
@@ -642,7 +642,7 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = radicle_daemon::state::init_owner(
+        let owner = crate::daemon::state::init_owner(
             ctx.peer.librad_peer(),
             Person {
                 name: "cloudhead".into(),
@@ -673,7 +673,7 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = radicle_daemon::state::init_owner(
+        let owner = crate::daemon::state::init_owner(
             ctx.peer.librad_peer(),
             Person {
                 name: "cloudhead".into(),
@@ -707,7 +707,7 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = radicle_daemon::state::init_owner(
+        let owner = crate::daemon::state::init_owner(
             ctx.peer.librad_peer(),
             Person {
                 name: "cloudhead".into(),
@@ -741,7 +741,7 @@ mod test {
         let (ctx, _) = context::Unsealed::tmp(&tmp_dir)?;
         let api = super::filters(ctx.clone().into());
 
-        let owner = radicle_daemon::state::init_owner(
+        let owner = crate::daemon::state::init_owner(
             ctx.peer.librad_peer(),
             Person {
                 name: "cloudhead".into(),

--- a/upstream-proxy/src/http/source.rs
+++ b/upstream-proxy/src/http/source.rs
@@ -142,7 +142,7 @@ mod handler {
         });
 
         let branch =
-            radicle_daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
+            crate::daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
                 .await
                 .map_err(error::Error::from)?;
         let blob = browser::using(&ctx.peer, branch, |browser| {
@@ -161,7 +161,7 @@ mod handler {
     ) -> Result<impl Reply, Rejection> {
         let peer_id = super::http::guard_self_peer_id(&ctx.peer, peer_id);
         let default_branch =
-            radicle_daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
+            crate::daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
                 .await
                 .map_err(error::Error::from)?;
         let branches = browser::using(&ctx.peer, default_branch, |browser| {
@@ -179,7 +179,7 @@ mod handler {
         ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
                 .await
                 .map_err(error::Error::from)?;
         let commit = browser::using(&ctx.peer, default_branch, |browser| {
@@ -199,7 +199,7 @@ mod handler {
         let revision = super::http::guard_self_revision(&ctx.peer, revision);
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
                 .await
                 .map_err(error::Error::from)?;
         let commits = browser::using(&ctx.peer, default_branch, |browser| {
@@ -227,10 +227,9 @@ mod handler {
         _query: super::TagQuery,
         ctx: context::Unsealed,
     ) -> Result<impl Reply, Rejection> {
-        let branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
-                .await
-                .map_err(error::Error::from)?;
+        let branch = crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), project_urn)
+            .await
+            .map_err(error::Error::from)?;
         let tags = browser::using(&ctx.peer, branch, |browser| radicle_source::tags(browser))
             .map_err(error::Error::from)?;
 
@@ -250,7 +249,7 @@ mod handler {
         let peer_id = super::http::guard_self_peer_id(&ctx.peer, peer_id);
         let revision = super::http::guard_self_revision(&ctx.peer, revision);
         let branch =
-            radicle_daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
+            crate::daemon::state::get_branch(ctx.peer.librad_peer(), project_urn, peer_id, None)
                 .await
                 .map_err(error::Error::from)?;
         let tree = browser::using(&ctx.peer, branch, |browser| {
@@ -360,7 +359,7 @@ mod test {
         };
         let arrows = "text/arrows.txt";
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn.clone()).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn.clone()).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::blob(browser, Some(revision.clone()), arrows)
         })?;
@@ -418,7 +417,7 @@ mod test {
         // Get binary blob.
         let ls = "bin/ls";
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn.clone()).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn.clone()).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::blob(browser, Some(revision.clone()), ls)
         })?;
@@ -499,7 +498,7 @@ mod test {
             .await;
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::blob(browser, Some(revision), path)
         })?;
@@ -525,7 +524,7 @@ mod test {
             .await;
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::branches(browser, RefScope::All)
         })?;
@@ -555,7 +554,7 @@ mod test {
             .await;
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::commit::header(browser, *sha1)
         })?;
@@ -611,7 +610,7 @@ mod test {
             .await;
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::commits(browser, Some(revision.clone()))
         })?;
@@ -677,7 +676,7 @@ mod test {
             .await;
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::tags(browser)
         })?;
@@ -713,7 +712,7 @@ mod test {
         let res = request().method("GET").path(&path).reply(&api).await;
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::tree(browser, Some(revision), Some(prefix.to_string()))
         })?;
@@ -785,7 +784,7 @@ mod test {
         let res = request().method("GET").path(&path).reply(&api).await;
 
         let default_branch =
-            radicle_daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
+            crate::daemon::state::find_default_branch(ctx.peer.librad_peer(), urn).await?;
         let want = browser::using(&ctx.peer, default_branch, |browser| {
             radicle_source::tree(browser, Some(revision), None)
         })?;
@@ -798,7 +797,7 @@ mod test {
     }
 
     async fn replicate_platinum(ctx: &context::Unsealed) -> Result<Urn, error::Error> {
-        let owner = radicle_daemon::state::init_owner(
+        let owner = crate::daemon::state::init_owner(
             ctx.peer.librad_peer(),
             link_identities::payload::Person {
                 name: "cloudhead".into(),

--- a/upstream-proxy/src/identity.rs
+++ b/upstream-proxy/src/identity.rs
@@ -154,10 +154,10 @@ impl From<Ethereum> for EthereumClaimExtV1 {
 ///
 /// # Errors
 pub async fn create(
-    peer: &radicle_daemon::net::peer::Peer<BoxedSigner>,
+    peer: &crate::daemon::net::peer::Peer<BoxedSigner>,
     metadata: Metadata,
 ) -> Result<Identity, error::Error> {
-    let user = radicle_daemon::state::init_owner(peer, metadata).await?;
+    let user = crate::daemon::state::init_owner(peer, metadata).await?;
     Ok((peer.peer_id(), user.into_inner().into_inner()).into())
 }
 
@@ -165,19 +165,19 @@ pub async fn create(
 ///
 /// # Errors
 pub async fn update(
-    peer: &radicle_daemon::net::peer::Peer<BoxedSigner>,
+    peer: &crate::daemon::net::peer::Peer<BoxedSigner>,
     metadata: Metadata,
 ) -> Result<Identity, error::Error> {
-    let current_payload = radicle_daemon::state::default_owner(peer)
+    let current_payload = crate::daemon::state::default_owner(peer)
         .await?
-        .ok_or(radicle_daemon::state::Error::MissingOwner)?
+        .ok_or(crate::daemon::state::Error::MissingOwner)?
         .payload()
         .clone();
     let new_payload =
-        update_payload(current_payload, metadata).map_err(radicle_daemon::state::Error::from)?;
-    radicle_daemon::state::update_owner_payload(peer, new_payload).await?;
-    let user = radicle_daemon::state::default_owner(peer)
+        update_payload(current_payload, metadata).map_err(crate::daemon::state::Error::from)?;
+    crate::daemon::state::update_owner_payload(peer, new_payload).await?;
+    let user = crate::daemon::state::default_owner(peer)
         .await?
-        .ok_or(radicle_daemon::state::Error::MissingOwner)?;
+        .ok_or(crate::daemon::state::Error::MissingOwner)?;
     Ok((peer.peer_id(), user.into_inner().into_inner()).into())
 }

--- a/upstream-proxy/src/lib.rs
+++ b/upstream-proxy/src/lib.rs
@@ -20,6 +20,7 @@ mod cli;
 mod config;
 mod context;
 mod control;
+mod daemon;
 pub mod env;
 mod error;
 mod peer;

--- a/upstream-proxy/src/patch.rs
+++ b/upstream-proxy/src/patch.rs
@@ -50,9 +50,9 @@ pub async fn list(
     let mut patches = Vec::new();
 
     let default_branch_head_commit_id = {
-        let project = radicle_daemon::state::get_project(peer.librad_peer(), project_urn.clone())
+        let project = crate::daemon::state::get_project(peer.librad_peer(), project_urn.clone())
             .await?
-            .ok_or_else(|| radicle_daemon::state::Error::ProjectNotFound(project_urn.clone()))?;
+            .ok_or_else(|| crate::daemon::state::Error::ProjectNotFound(project_urn.clone()))?;
         let maintainer = project
             .delegations()
             .iter()
@@ -62,7 +62,7 @@ pub async fn list(
             })
             .next()
             .expect("missing delegation");
-        let default_branch = radicle_daemon::state::get_branch(
+        let default_branch = crate::daemon::state::get_branch(
             peer.librad_peer(),
             project_urn.clone(),
             Some(PeerId::from(*maintainer)),
@@ -76,11 +76,11 @@ pub async fn list(
     };
 
     for project_peer in
-        radicle_daemon::state::list_project_peers(peer.librad_peer(), project_urn.clone()).await?
+        crate::daemon::state::list_project_peers(peer.librad_peer(), project_urn.clone()).await?
     {
         let remote = match &project_peer {
-            radicle_daemon::project::Peer::Local { .. } => None,
-            radicle_daemon::project::Peer::Remote { peer_id, .. } => Some(*peer_id),
+            crate::daemon::project::Peer::Local { .. } => None,
+            crate::daemon::project::Peer::Remote { peer_id, .. } => Some(*peer_id),
         };
 
         let ref_scope = match remote {
@@ -90,7 +90,7 @@ pub async fn list(
             None => RefScope::Local,
         };
 
-        let branch = match radicle_daemon::state::get_branch(
+        let branch = match crate::daemon::state::get_branch(
             peer.librad_peer(),
             project_urn.clone(),
             remote,
@@ -99,7 +99,7 @@ pub async fn list(
         .await
         {
             Ok(branch) => branch,
-            Err(radicle_daemon::state::Error::MissingRef { .. }) => {
+            Err(crate::daemon::state::Error::MissingRef { .. }) => {
                 // The peer hasn’t published any branches yet.
                 continue;
             },


### PR DESCRIPTION
The radicle-link codebase wants to delete the radicle-daemon code
and continue to work on the linkd/node-lib code as a
replacement. Since radicle-upstream is the main (and only) consumer of
this package, we decided to move the code here for the interim.

The process of the move consisted of:
* Create daemon module under upstream-proxy, copying over all contents
of radicle-link/daemon to here. Fixing up any imports of crate ->
crate::daemon.
* Remove depedency of radicle-daemon in Cargo.toml files
* Update all imports of radicle-daemon -> crate::daemon
* Remove any unused code that was reported by cargo

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>