### PR TITLE
Add base `/` to url

### DIFF
--- a/design-system/Emoji.svelte
+++ b/design-system/Emoji.svelte
@@ -47,7 +47,7 @@
 <div {style} class="container">
   {@html twemoji.parse(emoji, {
     className: `emoji ${size}`,
-    base: "",
+    base: "/",
     folder: "twemoji",
     ext: ".svg",
   })}


### PR DESCRIPTION
Fixes an issue that workstreams can't find emoji's because it url based.